### PR TITLE
Refactor Azure refresh parser to make a single call to get network interfaces

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -11,21 +11,22 @@ module ManageIQ::Providers
       end
 
       def initialize(ems, options = nil)
-        @ems               = ems
-        @config            = ems.connect
-        @subscription_id   = @config.subscription_id
-        @vmm               = ::Azure::Armrest::VirtualMachineService.new(@config)
-        @asm               = ::Azure::Armrest::AvailabilitySetService.new(@config)
-        @tds               = ::Azure::Armrest::TemplateDeploymentService.new(@config)
-        @vns               = ::Azure::Armrest::Network::VirtualNetworkService.new(@config)
-        @ips               = ::Azure::Armrest::Network::IpAddressService.new(@config)
-        @nis               = ::Azure::Armrest::Network::NetworkInterfaceService.new(@config)
-        @rgs               = ::Azure::Armrest::ResourceGroupService.new(@config)
-        @sas               = ::Azure::Armrest::StorageAccountService.new(@config)
-        @options           = options || {}
-        @data              = {}
-        @data_index        = {}
-        @resource_to_stack = {}
+        @ems                = ems
+        @config             = ems.connect
+        @subscription_id    = @config.subscription_id
+        @vmm                = ::Azure::Armrest::VirtualMachineService.new(@config)
+        @asm                = ::Azure::Armrest::AvailabilitySetService.new(@config)
+        @tds                = ::Azure::Armrest::TemplateDeploymentService.new(@config)
+        @vns                = ::Azure::Armrest::Network::VirtualNetworkService.new(@config)
+        @ips                = ::Azure::Armrest::Network::IpAddressService.new(@config)
+        @nis                = ::Azure::Armrest::Network::NetworkInterfaceService.new(@config)
+        @rgs                = ::Azure::Armrest::ResourceGroupService.new(@config)
+        @sas                = ::Azure::Armrest::StorageAccountService.new(@config)
+        @options            = options || {}
+        @data               = {}
+        @data_index         = {}
+        @resource_to_stack  = {}
+        @network_interfaces = []
       end
 
       def ems_inv_to_hashes
@@ -48,7 +49,7 @@ module ManageIQ::Providers
       private
 
       def get_network_interfaces
-        @data[:network_interfaces] = gather_data_for_this_region(@nis)
+        @network_interfaces = gather_data_for_this_region(@nis)
       end
 
       def get_resource_groups
@@ -132,7 +133,7 @@ module ManageIQ::Providers
 
       def get_vm_nics(instance)
         nic_ids = instance.properties.network_profile.network_interfaces.collect(&:id)
-        @data[:network_interfaces].find_all{ |nic| nic_ids.include?(nic.id) }
+        @network_interfaces.find_all { |nic| nic_ids.include?(nic.id) }
       end
 
       def process_collection(collection, key)
@@ -148,11 +149,9 @@ module ManageIQ::Providers
       end
 
       def gather_data_for_this_region(arm_service, method = "list")
-        results = []
-        @data[:resource_groups].each do |resource_group|
-          results << arm_service.send(method, resource_group[:name])
-        end
-        results.flatten
+        @data[:resource_groups].collect do |resource_group|
+          arm_service.send(method, resource_group[:name])
+        end.flatten
       end
 
       def parse_resource_group(resource_group)

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -49,19 +49,19 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
   def assert_table_counts
     expect(ExtManagementSystem.count).to eql(1)
-    expect(Flavor.count).to eql(33)
+    expect(Flavor.count).to eql(42)
     expect(AvailabilityZone.count).to eql(1)
-    expect(VmOrTemplate.count).to eql(13)
-    expect(Vm.count).to eql(9)
+    expect(VmOrTemplate.count).to eql(17)
+    expect(Vm.count).to eql(13)
     expect(MiqTemplate.count).to eql(4)
-    expect(Disk.count).to eql(11)
+    expect(Disk.count).to eql(15)
     expect(GuestDevice.count).to eql(0)
-    expect(Hardware.count).to eql(13)
-    expect(Network.count).to eql(15)
-    expect(OperatingSystem.count).to eql(9)
+    expect(Hardware.count).to eql(17)
+    expect(Network.count).to eql(23)
+    expect(OperatingSystem.count).to eql(13)
     expect(Relationship.count).to eql(0)
-    expect(MiqQueue.count).to eql(13)
-    expect(OrchestrationTemplate.count).to eql(3)
+    expect(MiqQueue.count).to eql(17)
+    expect(OrchestrationTemplate.count).to eql(2)
     expect(OrchestrationStack.count).to eql(7)
     expect(OrchestrationStackParameter.count).to eql(72)
     expect(OrchestrationStackOutput.count).to eql(5)
@@ -73,10 +73,10 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
       :api_version => nil,
       :uid_ems     => "a50f9983-d1a2-4a8d-be7d-123456789012"
     )
-    expect(@ems.flavors.size).to eql(33)
+    expect(@ems.flavors.size).to eql(42)
     expect(@ems.availability_zones.size).to eql(1)
-    expect(@ems.vms_and_templates.size).to eql(13)
-    expect(@ems.vms.size).to eql(9)
+    expect(@ems.vms_and_templates.size).to eql(17)
+    expect(@ems.vms.size).to eql(13)
     expect(@ems.miq_templates.size).to eq(4)
 
     expect(@ems.orchestration_stacks.size).to eql(7)
@@ -84,9 +84,9 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   end
 
   def assert_specific_flavor
-    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Standard_A0").first
+    @flavor = ManageIQ::Providers::Azure::CloudManager::Flavor.where(:name => "Basic_A0").first
     expect(@flavor).to have_attributes(
-      :name                     => "Standard_A0",
+      :name                     => "Basic_A0",
       :description              => nil,
       :enabled                  => true,
       :cpus                     => 1,
@@ -200,7 +200,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     network = v.hardware.networks.where(:description => "public").first
     expect(network).to have_attributes(
       :description => "public",
-      :ipaddress   => "40.76.199.78",
+      :ipaddress   => "40.121.149.27",
       :hostname    => "ipconfig1"
     )
     network = v.hardware.networks.where(:description => "private").first
@@ -345,7 +345,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   def assert_specific_orchestration_template
     @orch_template = OrchestrationTemplateAzure.where(:name => "spec-deployment1-dont-delete").first
     expect(@orch_template).to have_attributes(
-      :md5 => "83c7f9914808a5ca7c000477a6daa7df"
+      :md5 => "b5711eee5c9e35a7108f19ff078b7ffa"
     )
     expect(@orch_template.description).to eql('contentVersion: 1.0.0.0')
     expect(@orch_template.content).to start_with("{\n  \"$schema\": \"http://schema.management.azure.com"\

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Length:
       - '188'
       Content-Type:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 1c22f999-fa58-4cc6-a48b-78c90835786d
+      - 04c009de-91fb-4e73-a679-0314e0505ff2
       Client-Request-Id:
-      - bac967f7-ef59-4a57-b725-ad37f947ebc4
+      - 56a34328-dcf6-4844-a3bc-bff544fa4fca
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_112
+      - ESTSFE_IN_21
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -51,14 +51,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 10 Nov 2015 19:21:05 GMT
+      - Tue, 19 Jan 2016 13:48:57 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1447186865","not_before":"1447182965","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1453214937","not_before":"1453211037","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ"}'
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:05 GMT
+  recorded_at: Tue, 19 Jan 2016 13:48:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -71,11 +71,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -98,15 +98,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - f07bc081-02bb-41af-b868-49fc78d455ff
+      - 98618e90-115e-4b6a-855a-fe56e300f811
       X-Ms-Correlation-Request-Id:
-      - f07bc081-02bb-41af-b868-49fc78d455ff
+      - 98618e90-115e-4b6a-855a-fe56e300f811
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:f07bc081-02bb-41af-b868-49fc78d455ff
+      - NORTHCENTRALUS:20160119T134858Z:98618e90-115e-4b6a-855a-fe56e300f811
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:05 GMT
+      - Tue, 19 Jan 2016 13:48:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -118,7 +118,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:06 GMT
+  recorded_at: Tue, 19 Jan 2016 13:48:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -131,11 +131,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -158,15 +158,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 169ef359-a005-40be-afcf-caf7a9e16f30
+      - 6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
       X-Ms-Correlation-Request-Id:
-      - 169ef359-a005-40be-afcf-caf7a9e16f30
+      - 6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:169ef359-a005-40be-afcf-caf7a9e16f30
+      - NORTHCENTRALUS:20160119T134859Z:6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:06 GMT
+      - Tue, 19 Jan 2016 13:48:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -179,214 +179,243 @@ http_interactions:
         6VnngPnNwdMJnzP3LfK2LqbfHPCyuvjmgGXLanm9qNYNvbYmtL8uZIY9IIur
         4otsSZywIF4g8D4GANTDidAA9ahpgMnxumnrrCyy9DRrAMh98Lpat0Rs/vSE
         eqFPgfPoI7QMfkv36PcXNNnzNGjIEMKPzMhN+9N1TRJCf/IX9i8GfNwUGf3O
-        UICH+eA72SpbGnzlD7xNfzypsx8UpWA+SNy97d19Ii6RtkMi0n/FLGtz1Wwv
-        iPAE0yfXe4OczvPpWw/e8WVWlNmkKIv2+huB/U0DFaF9luezSTZ9+6HQGEUD
-        7FX+i9ZFnc8+FChxSFyj3gCJYQ1J00oniUD63QFKDwHqJFutur0LzzJrgxvl
-        N+bEUAI6fM9vxRibgdhmDKgvBGhEfwjMoJvgj0AutE8V27i8u0/Rlj5AR+nZ
-        csZ9c0v7l+lJ/o5Owv3tnXuk0rZXdX5Z5Ff0kvfhJG8BxvskK1dzgoT56pF+
-        dTaj/oq2oLn50QTwX6Yn+ftndwIuSD9eZdc/or3+ZXqSv392aT/LV2V1DYPf
-        5otVSTPRnYb373+4NyL9e6hZA29jJ9zNgAYmolZ18QPuhd72kUEfPfTqqsyP
-        m6a4WIIgt8XxAaFDTeWPT/0/6H8d7Pe3d3ciHzKM3of0P/chjzOC79P8vFiS
-        6gJK/2/Hd1pmRN3p8WxBKEMe2qrnxw5h/UNFlNh0URCqwOB26KEfaip//FBx
-        Jeze3hZLjQH6QN5bMIErNZU/GCz/MTQ0pkis41VVFtPr92bisJdhwO8tzbcA
-        XFeXxSyvv/w6JLOQmTD6IXXDHQ1qsWrBwOklHxeA7mGX2dbH02m17o9b7Zxa
-        Ifwwhost0rB95A9Ck7jBSm62XWAYSwoe+43DuFuvl5Oq6rH6/2fHE6SG/r85
-        KsJhAP0eGrfsg3uJy8GTrJ3C1/JxAKAeVhM0NGSmFwLEQvIpYd1vjsT8aYR0
-        Hc9PWliAQVOGqfMSzKdzBhkM5o8+lSbonP6wXxgA/EGIigOjcKWNTKrDxfwN
-        yPrH0Gw8pNmglvIHqyb+gxQ4/Y15Ki7JQ3TTRZPVIT6RYYAluHtLKGAso9Df
-        fkR52IE+QR0NQ3p+fUB3f9G6arMuPEHSkhPjkrHqbz+aH5CVCTugn4qL42VW
-        XreSQvapDzi9+cgGNBQwplEQvYdwOSBcSBZFCFVA2W8hBAm9gX7uUhoye569
-        zYdU43t2vLGvhjx7SiT/HHQFu9pmxZIg/tz0erek0OZ11ryp3uYE+5vHwcEL
-        Yd8K4I3sYiHeJbkVVU4t1mVvEr+Z7mwn3wR47mBIOpcXX2ScYPUxAOAeTots
-        RUshaOojJFqCpm7rZVa3NNN3qIF+NjiZZENppoFWp4/3HvcgJLDbSbVYrJeF
-        QHlZ5+d5nS+JAh8Ier0inZF/I8AZ/NDU/OBNVpoVDdDDRwOgeojpK9TUR8EI
-        F31s5qVnhvgL+xebBd+WMAT9Xd40toKBBYZI/sAb9AdD8htH6UGOFP3P8e9G
-        upxktNRBoP2xA1CPGq/yWZ9bI9j3cHSWkP/AuBxtBID9k7/kZhhx8Bspsw41
-        5I/v5vxHxy/gn0M07xlu94F9jz41aIvNVuTMH9xQ/4rOAnEltAg1lT+QT5Q/
-        aHLof25+gg8l4+h/RPNHs9eZDZq0r7eERpj8LKJFs/h+CudnERdm2BOOf13m
-        h177emgN9nBXFvRdF92hK48bbmKeFu4JPgIrBr8xwzPP8af9xsrNDAssaz6Q
-        /kKZsn+J0OB9+wca0B8dCYrLhPtUQRi0RBK0N/MHv6l/RUlNk0f/20RdevVi
-        WTXk777O25bsa4+8QMSjihJOiGCw46/lI0sJxtT+1Rk9f8lvBSD46xCq0BBd
-        2z/wMv2Bz8yc8IugofmgR0j3gW1Ln5quhIaKl/mDG+pfN5CXCTxgAWaQCp/4
-        eL03HZSRPC9K+q5DfoMhEwNjCX4bmgtBPfiIh8a/SXs7NfyF/YsBKxEZCihl
-        PhD6o4n9A2/TH535ddTWxu4DbgKgcZqSQhjOMyuN7ubL2aoqyGUnyD+i1q2p
-        dZcW0i4KevlHVHsfqk0JbrWYUe73R7TbSDvCUNwT+jwSbPq0+mDYd3Wi9M8f
-        YleWM/Tvn8OuVaD1r59LRHwZ0c++SXRu449/UAd2vN8o2vnsIl9Ws41W/Qag
-        DHbAs5CVeArtV+sWusHvHZB6+Mj8gI49jKAHjBqxKsB8wF8SrvY31mtQLfQ7
-        /SYayxuUwgg/Cv6QV6xaY1j2L1Fd6Mv+gQb0x9fRYwYZ8eQcHuZvgLZ/AA5h
-        mO6lW69bSg4iQSS4mtfoS/PVwNxJKsvENzyR/Ac5i8EfWDejKaYJ7swTs/tT
-        O1kbmP5nCwOPU+42ZdWXZqaTsgeTF6Q2H/CXPM3624/4hb/6oc3W3boiH4Ze
-        /NGcyd8Abf8AHMLw/5VzdmO+I4oPdUT/+zodfTD4y6Ju11n5BSU6aemkC05o
-        rSzGU4TpMh/wl8wq+tuPeI6/ik7C7XmO/uf+GGTAKY2fbUrRm7Wv2X+sl+g6
-        9deEb/4YHFKHF3++Z7f4d8uBpmPzNzqyfwAOofQB7EnzQv+73byI6hnWcQYd
-        +lh/+9G0KO3NkM1r9KX56hualt5kdDuk72UIwUeKqvuNp4xHw5/2GyvVGBZI
-        Yz6Q/uwsMgj7l8wG3rd/oAH90ZltR3tt7D7gJuiRPuXfLb0NkuZvgLZ/AA6h
-        /7M0GTS8eAQahXR7ZUn/c38Mak7/z28IgdvEri/y9qqqsQYcIhCJXZVZ9Y0u
-        jjI5ykA8p5hf8wF/6RiPpinkze4s0kcMI/wo+ENesWzJsOxfwpfoy/6BBvTH
-        /weYNDqZ5o9NDERr//nsbPWjqfl/2dTc4ILdBP9G+BdZm19l16/XqxWNJp89
-        pUXlKQlxyAbf4IBoJt9LVYZggz/of+4P7ZC73Ki2XrdVTbNEL/qYocMerpQW
-        RdPj6bRa02ICveIjLDyhosCsBLYyH/CXzNL6249kg7/6etO8PclbdOU+sX/o
-        xNO0d2bvZ1t0ONGn3KQs8v7JvrCv4I/BjjtseRfKOyK0MknMOW4e6A+Z2eAj
-        4RfMo/0DL9Mf+MywNL8I9jAfOM5Bs+AD25Y+5d8tt5iOzd/oyP4BOIKS/sZS
-        02Um+5HlfgZi/wo4Pkp4Ii/97/3Iqy72cOTzTff0jcMXsD+LA5AOPhjs+2c3
-        QsnhP2KAZ0XT8z4/DGKxoPF/syCr5uxnAejPndm9/RJX5qlPSvp0UTU6gT7W
-        31g7sOzzpxENEXzECiH8SFpZzcGw7F/ci+o6fhcKzXwgahJN7B94m/5wWlC/
-        dR9YKPTpzVqKp2H3PrWVP+h/u9urmly0/IqITiTvEFDjLJMUoBd/RL8PoN/d
-        /F2bLwXij0j5YaQk+/610rkYCP1Ov0WIFXzE2IcfSStLRIZl/+JelIL8Lohh
-        PhAqoon9A2/TH46C+q37wEKhT28mKWlP+h+0583UE8M6bLllMDxm/e1HxFPi
-        vZ5mZU489/OeZCSyHyLClo4/0ooyWKHiN0PS8PMf0fWboutSMs5nyzavz8kz
-        /RFlvynKhp//iNIfTmlHrZBy3zD0u0SeeCgoJGPK6m8/mqIhIl4uXhc/+BGT
-        E8W+LgXXTSTJIQPicetvPyLgEAFX60lZNHOCR2/bjwEXOMnY9bcfETEkIqEd
-        V4FfBzx3EM99Pc3a7KRaLvMpBuIjAdg9tKbSlLr+IluSdPRnFpTDhAzheRCi
-        Roh1unDQftYgOwPzKm/WZT/w+uCueOXlBVF8w3rL+/bC/QzP4rNsSrludOLj
-        AnA97Ga2eT99bbHqSRREQL7Q31hmpVEgiQzBvhYIR0ey+cPwZZE/9GD/ADz6
-        A58ZkeUXIX3ywQAFd3eIgtSa/9h56P8B2to/HtAfltDmQ/pf/0Mkk8MP97d3
-        92Ifouvuh8MJgWBGvnYmKjIX8pGdDJDS/dWZGv6S3wpA8NchVJkXdG3/wMv0
-        Bz6TOdEXb5ik/VsT5WsmmIQAAfbykaUCMHd//b+cJqxYPHG/QcdE4RMf0/86
-        3Mmf0P/Mh4OdH/9gXecfjAHLBzXlP7550Yxh79jp+jWNZIHp+H8npsSJYp66
-        PP5zhSIjOWx6nmdvITr+KIBcb1yYAbQ1q7H0jj86ERSW2+hAVasSPoRNB7SD
-        E8L8+oCck0AtIk7CDZAZ9maSHS+z8pqUPCBTHxYLAOvhlX09milzeHNJaA2A
-        vmvm5zXJyNedpPfqsLM6/0Ps6i55sm1GeaG+B/vD6fUuRUbt66x5U72lVPXP
-        Ag4OXgj7wwF+Lcm4TQ8W7teEyDA3yxyzNkH3ewbAHi5mCqmtj8k3MTMG9N3z
-        os6vsrJ8tS4JiW++IwcvhP3hAP8/yQLURrK+fp8A1cOC3IObwzedIPq441Dy
-        F8PuHZnXAwrWPaQJ5Q4CZ1X77fUEuP4sdcmdDtLpDTmuz7MJAfbxArQepkSd
-        HpodJ1fRY7zhEnu/RQagvzPnG0can9g/8OLgMO9v7/nsQIPs4JsvaV2gWi7I
-        df//FN7U3XsJRgjR+HX0PzgnffAO4teAvhGgUxVd2IZg9LH+xqQDneh381uU
-        1L2ZEhKjif0Db9+W3jyCAXGopmtwy9MnBNkfJKD1hg0XapI11uLTO8GQgZQM
-        riPB/IX9CwORZvybDrI3apeORLPgA9uWPjVx6tmSMgv0N3/X+cu0oU6HaEZB
-        6QG1pz/oN/pfnJM6FIAW/XlIBRrAANPzEAn+/1/GzqMfEp0FObuv8gtydYUa
-        9LJPKIDukW7Gb/XodlFWk6zchJoLdJGRI9QIsQ7stlo9zy/zUjD72emDnQfp
-        YJP78I30hSBCunqVT6sF6SkSPwb0s9HbJfEVwc9Nj25ez5bnVb3gXwnMN9/z
-        RU4xE/X8uqle5b9oTZJC73zz3ZDoUS/85oeD5w4GBOOaPqfA//ntYv9y2qzq
-        6qdp4QXNA7w66UooAaMa+HcSZmMP8bf9A8qG/hAV5Em++cjqIYYctsC7rgH/
-        xZ9zUygcg0HwFrqn39jEf/H62RtGgT4wf+r3wZ8Khz/o4OX0HFoGH1g8BqeL
-        /re7nZWrOaDLR5jBzkf3+h9hasltKC6JF4330Pku8uEkbzsgBCpzyPBcI1uA
-        1baqn6P40bRzy+ADi8f/56e9rNazWb4qq2tS6D+Sedutm2u0DD6wePx/cfJp
-        dANm50dTzS2DDyweg1PN5DazstEQn17SGCjTQh34cwJYvVmyEHqz5HDbgGyc
-        Xu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfsH+iO/pC+LO3xqfkrSmKS
-        G15kYsJ2qMTeLwd9INUGBzgKmSbPrVht6oZwi4vM+4BlwHZaCapjjGd51tI6
-        J6DTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4ZgstiRu99PYAM0h8VeZo6Kgp5
-        ios5WxS/T8DqYUHhxKpaErOhtY+Gz8ffH0VQImrT/xy1gZ/9g/4H0hOK0p/t
-        7yqftMR4P6TeKIaoCxr4N9FZDH5W5nVbx/L6LF0EX4WXf9sggNpMRZpl2Zdx
-        kWM0sX/gbfpDYHoD0rfDj/Am/cbKJ/jCqTA0CT5gMECCPg10zBDJiFCOZPS/
-        AZKt26qZEuGavG2L5cWPKKfEupFylNFYti393iXZbcDuYq3f/CHfxPpwYMMu
-        DB0+cAgWpEsXv3qflSWBfGM3FvjXAvup/wf9L94H+JhSIfns9N2KOOn1j7g5
-        Skz6X5x+lJO8WFZNW0x/HpLO9GBSswag+RuY6R9DVH4wRNhF3tbF9Gl+XiwL
-        oeWP6Gr+Bmb6x3vTtawufkRUIGcAmr+Bmf5xA1GZrL7P6jzx3yu//smMDAHB
-        8+kOGL2ZuETD3gxEKIMxym/ypSU+o2z/4mZKeR4qqGA+4C9jpOSWYX8Mln+T
-        OcO79g98SX84guu37gOGiL7p02AGhsjqW6rdve3dh158QJSOku1uk0/r/Efk
-        e2/y0WDfz6nYBJ47GJCEagnC+b0DaA+ft9ROV1+7GHlUjyJH+OwAOcaiA9bB
-        CWF+fUDO16MWYMH3g8yw46R6Xl0UU4JGcG3PANDD5aqq356X1VW3a2XsgAuD
-        P5iBwu/lFcv94Ev3FxNeWZ/fBT+aD7gpw+Bm/m80Ux1Glz/wNf0RsLPP8/q9
-        +4CboNP4zBNbIpi1nMjsSR92cmlE8Q4FaXgyhz8i4e1IyESMs+0XWf02b1cl
-        ff5lTRkgcn4Jik9w9NWbguyizvPoUgFjHJIYJMBvQ0Ng5cQ4dnqhSYhP9A2Q
-        GFZ8vC/yFgJI8Py+AKLX+2VRt+us1De6KNhR2Umn374+M8mbAdm4TfhR8AfD
-        C3gNn9g/0Dn98U3y2qfbu/fpFfmD/ud4jD8kPdlhPJqGDlFX60lZTM9eHs9m
-        9E1DlP8RWb8Bsi6FSc+WbV6fE8//iKzfCFnLKps9ycpsOSXo9NqPSPrBJFVO
-        fZ1P1zUt0XxeV+vVj0j7jZCWSNnmb7IJ5bPppR8R9IMJGnoAn1OG9Sq7/hFt
-        vxHagoQ/ouzPBmWn1XKZT4WIPyLoN0DQbLUin5Wp+CNOpcES2YiQ3wBhHQlD
-        cv7sdinduEzQz23v77fm+I3icDLPp2+fLpsXFCkfX2ZFmU2KknwygmUbUdc/
-        FFzWTXbRc1t+Fnu29P8h9pm/o2+b5hWJVn5S1NN10Zt30RK+RNNvog6s6uAm
-        9i9upnrDCq35QN4MFAW3CT8K/mB4/19TJD5lX+f1ZTHNX9bVZUEJrS6Ffxax
-        mC2bH1TLHhd/dFFWk6wcHD/9b/9WcO8e/+xBpudnDfjJi+MvTn/WoL988+pn
-        DfYXv/fPGug3v/ebnzXYr1/95DcNm6T5/LyYLrIl6el6VVfnRSTMvKGX/e29
-        g429TGGR3khXX0hXNxin9+ySOx3IDFdtQd0y5G+vJxibjx1g9vC1kNA6QMsp
-        wA0aMa563W+shKFx6Xf67XbanN9V/c9foyvzQUdvi07HG/YPdEd/SF/WyuBT
-        81eU1PvbOw9JPxKJicCDVLq77BP5R2QbIBsLA9ifabdJBhyRFCf3AaOModCn
-        /fH6v/3/hGpEoZIWsd4UeU2gfkSmATLRS3H/1yOK4uA+YBSBOn3aH5//2/8n
-        qcR0ssqKiOSMw5eGXFl5tmyKizl77j5NAa5HZSS3GBhaB1QG5jLqGxG8v727
-        SwhaK8b+KJm2e9t7O/IHOae727vujx36H42HRtPBp2mrmoyqDuGkWp4XF13U
-        ojhsAkri9vZNVl/kTBMflB1lFGZ3CIMdEGWE+F34UbAEiYmxcT5f5YuqzY9X
-        K4Lo9wYgvf6nVVkOJNScbGCo9K37gDkVHEyfdph3kOv5d/epypGwNz6xf4Bp
-        6A/h9QCcfKT8FJEj/iB8BcDcG/wXfT5AXCMsRNphMt31UmY/otktadboktiq
-        LpbTYpWVP6LcBspl02m1XvZVztcG2OaLVUnp3bMFacivC5YBD6kc6Q6g/a4B
-        pIdMQ77xtC5W0n+ISxQFUqYwEtSU/iB86H/OYjBWm3q4SwHde2VLPqQvmnhR
-        59TqPVKf79el+TO+vhwwJFg94FefgflL10xlxHCDEYAAHsMIP5JWIdPbv0TG
-        AN7+gQb0R0eQ49LuPlUQeDk9W84Yf25p/zJIyd/fDKWbYHIdmUOS/2z01WYX
-        LGr0/jffFbyanx3INOvC/+8FfqNueU2x4mxdcsjj9wYgvf5/upp4Zofe8HFQ
-        VjWMwtwrPBR8JK0sCzPL2b/Ah0Z++F1wqvmAmzIMbsa/BUwvf+BL+qMjAQEO
-        aEK/sUD2hMB9wO8CA/qUf1fud9DM30BA/4hOBc3sAU3F15tcJZnpk0cg6AQf
-        SStLSkbJ/oWxGTryuxiW+YCbMgxuxr8JLfGN/QNf0h//Lycsk3aA1/OsngJn
-        n/KA1JuLhlvqekBvPhgpf7z020bq8xgxXkNxfk9/lzfNwBkYtw8/kikAWPrD
-        URKA6IOBOdlAOFIOB9u7D6mx/LFH2U75g0j6YPve7vZLS1IiaIc+pDSmb5U8
-        yDNtSDEN9f41OvyaPfE4Y0BpcuIStxES40x/8ABu4Dcm0JM14Pt9A2QPGwsD
-        rX1s+tPtPuAZB2fRp2bWmV/QMviNZRL8Q7/Tb7fjOn5X+ZS/Rlfmgw7TCYfi
-        DfsHuqM/pC8rDfjU/BWlNDGEOsVE2g6VLCMwqTrc4FMtCpmmDeqCkKA/NnVD
-        uEVYg6C8D1gGbKeVoHqs8YtKau13Cli3R0OIyHPE9I9Mm0558IXMRPCRtjW/
-        6dwyUH+ygwmVP9Ce/hCYOp/h7PZ4xDGuvuw+4CbokT41CIr+UpjmD26of0Vn
-        gyaA/udsgpkV+h9mheakQ2VH2B8RWf/ghvrXN0zku1MaGCvwgpj+RxTXP7ih
-        /vXNUNyqyg1aUnBgOgkCBkf+CKOh335E8NsRvCF7TyCo4Y9IzH9wQ/3rGyXx
-        3VnWZpOs+ZEC+WEQGz/Jj/1y8tOI/C9/RPQfBtGz2aJYFkCIVt5+RHH7BzfU
-        v34WKW6XbSn5Hkk1C05MN0HI4MwfYXT0248m4P0mgD4mymeTMn9K6K/y2dMf
-        aXn6m2GaP7ih/vVNU39a0S9M/h/Rnf5mmOYPbqh/fbN0LxYrGgu1/xGl+Q9u
-        qH/9bFD69B3+/ZF+JwSFyArT/MEN9a9vlv6E8o9oLoRVmOYPbqh/fbM0Py/q
-        /Cory5rW+H5EcPsHN9S/vlmCm8j0dT5d15RweVmVxfRHmS6Caf7ghvrXzy7t
-        v8jbupj+iPT2D26of32zpM/WM0roLi9+xO70N8M0f3BD/eubpTk89sUiX87y
-        2WlJmBTTl1VV/oj09g9uqH99s6Q3muZHjI9PlcQK0/zBDfWvny3qT6vlEknJ
-        avkj+tPfDNP8wQ31r58t+jc/ryzt/8uIj9++yJq3P9I+oLLCNH9wQ/3rhzgB
-        d38UaDFM8wc31L++2WkwH69+5PMApvmDG+pf3yzBc/Exf0Rvhmn+4Ib61zdL
-        73WTXfxIlfwwKA09Lhp9wRmDp/k5rQQKyX9Efv2DG+pfP7vk/xHR7R/cUP/6
-        Zonua/Mf0Z3+ZpjmD26of/2s0332I3XDnTNM8wc31L++2Rlw6qatVj+xzmty
-        2+ntH9Gd/+CG+tfPPt3v/iL6ef0mfwe8fjQD/Ac31L++zgzwHCyzRd6ssikm
-        4ItiWldNdd6OX7dVTU4lveHPEeD2Z02aHk+n1XrZX6vF8Dyq6lzY39Ot1y29
-        fYc+47FxS/7NUo7bKvF5yKCN+SCYAPkDb9MfMhuGgAyX3w4/Cv6QV2zHX2fK
-        ovNwf3vn0+3d+/SK/EH/c5PCs9ChKfUvC+Bdcn4z4KMBwzcDejrPp29fEE8d
-        X2ZFmU2KkpbX6PVvvqcO392F9iimvWEJ+/D0gjHkN/2sz3527juswC8oy9nJ
-        Nh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM4AvHYGgSfMBggAR9GvBplLgk8PQ/
-        yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2SJvWebY4XmblNXl0oKM/BwAVmRW8
-        QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRDA/qD3+L3eXAYryE6fxCho34tYPA+
-        /SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs2v3t3R0Q3eiKh/4fn/p/0P/cHzxR
-        5o979IfVL/whfU3/w1TSRHamw5G/MxWggyOxwZ2Hj0HTbz+aCvmD/uf+YEKb
-        P4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgXywpB2+u8xVJvF1FvQvQ3jzkMsflr
-        +cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo2D/wMv2BzwyX8YtgEPOB4x00Cz6w
-        bePcQtSl/8VFjEB4tHwP46O//YiUlpQ0trj7KAOyo+e/GP1gLECFfvMIat+Q
-        kaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO635d8cFfBZ8AH3gU7p042zF6XaRq1w
-        QH9YcTcf3kZV0G/0P8wFz4bvBCysE9CsVysaM73hzxYQe4/5i1CNRx9+FPwB
-        ersJFAD2T/6Sm4HQwW88/TJl+MT+gVfojw7t+SemxUw23jG/u9nDp8EH9r2h
-        +dp5QJTdftmZFWhmIjcRu0M6oTJp3+nbvB+MyugD8jAC4UfBHxiuo5cAsH/y
-        l9wMA3O/0W//XyAfEzDOrZdFs87Kpl3Piope86kM4D26ZxI+UNOvQXAMS34D
-        deS3oIGACclu/+K3lVQMHPQwHwjR0cT+gbfpj84MOJpy4yg5Scjpfx0dQZ/s
-        be99SuQkYsapcndVVz+dT9Hrz1/qMH18ZnPx0XfzCbX2aQeYPWo2RUthKaUA
-        86X02yFnB2dgagbKvzOxZJT42/6hQxYybqIsQw5b4F3XgP/iz7mpT+rgLXRP
-        v7GO+OL1szeMAn1g/tTvgz8VDn/QwaszO/4HFg/6FF8S1CA2588A2vvMoep9
-        yBiKZXUtzN/ci/4V5Q3SObCu1FT+gFayf9zGxNIfe/aP/e3dXe8PDwD9Qf/r
-        8yD9DwqPODDKU01ZUebjR5z1I876pjmrWDZttqR0Gr3wI5ZCt46D0DL4wOJB
-        n+JLgvojluqxlCirHzHWjxjrG2Ysy1I/soT0QQcvx0xoGXxg8aBP8SVB/RF3
-        9biro7Z+xGP0QQcvx1JoGXxg8aBP8SVB/RGPeTy2Wk/KoplT+vgrWsD8EUuZ
-        bh0HoWXwgcWDPsWXBPVHLOWxFLETLeYgY5FdZkWZTUoQ9EdshW4dF6Fl8IHF
-        gz7FlwT1R2zlsZX8cVLReKryR4rKdOsYCC2DDywe9Cm+JKg/4igwkXKUVU80
-        0OnbH7GU6dZxEFoGH1g86FN8SVB/xFIeS5Ev1b6G237cNMXFMp+9qb5NxvAF
-        GUN6+UfshW4dN6Fl8IHFgz7FlwT1/9PsFWMRiergIoErnhSExvLiR8rHdOuY
-        AS2DDywe9Cm+JKj/P+UOifl//vGIsoSdSKIXf/AjHvF5hIhQq6b4kdaQbh0D
-        oGXwgcWDPsWXBPX/0xzBf3yDLss0r9vivCAu+tGaiO3WsQ9aBh9YPOhTfElQ
-        f8RPHj9RGvEyr59l9eJH7GS6ddyDlsEHFg/6FF8S1B+xk89OcIio2Y8YCd06
-        vkHL4AOLB32KLwnqjxipy0jiWVPjH7ETunXcg5bBBxYP+hRfEtQfsZPHTvV6
-        2RaLnmr6f8MgovgK+y/yti6m/59E+ml+XiwLQfn/U+izytFB/H8Y9f8v0t+5
-        ojqI/w+j/v9F+jMT1fm0Wizy5UwR/n8f8u+h9f9/NJaLvKrzC8b0/8vDECaj
-        5ouC0mKzGVAOx/Mj/+7/n/5djBuQM6f1lNPlZVFXS5LU/794+27m8GnwgQVC
-        n+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFuO/13F+uyLV5V
-        Zf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m9Y9YATPMnwG+
-        95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GACRa1j+//fiH4O
-        Zwsj+KbG5ilSHdiHT5XDhiaE/uf+YNTMHz8bU9Ufzv9P5qnDg8WyabPl9P+V
-        icvbB33vM1Cdzp93A/5/N/9+2NB9abXjJlA/D0aps/vza7T/f+HlRbYkl3r2
-        7f7w6V1/WD8KRvCZ68f7kPGScMO1MH9zL/rX/xtYI8oFs3xVVteY9ud2ysPp
-        /38D6rfn6qJRec4dQy+zRZ5dZkWZTUpw0/93Rzcts6Yppl9Uk6LMX9O6TEF6
-        iV77/+6ICNUvWBFhoo6n04rWsrsj+v+oAuIsuHuR/9Tvgz8VDn/QwcupLLQM
-        PrB40Kf4kqD+3OgwZoXtekqtvb8NA9x6zu+uqqu8Pl6tmle0EoRRyvT/iBWk
-        WzfzaBl8YPGgT/ElQf25YQXWMXbqlR/kw0neAoj3SVau5gTp1vwxrZbLfCqM
-        8COmkG4dD6Bl8IHFgz7FlwT154YpRB98uH5w8388/f9Lwpzn1L3If+r3wZ8K
-        hz/o4OVmHC2DDywe9Cm+JKj/32YB+tTnA//3H/GEh5djAbQMPrB40Kf4kqD+
-        /4onfsQHHl5u2tEy+MDiQZ/iS4L6/3k++NHce3i5qUbL4AOLB32KLwnq/+fn
-        nv/5EQN4eLn5RsvgA4sHfYovCer/9xmAYPxo4tGtm2e0DD6weNCn+JKg/n9/
-        4j3r/yMmMN26OUfL4AOLB32KLwnq/zuZgNkAydtmlU3BAy/yq1d5WUzHxy+/
-        oJd8DgHUPs8om1DbgCuEVgZjJqqg632kw+MvmSL8m7xpqcxN7F8MA4Rl6tEH
-        /B7/HqUApVF3aMTUkP8wSdLesF/ny9lFXczGpwtKYlNzf5gAduuBO4SGsOVR
-        6m/MizxE/lTGHpCIYYQfBX/IK5ZADMv+JZKGvuwfaEB/dKTWsa42dh9wEwwi
-        TmHKNYGnokRdTyl33jyhFb23zfikzLP66ROC7VMSYHq0nWVtNska+rJD3A7W
-        ASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovfixHO/1S75y/9HqPE
-        JXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B3Ty36hUZAEA
+        UICH+eA72SpbGnzlD7xNfzypsx8UpWBOf5qez5YzfpE/t3/hHf0jOg/3t3ce
+        bu/ep5b0B03K3vbuPk0KTUmHtKQ3i1nW5qoRX9CE0Us+mT8M/nSeT996wI8v
+        s6LMJkVZtNf09jfc0c9qD6ITnuX5bJJN31L7bw40I28gv8p/0bqo8xm99s31
+        QKwZV+XvA5YBD8n0SmeZXvL7BsgeNtRjtlp1URHJYQFj/ubfhO+NNPBHHenj
+        t2LixUBsMwbUF0U0oj8EZtBN8EdHOtEDfcHKI6513KdoSx+gIxVZRcb+ZXqS
+        v4dm5B4p1u1VnV8W+RW95H04yVuA8T7JytWcIGG+eqRfnc2ov6ItaG5+NAH8
+        l+lJ/v7ZnYAL0rZX2fWPaK9/mZ7k759d2s/yVVldw+1o88WqpJnoTsP79z/c
+        G5H+/XQuw9vYCXczoIGJqFVd/IB7obd9ZNBHD726KvPjpikuliDIbXF8QOhQ
+        U/njU/8P+l8H+/3t3Z3Ihwyj9yH9z33I44zg+zQ/L5akuoDS/9vxnZYZUXd6
+        PFsQypCHtup500NY/1ARJTZdFIQqMLgdeuiHmsofP1RcCbu3t8VSI5E+kPcW
+        TOBKTeUPBst/DA2NKRLreFWVxfT6vZk47GUY8HtL8y0A19VlMcvrL78OySxk
+        Jox+SN1wR4NarFowcHrJxwWge9hltvXxdFqt++NWO6dWCD+M4WKLNGwf+YPQ
+        JG6wkhttFxH5njIMkQDcY+nChLhxTHfr9XJSVT2+///H4ILU1f8PhkgIDYyl
+        h9PX6ZC7jMvOk6ydwj/zEQLUHooTNDQTQC8EWIaEVZK73xzx+dMIUTveorSw
+        AIOmDFNnLJhp50AyGMwsfSpN0Dn9Yb8wAPiDEBUHRuFKG5luh4v5G5D1j4Gp
+        obCYNJiZGlZn/Acpffob81Rcklfpposmq0N8IsMAf3D3llDAWEahv/2I8rAd
+        fYI6Gob0/PqA7v6iddVmXXiCpCUnxiVj1d9+ND8gKxN2QD8Vy4svMk77+JQH
+        jN5cLLIVpYnRtD8FROqtl1ndLvP6DjXQzwYRIyndI8QIrU4fRPa4JL43pJL8
+        +5NqsVgvC4Hyss7P8zpfEgU+EPR6hfTsNwKcwQ9NzQ/eZKVJ1IIePhoA1UNM
+        X6GmPgrCuDQbbl56jM5f2L+Y8XxuZQj6u7xpuJGBBawuf+AN+oMh+Y2j9CBV
+        Tf+Dqs5VR2+gy0lGqVkC7Y8dgHrUeJXP+twawb6Ho5M1/gPjcrQRAPZP/pKb
+        YcTBb6x8AmrIH3iF/uhoHv45RPOeanAf2PfoU4O2aAVFzvzBDfWv6CwQVx7Q
+        LFBT+QNZDvmDJof+5+Yn+FDyIP5HNH80e53ZoEn72osBP4to0Sy+n8L5WcSF
+        GfaEfW8Xj9JrXw+twR7uymKn66I7dOVxw03M08I9wUdgxeA3Znjmua9ef+S4
+        0TVRbmZYYFnzgfQXypT9S4QG79s/0ID+6EhQXCbcpwrCoCWSoL2ZP/hN/StK
+        apo8+t8m6tKrF8uqaYvp67xtyb72yAtEPKoo4YQIBjv+Wj6ylGBM7V+d0fOX
+        /FYAgr8OoQoN0bX9Ay/TH/jMzAm/CBqaD3qEdB/YtvSp6UpoqHiZP7ih/nUD
+        eZnAAxZgBqnwiY/Xe9NBeZLzoqTvOuQ3GDIxMJbgt6G5ENSDj3ho/Ju0t1PD
+        X9i/GLASkaGAUuYDoT+a2D/wNv3RmV9HbW3sPuAmABqnKSmE4eyX0uhuvpyt
+        qiISewYjRtfBbz/fqXWX0vsXBb38I6q9D9WmBLdazCjv9CPabaQdYSjuCX2+
+        LjdK5wfDvqsTpX/+ELuynKF//xx2rQKtf/1cIuLLiH72TaJzG3/8gzqw4/1G
+        0c5nF/mymm206jcAZbADnkVet8U5Yvr8VX5BGQQZAfXlowGQPcSm7tUva1qd
+        6SF4UVaTrBxEjh14Ru0mwHe9T76xXogZLws0/pwBHK9Wmnh4WRfLabHKyrPl
+        V01ev8mX2RLq7Rvp9ZL0I+dS3Ih8up8tz6ta1ia+Xo/c58BUy1IwZXFW6xZm
+        wEcNkHrIiihCZHpUh8o3FsNqe/MBf0lsaX9jEwYrQr/Tb2KcPP5VGOFHwR/y
+        irVgDMv+JVYKfdk/0ID++DomyyAjTrvDw/wN0PYPwCEM071063WbXeTIBQqu
+        5jX60nw1MHe7e5g7DWVp3cX9IQLMf1CQEPyBFRmab5rtzqSxmntqZ26Dsvuh
+        oOPx0N2mrPoqnSmojMOExySYD/hLZgD97UecxF/93Ezd3boir5Ze/NEEyt8A
+        bf8AHMLw//0TeGM6LIocdUT/+zodfTD4y6Ju11n5BeXBi+WPGJDwMH8DtP0D
+        cAjDHz4D0v/cH4PcOCVisB0qelP4TSAT6zK6hPpNdGb+GBxsh2V/vudI+XfL
+        qKZj8zc6sn8ADqH0AVxM80L/u928iIYaVoUGHfpYf/vRtCjtzZDNa/Sl+eob
+        mpbeZHQ7pO9lCMFHiqr7jaeMR8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB
+        /dGZbUd7bew+4CbokT7l3y29DZLmb4C2fwAOof+zNBk0PIlGu/SPQiJl+XU0
+        J/3P/TGoRv0/fzawifW5qC7z1+tJM62LFfp6pV9//f5jvVgi0yy16+aDoDP8
+        jUH/i7y9quq39KKPBsD2EFNR1De6aAnrqXgwx4J7zQf8pRMrYsJQ8ro8Sh8x
+        jPCj4A95xQodw7J/idShL/sHGtAf/x8QQZo/fzKFIfkPw53mj03iQTmrfHa2
+        +tE8/azPE8/GhnmiSaL/Refpa/uhIR8Efwx2dkE5xavs+vV6taI5yWdPc2Q1
+        f1i904SLXvuGO6T/uT8Ge1+K1nqdT9c1Jbw+r6v1j0SD8DB/A7T9A3AIw29a
+        hcXmpdEJebWmtAA19+fjwyD/rEeV3OlG4/q6rWqiEb3o44YOe9jSAheaHk+n
+        1ZqWhekVH2GZEWVEnkhMqvmAv2SG0t9+xJn81W2mWSaT/zAza/6g/+1uT/IW
+        /bpP7B+DquaHqtM5qa98pszzgYn9sOPgj0EsOtx7F85HxLTIXDKDuemiP4QB
+        go+ErTDd9g+8TH/gM8P5/CK4yHzgGAzNgg9sW/qUf7dMZTo2f6Mj+wfgEEq3
+        4zjb3P3Gsth9wX5kZYr7tH8FchSdNJoN+t/7zcYtck2MBuMXIMuIhPjLnGCQ
+        9g+8TH/gMzMf/CKIbj5w84FmwQe2LX3Kv9s5MB2bv9GR/QNwCKX/X0yQZDeG
+        k07fdE/fOHwB+7M4AOngg8F+oHMQqkX+I9bLrGh6cfI3CL5YEGV+FuFXzdnP
+        dg8/xJiA+9/orp0tz2vSCfV62q7r/IvignCDsPtIA5feMKax94eyQ6J3VB2y
+        AoHOMx/wl6x/9DdWT6x8+FPRSoGiYhjhR8Ef8opVXQzL/iWaG33ZP9CA/ghU
+        nK+ntbH7gJtgEHFNyDO1e/+GKagWq/XtqJ15/g3ZsTh9eeT6W4eEEeIEH/Fw
+        wo+klSUaw7J/cS86ffwuSGE+EJKiif0Db9Mfjn76rfvAQqFPg2nYSF/md/qD
+        /re7vaopuM+viOhE8g4BNZFncur04o/o9wH0u5u/a/OlQPwRKT+MlOTS3eCh
+        AkOhhP72/3OSkgGj/8GA3Uw9cY6GvS8ZDI9Zf/sR8ZR4r6dZmRPP/bwnGYns
+        h4iwpeOPtKIMVqj4zZA0/PxHdP2m6KqLA2fLNq/PyTP9EWW/KcqGn/+I0h9O
+        aUetkHLfMPS7RB4Kf/ErvW0/BlyMWCirv/1oioaIeLl4XfzgR0xOFPu6FFw3
+        kQyUDIjHrb/9v5qARC+gSdj+HBBwtZ6URTMnePS2/RhwgRORjj7W335ExJCI
+        hPaPVOBtSMfEi+f1nmZtdlItl/kUPfkEBuweyafSlLr+IluS5Pe5FkMDxYbw
+        PAhRI8Q6XThoP2uQnfGkJPC67AeVH9wVL/u+IIpvWOx93164n+FZfJZNaS0G
+        nfi4AFwPu5lt3l9esVj1WB48Kl/obyxU0igQFYZgXwu4tyN6/GH4sggIerB/
+        AB79gc+MTPGLEA/5YICCuztEQWrNf+w89P8Abe0fD+gPS2jzIf2v/yHWKsIP
+        92XRo/chuu5+OJzsCGbka2fZInMhH9nJACndX52p4S/5rQAEfx1ClXlB1/YP
+        vEx/4DOZE33xhkkiitD/bkOUr5k8EwIE2MtHlgrA3P31/3KasGLxxP0GHROF
+        T3xM/+twJ39C/zMfDnZ+/ANaPPtgDFg+qCn/8c2LZgx7x07Xr2kkC0zH/zsx
+        JU4U89Tl8Z8rFBnJYdPzPHubHy+z8po0FlD2hwMsewPMptNqvezbXZYUFtxN
+        I/UQI7QGQN/FdAOx1zTh+bF++rPZYUMdkUv0c9DVXXLL2owSOH137IfT610K
+        YdrXWfOmeks55Z8FHBy8EPaHA3S+ILWI+IJfuwcL92tCZJibZY5Zm6D7PQNg
+        DxczhdTWx+SbmBkD+u55UedXWVm+WpeExDffkYMXwv5wgP+fZAFqI+lZv0+A
+        6mFBtu7mWEQniD7ueEf8xbCvQrbigCJPD2lCuYMAAYqTQYD/LPV6VrXfXk9+
+        FrvkTgdn5w35fs+zCQH28QK0HqY0Jz00O36iosd4w6v0fosMQH9neTO+KD6x
+        f+DFwWHe397zmZAG2cE3X9KyQbVckPf7/ym8qbs4H94KonGN6H9x19xB/BrQ
+        NwJ0CqoL2xCMPtbfmHSgE/1ufouSujdTQmI0sX/g7dvSm0cwIA7VdA1uefqE
+        IPuDBLTesOG4TbLG+hn0TjBkICWD60gwf2H/wkCkGf+mg+yN2qXc0Cz4wLal
+        T02od7ak4Jz+5u86f5k23Gnwh1BTO5A/gOwgaSn8O6CW9Af9Rv+LM1yHUFDx
+        PyLWELFonAMiBODS888rEjGRhuR1QX79q/yCvHohGr3s0xOgexSe8Vs98l6U
+        1SQrN6HmAlRk0gg1QqwDu61Wz/PLvBTMfnb6YD9JOtjkKX0jfSFekq5e5dNq
+        QcqRhJkB/Wz0dknsR/Bz06Ob17PleVUv+FcC8833fJFTeEg9v26qV/kvWoNH
+        fza6IQmlXvjNDwfPHQwIxjV9TjmO57dLc5TTZlVXP00LJmge4NVJM0KUjQbh
+        3zeKudFUgU6Qj6y6YshhC7zrGvBf/Dk3hV4yGARvoXv6jf2KL14/e8Mo0Afm
+        T/0++FPh8AcdvJw6RMvgA4vH4HTR/3a3s3I1B3T5CDPY+ehe/yNMLfkqxSXx
+        onFZOt9FPpzkbQeEQGUOGZ5rJEawSlb10zE/mnZuGXxg8fi6064T9LWn/Rub
+        9rJaz2b5qqyuSaH/SOZtt26u0TL4wOLx/8XJp9ENmJ0fTTW3DD6weAxONZPb
+        zMpGQ3x6SWOg9A514M8JYPVmyULozZLDbQOycXq535hyjmhCj+AVhhV+xO8q
+        GflrdGU+6DCPcAbesH+gO/pD+rK0x6fuL9NfGFOYv7it/BGdDRIxXkfiOegQ
+        lB1ljjZB1Q2+chQyzbNblNrUDQ0jLl3vA5YBWw4gqI6HnuVZS0uZgE7/2p4B
+        sIfLuWt7IybUOTDxGJlQoHd9eGQzLosZvff1ADJIf1TklOqoKDoqLuZsfPw+
+        AauHBUUeq2pJfILWPhqWeYhZoygRtel/jtrAz/5B/wPpCcVOf1f5pCW++yH1
+        RuFGXdDAv4nOYvCzMq/bOrbawcJF8FXO+beNssrNVPpZTn11ICKPJvYPvE1/
+        CExvQPp2+BHepN9YTwVfOG2HJsEHDAZI0KeBOhoiGRHKkYz+N0CydVs1UyJc
+        k7dtsbz4EeWUWDdSjpIfy7al37skuw3YXSznmz/km1gfDmzYhaHDBw7BgnTp
+        7Ffvs94mkG/sxgL/WmA/9f+g/8X7AB9T1iSfnb5bESe9/hE3R4lJ/4vTj9yO
+        i2XVtMX05yHpTA/ifTmA5m9gpn8MUfnBEGEXeVsX06f5ebEshJY/oqv5G5jp
+        H+9N17K6+BFRgZwBaP4GZvrHDURlsvo+q/PEf6/8+iczMgQEz6c7YPRm4hIN
+        ezMQoQzGKL/Jl5b4jLL9i5sp5XmooIL5gL+MkZJbhv0xWP5N5gzv2j/wJf3h
+        CK7fug8YIvqmT4MZGCKrb6l297Z3H3rxAVE6Sra7TT6t8x+R773JR4N9P6di
+        E3juIC4Jz6uLYkrv+d0Dag+hq6p+e15WV118dLYC0gZ/MFXC7+UVO6UgtvsL
+        lDbzye+CyOYDbsowuJn/G096MHvyB76mP4I58idSv3cfcBN0OjiViNAseZnm
+        9GEnl0QU71CQhhefUqVHQKLgD8Yo/F5esUTDiN1fGJKhGL+L0ZgPuCnD4Gb+
+        b/+vJyGB+nKQigF6t+o31sUiW2YX+ex4Vfysd3Aiqzb8/jfQFXcWl/Ivsvpt
+        3q5K+vzLmrJA5ABTjz5iANtDNbuo8zy6ssCIhRwJjsFvQ9iygmIcO70Qz8Zn
+        9AZIDCs+3hd5C31F8Py+AKLX+2VRt+us1De6KNhRWRmh376+7MmbAdm4TfhR
+        8AfDC0QTn9g/0Dn9EfCLL4na2H3ATYDThonavU+vyB/0P8dj/CGbF+9DnoYO
+        UVfrSVlMz14ez2b0TUOU/xFZvwGyLoVJz5ZtXp8Tz/+IrN8IWcsqmz3Jymw5
+        Jej02o9I+sEkVU59nU/XNS3TfF5X69WPSGtIq3/Q/xwVb01aImWbv8kmlNOm
+        l35E0A/m1dAD+JyyrFfZ9Y9o+43QFiT8EWV/Nig7HQ4egDCNhz4GavKbkMWS
+        kJvYv7iZ0s8ibz6QNwOCcZvwo+APhvf/NYJmqxX5rEzFH3EqDZbIRoT8Bgjr
+        SBiS84fRpVv5+7nt/f3WHb9RHE7m+fTt02XzgiLl48usKLNJUZJPRrBsI+r6
+        h4LLuqHUxw+RCpb+P8Q+83f0bdO8ItHKT4p6ui568y5awpdo+k3UgVUd3MT+
+        xc1Ub1ihNR/Im4Gi4DbhR8EfDO//a4rEp+zrvL4spvnLurosKKHVpfDPIhaz
+        ZfODatnj4o8uymqSlUPj393dvrdDr5g/6F/TiX4IdPbth5t6vntM7/yc9U0P
+        vfZz1f3Ji+MvTum9n6v+X755RW/9XPX+xe9NL/1cdf7m935Db/1c9f761U/S
+        Wz/k3km7nZ8XU0nZ16u6Oi8iYfeNeFC62nS5v713sLHLKcz1G+n3C+n3Bsv9
+        If0zBgM59KotCAfu5tvrCUbto4oOeshbSGgd4OhMxQbbETdS7jc2V7BN9Dv9
+        dju7x++qpeSv0ZX5oGPhxPrhDfsHuqM/pC9rj/Gp+StK9/3tnYegOxN4kEp3
+        l30i/4hsA2RjyYAsMO02CYQjkuLkPmCUMRT6tD9e/7f/n1CNKFTSct+bIq8J
+        1I/INEAmeikeKXhEURzcB4wiUKdP++Pzf/v/JJWYTlZZEZGccbCr8Fl5tmyK
+        iznHOD5NAa5HZaQBGRhaB1QG5jLqGxFUk2atmDFt97b31N6TG0/23v2xQ/+j
+        8dBoOvg0bVWThdUh0Hr8eXHRRS2KwyagJG5v32T1Rc408UHZUUZhdocw2AFR
+        RojfhR8FS5CYGBvn81W+qNr8eLUiiH5vANLrf1qV5UDq0ckGhkrfug+YU8HB
+        9GmHeQe5nn93n6ocCXvjE/sHmIb+EF4PwMlHyk8ROeIPwlcAzL3Bf9HnA8Q1
+        wkKkHSbTXS+5+COa3ZJmjS4erupiOS1WWfkjym2gXDadVutlX+V8bYBtvliV
+        lAg/W5CG/LpgGfCQypHuANrvGkB6yDTkG0/rYiX9h7hEUSBlCiNBTekPwof+
+        5ywGY7Wph7sU6r1XXulD+qKJF3VOrd4jSfx+XZo/4yvxAUOC1QN+9RmYv3TN
+        VEYMNxgBCOAxjPAjaRUyvf1LZAzg7R9oQH90BDku7e5TBYGX07PljPHnlvYv
+        g5T8bSn9QZRugsl1ZPZITqB/NvpqswsWNXrfdftNdQWv5mcH8ixfldX1gqbi
+        Zx2+k7Wfna6+HviNavI1hb2zdcnRm98bgPT6/+lq4llQesPHQaXO8DwLoohD
+        8JG0stLI0mP/gkgZVcDvQujMB9yUYXAz/i2QX/kDX9IfHWEOcEAT+o11S0+e
+        3Qf8LjCgT/l3FWQHzfwNBPSP6FR8SvNA/6OW9AdN8wH98fVmWulnEODhCG7B
+        R9LK0pXxs39hoIao/C7GaD7gpgyDm/FvQlh8Y//Al/TH/7epfF5WV7chcPCH
+        4Bh8JK9Y+jKe9i8M2BCX38VYzQfclGFwM/83ppsQG63sH/ia/uhQ3tFTv3cf
+        cBN0GqcaqYmAUEw9+rCzUsX0G9AheVZPgYRPXoDvEbzhlrq41qM8hkkDp48x
+        BvltI2ntyAw5+T39Xd4M5onbhx8JTQGW/nA0AyD6oENk8+YGHiTCHWzvPqTG
+        8sceJcTlD2LIB9v3drdfWpISQTv0IWU8favkQSpyQxZyqPev0eHX7InHGQNK
+        kxNXXhshMc70Bw/gBn6TyI1e8XsGwB4uJsp73WbtuouPnVBmBcw5fotiKbrl
+        3nZWrubgLvvRXv+jXf8jSiexJAUf0cT0PuJ3nbzR6DcOhYb7/5/B3L0s6nad
+        lV9k03lBy3EE5/83Q8uXs1VVkHdIEP5/M6hmPVlGEpD/nxpSmzW9kOP/WyPI
+        yG////gkLKplQVlyWkKid/7/MIy7q6xlZ+j/F4OZZE1OoTmcrf9fjCdbtsUi
+        K6+y+v/bQ5plbXZiQ/HjC8K9pwd4DOoMswfb85RpgPY3DjfgB9Pv9NvtvOfg
+        D3nFOucMy/4lfjb6sn+gAf3R8bF7Prj7gJtgEPQp/66OuMPD/A3Q+sf/N2aQ
+        stWR3KzMjc4YjxijNx/wl0x5/e1HU4iPfnhTuKpo0a34/7i3ykuH2TISjv9/
+        ahhX+YSWl2k+GP9nRZ1fZWV/Se//xWPiUQ0FvJwReMIBrD9wINsjhYWB1sHo
+        nRxi6PSt+4CFUQUzSiT729fSMvyu6i3+Gl2ZDzrqQ1QL3rB/oDv6Q/qyCgmf
+        ur9Mf6IztBv7F7eVP6LTTckSXVOkWegQ1CZJmKpfK1NCkHnaN3VDw3jftAlB
+        6oBlwJYDCGqPi55lk7qY0nt+94DaQ2haEntQr9TWR0do6aaVf+PP7FwI7c2M
+        UIOhIXjCsxn3X1QSWB8/AOlhTL3HSdjFlH/rYWkHxDwefCGsF3zEbZWFGZTP
+        0wHfyh9oT3/gM0cpgWv/7IiCk0992X3ATdAjfWrQEv7WLswf3FD/ik4DMQ/9
+        z6kiw1H0P3AUzUmHyo6wPyKy/sEN9a9vmMh3pzQwVjcRVwMYC6EYHf5NcDHo
+        8kfa7EcUp0/of3GKWzW/QcMLdZhOjA3/JqgYbPkjbfZzQ3Dq//8TBG/IIBEI
+        avgjEvMf3FD/+kZJfBfRJnI5PyK2/YMb6l9RYpN7Qv+LEzv64cYZwE/yvr6c
+        /DQi/ssfzcR7zAQRl/73NYiezRbFsgBClP/7EcXtH9xQ//pZpPiXxh3flN5i
+        ujF2/JugZrDnj7TZjyaAPqH/bZ4A+pgon03K/Cmhv8pnT3+k+ulv7sL8wQ31
+        r2+a+tOKfmHy/4ju9Dd3Yf7ghvrXN0v3YrEi7Kn9jyjNf3BD/etng9Kn7/Dv
+        j/Q7oSVE1i7MH9xQ//pm6U8o/4jmQljtwvzBDfWvb5bm57qcUK/LH6nzHwbB
+        Tbj6Op+ua8rCvBxYaQPuQjJGjH8TrAzi/JE2+xHt6RP63/vR/ou8pfWCH5He
+        /sEN9a9vlvTZekZZ3uXFj9id/uYuzB/cUP/6ZmkOj32xyJezfHZaEibF9GVV
+        9ReOgbpQjPHi3wQpgzd/pM1+RHr6hP63mfRG0/yI8fGpkli7MH9wQ/3rZ4v6
+        02q5RFKyWv6I/vQ3d2H+4Ib6188W/ZsfWVqlsHZh/uCG+tfPFvHx2xdZ8/ZH
+        2gdU1i7MH9xQ//ohTsDdHwVa3IX5gxvqXz9b02CU0HGZ162ZCAIUTAFjZUfK
+        fzEdBUEzBv4Io6Xfbj8N7jelPwMFecwHMgfo1f6B9vSHwLSI/RxPwftNwe0J
+        zxRiqkTJZ0ltvxCyxNqa35SyDPRrkRpN3F8/F4SnNVr6n+P9TbR27G48ztd5
+        ix8/Irj9gxvqXx9M8B+RmRAUWipM8wc31L8+mMzm49WPQld0Yf7ghvpXlMak
+        nOl/jsa3Vtq5pAp+RG/uwvzBDfWvb5be6ya76FtFYCoEYjT4N8HBoMkfabMf
+        UZo+of9tprQzkQsOR5/m58WSdDhA/4j8+gc31L9+dsn/I6LbP7ih/vXNEt3X
+        5j+iO/3NXZg/uKH+9bNO99mP1A13zl2YP7ih/vXNzoBTN221+ol1XkdiT+At
+        5GKk+DfByCDNH2mzH9GdPqH/vT/d7/4i+nn9Jn8HvH40A/wHN9S/vtkZyGaX
+        RVPVP+J2+wc31L++WVqrnsfC6in9ssjaH2mZ96A7pQHof47u3/8lTOxltsib
+        VTYFpb8opnXVVOft+HVb1RQrEVx/MgCqPz3S9Hg6rdbLdsOM6G9MdPt7uvW6
+        pbfv0Gc8HG7Jv1licVulN48S5DAfBDSXP/A2/SEkNzRjuPx2+FHwh7xiO/46
+        szRE+k+3d+/TK/IH/c+fB5qFDk2p/1pJGJLzmwEfjYO/GdDTeT59+4J46vgy
+        K8psUpSUlKbXv/meOnxHGfD6spj2hiXsw9MLxpDf9LM++9m577ACv6AsZyfb
+        fCBshyb2DwCjPwRKwGP8dvgR3qTfWDCCLxyDoUnwAYMBEvRpwKdR4pJupf8N
+        qNcBOqor/Z6Ru37285CyTNshbVrn2eJ4mZXXZMBAR38OACoyK3iFkt0/XU3w
+        QkD4YCggSIecOmKhkf1K6IcG9Ae/xe/z4DBeQ3T+IEJH/VrA4H36Q7rot+Xf
+        HE3xWfAB94FO6dOAyG6eNpqy3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/wh
+        fU3/w1TSRHamw5G/MxWggyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh9Cm6q
+        NutOws8dYkRDJ6V3iUgXy4pc0+nQQhWILxOiv3nMYYjNX8tHll8wxe6vjbOk
+        jRmK+Yb/4OZhL8I/QMX+gZfpD3xmuIxfBIOYDxzvoFnwgW0b5xaiLv0vLmIE
+        wqPlexgf/e1HpLSkpLHF3UcZkB09/8XoB2MBKulXPkHtGzIyNKA/LIZmNPxB
+        SBc0NV/Ly+iU/hDA/bb8m6MCPgs+4D7QKX26cfaiVNuoFQ7oDyvu5sPbqAr6
+        jf6HueDZ8J2AhXUCmvVqRWOmN/zZAmLvMX8RqvHow4+CP0BvN4ECwP7JX3Iz
+        EDr4jadfpgyf2D/wCv3RoT3/xLSYycY75nc3e/g0+MC+NzRfOw+IstsvO7MC
+        zUzkJmJ3SKdUJh38Nu8HozL6gDyMQPhR8AeG6+glAOyf/CU3w8CC3/6/QD4m
+        YJxbKa21zsqmXc+Kil7zqQzgPbpnEj5Q069BcAxLfgN15LeggYAJyW7/4reV
+        VAwc9DAfCNHRxP6Bt+mPzgw4mnLjKDlJyOl/HR1Bn+xt731K5CRixqlyd1VX
+        P51P0evPX+owfXxmc/HRd/MJtfZpB5g9ajYFZfzuUmY7X0q/HXJ2cAamZqD8
+        OxNLRom/7R86ZCHjJsoy5LAF3nUN+C/+nJv6pA7eQvf0G+uIL14/e8Mo0Afm
+        T/0++FPh8AcdvDqz439g8aBP8SVBDWJz/gygvc8cqt6H0mX0K0ZejK572fzN
+        COhfUbYhdQTDS03lDygs+8dtrC/9sWf/2N/e3fX+8ADQH/S/PnvS/6ALiTmj
+        7NaUFSVFfsR0P2I6+o15xfzxs8h0xbJpsyUl4eiFH3EbunXMhZbBBxYP+hRf
+        EtQfcdv7cJuouB/x3I94TlnF/PGzyHOW235kWumDDl6Oz9Ay+MDiQZ/iS4L6
+        I8Z7H8brKLsfsR990MHLcRtaBh9YPOhTfElQf8R+t2O/1XpSFs2cEtxf0RLr
+        j7jNdOuYCy2DDywe9Cm+JKg/4rbbcRtxGq1EId2SXWZFmU1K0PpHHIduHYOh
+        ZfCBxYM+xZcE9UccdzuOkz9OKhpPVf5IvZluHW+hZfCBxYM+xZcE9UfMdjtm
+        s0qNBjp9+yNuM9065kLL4AOLB32KLwnqj7jtdtxGflv7GtHDcdMUF8t89qb6
+        NlnXF2Rd6eWvyXlmhv7fynlAj2aXMGRG4z/BHuYDYYMfcZ75gzkvxj0Sd8Id
+        A8M8KQiN5cWPVJbp1vEJWgYfWDzoU3xJUH/+Mc6sWmTF8surJfU8L1ZnM8Kx
+        OC/oL4LwIxZCt45j0DL4wOJBn+JLgvrzj4Uk5/UjDWQ+6ODluAUtgw8sHvQp
+        viSoP5/Yh+hTK4P8iFmkW8cbaBl8YPGgT/ElQf3/K7PwH9+ghz3Naxg1YrAf
+        rT/abh1noWXwgcWDPsWXBPX/nawWsoB+aP/4fw3/UUb+Mq+fZfXiR+xnunXc
+        hpbBBxYP+hRfEtT/d7IfNZU//t/DafDIqNmPeAzdOpZCy+ADiwd9ii8J6v87
+        eSyce/3Q/vH/LsaTUIAa/4j90K3jNrQMPrB40Kf4kqD+v5P9qKn88f8aTqvX
+        lKFY9LTc/xsGEcVXJGORt3Ux/f8k0k/z82JZCMr/n0KftZEO4v/DqP9/kf7O
+        4dVB/H8Y9f8v0p+ZqM6n1WKRL2eK8P/7kH8Prf//o7Fc5FWdXzCm/18ehjAZ
+        NV/QckE2mwHlcDw/cv1+3rl+MUbB0gAtCZwuL4u6WpIQ//8lRnCTik+DDywQ
+        +hRf8iveDPFngO995vrxPpRxRL9ilGUe3cvmb0ZA//rGZ9n88R56pcMZg5xx
+        d7Eu2+JVVeYvq6r8EaPwZ4Dvfeb68T6UcUS/YpSFFdzL5m9GQP/6/xSjXFX1
+        27z+EZdghvkzwPc+c/14H8o4ol8xysIH7mXzNyOgf/1/ikvEh+9yyP8Hh/D/
+        wTAkOphAvevY/v83ov+fzJanY3Vg/z8bzv9P5qnDg8WyabPl9P+VSdLbB5jv
+        M1Cdzp93A/5/N/9+2NB9abXjJlA/D0aps/vza7T/f+HlRbYkl3r27f7w6V1/
+        WD+KU/CZ68f7UMYR/YpRlkjEvWz+ZgT0r/83cE2UQWb5qqyuwRHPLTeEnPH/
+        BtRvz/CrurosgOnnZTXJyuPV6jWtohTT/GVdLKfFKivPll/RwsqbfJktwRr/
+        3x1q0ahWy51YL7NFnl1mRZlNSsjU/3dHNy2zpimmX1STosx1Dv+/zZqE6hcZ
+        1DEm6ng6rdb/v1HDvO7gXuQ/9fvgT4XDH3TwcoobLYMPLB70Kb4kqP+v0+TM
+        Jdv1lFp7fxveuDU73F1VV3lNWqt5RctyIIBwxo+4RLp1TIGWwQcWD/oUXxLU
+        /9dxCWsmyxXKKvLhJG8BxPskK1dzgnRr1plWy2U+FR75Eb9It4490DL4wOJB
+        n+JLgvr/On4RLfLhWsWxxvH0/y9LFDzd7kX+U78P/lQ4/EEHL8cMaBl8YPGg
+        T/ElQf3/LXfQpz6L+L//iF08vBx3oGXwgcWDPsWXBPXnC7sc/3+dRWSyaOJ4
+        zn/EIt+MRvmR5vDwclyAlsEHFg/6FF8S1P8/swX/8yPe8PByrICWwQcWD/oU
+        XxLU/1/zBsH4EU+gW8cCaBl8YPGgT/ElQf3/NU94zuiP+MN069gBLYMPLB70
+        Kb4kqP+f4w/mEKSym1U2BXu8yK9e5WUxHR+//IJe8pkHUPvspBxEbQOG6Y6J
+        vhd0g494ePwbE4t/kzftBHAT+xfDAM2ZsPQBv8e/RylASeUdGjE15D9Myrg3
+        7Nf5cnZRF7Px6YJS+tTcHyaA3XrgDqEhbHmU+huzKQ+RP5WxByRiGOFHwR/y
+        iiUQw7J/iRCiL/sHGtAfHYF2XK2N3QfcBIOIU5hyaOCpKFHXU1pJaJ7QKu/b
+        ZnxS5ln99AnB9ikJMD3azrI2m2QNfdkhbgfrgBBAfDOdhQD4xP6h1BAiBuDk
+        I0tJ7hJUMF3gTfc1/8XvxQjnf6rd85d+j1HiErvS/0BcIm2HSNOSYFJzAvYj
+        GjGNmEo+A76pSay/KKZ1NX6a57Q+OV3XRXtNoH1aAlCPukPirYNIt15mdbvM
+        ayjpmzAkEfl0e/c+YUj4dfoh0sRXHt4bUkmLGCfVYrFeFgLlZZ2f50QBIsUH
+        gl6vSCLzbwQ4/vt/AJDRaEYHkAEA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:06 GMT
+  recorded_at: Tue, 19 Jan 2016 13:48:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
@@ -399,11 +428,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -422,17 +451,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14999'
       X-Ms-Request-Id:
-      - 9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - c94bd72c-2878-4954-a90f-79f9b764e65d
       X-Ms-Correlation-Request-Id:
-      - 9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - c94bd72c-2878-4954-a90f-79f9b764e65d
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192106Z:9f53ea95-ff84-4cf9-bd08-2bfa77e7085c
+      - NORTHCENTRALUS:20160119T134900Z:c94bd72c-2878-4954-a90f-79f9b764e65d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:06 GMT
+      - Tue, 19 Jan 2016 13:48:59 GMT
       Content-Length:
       - '411'
     body:
@@ -449,7 +478,784 @@ http_interactions:
         5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
         dX0nBgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b5ec7302-cf6f-4506-aae5-9262d3ed337e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 573d9dd2-ae1d-44dc-bdf9-d99779c2d9fd
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134901Z:573d9dd2-ae1d-44dc-bdf9-d99779c2d9fd
+      Date:
+      - Tue, 19 Jan 2016 13:49:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x+dzPPz7Zd1Ndt+nU+r5Wz7bNnm9Xk2zT8a2cbFDE3vNutJM62LVVtUy+bu
+        /qd753vZ+cF2/umDfHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/r
+        ar1q7tre7q7q6rKY5XVz94tiWldNdd6OX+TtVVW/vbuUnxYT771NWOZtdgE8
+        v3v39/0oO3g4m+3sTbbvTbPd7f1skm0f7DzY2c7PZ/cn+f7uzu5+9vt+5L3c
+        Xq+YHrfAxnurrKYZqIE386xp1/6XNMRVXrcFvfHIUV6+uCwaeq1YXrxus5Y7
+        fr2eTvN8ls8cBGpq6beWOfh0dv7pbGfv/vanBzs0rvsPz7cf7uU72/ufPtyf
+        Pnjw8GH+aRYAKFYn1fK8uFjXjChQUV6Qx8MLj+WLYkV0pvd2fWh4/t/MDHe7
+        o6UPqAV90B/Gh3CLPJjH6ATLg69vOc3y0AvFJTU7e3k8mxGtAPWj3Z0x/tvd
+        2di+NIz4Rd7OK56gp9c0lcU08hrNHBGV2vRQpi+/udmtFqt1m//kF83G6b0s
+        6nadlfpn8BrhQHg2d2f5ebYu24+62P6S8IPgT++P73sU+Gi2bF7nbUszAuoG
+        BJDv6kvCk776nv8afZmtVmWRz56GbVyTX+I1/yhfZpOS5uVZVV9l9Yx6o9bn
+        WdnkppHiZ96yiFj5m4LJiXCz+3ve1H+D0wP4EKKNs0P0x08rYM3dAbx8aXrw
+        ab77aZ7tb9/f+/Rge//8we72wae797d3H9779P70wezewcG5L03/X9G9ewef
+        Ts7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nYCNUM6NNRGBOT/67rX
+        n35SruH46IMhxD+EP+TBzEWnVB58fcuJlYdeMNoz0LZ7pG33NzZ/L2W7Wk/K
+        Ykpv2U56qFOrH/K8dpCiebXv9bVsf0yEJnEGYfz/gqH07Id9izAgLP+/aD4W
+        2VRnhlp9tLOzvfN0+97x9u7e9vH+9tNnPpdtMDV+KyIEyEP+0rou2mumMLUL
+        B/BDnrkYTt673nwFxCE5XGT1NaHa1utgkMoKX2TTebGE+P+cDE8dGMOYio33
+        lj8w86v+YgZqEbcmYVU17QXhsT3LL/fv3Xcs8MMaVmfWPJMwjJqv9Gf3zu9P
+        7pO+fzAlfb8/fZhvP/x0P9/emexnu7MHs/1Pp1Nf6f9/xSnYzfLde5PdyfbB
+        wf6D7f2HD/a3Jw/272/fzyfT88nOvcnk4UEAoGs0Ccj/152CDgeQGxAOkT4Y
+        wv1DWEQeTF50VuXB17ecW3noBWPonQ5Wv8BjbvN4zf//6Be8NFP7NL/0FJc8
+        Rl255yPClPiDkP5/wWhUA+uf/luEAWHZ/H/QNfj/m7kf4K9gzDqPakkJ6Z+t
+        cXz79Nn2y1dfPo2OY8iuD43A/Kq/mBFZ3K1iry/avGmdivjmBmSDteiAOhPj
+        6fMeRr6WfvBgZzfPPt3Znsx2yeBNJg+2H+az+9sP9mb37ue7ZPOmu76W/v+K
+        Ib/34NPz8wnZ8N2HBw+39/cPJtvZ/nRn++GDbPLg/v7BbCcL9DgZ5NDKEZBb
+        GfIudeX5f8usk60Oh6Wf9/D9EJ6QB7MVnUZ58PUtJ1MeesGYYrFfaK+We//B
+        xvb/bzbdt5vPDlJ2Prf1i5Wnm+QxGsk9HxGyxBeE98/qgG5nL1TP6p/+W4QB
+        YdkMW+/+wGimvaAx/FoVtDzeH76ZFgv+s27dhwP/p/vb+6c+L97SEwgH7n+j
+        9FU7Rg3CQX1jsz0Vu3m5oDghMt1DZlW415tbOzP6iyGcRdtTsL8/v6sN6Jtv
+        bjBgQhrGZtYl7sTPQLd2UfLVZ7Y33Xuw8/D+9uz+jOb505yiyfu0vJc/nOT3
+        JvnewfTTe776/P+KSc2nk3vns4cPtu/dv0cU3qewODvP72/vPNw//3Tv4c50
+        fxJEVB9gUjvklef/NfMeM6r8RQ/jD2ELeTBhmMneTMqDr285n/LQC8ZKOtVk
+        rOqnG9v//9Oq8sT9yKzSg6n2rEv4tappebw/fPsopvNn3awOm0rTSPEzb1lE
+        rIZpZuf0P8e2P+xpo5nBT0+1EDr0Pw8jX3Xc2/t0+unDbHd78ulsj5bYDva2
+        J/cfzrYn9Ntkb2cymU33fdXxs2FRCB3Myi82RKWPaIRR1YQvbqmUPrLkUyOz
+        u3dvB4py+3z/Hq0mZgeUgN2ZzLb39h7c+/TBbDqZHAS+/9c2MkRt+p8PCs//
+        Wxihb2LoQ/pfD98PYRN5MFvRaZQHX99yMuWhF4zFEDWL9mphdoO5k8dr/14W
+        hqaIqEdteijTlz/kafyRGv5aahim9/dfFtPdnR03wT/suaPpwU9PBONo+ZL2
+        YGfn4e7e/sH2bP/+ZHt/dy+nXEk22Z5M93f3d87v37u/k/uS9rOhkGlMUbHF
+        F7cU2I8swYz2PbhPGmT3fJuyP7Rmc39CCbN7Ow+2dz7dOdjN9iiDthcC6Kop
+        AnIr7bsofhGofPYyoLE8/69igL4i3oj6hzCJPJi+6LzKg69vObvy0AtGvfbU
+        8X4Qr8njtX8vdawetNdLD3dq9UOe2g5SNLX6yQqT18XPKCr3fESIEnsQzv8v
+        GMzPRyMznEI7ebJ9cM/nww0GyW8VDtz/RumrOStqEA7qG5vtr5lCg9JB+5Bz
+        7fToL4Z6FnercvE+lNq+I9o3NybHi0CxOyRl2Q2a1kfK16H3D3bu79+bYQFi
+        /9Pt/dmne9sPJ/f3CbWdezv3Z+f79x8GSZP/rxjaBzv7Ow/yfH872yNru79D
+        BoKWWWihKv/0fLabT6b3HoYAumaIgLyfod3zweH5f9HkbzCyfbQ/hD3kwcRF
+        Z1QefH3LeZWHXjAm0+kqNbG7P39N7L6npuQxysk9HxGaxBiE8f8LhqIaV//0
+        3yIMCMsNBjb8IPjT+8O3hGIkf9YN6LBRNI0UP/OWRcSqEAgii6mXHv5hTw1R
+        Hz9jysPHytcN+wcH9+7vk27Y25uSip3tn5P7TSmR3Sz/9NO9nXu7e5OJrxv+
+        v2I6Du7N9u5nO7Pt/ekuxWjnn+5uP9x9cG/7/NP9+wfZbDLZnwRpov9/m45P
+        v7bteF/+kAczF51SefD1LSdWHnrB2AJRoGivtuPewcb2/7+2HQ/6OrY/KMKT
+        WINQ/n/BWD7AePQHRpPsBSnh16qv5fH+8K2EGJD/LxiXywVk1feSftgTR3OD
+        n55yieDkK47ZfXLRyfPcnj44yGgdPLu3Tdn1B9uTg4OH04O9B/cfhgu5PxuG
+        hdDBzPxsr8Z8mtOq9P4BrVQf7JGtyTPKDB5M8+3z6flBlpHFmfhUIgBdZUxA
+        bmVr+iSX5/89zNC3M+abHs5fh1k6IAjHcDLpQ/fg61tOqTz0grEaomrRXq3M
+        j5ZkOrg6mTIP6PHzSx/7TvUPeeJobvCzL4I+Tr6I3ft0/97k3sGn29OHn1Ke
+        /WA62c6wbnx/b5Lf39m7d3Cw//8Xfbxz8HDv/OH5dPv+OeWO9pE7yg7u0SLN
+        g739B3uT/YeU8wgAdJUWAXkffeyRXJ7/9zDDoD7u4/whzCIP5iw6mfLg61tO
+        qTz0glGwPX38DTr9NEtEQGrTw5i+/CHP5I/08YfoY89I/7AnjuYGP/si6OPk
+        i9ju/r3z/QcPJ9v53t7B9v5DQuogf0hJ2Z17+59m98+zWf7AF7GfDX1MA4rK
+        K764paR+ZKmlyvfBjEaRz6a0+pRR9iWjwU0ms9n2wf39/Z3J5NPpvWmQcfhQ
+        5evRV57/98z8oPLt4/whnCEP5iw6mfLg61tOqTz0gtGmPeX7cGPz91K+msrw
+        OumhTq1+yFPaQcqb0m39anUb/UvoEnMQ5v8vGNIHGJbwg+BP7w/fAohx+P+Q
+        4fC8iR/2xBDt8bOvPnycfPVwL3t4fn7wcLa9ezC7v71/b+fT7YNP6c979/Js
+        Jzvf271/L8jI/mwYDkIHM/Oz7chPd6c7kwNa9c3vPaSFy4fnD7cfPvx0ur13
+        kN3PZ+e7kwe5tyROALoKl4C8jy3xSC7P/3uYYdCW9HH+EGaRB3MWnUx58PUt
+        p1QeesEYB9GoaK+2ZHdnY/v3MiY0TURBatNDmb78IU/lByjc/sCIHj+/PHnP
+        w/hhTxzNDX72ZdDHyZexB9nB7vnDyafbe/s5aalP701ISz3Y3c7zTx/u3X+Q
+        PZhNAn/t/8MKmcg63f2UlAi1nFKmm5LcDx/ez7bz+weT6Xn+aT6ZBYneD1XI
+        Hsnl+X8PMwwq5D7OH8Is8mDOopMpD76+5ZTKQy8YBdtXyLsb2/9IIdMDevy8
+        Ush7HlP8sCeO5gY/ezIY4OTLWHZw/iC7fz/fzj6lBcf9T/fvb08ePjjY/vR8
+        MtmZ3r937+D+p76M/X9YIR/s3D9/cD/f2d7bI128P5nRKuvO/u52treT3X94
+        fzr5dC9wED9QIfskl+f/PcwwpJAjOH8Is8iDOYtOpjz4+pZTKg+9YBRsXyHf
+        29j+RwqZHtDj55dC9pKoP+yJo7nBz74M+jj5MnZ/untvb38329598Gm2vf9g
+        52D74STPKTH8YHdKUrabZTu+jH1thSyCgG5/rhTybHqP9MmEMt87e+Tf5Xv7
+        25P8IN++9/DBzsP97NMse5gFALpai4C8j0L2SC7P/3uYYVAh93H+EGaRB3MW
+        nUx58PUtp1QeesEo2L5CDpJO8njtf6SQ6QE9fn4pZM9K/7AnjuYGP/sy6OPk
+        y9j5pwcHD/f2s+2MVuVIxqbZ9mRKYf2D2b3d873J9N7BTu7L2P+HFfK9/YN7
+        pI/vb892dnaI6jsPtw+mDx5ivPvT8+lBfnDuUYkAdLUWAXkfhRwAw/P/HmYY
+        VMh9nD+EWeTBnEUnUx58fcsplYdeMAq2r5A/3dj+RwqZHtDj55dC9jKRP+yJ
+        o7nBz74M+jj5MjbNJw9oYX9n+945OYv7Owf3tx8+uPdg+16W7U13DiYPP723
+        58vY/4cV8sPZ7CGN6NPtndm9ve392d697exgcrC9f/9gmt3bv3f/03vnAYCu
+        1iIg76OQPZLL8/8eZhhUyH2cP4RZ5MGcRSdTHnx9yymVh14wCravkIOkkzxe
+        +x8pZHpAj59fCtmz0j/siaO5wc++DPo4+TJ2/vD+/oySp9t7D3cf0sI5RfQP
+        H+wRUllOyzcP9/bund/zZez/wwp58nD3PuUl7m/vTvZpqNmDT7cP7s3Ot2eT
+        LJs+yIkQWbBG/6EK2SO5PP/vYYZBhdzH+UOYRR7MWXQy5cHXt5xSeegFo2D7
+        Crm3Khm0/5FCpgf0+PmlkB+42f1hTxzNDX72ZdDHyZexnXxvNj2f7W+f5+T5
+        7D/cfbB9cEDLNvcOyAuidfT83sOJL2M/GwqZBhQVWHxxS1H9yFLLaN98MpvM
+        iMSECK0/HezvbGf7Bw9pOerg03xvL5tMPg2Uz4dqX4++8vy/Z+YHtW8f5w/h
+        DHkwZ9HJlAdf33JK5aEXjDbtad+9wH7K47V/L+27Wk/KYkpv2V56uFOrH/Kc
+        dpDy5nRbv1rdRgETusQdhPn/C4b0AZYl/CD40/vDNwFiHf4/ZDm8+O6HPTFE
+        e/zs6w8fJ18/7E5ne7v5p7vb09nOdHt/uk+69tP797bvPdi7/2l+73z/0/PM
+        1w//X7Ecu/v3dib7NJrp9Pyc0ieTyfbkfvZg++H9fGf3wd75faJxAKCrXgnI
+        +1iOABie//fM/KDl6OP8IZwhD+YsOpny4OtbTqk89IKxBKI+0d5Yjt2N7f//
+        Zjk8y3HwdSxHZDqIXj9kNv2R5aDHItLVIl4g+sOeGKI9fvb1h4+Trx8eZjvn
+        e3t5tp1P6J/9vWy6ffDwIenah9Nsurebfbp7b9fXD/9fsRwPHuaf5jsTWtH7
+        dOc+jeY+kTijNdH7s8nB+QOKPvbu7wcAuuqVgLyP5fDoK8//e2Z+0HL0cf4Q
+        zpAHcxadTHnw9S2nVB56wViCvuXY29j+/8eW4+HPR8vRHxjN9c+rbNY9L8j+
+        YU8czQ1+9vRLgJOvP7Lz+w9m0+kuJdnvUcZ4b5ZtTw4eHGzPyP2cPqAcxr2d
+        fV9//H/Fsuzs3d/Zm+xl23v3ZrS4u0f/PJzln25/unNvZ+fe3uT+znmgWD/Q
+        svj0lef/PTM/ZFkiOH8IZ8iDOYtOpjz4+pZTKg+9YCyFqFe0N5bl3sb2//+1
+        LPd2fmRZ6MFc//yyLF4Q/sOeOJob/OzrFx8nX3/c+/TgHiWGZtuzhwcTygrt
+        UDZ8fz/fPt+Z5Lu7+w8nD+6f+/rj/yuWJZ8e7N1/QC72wYP7FLPcP7iHRNe9
+        7U+z3fxhlu1nDz8NFOuHWhaPvvL8v2fmBy1LH+cP4Qx5MGfRyZQHX99ySuWh
+        F4ylEPWK9sayBFGnPF77/x9blt0fWRZ6MNc/vyyLF6T/sCeO5gY/+/rFx8nX
+        H/cnO/d3s4yWWO89/HR7/1NabJ3sH5xvT/Z2dvZ3H36618mW/3/FsswePLy3
+        s3c+2Z7t7dO4Dg52tx8e5LQesPvp/vl0+uBBlk0CAF31S0Dex7J49JXn/z0z
+        P2hZ+jh/CGfIgzmLTqY8+PqWUyoPvWAshahXtDeW5f7G9v8/tix7P7Is9GCu
+        f35ZFi9I/2FPHM0Nfvb1i4+Trz+mu7sHu+e7O9sPZvf2SQNnD7ezh7QCSEmj
+        /d3d7N69/d0g5/H/Fctyb2/nwcGDfHc738vhcR8cbB+cTx9s73463Xm4OzuY
+        7M0CBfOhlsWjrzz/75n5QcvSx/lDOEMezFl0MuXB17ecUnnoBWMpRL2ivbEs
+        n25s//9jy3Lv/32W5ZZD+pFl+RDL4gXpP2xepLnBz75+8XHy9cfk4ODe3sE9
+        SnLs34dHv/dgezLbO9/Odw8+3Z882DufznJff/x/xbKcf7o3m83unW/vTg+I
+        xOfn97czWnvZ/vQ835tM8slkdz8PAHTVLwF5H8vi0Vee//fM/KBl6eP8IZwh
+        D+YsOpny4OtbTqk89IKxFKJe0d5Ylgcb2///2LLs/8iy0IO5/vllWbwg/Yc9
+        cTQ3+NnXLz5Ovv7Y/zSb7j84n26ff3pOnun+p9Ptg+nDh9u7lEx/cH86me3s
+        THz98f8Vy7J7f/fe5P49yoad0+rK/n2ic3bwab796d70U0qT7WUHeRYA6Kpf
+        AvI+lsWjrzz/75n5QcvSx/lDOEMezFl0MuXB17ecUnnoBWMpRL2ivbEsBxvb
+        ///Ystz/kWWhB3P988uyeEH6D3viaG7ws69ffJx8/ZGf5wf7B5Qmmtx/SCn1
+        2cN98u13s+298/x8MsvO7336MMim/3/Fsuwd5PvZvcm97cnuPVolmH1K2bC9
+        3YfbBw/vZbTIcm93lgXLDB9qWTz6yvP/npkftCx9nD+EM+TBnEUnUx58fcsp
+        lYdeMJZC1Cvaq2W5t7Ox/f+PLcunP7Is9GCuf35ZFs+V+mFPHM0Nfvb1i4+T
+        rz8+nR58en8nn23nO7Ndyqaf59uTyYNse3d3d//T3b2H9z59EOiP/89Ylmw3
+        23u4m2/vPdwhvfhwb0LrLPTb/cn5pw8PHhx8OnsQJIM+1LJ49JXn/z0zP2hZ
+        +jh/CGfIgzmLTqY8+PqWUyoPvWAshahXtDeWZXdj+/8fW5aDH1kWejDXP68s
+        y77nSv2wJ47mBj97+iXAydcf0+n+wf79bLb94AFlb/cfkPKd0NLs9uQ8y2YP
+        H366u3Nv5uuP/69Ylt1PKSw5OP90+/7BPdKLlAmjbNiDB9vZebY/3T3Pdh/u
+        BcmgD7QsPn3l+X/PzA9ZlgjOH8IZ8mDOopMpD76+5ZTKQy8YSyHqFe2NZQmi
+        Tnm89v//tSz7Oz9sy/KNDWnAstBbRFTi4R9ZFnosIl0t47lSP2xepLnBz75+
+        8XHy9cfu7F527x7p3fv55P72/qd5TgkjQurT/Wy2c76/+2C6M/X1x/9XLEt+
+        b3+2Bz97hxacaZVgh3I5+9nu9r39hw93p/f2du7t3wsAdNUvAXkfy+LRV57/
+        98z8oGXp4/whnCEP5iw6mfLg61tOqTz0grEUol7R3liWYAbl8dr//9iy7P7I
+        stCDuf75ZVk8V+qHPXE0N/jZ1y8+Tr7+eHhv72BKOng7f0Drgvu7lDXKPt15
+        sH1AqoQ+f7g7yfZ9/fH/FcvyYC/Psge7O9v3pgfn2/vnM1pi2aVVgvuTGdmU
+        808nuw+DZYYPtSwefeX5f8/MD1qWPs4fwhnyYM6ikykPvr7llMpDLxhLIeoV
+        7Y1lCfKZ8njt/39sWfZ+ZFnowVz//LIsHsP/sCeO5gY/+/rFx8nXH/mne7v5
+        g5297d0H9+9t79/7dLadzT7d2965t3NAjv29+w/O7/v64/8rlmW2N6VVgR3K
+        ge3vkmW5P81o/fnebPvTB5/u7+3Qsv5slgUAuuqXgLyPZfHoK8//e2Z+0LL0
+        cf4QzpAHcxadTHnw9S2nVB56wViKGatXtDeWJchnyuO1//+xZdn/kWWhB3P9
+        88uyeAz/w544mhv87OsXHydff+zkD7OH9x/mtAqxn23vT8/vU85jOtt++GB/
+        52E+m87u7z/09cf/VyxLNn0w2d29/+n2+aefTmlcDw+2ibafbs8e3s/OH+48
+        fDi9NwkAdNUvAXkfy+LRV57/98z8oGXp4/whnCEP5iw6mfLg61tOqTz0grEU
+        ol7R3liWIOqUx2v//2PLcv9HloUezPXPL8viMfwPe+JobvCzr198nHz98WBG
+        axAPHn66vYcc+v6EVAdl0+9tTx9m2cPJZC/79F7u64//r1iWnezebraT7W/f
+        p5V8Wn8mt3tykB1s72YPHt6fnD84z3cfBAC66peAvI9l8egrz/97Zn7QsvRx
+        /hDOkAdzFp1MefD1LadUHnrBWApRr2hvLEswg/J47f9/bFk+/ZFloQdzzZbl
+        541l8Rj+hz1xNDf42dcvPk6+/tjJp1m2s0Oe6cMZobI33aGsEaWOHmQ5LdVm
+        hNbknq8//r9iWe4TBvvTg53t+wf3drb3Z58SifOdyXZ+8HD3HgZ2EGbpP9Sy
+        ePSV5/89Mz9oWfo4fwhnyIM5i06mPPj6llMqD71gLIWoV7Q3luXhxvb/P7Ys
+        D35kWejBXP+8siz3vSzDNzdxU0wBzdnmiaO5wc+efglw8vXH9NPz+7ufksLY
+        nZASoazR/e2H+/fubT/YnU72adl2en964OuP/69Ylr0He58++HSSb08ePqSY
+        Ze/8HqVx7lEI8+lk52A6pVWC7JvMhvn0lef/PTM/ZFkiOH8IZ8iDOYtOpjz4
+        +pZTKg+9YCyFqFe0V8uyf29j+/83W5bbzWkHKW9Of2RZ6MFc//yyLJ4v+M1N
+        3O14keYGP/v6xcfJ1x+7D+99+jDbv7e9l5ODv79DTPtw7yGljmgBPN/bm+QH
+        54Fn+v8Vy0I68P5kB9T99D6ts9x/sLP9cLa/t51nB7v7k4d7e5QsCwB01S8B
+        eR/L4tFXnv/3zPygZenj/CGcIQ/mLDqZ8uDrW06pPPSCsRSiXtGeLAv+2/15
+        a1n+XxmzVIvVus1/8otm45h6psW9RjgQnj+yLfRYRLp65sDx7jc3dbfjRpob
+        /OxrGB8nX4McPJhO9/cm0+0sv0fe/f0ZrXXP9h5u35vu7s12H+4+OLj/wNcg
+        /1+xLTMyJ5/uPtzbnk3uPdzez7N72wf39w62HxzcO5/sZOezBw9DAF0FTEDe
+        x7Z49JXn/z0zP2hb+jh/CGfIgzmLTqY8+PqWUyoPvWBshShYtDe2JchoyuO1
+        //+xbTn4kW3hB7P9/y/bgh8E5Zf8P4xYKaY9+gAA
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2d618e26-0a73-4aef-8e2e-eeee35d84998
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 5ebb1de4-c862-42b8-95fc-b780ecb7c661
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134902Z:5ebb1de4-c862-42b8-95fc-b780ecb7c661
+      Date:
+      - Tue, 19 Jan 2016 13:49:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x9N5/l5k9eXeb178Om9j0a2QTHD13eb9aSZ1sWqLaplc3f/073zvez8YDv/
+        9EG+vb8z/XT74fnkfHtn72Bvf7Y7m+0f3L9b5021rqf553W1XjV3T6rFat3m
+        P/lFc3dVV5fFLK+bu18U07pqqvN2/CJvr6r67d2l/Dxbtnl9nk3z5u4ganmb
+        XQC57979fT96mB/sfro/vbd9vpsRRoTddvbpwf3t3clu/mAynTw8n01+34+8
+        l9vrFQ/8Fhh4b5XVNAMJ8GaeNe3a/5KGtcrrtqA3HjkSyxeXRUOvFcuL123W
+        csev19Npns/ymYNATS3R1kL4Sb4725vtT7aze3vT7f3pwe725Hxntr1778Gn
+        9x4+yPZmkzwAUKxOquV5cbGuGVGgopMuj4cXHssAxWrK7+360PD8v44D7naH
+        SB8M4f4hLCIPJi86q/Lg61vOrTz0QnFJzc5eHs9mRCBA/Wh3Z4z/7m9sXhrm
+        +yJv5xVPytNrmr5iGnmNZovoSG16GNOXP+wZvSzqdp2V+mfwGuFAeDZ3Z/l5
+        ti7bj7rY/pLwg+BP74/vexT4aLZsXudtSxMC4gYEkO/ASfjqe/5r9GW2WpVF
+        PnsatnFNfonX/KN8mU1KmpdnVX2V1TPqjVqfZ2WT+61ocBjz63y6rov2mulG
+        7UKkftjzEUOK2p39hL6/601DMGadyC+y6bxYgtN/bsahXxu+UnQCPeGPwPyq
+        v5gRWdytDszr1f0dTwh/aAPqTIyn+noo+Rptci/fP9/ZvUeY7Gfb+/v028Pp
+        /sH2/V1Sc/fzh+ezbOprtP+vGL1Ps91PZw9mNJCH+TlR+HxG48roz53Jp/dn
+        n04nebYTAOhaBALy/3mjJzNPti0cGn0whPOHsIY8mLTobMqDr285p/LQC8Z6
+        9Yzdwcbm72XsVutJWUzpLdtJD3Vq9cOe0g5WNKWnr156ekkeo43c8xFhSOxA
+        yP6/YRSqY/XP4DXCgfD8ke3+oc5HDKkuZwVj1QlUI0nI/tzgr18bflJ0epib
+        X/UXMxKLs1Xdi+IX7T3Ye+C0wQ9tJJ2Z8FR2HydfJWcP9/azyfT+9vTePUJl
+        sv9gO9ud3d/eyffOpwcPZ9lsmvsq+f8r1np/mj+4t79P49qhwe3nZLIprjrf
+        fpjNPs3zbPpgf89zYAhA16QRkP/PW2uderLO4djogyGkP4Q35MGsRadTHnx9
+        y0mVh14w9ldsFtqruX64sfn/L801BUR7nm6Sx2gk93xEKBJDELb/bxiG6lf9
+        M3iNcCA8f2Svf6jzEUOK2oWsFQxWZ1AtJGH7czMA/dowlKJDLTqom1/1FzMU
+        i7RV36QipwJzd3/vU6cXfmgj6kxJqL3jqPk6eufewWz/Xjbd3tmZEkbT+wfb
+        BwcPp9sPH0736audg/0Hn/o6+v8r9nvv4WRvhuzygwf5PuVFaXCTvU8/3X4w
+        yQ6yB+cHn+7t/v8/2g45gKx2OET6YAj3D2EReTB50VmVB1/fcm7loReMXRZb
+        hvZqxvc3Nv//qxnXd/2soDxGW7nnI8KU2IOQ/n/DaFT56p/Ba4QD4fkja/5D
+        nY8YUtQuymHBmHUi1YoS0j8349CvDV8pOtQiPgLzq/5iRmRxt6rdqc+9g/v+
+        Gu0Pa2CdCYpq9g5qvuLey/fze/keWb7dHYphP81JZ3+6v7v9cH/34AEp2Um2
+        88BX3P9fse2TTw/27j28/+n2vXuTT7f3DyYH25N9Ivf0008Psvvn97Odez+f
+        bDs4gEx5OET6YAj3D2EReTB50VmVB1/fcm7loReMsRYDh/Zq2z3H1Txe8/+f
+        23Y/JpHHaCv3fESYEnsQ0v9vGI3qYP0zeI1wIDx/ZNt/qPMRQ4raRTnMEll/
+        MTSwI7CKcVlMPQ37czUoTxt2EPJV3D4lHu/tTB5s3/v0IS0a5vuEx87DT7cP
+        Hk7u792b7Z2fZw99Fff/FSuY7U5ms9n5zva9/Yd72/vZp7vbk2mWb+/u5NPp
+        5NPp/nR3EgDomggC8v95K4h5J1MXDow+GML4QxhDHkxZdC7lwde3nFF56AVj
+        zMQAoL3avm8wrqU5IupRmx7G9OUPex67RmJx/ZMvTt/cpf4Jx+bua/657Tvt
+        8hiF5B4Su2z2JCuz5TSvn2TTt/lypnR8WVUliBnwuDwRGhCoHzYVfNRBg+dP
+        7k76I7iro8IffYoQTbofhYYOT0Cks+WkWi9nL7L21bpkHv7/EoGKEPu7r56+
+        3P7JL3ZuRZfwg+B77w+ffOJC/By6F6aR4mfesohYHU160FN2P/SZInHFz1Ax
+        +wj5ejeffJo93NnLtvc+PdihfOLe+fZkRvnEvYPs4ODBg4c7B9mOr3f/P2OQ
+        8/3JvYcHs+3dB7sH2/t7D+6RQb7/YHtvf5dsyf39+7RqHADo2i0CEsiihxce
+        O9nD5k0QuftzPO9kf8OB0QdDGH8IY8iDKYvOpTz4+pYzKg+9YCysqGG0V4Mc
+        LPnL4zX/kUEm1H2lraZL6QgLBmIGPC5PhAYE6odNBR910IDszY8M8g0Eihvk
+        29El/CD43vvDJ58Y3f8vGGTK6rR50+7f98PSH/Z8kdDip6eeo2j5Onj3/P40
+        m0xn1D0SgtP7+fZBRor43sOd89mD++ezTycTXwf/f8U4f7p7b38nn+1sz+7f
+        o2Bv9nC2PTmf7G9n2cHu/r29vfMH94Joi4xsaMMISCCXHl547MQPmzpB5O7/
+        K2afLHI4PPpgCO8PYQ95MHHRGZUHX99yXuWhF4zNFcWM9mqiAxdLHq/5e5lo
+        IpefmaXGPdSp1Q97WjtYuWnt6VyjndzzEWFJbEEI/79hJF2vw3uNcCA8f5Qr
+        /qHORwwpeqPHXZbA+osZv8XeKsP6Aq/u+sbm52hQnhaMIOWruIf39u8dfHqw
+        v/1wukdh3PT+w+2De9nO9t5enu8+yCbZ3mzfV3H/X7GAu/fzg/3zB5PtvQef
+        3tvevzd9SOHpvQfbB5N79+5le/nezuQ8ANA1EQTkVhawT195/l809WTtwrHZ
+        b3pIfwhryINJi86mPPj6lnMqD71gzJmYALQn67dH1m//4cb2/18xf6DIwKSS
+        OiqLwPyZqdvWr1aeqpLHKCj3fERMSOxBlOvNB335zTHqPD/ffllXs4182rOD
+        9i3CgLDcYAb7A6PJXmT1NQ2grdc2XpFH9bU83h++vRNT+HNoJk0jxc+8ZRHp
+        6hnPYf0GJ+4DNYyPlK9BJp+e5/fuZ7Tm9OD+ZHt/d3ZvO/s0298+n03y3YfT
+        2e7kPFhz+v+Kcfn0wf7e9P55tj27t7dPa2nnD7azycHu9sMHs4cPpg8f3jvf
+        80hCALoKmIC8j3EJgOH5f9HUDxqXPtIfwhryYNKisykPvr7lnMpDLxhjIQoW
+        7dW4+EkD83jt//9sXHZ/ZFzowWT//DIue451v8GJux0z0uTgZ1/D+Ej5GiR/
+        cH86e7hHSyf3H0zJPX24R0p49nA7e3j/fpbt5wfk4fsa5P8rxoUU4M5sNru/
+        Pdt/iNzdg53tg/z80+29h/leNjvf+XT3/jcauXj0lef/RVM/aFz6SH8Ia8iD
+        SYvOpjz4+pZzKg+9YIyFKFi0N8alZx2D9v9/Ni57PzIu9GCy/79gXBbZVGeQ
+        Wn20s7O983T73vE2uQjHD7Z37vnsuMEQ+a3CgfvfKH2/yKbzYgnpCgf1zc32
+        Zg7Wr810KzqOf73ZtXOjvxjSWcQ7ytZTW9/ccKaC7+UiPhxl10Et6+PkK9GH
+        0wez3XvTve1PH3z6gIKcB+dkhwif3YPsIa0iZdnOdOor0f+v2Nf7n+7f+3Tn
+        03z73qefkn3dnz7YfkjJwu3Jwf69fLK3t7s3mwQAujaIgLyHffXIK8//eyZ+
+        yLr2Uf4QvpAHMxadSnnw9S0nVB56wRhLp57UuO4fbGz//2bjessp7WDlpvRH
+        tpUezLVnYsKvVVPL4/3hG0mxnz+HtvUZ2dZjnxv/P2Nbb2Dgzbb165nWZpVP
+        t5fF1MvXfHPjUYSHfAXl14iOjWHlq9G9ab43O5gebB/cf0BqdA/hyb2Mlljy
+        ezuz6e6nOw/CGOX/M+b14OF0d+cBpUV3ZrsUgE0m2w/3Dh5sT7IH559+Ot1/
+        SHQOAHSNEAG5lXktVlN+rxdJ/b9p8vsmdhjtD+EOeTBv0QmVB1/fclrloReM
+        0XR6iows/ru/sfl72ViaKCIhtelhTF/+sCdTNZP+qVP5ky9O39wlFAjN5u5r
+        /rm96ykreYyKcg+JXzZ7kpXZcprXT7Lp23w5U1K+rKoS9Ax4XZ4IGQjUD5sQ
+        PupKhudP7k76g7irA8MffaIQWbofhTYTT0Cns+WkWi9nL7L21bpkTv7/GI2K
+        cAB3Xz19uf2TX+zcijThB8H33h8+BcUh+Vl3Vm7ngKj0qF2nFiE639z8fPnF
+        y6/enP7kF6+j86PTZ4RZ0dEZCqfCUlV/MYO2iFuDwy+TUvc09zc4IME4ynA0
+        IMNwpHjwM2JqfKx8S5Ll9x/cv5fNtim8pYW2fUqIZrP9/e3Jw4NPP713b29G
+        i5W+Jfn/ip/xYGd2f+f+/b3tvb1z+BkU0E9me+fbDye757v5vf3z89xzvQhA
+        1xITkECveHjhsdM+bLAFkbv/b5h8civC0dEHQ2h/CHfIg3mLTqg8+PqW0yoP
+        vWAcB7EraK9+xv7G5j/yM/gh8XOGSM2xkhJWGfQMeF2eCBkI1A+bED7qSgay
+        oT/yM26mUdzPuB1pwg+C770/fAqKL/EjP8OfH50+I8yKjs5QOBWWqvqLGbRF
+        3BqcywXnQjzr9Q2ORxC+id9I7+CnZ2kiSPl2hHK+9x+cTwiXB58+3N6f3Mu2
+        s5x+29mf7OUPJ9NPPz2479uRnw0vg9ABZ/1iQ1n6iMYYtVP44pYW6iNLQXU8
+        dmf3d3em5zS23ZyyHLv3yPHYu/+AZuHhND+f7N/fPQ9sFjkQoWkmIIGi8fDC
+        s4EP5Pl/ETeQlxGOzX7TQ/pDuEUeTFp0NuXB17ecU3noBeNGiJVBe/I6sIRA
+        q3yb2v+/0e2wCXOmw8BUqqLSP/23CAPC8v+PafZhi2IaKX7mLYtIRxT9daVv
+        cOI+TAgDpHwh2z/Yn50fTKbb9/LsnISMAqSDLN/Zns0e5vv0/517k4kvZD8b
+        KpkGFJVYfHFLWf3Ikkv1b/Zp9ul0tptvP3h4/9Pt/Qfn97eznXNSwrt7FAru
+        39u7Pwling/Uvz595fl/0dQP6d8I0h/CGvJg0qKzKQ++vuWcykMvGH3a07/7
+        PQMStH8v/atLol4vPdyp1Q97UjtYeZP6ozVcejDZP7+My0PHut/gxN2OGWly
+        8LOvYXykfA0y29v/NL8/29ueTpA3Oqf1vof39u9tnz+Y7Tw42MsfPJjOfA3y
+        /xnjMrtPaa9Jtn3w6YSMy8E03354/3yyTWPN7+/v7ua7+5MAQFcBE5D3MS4e
+        feX5f9HUDxqXPtIfwhryYNKisykPvr7lnMpDLxhjIQoW7cm44L9v0rlXXe31
+        0sOdWv2wJ7WDlTep/280LrcbU8+6uNcIB8LzR+aFHotIR9Pc9xyqH/rU0eTg
+        Z0/HBEj5OuTB+ad79x5m97c/fUhrE/s5+RHZwX62/WByfzK59/DTyfn5Q1+H
+        /H/FvDzMSSd+Oru3vbt3jxzvbOfB9mRnZ2/73v7+pw+mn06z3d1v0rz49JXn
+        /0VTP2ReIkh/CGvIg0mLzqY8+PqWcyoPvWDMhahYtCfzwrFLEH7K47X//7F5
+        ub/z/0bzYqOQTUPqWRf7FmFAWH6IcQkGp/paHu8P30qIAbHGJSCPfOcMh/ca
+        fflzZFzuOdb95iZuKsx4udjMjDQ5+NnXMD5SgQa5R8nmBwcHlHPeJR9//9Pp
+        9iT/dG/7wf379w8eTPZ2s08DDfL/FeMyyx4+nE33c0rj3Nvd3t/LDrYP8t2M
+        suoP9vcm53v39x4Eju+HGhePvvL8v2jqB41LH+kPYQ15MGnR2ZQHX99yTuWh
+        F4yxEAWL9sa4BFMoj9f+/83G5ZaT2sHKm9QfGRd6MNk/vyKXTx3rfnMTd0tm
+        pMnBz76G8ZHyNUj26cE90hiEy4Sc+/17s3w7y/LJ9nT/3sP7+ezB/b2H93wN
+        8v8V47K/c36wv/Pw4fb5Q1rr3idFuT2ZTe/RIvjD3dn5/kG2ey9wez/UuHj0
+        lef/RVM/aFz6SH8Ia8iDSYvOpjz4+pZzKg+9YIyFKFi0N8Zlf2P7/z8bl09/
+        ZFzowWT//8u44AdB+SX/D8Q9sUVEjQAA
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      X-Ms-Correlation-Request-Id:
+      - 116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134903Z:116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 19 Jan 2016 13:49:02 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - f36bfffe-686f-4031-8da0-f102c8c52ef9
+      X-Ms-Correlation-Request-Id:
+      - f36bfffe-686f-4031-8da0-f102c8c52ef9
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134904Z:f36bfffe-686f-4031-8da0-f102c8c52ef9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 19 Jan 2016 13:49:03 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 097237de-ae5e-46c6-a052-ae18f09babdf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 4dcad710-60b5-49f0-bb24-0d9d6880221c
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134904Z:4dcad710-60b5-49f0-bb24-0d9d6880221c
+      Date:
+      - Tue, 19 Jan 2016 13:49:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x/l9erB/YOPRvaLYoaP7zbrSTOti1VbVMvm7v6ne+d72fnBdv7pg3x7f2f6
+        6fbD88n59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au4uil+U/WBd57t3V3V1
+        Wczyurn7RTGtq6Y6b8cv8vaqqt/eXcrPs2Wb1+fZNG/u9jDK2+wCOH337u/7
+        0acHD2eT6Wx/O3+4M9nenx3c255Md7LtfEr4PLy/83B2sP/7fuS93F6veJy3
+        6Nl7q6ymGUaON/Osadf+lzScVV63Bb3xyFFUvrgsGnqtWF68brOWO369nk7z
+        fJbPHARqamm1FnpPd7PJzvnu/e17u+cPt/f3JhkRePfe9t79+w8fPrif7+X3
+        HwYAitVJtTwvLtY1IwpUdI7l8fDCY+e7WE35vV0fGp7/t0z83e7I6IMhlD+E
+        M+TBnEUnUx58fcsplYdeKC6p2dnL49mM6AKoH+3ujHfHO+P9jc1Lw3Nf5O28
+        4rl4ek2zVkxjr60nZTGlt2wnPdSp1Q95RjtI0Yyevnr5URevX9IfDSFI3EC4
+        /r9gEJdF3a6zUv/03yIMCMvm7iw/z9Zl2x9Y+EHwp/fH973xfzRbNq/ztiXm
+        6s2hfFdfEpr01ff81+jLbLUqi3z2NGzjmvhU/ihfZpOSeOxZVV9l9Yx6o9bn
+        WdnkfisaHIb8Op+u66K9ZqpRuxCpH/JsxHDqspWlrf5ihm4Rt7qP+jz49FMn
+        Tj9Ho/FUHr0XYuRrtPP9/ezBw+ls+yGptu39gyzbziafnkPBnWfn9/Js99Md
+        X6P9f8bWPdiffvpwsr/9cHb+6fb+w/v59mRvskv/0ICn5/fvH2Se+ScAXYtA
+        QP6/buvoPZp4Mm3hyOiDIZQ/hDPkwZxFJ1MefH3LKZWHXjDGSzQ+2qutu7+x
+        +f8fbd0XZz/hKSV5jCpyz0eEIHED4fr/gkH8yNb5doXahUj9kGcjhhO1C9jK
+        0lZ/4R9Eil/y/wDYpcgf7g0AAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      X-Ms-Correlation-Request-Id:
+      - 5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134905Z:5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Tue, 19 Jan 2016 13:49:04 GMT
+      Content-Length:
+      - '133'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3fb3b155-4389-44d3-aa3c-28040b85648e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - d242aea1-16f2-4d57-a608-328f4521d3af
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134905Z:d242aea1-16f2-4d57-a608-328f4521d3af
+      Date:
+      - Tue, 19 Jan 2016 13:49:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x9dLtq8afd3PxrZr4oZvrjbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d
+        6afbD88n59s7ewd7+7Pd2Wz/4P7dOm+qdT3NP6+r9aq5+8XZT/zkF7t3V3V1
+        Wczymj4opnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd0IQnmbXQCl7979fT+6
+        v3Nwf+c+9b53b39ne//80wfbB5OH+9vTvd1P9x7m2cPs03u/70fey+31igd6
+        i769t8pqmmHgeDPPmnbtf0kDWuV1W9AbjxxJ5YvLoqHXiuXF6zZruePX6+k0
+        z2f5zEGgppZUayH3fnZ/erCfH2yf5/lke//evYfb2cHD8+0Dou+n+fnDLJtl
+        AYBidVItz4uLdc2IAhWdZHk8vPBsmHB5/l8y7Xe747Lf9BD+ELaQBxMWnUl5
+        8PUt51MeeqG4pGZnL49nM6IKoH60uzPGf7u9AQTtS8NxX+TtvOKpeHpNc1ZM
+        Y6+tJ2UxpbdsLz3cqdUPc0I7GHkTuq1frT7qovhL+gMjXIk1CO2f1fGcVIvV
+        us1/8otm45gui7pdZ6X+GbxGOBCezd1Zfp6ty/Y2Q6OpXmT1NQ2hrdd5+PUv
+        8f/0/vi+B+aj2bJ5nbctsWJvwuW7+pLGQV99z3+NvsxWq7LIZ0/DNq6Jj+xH
+        +TKblMSQz6r6Kqtn1Bu1Ps/KxqKs+PEPgvJL/h9jtFhWaQYAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4e011c08-8d6d-4a76-b703-1cd42a78b16d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 91175de5-5526-45aa-b198-ec2300e0a344
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134906Z:91175de5-5526-45aa-b198-ec2300e0a344
+      Date:
+      - Tue, 19 Jan 2016 13:49:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
+        5x81WZk351U9zdfNwcFHI9ugmOHru8160kzrYtUW1bK5u//p3vledn6wnX/6
+        IN/e35l+uv3wfHK+vbN3sLc/253N9g/u363zploTwM/rar1q7r74fV59fndV
+        V5fFLK+bu18U07pqqvN2/CJvr6r67d2l/Dxbtnl9nk3z5u4gUnmbXQCt7979
+        fT/aeXhvOtmfnm8/yHZ3t/ezew+3Jw9397f396cH5w8nD+59Otn5fT/yXm6v
+        VzzkW2DgvVVW0wyDx5t51rRr/0sa1iqv24LeeOSIK19cFg29ViwvXrdZyx2/
+        Xk+neT7LZw4CNbXkWgvJJ9lePr3/MNue3bt/sL0/259t0wB3t6e7+b0H93Y+
+        nTyc7AUAitVJtTwvLtY1IwpUdLrl8fDCY6e+WE35vV0fGp7/F8393e7g6IMh
+        rD+EOeTBtEXnUx58fctZlYdeKC6p2dnL49mMSAOoH+3ujPfGO+NPNzYvDdt9
+        kbfziqfj6TVNXDGNvbaelMWU3rKd9FCnVj+8Se3gQ5P62k7qV6/PXn7Uxe6X
+        9MdEaBJvEMY/q0M5mefn2y/rarZxPJdF3a6zUv/03yIMCMvm7iw/z9Zl2x9Y
+        +EHwp/fH973xfzRbNq/ztiUW682kfFdfEpr01ff81+jLbLUqi3z2NGzjmvhU
+        /ihfZpOSOO1ZVV9l9Yx6o9bnWdnkfisaHIb8Op+u66K9ZqpRuxCpb242qsVq
+        3eY/+UWzcTpiSFG7s5/Q93e9aQjGrPP4RTadF0vI7s/SOAYFRBE0DKWIhOLh
+        I29+1V/MYCzaVpVfLtq8ae95OuWHMJrOfHg6PIKOr5wPPp3tfLr76f3thxn9
+        s3++M9t+OPl0un2wn+3u7z78dLb34J6vnP+/YrnJsOx+Onvw6fZevkPjOshm
+        25N7n+Zkgz59mO/vPXx4fu9BAKBr3AjIrSx3n77y/L9i0slCh6Oy3/TQ/RCm
+        kAfTFZ1HefD1LWdTHnrBmGAxXmivFnvv4cb2/z8z2WbStvWrlaeY5DHqyD0f
+        EabEGIT0z+ponP3dNCRVsvqn/xZhQFhusNr9gdE0L7L6mgbQ1us8/Fq1szze
+        H755Fsv9c2jVTSPFj38QlF/y/wDVYguvJw4AAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
@@ -462,11 +1268,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -489,20 +1295,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 0e486cc4-6169-4179-a940-8cdba8f86316
+      - 8ba2a572-cab6-4378-b1d9-a52400f2caa0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14893'
+      - '14999'
       X-Ms-Correlation-Request-Id:
-      - 22a7d03c-cdc2-42f0-8c0a-6a312d43b4e2
+      - f7ec23cf-a076-45f1-b7c0-a6c25b45a401
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:22a7d03c-cdc2-42f0-8c0a-6a312d43b4e2
+      - NORTHCENTRALUS:20160119T134907Z:f7ec23cf-a076-45f1-b7c0-a6c25b45a401
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Tue, 19 Jan 2016 13:49:07 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -519,14 +1325,17 @@ http_interactions:
         8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
         UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
         aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2vj1Jnn5JsxKR+P6Q/km
-        rcrrTcLiYfm1x7F38OBTr1UwkM4Y+wN5D6l/vUlUPHL9rAzkZv31HkL/epOg
-        ePT62iO5/2AvkGt/JDerr/eR+de7m8TE6+drj6WLrz+Wm2flffjrZ92sdNWt
-        P5TuMPtDeR8G+1k3Kz1l64+lO87+WN6PxTaJyzdiV/b2Ht574AEKRtMban84
-        72FXjg82DMbr5WuP5d7D3VDp+mP5Rmfm+OGGoXwj87JxLLeYl/cZzO6mJKTX
-        zc/OYL7ZidmolP/fNTP48f3fOPkl/w/0zz7qHRoAAA==
+        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjufce2nj397/cxGb/nzIsm4fi
+        Ifq1h7JR+L9R27J5LB7NvvZYNkr/zYrsPaR/f/NgPKJ97cFslP+bVdn7yP/9
+        zaP52dcAN6uz91IAN2gAD9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0E
+        Z/cGNfCzLjk3s9r7SM7uDYrgZ190vmHj+XqTs/lNmM6OSfGH8k1aztebZsXD
+        8muPY+/gwadeq2AgnTH2B/Ie4v96k5/pketnZSA3K7L3EP3Xm7xMj15feyT3
+        H+wFou2P5GYl9j5i/3p3k5h4/XztsXTx9cdy86y8D3/9rMdkXY3rD6U7zP5Q
+        3ofBftZjsp6y9cfSHWd/LO/HYpvE5RuxK3t7D+898AAFo+kNtT+c97Arxwcb
+        BuP18rXHcu/hbqh0/bF8ozNz/HDDUL6Redk4llvMy/sMZnfTCp7phr762RnM
+        NzsxG5Xy/7tmBj++/xsnv+T/AatCloxaIQAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -539,11 +1348,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -562,17 +1371,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
+      - '14999'
       X-Ms-Request-Id:
-      - 2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - 74ebf8e4-23aa-442b-a1cc-70f132bfb55c
       X-Ms-Correlation-Request-Id:
-      - 2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - 74ebf8e4-23aa-442b-a1cc-70f132bfb55c
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:2ef54e4e-2718-4451-bb06-1ef1087d5365
+      - NORTHCENTRALUS:20160119T134908Z:74ebf8e4-23aa-442b-a1cc-70f132bfb55c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Tue, 19 Jan 2016 13:49:08 GMT
       Content-Length:
       - '1446'
     body:
@@ -612,7 +1421,7 @@ http_interactions:
         ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
         b2cOFgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:07 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -625,11 +1434,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -648,17 +1457,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14999'
       X-Ms-Request-Id:
-      - 6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - 5b09a402-fa51-4477-9683-8a72507b2b24
       X-Ms-Correlation-Request-Id:
-      - 6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - 5b09a402-fa51-4477-9683-8a72507b2b24
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192107Z:6ea43e42-3cae-438e-9a25-502c3ed3249d
+      - NORTHCENTRALUS:20160119T134909Z:5b09a402-fa51-4477-9683-8a72507b2b24
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Tue, 19 Jan 2016 13:49:09 GMT
       Content-Length:
       - '1791'
     body:
@@ -705,7 +1514,7 @@ http_interactions:
         fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
         lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -718,11 +1527,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -741,17 +1550,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
+      - '14999'
       X-Ms-Request-Id:
-      - f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - 7b317067-5cb6-4fdc-94d3-ba7065ba3265
       X-Ms-Correlation-Request-Id:
-      - f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - 7b317067-5cb6-4fdc-94d3-ba7065ba3265
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:f5cbb3fa-d5f2-43f4-8d20-516356d826d2
+      - NORTHCENTRALUS:20160119T134909Z:7b317067-5cb6-4fdc-94d3-ba7065ba3265
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Tue, 19 Jan 2016 13:49:09 GMT
       Content-Length:
       - '133'
     body:
@@ -761,7 +1570,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -774,11 +1583,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -797,17 +1606,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14894'
+      - '14999'
       X-Ms-Request-Id:
-      - a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
       X-Ms-Correlation-Request-Id:
-      - a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:a45ec8c2-49d1-4ce1-8e24-d5ea7e941e50
+      - NORTHCENTRALUS:20160119T134910Z:d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:07 GMT
+      - Tue, 19 Jan 2016 13:49:09 GMT
       Content-Length:
       - '133'
     body:
@@ -817,7 +1626,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -830,11 +1639,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -853,17 +1662,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14999'
       X-Ms-Request-Id:
-      - 97facd28-d917-4249-ba90-29f63dd710e2
+      - f33ea29e-0458-4a6c-bf44-9d52872de0c7
       X-Ms-Correlation-Request-Id:
-      - 97facd28-d917-4249-ba90-29f63dd710e2
+      - f33ea29e-0458-4a6c-bf44-9d52872de0c7
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192108Z:97facd28-d917-4249-ba90-29f63dd710e2
+      - NORTHCENTRALUS:20160119T134910Z:f33ea29e-0458-4a6c-bf44-9d52872de0c7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Tue, 19 Jan 2016 13:49:10 GMT
       Content-Length:
       - '1160'
     body:
@@ -896,7 +1705,7 @@ http_interactions:
         a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
         dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:08 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -909,11 +1718,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -932,17 +1741,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14902'
+      - '14999'
       X-Ms-Request-Id:
-      - ad3c6072-1be1-4f37-8491-226045e517a1
+      - 15483e47-abd9-499d-be5b-a8042445bbc4
       X-Ms-Correlation-Request-Id:
-      - ad3c6072-1be1-4f37-8491-226045e517a1
+      - 15483e47-abd9-499d-be5b-a8042445bbc4
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:ad3c6072-1be1-4f37-8491-226045e517a1
+      - NORTHCENTRALUS:20160119T134912Z:15483e47-abd9-499d-be5b-a8042445bbc4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Tue, 19 Jan 2016 13:49:11 GMT
       Content-Length:
       - '133'
     body:
@@ -952,7 +1761,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -965,11 +1774,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -988,17 +1797,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14878'
+      - '14998'
       X-Ms-Request-Id:
-      - 8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - fe27ee76-2e66-4db6-be9e-1583a6548b26
       X-Ms-Correlation-Request-Id:
-      - 8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - fe27ee76-2e66-4db6-be9e-1583a6548b26
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:8a603adb-3b8b-43e3-9ab7-d191a19b28fa
+      - NORTHCENTRALUS:20160119T134912Z:fe27ee76-2e66-4db6-be9e-1583a6548b26
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:08 GMT
+      - Tue, 19 Jan 2016 13:49:11 GMT
       Content-Length:
       - '133'
     body:
@@ -1008,7 +1817,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
@@ -1021,11 +1830,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1044,17 +1853,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14884'
+      - '14998'
       X-Ms-Request-Id:
-      - 59c09c74-6334-42fa-96c0-59ab658a203f
+      - 25dff459-31a3-4d3e-81e5-5764b2160e18
       X-Ms-Correlation-Request-Id:
-      - 59c09c74-6334-42fa-96c0-59ab658a203f
+      - 25dff459-31a3-4d3e-81e5-5764b2160e18
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192109Z:59c09c74-6334-42fa-96c0-59ab658a203f
+      - NORTHCENTRALUS:20160119T134913Z:25dff459-31a3-4d3e-81e5-5764b2160e18
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:09 GMT
+      - Tue, 19 Jan 2016 13:49:13 GMT
       Content-Length:
       - '1084'
     body:
@@ -1086,7 +1895,7 @@ http_interactions:
         vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
         IA8AAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:09 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
@@ -1099,11 +1908,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1122,17 +1931,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14901'
+      - '14998'
       X-Ms-Request-Id:
-      - de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - 21e72d48-46bc-4f6e-be71-b9d9fcf5f599
       X-Ms-Correlation-Request-Id:
-      - de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - 21e72d48-46bc-4f6e-be71-b9d9fcf5f599
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:de07a101-c1fd-4ff4-abca-32c4dbe78dab
+      - NORTHCENTRALUS:20160119T134914Z:21e72d48-46bc-4f6e-be71-b9d9fcf5f599
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:09 GMT
+      - Tue, 19 Jan 2016 13:49:14 GMT
       Content-Length:
       - '502'
     body:
@@ -1151,7 +1960,7 @@ http_interactions:
         Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
         PiqhoAIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
@@ -1164,11 +1973,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1187,17 +1996,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
+      - '14998'
       X-Ms-Request-Id:
-      - 017c7249-0be2-45fc-a90f-587062e54fc2
+      - 2324e1a6-9269-4264-bd12-263e916ddad4
       X-Ms-Correlation-Request-Id:
-      - 017c7249-0be2-45fc-a90f-587062e54fc2
+      - 2324e1a6-9269-4264-bd12-263e916ddad4
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:017c7249-0be2-45fc-a90f-587062e54fc2
+      - NORTHCENTRALUS:20160119T134914Z:2324e1a6-9269-4264-bd12-263e916ddad4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:10 GMT
+      - Tue, 19 Jan 2016 13:49:14 GMT
       Content-Length:
       - '1685'
     body:
@@ -1242,7 +2051,7 @@ http_interactions:
         Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
         jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
@@ -1255,11 +2064,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1278,17 +2087,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14904'
+      - '14998'
       X-Ms-Request-Id:
-      - c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - d7719ef0-0c72-4b32-b755-42116367a4e7
       X-Ms-Correlation-Request-Id:
-      - c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - d7719ef0-0c72-4b32-b755-42116367a4e7
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192110Z:c6ec3826-0574-4b4a-8b8f-1b88599ed495
+      - NORTHCENTRALUS:20160119T134915Z:d7719ef0-0c72-4b32-b755-42116367a4e7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:10 GMT
+      - Tue, 19 Jan 2016 13:49:14 GMT
       Content-Length:
       - '501'
     body:
@@ -1307,7 +2116,7 @@ http_interactions:
         WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
         IniEAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:10 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:15 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
@@ -1323,8 +2132,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Content-Security-Policy:
       - default-src 'none'
@@ -1336,26 +2145,20 @@ http_interactions:
       - nosniff
       Strict-Transport-Security:
       - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
       X-Github-Request-Id:
-      - 17EB2E25:509B:1F8178E3:564243A7
+      - 17EB2C1C:2F28:56C3D06:569E3EDC
       Content-Length:
-      - '358'
+      - '9'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Tue, 19 Jan 2016 13:49:16 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2142-IAD
+      - cache-dfw1835-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1365,44 +2168,16 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 386abbf7e84f32a23643408a11eae895fe4a9d4a
+      - b8cbe8e00ea064cfbd6ccca8113f44d5597770b6
       Expires:
-      - Tue, 10 Nov 2015 19:26:11 GMT
+      - Tue, 19 Jan 2016 13:54:16 GMT
       Source-Age:
       - '0'
     body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
+      encoding: UTF-8
+      string: Not Found
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:11 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
@@ -1415,11 +2190,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1438,17 +2213,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
+      - '14998'
       X-Ms-Request-Id:
-      - 83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - ba9c7d11-870d-4664-90f5-1188b8b8af7b
       X-Ms-Correlation-Request-Id:
-      - 83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - ba9c7d11-870d-4664-90f5-1188b8b8af7b
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192111Z:83f2e6f2-40bb-4666-8b7f-fcaf4a339fc7
+      - NORTHCENTRALUS:20160119T134917Z:ba9c7d11-870d-4664-90f5-1188b8b8af7b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Tue, 19 Jan 2016 13:49:16 GMT
       Content-Length:
       - '493'
     body:
@@ -1466,7 +2241,7 @@ http_interactions:
         AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
         +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:11 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
@@ -1502,19 +2277,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2E24:5099:1AD71016:564243A3
+      - 17EB2C1D:2F2B:91C56D7:569E3EDC
       Content-Length:
       - '1004'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Tue, 19 Jan 2016 13:49:17 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2148-IAD
+      - cache-dfw1828-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1524,9 +2299,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - cd710ad53de5c1b4c2f21cb41043abba08aac970
+      - 8d76727f118a54d8239db40924b44b8a7eabec11
       Expires:
-      - Tue, 10 Nov 2015 19:26:11 GMT
+      - Tue, 19 Jan 2016 13:54:17 GMT
       Source-Age:
       - '0'
     body:
@@ -1563,7 +2338,7 @@ http_interactions:
             }
 
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
@@ -1576,11 +2351,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -1599,17 +2374,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
+      - '14998'
       X-Ms-Request-Id:
-      - 2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - b73aad4b-41b9-4505-8b22-6f8b237175e2
       X-Ms-Correlation-Request-Id:
-      - 2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - b73aad4b-41b9-4505-8b22-6f8b237175e2
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192112Z:2ce3c32c-f445-4813-9d37-86d5bb597f86
+      - NORTHCENTRALUS:20160119T134917Z:b73aad4b-41b9-4505-8b22-6f8b237175e2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:11 GMT
+      - Tue, 19 Jan 2016 13:49:17 GMT
       Content-Length:
       - '1505'
     body:
@@ -1650,7 +2425,7 @@ http_interactions:
         DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
         VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -1680,25 +2455,25 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
+      - '"2a32c9038c31cc78002452c1ae91ca30b2fbb93d"'
       Content-Type:
       - text/plain; charset=utf-8
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2E15:5099:1AD71810:564243A7
+      - 17EB2C14:2F28:56C4012:569E3EDE
       Content-Length:
-      - '1902'
+      - '1903'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Tue, 19 Jan 2016 13:49:18 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-iad2126-IAD
+      - cache-dfw1828-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -1708,9 +2483,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - f7fe52e11eea87a782ee5cf9fe3882a83801caa7
+      - 222c41dac9fdadd7f0b9958585dec2b1a1b1a2c2
       Expires:
-      - Tue, 10 Nov 2015 19:26:12 GMT
+      - Tue, 19 Jan 2016 13:54:18 GMT
       Source-Age:
       - '0'
     body:
@@ -2017,7 +2792,7 @@ http_interactions:
                   "vmSize": "[parameters('vmSize')]"
                 },
                 "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
+                  "computerName": "[concat(parameters('vmNamePrefix'), copyIndex())]",
                   "adminUsername": "[parameters('adminUsername')]",
                   "adminPassword": "[parameters('adminPassword')]"
                 },
@@ -2055,7 +2830,7 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:12 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
@@ -2068,11 +2843,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2091,17 +2866,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14882'
+      - '14998'
       X-Ms-Request-Id:
-      - ffa518dd-d755-478a-8177-721f2badd825
+      - b01227ff-dcf5-4282-9ce4-90f349207deb
       X-Ms-Correlation-Request-Id:
-      - ffa518dd-d755-478a-8177-721f2badd825
+      - b01227ff-dcf5-4282-9ce4-90f349207deb
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192112Z:ffa518dd-d755-478a-8177-721f2badd825
+      - NORTHCENTRALUS:20160119T134918Z:b01227ff-dcf5-4282-9ce4-90f349207deb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Tue, 19 Jan 2016 13:49:18 GMT
       Content-Length:
       - '1307'
     body:
@@ -2138,7 +2913,7 @@ http_interactions:
         miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
         AAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
@@ -2151,11 +2926,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2174,17 +2949,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
+      - '14998'
       X-Ms-Request-Id:
-      - a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - 28e09461-e80d-4022-b61b-1685c6f60a30
       X-Ms-Correlation-Request-Id:
-      - a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - 28e09461-e80d-4022-b61b-1685c6f60a30
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192113Z:a530fe3e-b19b-4d7a-9b00-46fb325b400c
+      - NORTHCENTRALUS:20160119T134919Z:28e09461-e80d-4022-b61b-1685c6f60a30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:12 GMT
+      - Tue, 19 Jan 2016 13:49:18 GMT
       Content-Length:
       - '1090'
     body:
@@ -2216,7 +2991,7 @@ http_interactions:
         557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
         /h+BjiSEdgwAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2229,11 +3004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2254,20 +3029,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6e2845f4-4dfa-493f-b6a4-9b6b10b3dc2a
+      - 232d912e-0114-41ca-b1d2-f67b8a7746d5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - cc893dd2-1bff-4a38-a44a-5b9ff2a66e7c
+      - a0aa73ad-2891-498e-9ce9-54996398018f
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192113Z:cc893dd2-1bff-4a38-a44a-5b9ff2a66e7c
+      - NORTHCENTRALUS:20160119T134921Z:a0aa73ad-2891-498e-9ce9-54996398018f
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Tue, 19 Jan 2016 13:49:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2276,18 +3051,29 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
         5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
         d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/1o9vDe/u7B
-        vWw7f7BLmOx/em/74XR3ur2fne/ku7v75wf709/3I+/l9nrFY72xa++dsppm
-        GDjey7OmXftf0mhWed0WeUNfW5rKF5dFQ68Vy4vXbdZyt6/X02mez3JvPNTU
-        kmot5N59uP/pgwf57vaDg4Od7f37s2x78vBBtj09Pzi/vzeZzD69dx4AyGYz
-        gtG8XmVTdOOh4b58WefnxTtGUznAPB/t7oz3xjvjnbu7n37kf/V998cv8bsj
-        bljmbQ9S0C01M3w1y8+zddn6GOP5fw1v3SUMMJ67Q4h+CMfJA26Isok8+PqW
-        zCJPOKlobOdwbz/SvFidVMvz4mJdMycDiWDq5OnhheeHPU00E/h5tmzz+pz4
-        ubk7xXv0yuz+3s7d7kjogyl/sBuwrjw+15rn/6WDXFVNe0Gwtmf55f69+zSs
-        /3eP88Xv8+rz9xxik5V5c14RjHVzcEADep8Rdj/ydBOe4HvvD9tMP+Mf9OEv
-        +X8AsdVUNRQHAAA=
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/3o/qf5fnaw
+        d7796cPs3vb+/dnudra3s799kO+dTw6mD/YmWfb7fuS93F6veKw3du29U1bT
+        DAPHe3nWtGv/SxrNKq/bIm/oa0tT+eKyaOi1Ynnxus1a7vb1ejrN81nujYea
+        WlKthdy7D/c/ffAg391+cHCwg1Fl25OHD7Lt6fnB+f29yWT26b3zAEA2mxGM
+        5vUqm6IbDw335cs6Py/eMZrKAeb5aHdnvDfeGe/c3f30I/+r77s/fonfHXHD
+        Mm97kIJuqZnhq1l+nq3L1scYz/9reOsuYYDx3B1C9EM4Th5wQ5RN5MHXt2QW
+        ecJJRWM7h3v7kebF6qRanhcX65o5GUgEUydPDy88P+xpopnAz7Nlm9fnxM/N
+        3Sneo1dm9/d27nZHQh9M+YPdgHXl8bnWPP8vHeSqatoLgrU9yy/3792nYf2/
+        e5wvfp9Xn7/nEJuszJvzimCsm4MDGtD/u0f4dWeyzZv2918W030aUGeEi+IX
+        4duzl3v/3x7i5QLD2I1wqfnm/xfj+3RwfKGdlOf/e+N7MDi+B/+/GF9Ex5hv
+        /n8xvoeD43v4/5LxVYvVus1/8guyb19jgDFzb775f8kAP2gC93YHx/f/cRuo
+        o9gbHN//Lwzg3r3B8d37//b4mtk5/a8/OvqQ/vf/7bHpDA06L3v/v3Be9gad
+        l73/Xzgve4POy97/L5yXvUHnZe//F87L3qDzsvf/Fuflg8Z3b9B3uff/C9/l
+        3qDvcu//F77LvUHf5d7/L3yXe4O+y73/j/suOopI+sV88/+L8Q36L/f+X+K/
+        fI0MoQ5g0HW59/8L1+X/9+MbdF3u/f/CddkfNO37/78w7fuDpn3//xemfX/Q
+        tO///8K073dNH2Fhvvn/xfgGTd/+/0tM3weOb9A+7P9/3D5gDLw0Fhnh/7/W
+        xvYH0xP7/29JT3xYbn5/0Mjv/7/FyH/YAO8PWvn7/y+x8lMZ4OXiaw5wMAK8
+        //+SCHAKEaShfT0RvD9oJu7/v8RMfOgERrSo+eb/HQP8ujoUY4Cd2N2JCKE1
+        FPTt/zuG+XX5tL74/TGS/hD1i/+vjw5jiA0On/+/ZGxfVwJlEJFAQr/4f8fw
+        vrYJlFHsRqTPfPP/jwFGIl3zzf8/BjjIobtRFu1+9P3wg+B77w/bTD/jH/Th
+        L/l/AADf3cB6LgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:13 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2300,11 +3086,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2325,20 +3111,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7494af24-9d2a-46e9-b825-90010373baf5
+      - a389b09e-c00a-416f-aba3-d8b3e27a921f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 75d44c8c-3d8e-406e-ace3-c9f7f6f7c061
+      - 462a29e4-7bda-4840-a3b5-44b5b8aa9f9f
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:75d44c8c-3d8e-406e-ace3-c9f7f6f7c061
+      - NORTHCENTRALUS:20160119T134921Z:462a29e4-7bda-4840-a3b5-44b5b8aa9f9f
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Tue, 19 Jan 2016 13:49:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2347,28 +3133,29 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
         5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
         3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o3vZg+nu
+        g2yPMNidbe/v7dzfPtj99NPtB/v7O/lsZ3Jvb3fv9/3Ie7m9XvFwb+zbe6es
+        phmGjvfyrGnX/pc0nFVet0Xe0NeWrPLFZdHQa8Xy4nWbtdzt6/V0muezfOYg
+        UFNLrLUQfPpwPzvf2cm2pw93zrf3dw8m2w8fHuxsn092s3sPHn56TmMLAGSz
+        GcFoXq+yKbrx0HBfvqzz8+Ido6lMYJ6PdnfG/N/d3U8/8r/6vvvjl/jdET8s
+        87YHKeiWmhnWmuXn2bpsfYzx/L+Iu+4SDhjR3SFUP4Tn5AE/RBlFHnx9S3aR
+        J5xWNLazuLcfaU7Dw6hf59N1XbTXTDl6q4cINf1hz0sMNWp39hP6/m7AlHh8
+        bpTno2J1Ui3Pi4t1zbIKIgfMKU9kuHj352bAZ8s2r89JZJu7i+IXTeXd3f29
+        T+92B0MfTPmDPilixPh/7zin8/y8yevLvN49+PQeDev/p+N087l3cP//x+Nc
+        rSdt3rT793doSP8/HWNer+7v3Kfh/P90fMSrew/2HtB4/l8+QNId2y/ravae
+        47PvbZOFqZazbfsdjfD/3UMmG/iTX+y+53gvFyySuzSYzujMN//vGNzXZlgd
+        xsPBAT78f8cAYey2aWjvy7AyivsRiTTf/P9ifAeD4zuIja/7kRec4Am+9/6w
+        zfQzQydLGxumLK5/8sXpG+c6f3OEuiWnd+OTHkJ+FDLZ2ZnOpjv72zvkMm7v
+        ZxQtPnxAeEz38tmn+WTnwcPzzI9C/r8R+e5+urs3ne4dbD/c+ZRGtX/vfDs7
+        //Th9qd7+we7FAzvZvd3AwAaBf2/NPJ9zc23A5Tx/L+Ete5S/4Rfc3cQzw/h
+        OHnADVE2kQdf35JZ5AknFY3tHEbj3q6OoTeCqZOnhxeeH/os0Rzgp6cql8X0
+        /8eeNY0u4qVsHF33I09Q8QTfe3/YZvqZoZKljBXZZpVPtyEcjpd+6JTqSmsM
+        J18ys53p3u7+wYPtTw/OCZXswcPtSXa+u71z/8GnD/f27x18ur/rS+b/N2zB
+        /gGR89Pp+fbk4c7B9n5+b0b65l6+vbtzfn8629vf3T3YCwCoZviRLfia3HWX
+        UCAUb2kO3pfp5AFDRDlFHnx9S36RJ5xXNLbT+P9Dc8BT9TW0Zo8O/+8f4vua
+        ve5HntTiCb73/rDN9DP+QR/+kv8Hh2yljTcbAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2381,11 +3168,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2404,17 +3191,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14877'
+      - '14998'
       X-Ms-Request-Id:
-      - 3979703f-07d5-44db-95e5-77e9a27cb752
+      - bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
       X-Ms-Correlation-Request-Id:
-      - 3979703f-07d5-44db-95e5-77e9a27cb752
+      - bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:3979703f-07d5-44db-95e5-77e9a27cb752
+      - NORTHCENTRALUS:20160119T134922Z:bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Tue, 19 Jan 2016 13:49:21 GMT
       Content-Length:
       - '133'
     body:
@@ -2424,7 +3211,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2437,11 +3224,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2460,17 +3247,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14899'
+      - '14997'
       X-Ms-Request-Id:
-      - 4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - 51f5f3c8-545f-4ed1-808c-60383f9c1f3e
       X-Ms-Correlation-Request-Id:
-      - 4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - 51f5f3c8-545f-4ed1-808c-60383f9c1f3e
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:4db0fea0-bbd7-4f2d-b9dd-a0bb67ae0306
+      - NORTHCENTRALUS:20160119T134922Z:51f5f3c8-545f-4ed1-808c-60383f9c1f3e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:13 GMT
+      - Tue, 19 Jan 2016 13:49:22 GMT
       Content-Length:
       - '133'
     body:
@@ -2480,7 +3267,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2493,11 +3280,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2518,20 +3305,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f9c136df-73d2-4256-939f-9bef42c2aa95
+      - 9c06368b-92bb-41cb-8f72-4b6f0309a97b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - d0b670e1-902a-4162-b4c1-7737e43b92ec
+      - ea886f8b-3533-47f6-9e92-35dfa812c022
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192114Z:d0b670e1-902a-4162-b4c1-7737e43b92ec
+      - NORTHCENTRALUS:20160119T134923Z:ea886f8b-3533-47f6-9e92-35dfa812c022
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Tue, 19 Jan 2016 13:49:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2550,7 +3337,7 @@ http_interactions:
         c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
         9/6wzfQz/kEf/pL/B5s5aaAjBgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:14 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2563,11 +3350,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2586,17 +3373,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
+      - '14997'
       X-Ms-Request-Id:
-      - aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - e72e467d-3c26-41a4-bf7b-ec5c01110acc
       X-Ms-Correlation-Request-Id:
-      - aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - e72e467d-3c26-41a4-bf7b-ec5c01110acc
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:aa9d607e-eff6-4d27-a9c8-98fc779991f3
+      - NORTHCENTRALUS:20160119T134923Z:e72e467d-3c26-41a4-bf7b-ec5c01110acc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Tue, 19 Jan 2016 13:49:22 GMT
       Content-Length:
       - '133'
     body:
@@ -2606,7 +3393,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:15 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2619,11 +3406,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2642,17 +3429,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14892'
+      - '14997'
       X-Ms-Request-Id:
-      - d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - 2cabca80-1dea-431f-975b-806a6a84a2ca
       X-Ms-Correlation-Request-Id:
-      - d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - 2cabca80-1dea-431f-975b-806a6a84a2ca
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:d698d563-2553-4a5a-b770-d8c75bdfe97d
+      - NORTHCENTRALUS:20160119T134924Z:2cabca80-1dea-431f-975b-806a6a84a2ca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Tue, 19 Jan 2016 13:49:24 GMT
       Content-Length:
       - '133'
     body:
@@ -2662,7 +3449,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:15 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:24 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
@@ -2675,11 +3462,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2698,17 +3485,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
+      - '14998'
       X-Ms-Request-Id:
-      - 44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - cbbd9e2e-7d01-4295-b975-f15de1cbfb80
       X-Ms-Correlation-Request-Id:
-      - 44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - cbbd9e2e-7d01-4295-b975-f15de1cbfb80
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192115Z:44df4b4e-8210-4608-ba5a-23b8fd5f6b73
+      - NORTHCENTRALUS:20160119T134924Z:cbbd9e2e-7d01-4295-b975-f15de1cbfb80
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:14 GMT
+      - Tue, 19 Jan 2016 13:49:24 GMT
       Content-Length:
       - '133'
     body:
@@ -2718,7 +3505,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:24 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2731,11 +3518,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2758,20 +3545,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - c303ccc4-09e0-4f9b-aeaf-a7757e368df6
+      - 5c147a65-fae3-4698-a9d8-7f34d5ecb177
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14876'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 3b4a9019-465d-4aa1-a0a3-9e4b91938cad
+      - a8fe69a2-a61d-430c-bf5e-6ad3f827e96f
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192116Z:3b4a9019-465d-4aa1-a0a3-9e4b91938cad
+      - NORTHCENTRALUS:20160119T134925Z:a8fe69a2-a61d-430c-bf5e-6ad3f827e96f
       Date:
-      - Tue, 10 Nov 2015 19:21:15 GMT
+      - Tue, 19 Jan 2016 13:49:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2782,28 +3569,29 @@ http_interactions:
         Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
         /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
         VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
+        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzRk6wp
+        pr//8c4QpKat6uxiEFCxoC9f5ed5nS+nva+pwWo9KYtmntf03UdTjBojBG4+
+        4fF8VJ0TGNcsry/pz26j5u3aNJlcV2Xve3qnoVlBmzJr86b1BhYOjRpXzdOi
+        eUttu1hXzZvrFYbz0fNiuX7X62WZLfhbO429FtM6p+6/ZBZBy2d1tTgDsXot
+        L+dgqg4G9Pm6Lujzj+Ztu3p09y4GTKwyu7+7tzOelNVkPK3qfHxVLGfVVTNe
+        5u1dAuQx1pj+DMbeHT11Mc2m82J5gW5ekUB8ty7aPHgnfOOjWdZmoBjk7Xvf
+        d1/5zYh21H2UWabC1vWLzdT7KJstiuVXxACGzJO6WmYX86bTrsTcnFTL8+Ji
+        XWdK6aBLajQrmmxS5i+zprmq6tnxup3ny7aYmvbnWdnk/jv+YOj9JqepbDeO
+        mIhPoN/SSMywzUdnSxrueTaFhvreLw4U1i/+JaOPoE5+9rXJC8Hlbg8nZqpt
+        emV2f2/no1/y/WBQsyK7WFYNUWpwPidV1T51zbrfU4t8CdrTKNO2XuceeDxG
+        t3zlGL25HaeHPOr+CAZAMC4L6ALi8NctCSM6eb2eTvN8RiiZlu6djwxVMRI1
+        NniCQX2EOfshmoDLom7XWflFBkmlKXNv5e/afInx+a+d0ScX87YZ/+QX3syQ
+        7WiJCo0dNA3b/Pp9N/7/twzNifkmRftRqyr6RsjeO2VlBf+jPGvatf9lmxGJ
+        iIk9lliVGdp6LGBRAp92TdAtzR14c7aewr/QRmLsTAudHIOH7R3vWQXiPqYv
+        jMdzPj2/N5vm0+3zycFse//h+f3th7OD6fZk934+m56fP9jZnwaYdFwMguGB
+        pe9/yDzRQednw+MhXbCcUesfltNjB/ld0WCvZa69/vA472dzM/V/9nZ2DrZf
+        7W2/frnba0KvQS2g2TfiAilCvX6MILwkJXNBs739NL/sNSLjSTj88P0gH6n/
+        D7hCProhZW7tDSkJbvKHiHhiFn/yi+ML8oSoScw2i+Umb6laEKTpVysaMGsd
+        NPbb+gOm975Jdwm652df9Qy7RyszKbP8cv/e/f9XeEi3EoGQcd0fAfoEQhiB
+        2J50IrE7dfH/ef/IF6T//7lI/uic+N+gib8pR0m+Y6qQaP+S/wc0uTP1nREA
+        AA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2816,11 +3604,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2843,20 +3631,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 2d444234-abdf-4a6e-b563-8dce0e024ae4
+      - 4dabecda-4faa-46f6-80b0-c96efabdc433
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14885'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 18b52b23-4354-4697-9c5d-739a888171b2
+      - e0287391-7dcd-4032-a469-2a953458f72c
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192116Z:18b52b23-4354-4697-9c5d-739a888171b2
+      - NORTHCENTRALUS:20160119T134925Z:e0287391-7dcd-4032-a469-2a953458f72c
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Tue, 19 Jan 2016 13:49:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2894,17 +3682,38 @@ http_interactions:
         HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
         WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
         6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
+        Xxg/Lsvv3dvNdve375+ff7q9f2+XXLj79Ofegwf57nn2ILu/m7kO6cV59v5+
+        3D3Lww5HPDf5cd+A91NfkPZp8/t796ez+5PtfPfe/vb+7j6Ncv/+/e3d3U+z
+        /WxncjB9mLH274IhnUTy6KzSsIPEPic16aBK33h2qYFhomUmmpbZfVodGjBL
+        zTWhvIgwIXdNfEoBzQUJ6fa0WrbuLyHX+Hx6fm82zafb55OD2fb+w/P72w9n
+        B7T8tHs/n03Pzx/s7E95sCGm/sTgGbK0X2M8i4zsTl78orsyG79/tnPw8MG9
+        6c72/QNaFtt/mE23Hz7Y298+mN0//zS/f2+2+/BWGHqG+P29wiErc3vTK6MJ
+        OeHnsdWFvfkmzA0YapvGPYvq42Ejq9PxwcYV4/i5tJs6DoeQ4aTeF9+QPZHv
+        DAUsB4J0m43Hw3uTe9OD82z7weTg/vb+p/sz0jR5tr1zThn5yb2Hu5P7B65r
+        enGevb/x+LpJANGG3Y/5i/czHrt7e9MdGuk5qaq97CHpq5397ckDGuy9/MFk
+        en9672E+2WF91QVEwkUc9yPz4T1fYzwd87G79/tPs9nOw/uzyfZBNtnb3p/c
+        y7azvVm2ff7pwxmt/pzPHu4+uA2O/68wILudcPhHJuRnW/PeZENoRv5/YkVo
+        JA4lw06Rr36uLcm9B/fye/sP723vHOyck4Oek2jfm55vf5o9IGfw4Ww/m+64
+        runFefb/QUuyd757/unB/sO97YdZvkvD3Hu4PXm4d3/7/Jyy6Nn+7r0sy1lv
+        deGQiBHT/ciQeM/XGE/HkOz9/gc7+wcP7z34dPsB2Yzt/f2HB9uT/X3Cc+fB
+        w3ufZucPd6f7t0Hx/xV2xJNnPD8yIx+sepXOlEOOqt6bzMj/b6yIx1ldjeZ9
+        83NtQ/Js90GeURohm2UQ5um97ezg4OH2zs7+vfPJ3u79h+ceuvRidpkVZTYp
+        yqK9psVhguGBpe9/2MTv4ENNfp/jn3x9+kZJgseQBc/XsYFPd4eA3WAD2ay8
+        /5Kq2sXXeU3Lnj7x8fTWVAea6crq3s7u3varve2npDynpIAiLeltiBda/1DW
+        VqsGKz29r0mTUe+3sdawLT0E6HPPtpFpa1b5dFcnaHfAthGk5q7gI7FoCDMc
+        O/Xwc2yyMKTtn/wicOqoWc9m0a80qfxxp6kO/kdm633VzbDZ4klZFuRqdwzX
+        rMguluTeFdPBCZ5UVfvUNet+Ty2ExDRGpqkHHo/RP1+9L+OHPOv+CPBnMoAJ
+        iONJFxKnUx//rza8GHkoH1bpRL76uTa9O5P72V62f769O/v0AcU1s3w7292b
+        bt/bne082P304d6ne4Hu+5Hp9YEpgw/B+pHp9R4rBWLqel+TNqbef85M7+7/
+        d0yvtzCN5/9HpteOythZjzL4CB85q/f/LtO7+yPTi7n4Yer+jonkkYfyYZVO
+        5Kufa9M7mTzI7+8/2N/e2d2hlOLD2d52dn6wu72zv5/f37u3SynHzHVNL86z
+        9zZdxzuKHx6DIx7DOkOwvgE9fzUnniHj8vvPPs3u04Jbtj19cE4cMKWEXbb/
+        kLKLn5J3cb43ycnrYO3bhXR7k8CWlpp0sKVvPKNwy1zj/29zp7Dt1PZy9/d/
+        cG/3wWyPlkXv36dF3/3ZvYfEevfub88opT3Z2ckeTD+9dxskf47t4aL4RdkP
+        1nVOo93d8bxqPH2r+KMkavaeWph4a5u6m0WV8LBFpAG3vz8sIs1JxyYyIFCR
+        uIaUFHELTcz/q20KBoP2GIzDyvBU/Ntv1rLgB/HEL/l/AE0zpyj9SAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:16 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2917,11 +3726,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2940,17 +3749,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
+      - '14997'
       X-Ms-Request-Id:
-      - 8a6f16dc-4047-4723-ae61-e36918f20122
+      - 5a1149d2-01b4-4738-a7a2-4848a302beae
       X-Ms-Correlation-Request-Id:
-      - 8a6f16dc-4047-4723-ae61-e36918f20122
+      - 5a1149d2-01b4-4738-a7a2-4848a302beae
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192117Z:8a6f16dc-4047-4723-ae61-e36918f20122
+      - NORTHCENTRALUS:20160119T134926Z:5a1149d2-01b4-4738-a7a2-4848a302beae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Tue, 19 Jan 2016 13:49:25 GMT
       Content-Length:
       - '133'
     body:
@@ -2960,7 +3769,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:17 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -2973,11 +3782,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -2996,17 +3805,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14903'
+      - '14998'
       X-Ms-Request-Id:
-      - 636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - 1b9522b9-7b3c-47e1-a320-006c70a6247a
       X-Ms-Correlation-Request-Id:
-      - 636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - 1b9522b9-7b3c-47e1-a320-006c70a6247a
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192117Z:636fd120-7fa5-4e7e-8f7d-34ecc62b6952
+      - NORTHCENTRALUS:20160119T134927Z:1b9522b9-7b3c-47e1-a320-006c70a6247a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:16 GMT
+      - Tue, 19 Jan 2016 13:49:26 GMT
       Content-Length:
       - '133'
     body:
@@ -3016,7 +3825,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:17 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3029,11 +3838,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3052,17 +3861,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14997'
       X-Ms-Request-Id:
-      - 8c433189-24f1-45d6-95f1-4559049980f2
+      - ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
       X-Ms-Correlation-Request-Id:
-      - 8c433189-24f1-45d6-95f1-4559049980f2
+      - ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:8c433189-24f1-45d6-95f1-4559049980f2
+      - NORTHCENTRALUS:20160119T134927Z:ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:19 GMT
+      - Tue, 19 Jan 2016 13:49:27 GMT
       Content-Length:
       - '133'
     body:
@@ -3072,7 +3881,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3085,11 +3894,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3108,17 +3917,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14902'
+      - '14997'
       X-Ms-Request-Id:
-      - 44f6db10-b25b-435b-845f-ff636d64dce1
+      - 88cee134-206f-4f86-8875-10f536517521
       X-Ms-Correlation-Request-Id:
-      - 44f6db10-b25b-435b-845f-ff636d64dce1
+      - 88cee134-206f-4f86-8875-10f536517521
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:44f6db10-b25b-435b-845f-ff636d64dce1
+      - NORTHCENTRALUS:20160119T134927Z:88cee134-206f-4f86-8875-10f536517521
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Tue, 19 Jan 2016 13:49:27 GMT
       Content-Length:
       - '133'
     body:
@@ -3128,7 +3937,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3141,11 +3950,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3164,17 +3973,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14899'
+      - '14997'
       X-Ms-Request-Id:
-      - 27af5ee5-07c7-4207-9374-294c45078141
+      - e892447b-6efd-4ad1-8629-778838f1e4df
       X-Ms-Correlation-Request-Id:
-      - 27af5ee5-07c7-4207-9374-294c45078141
+      - e892447b-6efd-4ad1-8629-778838f1e4df
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:27af5ee5-07c7-4207-9374-294c45078141
+      - NORTHCENTRALUS:20160119T134928Z:e892447b-6efd-4ad1-8629-778838f1e4df
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Tue, 19 Jan 2016 13:49:28 GMT
       Content-Length:
       - '133'
     body:
@@ -3184,7 +3993,7 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:20 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
@@ -3197,11 +4006,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3224,20 +4033,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 364bdb9a-98ff-46ce-8ba0-97fd129a0fa5
+      - 3fcde00a-cd3c-405f-aba1-152abd1ce38d
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - 72e1ccd3-f367-461a-a7be-3f7b28cf1363
+      - aabadf99-3e97-43db-aafa-e790813b75fc
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192120Z:72e1ccd3-f367-461a-a7be-3f7b28cf1363
+      - NORTHCENTRALUS:20160119T134928Z:aabadf99-3e97-43db-aafa-e790813b75fc
       Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
+      - Tue, 19 Jan 2016 13:49:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3262,153 +4071,7 @@ http_interactions:
         3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
         tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 1e56ec3f-5b83-47ef-a623-76d4c630ba2a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
-      X-Ms-Correlation-Request-Id:
-      - 5fda7017-e071-4afe-9db5-b431dd23af33
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:5fda7017-e071-4afe-9db5-b431dd23af33
-      Date:
-      - Tue, 10 Nov 2015 19:21:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3t3d3
-        3uw+fLS3S//7ZGfn0c7OR6bxL5Ffvo8fv4RBANO3wFCpYmny0TITqCfz/Hyb
-        yDJzfUap6b2LZwNFm/V0muez3IOIx1H0bHledb4jNEOC+mDTIYhdyuzsvdl9
-        8Gh/99H93fH9g9179+91KUR0Mb8ylfTv7zPcj/J3bb5Ep0BBR25HbSn2RTGt
-        q6Y6b8dn1Phi3jbjn/ziaZFdLKumLabN67xtCetGO/U76BPWgX8vgg4R8/0J
-        OUDE+0THe+MH+/c+ffjwfkBEYawo5tVVXqPn/G69XqJDr5tbI0ySYt6WRkLA
-        3zj5Jf8PLXm+oVoEAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"067c85f3-0cb4-4178-bf6f-c7f357964084"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f78436a4-e5e4-47f3-8a9e-ab257e6bc589
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14901'
-      X-Ms-Correlation-Request-Id:
-      - 59d07b75-8d1a-49fe-bb78-29d59b0dacff
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:59d07b75-8d1a-49fe-bb78-29d59b0dacff
-      Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+Pdj59MD24f35ve2c6
-        2d/e331wsD05//R8e/rg/N79Bw8/3d852P99P9IX2+sVj/MW/eobZTXNMGa8
-        lWdNuzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJr
-        oe7ewaeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbn
-        xcW6ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++
-        usXEyUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7
-        ynpSFlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7p
-        v0UYEIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm
-        9EW2WpVFPnsafi9fG+p9tMimSmn69qOdne2dp9v3jrd3d7efHGwfWAb7KF9m
-        k5I461lVX2X1jLCg9udZ2eSmBQ0OQ36dT9d10V4z1aiNQ/SHPBMxfLx3lf6W
-        ECQ7i6y+JhTbem0HpdP5RTadF0uI6Q99OCfVYrVuc8NYion3lhkIftA/v+T/
-        Ae0xubNkBwAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:21 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
@@ -3421,11 +4084,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3444,24 +4107,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"98077b54-1aca-4f76-aec9-c6bdf31d49f2"
+      - W/"553ae346-9be8-4094-9df9-b03bcf792e31"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 962d3dde-f1e0-4508-95b8-1a606fcaf5c0
+      - b7c2c518-abbd-4bf2-ad7e-0e873c03b05e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14890'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 5a51b4be-d7bb-42ca-82ee-5269226fb8ce
+      - 10a10d3b-31cc-454c-8995-ed9fe5a3eaee
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192121Z:5a51b4be-d7bb-42ca-82ee-5269226fb8ce
+      - NORTHCENTRALUS:20160119T134929Z:10a10d3b-31cc-454c-8995-ed9fe5a3eaee
       Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
+      - Tue, 19 Jan 2016 13:49:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3470,18 +4133,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
         vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
         P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/eniw8+DB5P7+9m42zbb3
-        zx98up3l04fb008ns/N7u7P9h+d7v+9H+mJ7veIR3qJTfaOsphkGjLfyrGnX
-        5gsawSqv24JaPkqZfvLhZdFQ82J58brNWu7s9Xo6zfNZrthTM+pByLIW0s52
-        7s12dh/Mtj+d7BAtD/bOtx/uTSfbD3cn2eTezr17NEb7crFSHPHm/s74wafj
-        3YcPxw8ObAs7ltJg/0Xezol69MLTa5rlYmrbFrMyf1Ms8mrdni2/KJbrlge0
-        b79fnVTL8+JiXTMg+krHiu8Y4t0fFl8s5efZss3r82xKfDHFe/TK7P7ezt0O
-        pg19MOUPdj8SjH8JftA/v+T/AbZb5zfuAgAA
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/un//Xpbf26feJ/kB4fFw
+        f/vh7Pzh9mTn3mR6/uDhXn5v9/f9SF9sr1c8wlt0qm+U1TTDgPFWnjXt2nxB
+        I1jldVtQy0cp008+vCwaal4sL163WcudvV5Pp3k+yxV7akY9CFnWQtrZzr3Z
+        zu6D2fankx2i5cHe+fbDvelk++HuJJvc27l372DngX25WCmOeHN/Z7y7tzve
+        3X843nNN7GBKg/4XeTsn8tEbT69pmoupbVvMyvxNscirdXu2/KJYrlse0b79
+        fnVSLc+Li3XNgOgrHSy+Y4h3f1iMsZSfZ8s2r8+zKTHGFO/RK7P7ezt3O5g2
+        9MGUP9j9SDD+JfhB//yS/webJePn7wIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3491,11 +4154,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3518,115 +4181,41 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 282c33a7-d110-45d5-81a0-235a168007ca
+      - 4a67d016-b0e5-418b-b14f-d2cd59a7cfca
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14877'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 0d9efbd9-10cd-4834-80d8-3de2afed84a9
+      - b45d873b-b6aa-43e4-b04f-175ab5cdb8db
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:0d9efbd9-10cd-4834-80d8-3de2afed84a9
+      - NORTHCENTRALUS:20160119T134931Z:b45d873b-b6aa-43e4-b04f-175ab5cdb8db
       Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
+      - Tue, 19 Jan 2016 13:49:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbS398nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBfVk17QV1vP80vXbdR2nmv49lA
-        v2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2C2CXOzu6bnf1H+wdElvHuvU/v
-        7+097BCJSGN+ZULp399nuB9Nqqp9WmQXSyJLMQUeOmYa7bKpyvz1tM7zZTOv
-        2idlNfmqLqjJR/O2XTWP7t6dzvPzVV3N7u/u7Ywn9P14WtX5+KpYzqqrZrzM
-        27voYOY62F7RT9B/tn0+Pb83m+bT7fPJwWx7/+H5/e2Hs4Pp9mT3fj6bnp8/
-        2Nmf3vWna3ybN8aNRXg8WayYDMob+buWviACY5g6yzpa+tYwyBfFtK6a6rwd
-        n1Hji3nbjH/yC49Er/O2pRlqGDLBxg8lZp+JHPj3Yp4hxnl/ptnMMAf39u/v
-        fRowjNAqhvmXr9FtfpckOK+zsvhB0M+tMSYl4EOQhsO9vqyu8hpv53dneVaW
-        1ZR+/bod+xCkoUzfb5z8kv8HgBrmiLIFAAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7u5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZJ6fbxMFZq7PKOG8d/FsIF6z
+        nk7zfJZ7EPE44p0tz6vOd4RmSDsfbDoEsUeZvTd7u4/u7zy692D88N7B/u7+
+        /Q6FiC7mV6aS/v19hvvRpKrap0V2sayatpgCDx0zjXbZVGX+elrn+bKZV+2T
+        spp8VRfU5KN5266aR3fvTomSKyLk/d29nfGEvh9PqzofXxXLWXXVjJd5excd
+        zFwH2+aV7XsPp/fv7e1Mt3cmO/e29z/NH24/PN85395/cI8Y6MGnB+fZ5K6d
+        qvFtmo8bi+x4slgZ0n3U5HWRlScyoOfVxf8XRsIo6xyMy+qC51M5PH/X0iiJ
+        UzBfyq46bfStYfMvimldNdV5Oz6jxhfzthn/5BfeXL/O25ZYrWHIBBs/lCv6
+        0uDAv5cUDEnA+3N/lPP3Hu18+mh3Z3z/04PdnYNPA84XWkUxr67yGj3nd+v1
+        Eh163dwaYdJk5m1pJAT8jZNf8v8A/BfbJ/oFAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"de7fc201-9022-4e98-933d-f11b78b3ba34"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b5cdf354-8db1-4689-9ac1-9a0ec7cbbe5a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14891'
-      X-Ms-Correlation-Request-Id:
-      - 7642b49c-6cc6-40d0-89e9-cc9192efe371
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:7642b49c-6cc6-40d0-89e9-cc9192efe371
-      Date:
-      - Tue, 10 Nov 2015 19:21:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+a5Q/Op3s7
-        u9sPd/b2tvfzhwfbD+/dm22f7+5OHhxM7k2ye/u/70f6Ynu94tHeomt9o6ym
-        GYaNt/KsadfmCxrHKq/bglo+SpmW8uFl0VDzYnnxus1a7uz1ejrN81k+kzep
-        GQ1IiLMWAu9m+e69ye5k++Bg/8H2/sMH+9uTB/v3t+/nk+n5ZOfeZPLwwL5c
-        rE6q5Xlxsa4ZMXT/PfkqNXjgsTNbrKbcftdAwPP/upm92x0WfRDD++tOvTyY
-        oN6syYOvbjF38lDj4pKanL08ns1oEID20e7OeG+8M1YmNY/XtDTM9EXeziue
-        gKfXNE3FtPvKelIWU3rDAg9QpRY/5OnrIETT99JM39P88iMfuV8SDoUwpLkn
-        ZH+OR3BZ1O06K/VP/y3CgDBs7s7y82xdtuFg3B/2V/3l+zrOj2bL5nXetsQ1
-        wUTJ5/UloUMff880py+y1aos8tnT8Hv52lDvo3yZTUpimmdVfZXVM4JOrc6z
-        sslNC0IaQ3mdT9d10V4zNaiNQ+CHTOEYPlE+sWPUOfkim86LJcTtZwP3b58+
-        23756sunUdxPqsVq3eaGOxSTONb4Qf/8kv8HN0M1cTgHAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:22 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
@@ -3639,11 +4228,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3666,20 +4255,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f33cabb6-c276-4b69-93d7-b9b0acfcab70
+      - f9330761-0298-4fa4-aa73-9787673c1e3e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 4cb5e0c9-4108-4ac0-82a3-3cfd93da1dfb
+      - ff05904e-09a0-42a6-a372-96c35e33fd37
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192122Z:4cb5e0c9-4108-4ac0-82a3-3cfd93da1dfb
+      - NORTHCENTRALUS:20160119T134932Z:ff05904e-09a0-42a6-a372-96c35e33fd37
       Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
+      - Tue, 19 Jan 2016 13:49:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3696,7 +4285,81 @@ http_interactions:
         NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
         SP8S/KB/fsn/AwfrPqbVAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - 7a1e7e14-62d7-4ea8-9412-f913565ac513
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 0452b15f-dff4-4f61-aeb4-d1aa1acdfdb4
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134932Z:0452b15f-dff4-4f61-aeb4-d1aa1acdfdb4
+      Date:
+      - Tue, 19 Jan 2016 13:49:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN79z7Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqy6ppL6jr7af5pes2SjvvdTwb
+        6Nesp9M8n+UzBxGPo9/Z8rzqfEeYhuTzwaZDED3i3N/e3SX6vNnZf7R/QGQZ
+        79779P7e3sMOkYg05lcmlP79fYb70aSq2qdFdrEkshRT4KFjptEum6rMX0/r
+        PF8286p9UlaTr+qCmnw0b9tV8+ju3ek8P1/V1ez+7t7OeELfj6dVnY+viuWs
+        umrGy7y9iw5mroPtFf0E/Wfb59Pze7NpPt0+nxzMtvcfnt/ffjg7mG5Pdu/n
+        s+n5+YOd/eldf7rGt3lj3FiEx5PFismgvJG/a+kLIjCGqbOso6VvDYN8UUzr
+        qqnO2/EZNb6Yt834J7/wSPQ6b1uaoYYhE2z8UGL2mciBfy/mGWKc92eazQxz
+        cG///t6nAcMIrWKYf/ka3eZ3SYLzOiuLHwT93BpjUgI+BGk43OvL6iqv8XZ+
+        d5ZnZVlN6dev27EPQRrK9P3GyS/5fwCGLAvDsgUAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
@@ -3709,11 +4372,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -3736,20 +4399,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - b7af4ba1-d8a9-4765-9e13-65079dbe99bd
+      - 7230c493-1cd3-40aa-b63c-b306b135063a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14876'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 9d597001-cccc-4651-9287-0fe1e837937d
+      - eed1204e-852b-4cb8-9ee6-22ae5c1cb3f9
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192123Z:9d597001-cccc-4651-9287-0fe1e837937d
+      - NORTHCENTRALUS:20160119T134932Z:eed1204e-852b-4cb8-9ee6-22ae5c1cb3f9
       Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
+      - Tue, 19 Jan 2016 13:49:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3759,233 +4422,15 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR375OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBO5/l5k9eXeb3reo2Sznsbzwby
-        NevpNM9n+cxBxOPId7Y8rzrfEaIh9Xyw6RDELm12dt/s7D/av/do//5458H9
-        B/s7ux0aEWXMr0wn/fv7DPej/F2b0xTQNBBUHbkdtaXZF8W0rprqvB2fUeOL
-        eduMf/KLp0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5EYi7u7t3T/4
-        NGQ0Ya0o5tVVXqPn/O4sz8qymtKvfle3RppEw4cgDYWQv3HyS/4fgM2Crk8E
-        AAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7+5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
+        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcgerS5v727S+R5s7P/aJ/Ic3+8
+        8+D+g/2d3Q6NiDLmV6aT/v19hvtR/q7NaQpoGgiqjtyO2tLsi2JaV0113o7P
+        qPHFvG3GP/nF0yK7WFZNW0yb13nbEtaNdup30CesA/9eBB0i5vsTciMRd/f2
+        7h98ei8gorBWFPPqKq/Rc353lmdlWU3pV7+rWyNNouFDkIZCyN84+SX/D/av
+        A9VPBAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ed09297-b9d3-46c3-be3a-d8e85cbf0e1e"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 88bf2a94-dafd-4ca8-9a75-78142baa3b8e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14898'
-      X-Ms-Correlation-Request-Id:
-      - 98f8dd2f-a707-4da3-adc9-30f873c19770
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192123Z:98f8dd2f-a707-4da3-adc9-30f873c19770
-      Date:
-      - Tue, 10 Nov 2015 19:21:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96F4+23m4
-        9/DB9uTh7N72/qfTe9uT/F62PTvID+5PJ+c7+W7++36kL7bXKx7sLXrWN8pq
-        mmHYeCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mT
-        mlnirIXAk3x3tjfbn2xn9/am2/vTg91tQny2vXvvwaf3Hj7I9maT3L5crE6q
-        5Xlxsa4ZMXT/PfkqNXjgsRNbrKbcftdAwPP/upm92x0WfRDD++tOvTyYoN6s
-        yYOvbjF38lDj4pKanL08ns2IIID20e7OGP/dH2xaGmb6Im/nFU/A02uapmLa
-        eYVmhehF3wcY0hc/7Fm7LOp2nZX6Z/Aa4UA4Nndn+Xm2LtuPfEx/ifvD/qq/
-        fF9H+tFs2bzO25aIDeLZgcrn4Ap8/D3TnL7IVquyyGdPw+/l61+izT7Kl9mk
-        JFo/q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2mulBbRwCP2waxxCidmc/oe/v
-        KmntGHVSvsim82IJLv3h465fG/5QVAKZNljjB/3zS/4ftlmBnm4GAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
-      X-Ms-Request-Id:
-      - 8af9ccbd-6538-428e-882a-08649a74ed73
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14889'
-      X-Ms-Correlation-Request-Id:
-      - e46f3407-c4eb-4f82-a3e3-04b6951cfecf
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:e46f3407-c4eb-4f82-a3e3-04b6951cfecf
-      Date:
-      - Tue, 10 Nov 2015 19:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbS3/8nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBPX710vUVJ5r2FZwPZmvV0muez
-        fOYg4nFkO1ueV53vCMGQaj7YdAhilyY7u2929h/t33u0f3+88+nOzsGD+x3a
-        EEXMr0wf/fv7DPej/F2bE+mJ/ARVR25HbWn1RTGtq6Y6b8dn1Phi3jbjn/zi
-        aZFdLKumLabN67xtCetGO/U76BPWgX8vgg4R8/0JuZGIu3t79w8+vRcQUVgq
-        hvmXr9FtfpeYOa+zsvhB0M+tMSZ58CFIw+FeX1ZXeY2387uzPCvLakq/ft2O
-        fQjSUKbvN05+yf8DKJMver0EAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"4b49f47c-50d4-41f2-b4ac-dcef7d22f3e9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f9059a0b-7d52-4a73-b276-56bef8feb5e0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
-      X-Ms-Correlation-Request-Id:
-      - 281c80ea-9394-4448-a6a7-5e4cf9986e2e
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:281c80ea-9394-4448-a6a7-5e4cf9986e2e
-      Date:
-      - Tue, 10 Nov 2015 19:21:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+360P9l/eL7/YLp9f2e2
-        v72/e763PdnPptuzaX7+YLa3d34vf/j7fqQvttcrHtwtetQ3ymqaYbh4K8+a
-        dm2+IPRXed0W1PJRyqSTDy+LhpoXy4vXbdZyZ6/X02mez/KZvEnNLFHWQthP
-        s91PZw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ
-        /ffkq9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlD
-        jYtLanL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1h
-        gQeoUosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2
-        d2f5ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW
-        +exp+L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTG
-        IfDDpnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/kpjlQCQcA
-        AA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
@@ -3998,11 +4443,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4025,20 +4470,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8bbd00ba-fc75-4623-9ada-956ec0f1f438
+      - 93cd86c7-c0fa-4805-aa88-1b3b2ce4af60
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - e0d0859c-7976-4d37-a02f-73e943fd2142
+      - 7e82b55a-f986-4d2a-845b-080d0b3ead07
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192124Z:e0d0859c-7976-4d37-a02f-73e943fd2142
+      - NORTHCENTRALUS:20160119T134933Z:7e82b55a-f986-4d2a-845b-080d0b3ead07
       Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
+      - Tue, 19 Jan 2016 13:49:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4055,10 +4500,10 @@ http_interactions:
         O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
         MQDoSbwCAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:24 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4068,11 +4513,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4095,111 +4540,38 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 06ff7c20-f60e-4341-b7d8-5b2ae831bdae
+      - c8596422-0bda-4fea-b657-2a58f088639b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14888'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 4e6988e1-bcd3-431d-ad86-b710172145ce
+      - 0283db3a-8c1a-4e8f-9703-01756e9cec70
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192125Z:4e6988e1-bcd3-431d-ad86-b710172145ce
+      - NORTHCENTRALUS:20160119T134934Z:0283db3a-8c1a-4e8f-9703-01756e9cec70
       Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
+      - Tue, 19 Jan 2016 13:49:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR3/5OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
-        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQewSZWf3zc7+o/17j/bvj3ce3H+wv7Pb
-        IQ6RxPzKBNK/v89wP8rftTnRnuhPUHXkdtSOWMW0rprqvB2fUeOLeduMf/KL
-        p0V2sayatpg2r/O2Jawb7dTvoE9YB/69CDpEzPcn5EYi7u7t3T/49F5AROGp
-        KObVVV6j5/zuLM/KsprSr35Xt0aaZMKHIA2FkL9x8kv+HypTnSpIBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN79z/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATq6auXrrcoyby38GwgW7OeTvN8
+        ls8cRDyObGfL86rzHSEYUs0Hmw5B9Ghyf3t3l8jyZmf/0T6R5f5459OdnYMH
+        XdoQRcyvTB/9+/sM96P8XZsT6Yn8BFVHbkdtafVFMa2rpjpvx2fU+GLeNuOf
+        /OJpkV0sq6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5kYi7e3v3Dz69FxBR
+        WCqG+Zev0W1+l5g5r7Oy+EHQz60xJnnwIUjD4V5fVld5jbfzu7M8K8tqSr9+
+        3Y59CNJQpu83Tn7J/wOV12NkvQQAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"e964bc6c-1d3e-4778-8aca-3856bd1bf506"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0b3e3582-f719-435c-82e1-8912ef5670d5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14896'
-      X-Ms-Correlation-Request-Id:
-      - 1cc564f5-c087-486f-b873-89031ee016be
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192125Z:1cc564f5-c087-486f-b873-89031ee016be
-      Date:
-      - Tue, 10 Nov 2015 19:21:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P8offro/mX463d6d
-        3SM0Hjw42D7Iptn2vYP7n05mu5Pz+zuf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
-        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
-        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
-        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
-        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
-        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
-        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
-        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
-        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
-        PwuqUY4PBwAA
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:25 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
@@ -4212,11 +4584,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4235,24 +4607,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
+      - W/"ba524d82-0c52-4472-9e79-396c6e961fa4"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4e97cd2a-450b-4f55-9bdd-4a419916bc49
+      - 28b498da-bc37-4592-80a0-9fec42fc2d39
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14882'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 253a3708-594e-498f-a0d1-2697a9ef699e
+      - f6783db7-2fc1-4f1e-8d9f-ea76a0354424
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192126Z:253a3708-594e-498f-a0d1-2697a9ef699e
+      - NORTHCENTRALUS:20160119T134935Z:f6783db7-2fc1-4f1e-8d9f-ea76a0354424
       Date:
-      - Tue, 10 Nov 2015 19:21:25 GMT
+      - Tue, 19 Jan 2016 13:49:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4261,18 +4633,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
         cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
         2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
+        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H02y+9TXwd72zvT+
+        3vb+/oO97Yf5g4fb9x5+Ov00f/jp7nm2//t+pC+21ysZ2M396RtlNc0wWLyV
+        Z027Nl8Q8qu8bgtq+ShlssmHl0VDzYvlxes2a7mz1+vpNM9n+UzepGbUg5Bk
+        LWTdyQ/2D/KHk+18srO/vT/Zv7f98P70IY3m4f5k5/zTg+mBDp1etpiWBrcv
+        8nZeMaCn1zR1xdS2LWZl/qZY5NW6PVt+USyJ8EB3336/OqmW58XFumZA9JWO
+        BN8xxLs/tBlfys+zZZvX59mUZnxR/KK9B3sP7nawbOiDKX+w+5Fg+0vwg/75
+        Jf8PB5XUGL8CAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:26 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4282,11 +4654,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4309,112 +4681,37 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 236380c9-25c8-4fdf-a626-1176f2ac5bae
+      - a94e90b7-3648-4995-a780-810c8953ac97
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14897'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 5d31a0a4-0d08-4b64-afdf-63c567de6cc7
+      - 736ddabe-7952-449b-adb5-699820dbaef9
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:5d31a0a4-0d08-4b64-afdf-63c567de6cc7
+      - NORTHCENTRALUS:20160119T134935Z:736ddabe-7952-449b-adb5-699820dbaef9
       Date:
-      - Tue, 10 Nov 2015 19:21:26 GMT
+      - Tue, 19 Jan 2016 13:49:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
-        uztvdh8+2tt9tPfgk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoH5x
-        9hMn1WK1bvNd12uUdN7beDaQr1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcg
-        dmmzs/tmZ//R/t6j+w/GD3Y//XRv56BDI6KM+ZXpRH8rSDs6S5tZ1maE19v/
-        31Hm3t7ew9373wBl9lyvP78ogx/fZ7gf5e/anMSWRJeg6sjtqC3FviimddVU
-        5+34jBpfzNtm/JNfPC2yi2XVtMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcT
-        8eH+g/sPdgMi9lnJYl5d5TV6zu/O8qwsqyn96nd1a6RJnfoQpKEQ8jdOfsn/
-        A5mzpgJIBgAA
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7Dz7Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqF2c/see6i9LMew3PBro16+k0
+        z2f5zEHE4+h2tjyvOt8RhiHZfLDpEMQeUe692b3/aPfTR/fujXc/fXBv716H
+        NkQR8yvTR//+PoP9KH/X5kR6Ij8B1YHbQTtaFdO6aqrzdnxGjS/mbTP+yS+e
+        FtnFsmraYtq8ztuWkG60U7+DPl0d+Pei5xAt35+OG2m4t/fwYPcgJKKwVBTz
+        6iqv0XN+d5ZnZVlN6Ve/q1sjTSLhQ5CGQsjfOPkl/w/qXwxFRwQAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"038d43ac-00ce-4c58-889c-99c438d08476"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 17a36f6d-92b2-4fdc-9dc6-5a66e05489ff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14896'
-      X-Ms-Correlation-Request-Id:
-      - cd705775-0f05-48a4-bcd1-ab16178594cb
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:cd705775-0f05-48a4-bcd1-ab16178594cb
-      Date:
-      - Tue, 10 Nov 2015 19:21:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vRzv3Dmb797Lp
-        9s7OlLCZ3j/YPjh4ON1++HC6T1/tHOw/+PT3/UhfbK9XPNhb9KxvlNU0w7Dx
-        Vp417dp8QcNY5XVbUMtHKZNSPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s8RZ
-        C4H3Hk72Zvf2ptsPHuT72/vnNJDJ3qefbj+YZAfZg/ODT/d2d+zLxeqkWp4X
-        F+uaEUP335OvUoMHHjuxxWrK7XcNBDz/r5vZu91h0QcxvL/u1MuDCerNmjz4
-        6hZzJw81Li6pydnL49mMCAJoH+3ujPHf/mDT0jDTF3k7r3gCnl7TNBXT7ivr
-        SVlM6Q0LPECVWvywp6+DEU3fF2c/oe/ufuQj90vCoRCGNPWE7M/1CC6Lul1n
-        pf4ZvEY4EI7N3Vl+nq3LNhyO+8P+qr98X0f60WzZvM7blvgmmCr5vL4kfOjj
-        75nm9EW2WpVFPnsafi9fG/p9lC+zSUls86yqr7J6RtCp1XlWNrlpQUhjLK/z
-        6bou2mumB7VxCPywaRxDiNr1OMWOUSfli2w6L5YQuB8+7vq14Q9FhVr0scYP
-        +ueX/D+V0+PkOQcAAA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
@@ -4427,11 +4724,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4454,20 +4751,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ff854fcc-5084-42e7-b9a2-894f534d4191
+      - 64e2b270-d446-4a04-a6ef-bf7a43f7f0c5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14881'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 21ed37da-9650-48f0-acf5-56083bb8cac7
+      - aa3c99a4-c72a-4c49-8be1-ba3946c5a2ab
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:21ed37da-9650-48f0-acf5-56083bb8cac7
+      - NORTHCENTRALUS:20160119T134939Z:aa3c99a4-c72a-4c49-8be1-ba3946c5a2ab
       Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
+      - Tue, 19 Jan 2016 13:49:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4484,7 +4781,504 @@ http_interactions:
         OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
         +EH//JL/B0wm3MTUAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - beae932a-635c-4dcc-9095-aa0dc44f003a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - ffb4eae6-ade4-440c-8ea9-2a110e9d220e
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134941Z:ffb4eae6-ade4-440c-8ea9-2a110e9d220e
+      Date:
+      - Tue, 19 Jan 2016 13:49:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d3a3
+        dx++2b33aP/ho/29T3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
+        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
+        6NHm/vbuLpHnzc4+EebR/QfjB7uffrq3c9ChEVHG/Mp0or8VpB2dpc0sazPC
+        6+3/7yhzb2/v4e79b4Aye67Xn1+UwY/vM9yP8ndtTmJLoktQdeR21JZiXxTT
+        umqq83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+f
+        kJuJ+HD/wf0HuwER+6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTn0I0lAI+Rsn
+        v+T/AfMpzztIBgAA
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/chef-prod/providers/Microsoft.Network/publicIPAddresses/rgtest-publicIp?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0b530b36-edee-4b17-ae72-076b1003db6b"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2ba89c0e-1427-4df6-8515-9d24739bd768
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - db19d6a1-a7c2-4b4d-884c-507ecab08569
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134941Z:db19d6a1-a7c2-4b4d-884c-507ecab08569
+      Date:
+      - Tue, 19 Jan 2016 13:49:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bdXq0nZTE9
+        W3004m+LGb6726wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
+        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquTud5+fbq7qa3aV/LotZXjd3vyim
+        ddVU5+34Rd5eVfXbu9r7y+PZjN5v8uZuHK28zS6A2Hfv/r4f7Uzu39uZ3Pt0
+        O5/lhM1k98F2lj/Y29558Olkd2fn3mzy6eT3/UhfbK9XPNpbdK1vlNU0w7Dx
+        Vp417dp8QeNY5XVbUMtHKdNSPrwsGmpeLC9et1nLnb1eT6c5YTeTN6kZ9SDE
+        WQuB9yb3Zweze7vbn+4ePNjef5Dtb2cPJve279+f7D/Mz+9lDx5M7MvFSnHE
+        m/s74wefjncfHtD/bQs7ltJg/0Xezivu6uk1zXgxtW2LWZm/KRZ5tW7Pll8U
+        yzXRm9rt2+9XJ9XyvLhY1wyIvtKx4juGePeHxR1L+Xm2bPP6PJta7rjbwdF8
+        /pEg+kvwg/75Jf8PV4k/s/ECAAA=
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - b91b770c-4c21-4a09-8181-35151c0ff2c2
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - aa996769-586b-491f-b703-c8579c301dd0
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134942Z:aa996769-586b-491f-b703-c8579c301dd0
+      Date:
+      - Tue, 19 Jan 2016 13:49:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
+        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
+        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
+        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr36Sc7O492dj4yjX+J/PJ9
+        ffuj/F2bLzHab1OPJZGQwETJ016vuIsvimldNdV5Oz7+wbrOx0+L7GJZNW0x
+        bcZnWfba+ztEkd7XPryZ2h3vjXfGO0FLmSj61uuePn7P+aE3BmeIvrt5jqiR
+        N0svy/VFsUzzZTYp81m6tcwW+aP0PYgxSi9l2I9SHfSdsZ0VOy/2l+/jxy9h
+        dIDrW+Co82LJ8hGQoM8/qi9a4qH8/t796ez+ZDvfvbe/vb+7/3D7YP/+/e3d
+        3U+z/WxncjB9mI0v5x6VlNShTHgd4PnZprsPNh2C2OPvgze7nxJzP9r9dPwp
+        ffbpvfsdPifimV+ZlPq38H1k3HbM7zfeobG+/zgHxrh/79H9nfG9T3f293Yf
+        BGMU5ohiXl3lNXrO76o68bq5NcI/+YVRRqZD/CBi/pL/B2vfg5qJBQAA
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/rgtest12-publicIp?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"d7ca7f34-1756-44df-998b-2e300446ce97"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a7f7dea2-32f5-4c25-9c5b-fde31a94e542
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 0dfb6f5c-da57-4290-acc7-248558b6e5b7
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134943Z:0dfb6f5c-da57-4290-acc7-248558b6e5b7
+      Date:
+      - Tue, 19 Jan 2016 13:49:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bd3dterSdl
+        MT1bfTTi74sZvr3brCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n
+        59s7ewd7+7Pd2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd
+        3P2imNZVU5234xd5e1XVb+9q9y+PZzMC0OTN3SHM8ja7AG7fvfv7fjR7MM0e
+        nN/b3959cP/T7f392fn2w4cHk+29/N7Ozv7+p9P84YPf9yN9sb1e8ZBv0bm+
+        UVbTDCPHW3nWtGvzBY1klddtQS0fpUxQ+fCyaKh5sbx43WYtd/Z6PZ3m+Syf
+        yZvUjHoQ+qyFxtPpTjbdmd7b3r9P9Nz/dOfe9sFsRv/cm2AQD2Z5NrEvFyvF
+        EW/u74wffDq+92C8t3/PtrBjKQ32X+TtvOKunl7TtBdT27aYlfmbYpFX6/Zs
+        +UWxpHkC4H37/eqkWp4XF+uaAdFXOlZ8xxDv/tAYZCk/z5ZtXp9nU49B7nbQ
+        dN98JNj+Evygf37J/wPK70Rq+wIAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest12/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - 24692753-636c-4434-aa94-25a82e72fcfd
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 8af5c793-1390-41d1-84b4-63cf609148fd
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134944Z:8af5c793-1390-41d1-84b4-63cf609148fd
+      Date:
+      - Tue, 19 Jan 2016 13:49:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
+        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
+        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
+        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr34JOdnUc7Ox+Zxr9Efvm+
+        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
+        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
+        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
+        OsD1LXDUebFk+QhI0Ocf1Rct8dDu3t50597k3vl0e38ve7i9/3Bnf3vyYH+2
+        fS9/MJnen957mE92xpdzj05K7FAqvC7w/GxT3gebDkHscfjBm729R/d3Hu3u
+        jnce7hzsf9phdKKe+ZVpqX8L40eGbYf8fsMdGur7D3NoiAePdvfGnz64v7fz
+        6UEwRuGOKObVVV6j5/yu6hOvm1sj/JNfGG1kOsQPIuYv+X8AYF7KcooFAAA=
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/computevms/providers/Microsoft.Network/publicIPAddresses/rgtest2-publicIp?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"9dbc62b2-d8bb-4610-add3-3b22922b2c83"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 466f76ac-da66-4840-aef3-146c44fbe881
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 6fa629e9-1deb-4c08-a3b6-055a00bbc399
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134945Z:6fa629e9-1deb-4c08-a3b6-055a00bbc399
+      Date:
+      - Tue, 19 Jan 2016 13:49:44 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bd216tJ2Ux
+        PVt9NOKvixm+vNusJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn
+        2zt7B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrk7rRardZtfLpq7q7q6LGZ53dz9
+        opjWVVOdt+MXeXtV1W/vavcvj2czAtDkzd0BxPI2uwBq3737+370cDaZfro3
+        2dueHUwm2/uf7u5sZ7PZve17k729h3v0xfTg3u/7kb7YXq94wLfoW98oq2mG
+        geOtPGvatfmCBrLK67aglo9SJqd8eFk01LxYXrxus5Y7e72eTvN8ls/kTWpG
+        PQh51kLi/Wx67/7+w4fbO9PZ/vb+7N7e9iR/eH978vDhp/nB/t7Bwezcvlys
+        FEe8uXvvwXh3l/6/8+l498G+bWSHU5oBfJG384p7e3pN815MbdtiVuZvikVe
+        rduz5RfFkmYKsPft96uTanleXKxrBkRf6XDxHUO8+0NjkaX8PFu2eX2eTR2L
+        3O1gab/4SHD9JfhB//yS/wd0EkRB+gIAAA==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest2/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - f313851c-ea89-4471-ba50-db56f93ee9fc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 61fe9673-3f3a-4bd2-ae91-2a719cda4fe9
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134946Z:61fe9673-3f3a-4bd2-ae91-2a719cda4fe9
+      Date:
+      - Tue, 19 Jan 2016 13:49:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
+        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
+        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
+        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr38JOdnUc7Ox+Zxr9Efvm+
+        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
+        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
+        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
+        OsD1LXDUebFk+QhI0Ocf1Rct8dDe+e75pwf7D/e2H2b57vb+7t7D7cnDvfvb
+        5+cHeZ7t797Lsnx8OffIpLQOhcLrAc/PNuF9sOkQxB6DH7zZ/fTR/f1Huw/H
+        u/d3d/Y/PegwOlHP/Mq01L+F8SPjtmN+v/EOjfX9xzk0xgeP9h6MP/304c7e
+        /qfBGIU7ophXV3mNnvO7qk+8bm6N8E9+YbSR6RA/iJi/5P8BLSBqRooFAAA=
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
@@ -4497,11 +5291,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4524,20 +5318,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - cacfdae5-c56d-4639-85c4-1004af7062d1
+      - 26fa3118-ef29-4340-992e-9650a3a4edd3
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 86e2e449-051c-4ab1-9d66-34e317207d86
+      - 093f1cbc-45aa-4b3d-9d25-338485664e07
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192127Z:86e2e449-051c-4ab1-9d66-34e317207d86
+      - NORTHCENTRALUS:20160119T134947Z:093f1cbc-45aa-4b3d-9d25-338485664e07
       Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
+      - Tue, 19 Jan 2016 13:49:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4547,91 +5341,16 @@ http_interactions:
         pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbT34JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
-        PnMQ8TjKnS3Pq853hEBIOB9sOgSxS5ad3Tc7+4/2Dx7tfzre2fv04e69DnWI
-        JuZXppD+/X0G+9GkqtqnRXaxrJq2mAINHTINdtlUZf56Wuf5splX7ZOymnxV
-        F9Tko3nbrppHd+82q3y627RVTTO7O55Qg/G0qvPxVbGcVVfNeJm3d9HDzPWw
-        jXcuFzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94vscdbP/k
-        Fzvj27QeNxbX8WSxYgooP/RnV4dJ373XrA7N6PvP5uaZPHi4/+m9vWAqZShR
-        zKurvEbP+d1ZnpVlNaVf/a5ujTSJpg9BGgq//MbJL/l/AI8MyTfPBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aP9g092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
+        +cxBxOMod7Y8rzrfEQIh4Xyw6RBEjyz3t3d3iTJvdvaJJo/2Px3v7H36cPde
+        hzpEE/MrU0j//j6D/WhSVe3TIrtYVk1bTIGGDpkGu2yqMn89rfN82cyr9klZ
+        Tb6qC2ry0bxtV82ju3ebVT7dbdqqppndHU+owXha1fn4qljOqqtmvMzbu+hh
+        5nrYxjuXi53tPNt9kGd7+9vZLJtt7+9P721nBwcPt3d29u+dT/Z27z883+MO
+        tn/yi53xbVqPG4vreLJYMQWUH/qzq8Ok795rVodm9P1nc/NMHjzc//TeXjCV
+        MpQo5tVVXqPn/O4sz8qymtKvfle3RppE04cgDYVffuPkl/w/Lg2IFs8EAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2ce2d8c8-8577-42d9-a3a9-8e30dc1607bf"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5a56d238-ef80-42e0-8ca7-650a6fdbcc7b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14884'
-      X-Ms-Correlation-Request-Id:
-      - 4f9460ca-900f-4359-a97c-74faf6366c25
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:4f9460ca-900f-4359-a97c-74faf6366c25
-      Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9HeNN+bHUwPtg/u
-        P3iwvb83e7id3csebh/k93Zm091Pdx5Mzn/fj/TF9nrFQ7xFp/pGWU0zjBhv
-        5VnTrs0XNIJVXrcFtXyUMgHlw8uioebF8uJ1m7Xc2ev1dJrns3wmb1IzS5e1
-        0Pb+wcPp7s6DfaLjbHd7//5ksv1w7+DB9iR7cP7pp9P9h0RP+3KxOqmW58XF
-        umbE0P335KvU4IHHTmexmnL7XQMBz/+bJvVud0T0QQzlrzvr8mBuehMmD766
-        xbTJQ42LS2py9vJ4NiNaANpHuztj/Hd/sGlp+OiLvJ1XTPun1zRDxbTzCk0I
-        kYq+DzCkL37YE3ZZ1O06K/VPna6ffHH65i6hQCg2d1/zz+3dj3xMf0k4nLLK
-        Zk+yMltO8/pJNn2bL2dKtpdVVYJ2lnfl6QybQPywB+6jrMN+/uTupI/8XR0Q
-        /giJQGTw//z+ME3OlpNqvZy9yNpX65I58/8j9ChCxO++evpy+ye/2NlIBveH
-        /Vx/MRT6aLZsXudtS3IIWtjBy+f1JWFAH3/PNKcvstWqLPLZ0/B7+drw4kf5
-        MpuUJIbPqvoqq2cEnVqdZ2WTmxbK7V9k03mxhPi7rr85en/5xcuv3pz+5Bev
-        o/TW6TCCp6goxR1pmWL0zy/5fwAzzH7ZtQcAAA==
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:28 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
@@ -4644,11 +5363,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4671,20 +5390,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 19928ad9-0635-4e67-91d4-a341383d4d3b
+      - 5ac2d856-4d34-407d-83ae-357fcca12395
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14900'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 466b7179-c8c3-49fd-a370-f8f436d938fb
+      - 7f20999e-0edd-47f1-868f-459483d94186
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:466b7179-c8c3-49fd-a370-f8f436d938fb
+      - NORTHCENTRALUS:20160119T134947Z:7f20999e-0edd-47f1-868f-459483d94186
       Date:
-      - Tue, 10 Nov 2015 19:21:27 GMT
+      - Tue, 19 Jan 2016 13:49:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4694,19 +5413,19 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727u727s7b3YfPtrbfbR38MnOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
-        nzmIeBzlzpbnVec7QiAknA82HYLYJcvO7pud/Uf7B4/2Px3v7d//dGenSx4i
-        ivmVSaR/f5/hfjSpqvZpkV0sq6YtpsBDx0yjXTZVmb+e1nm+bOZV+6SsJl/V
-        BTX5aN62q+bR3bvNKp/uNm1V09TujifUYDyt6nx8VSxn1VUzXubtXfQwcz1s
-        453LBWE+uZ/tZfvn27uzTx9s7+/O8u1sd2+6fW93tvNg99OHe5/uEWGp8fZP
-        frE7vk3rcWNxHU8WK6aAMkR/enWY9N17TevQlL7/dG6eyod79+8d3AumUoYS
-        xby6ymv0nN+d5VlZVlP61e/q1kiTbPoQpKHwy2+c/JL/BymctvTQBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aP9g092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
+        +cxBxOMod7Y8rzrfEQIh4Xyw6RBEjyz3t3d3iTJvdvaJJo/2Px3v7d//dGen
+        Sx4iivmVSaR/f5/hfjSpqvZpkV0sq6YtpsBDx0yjXTZVmb+e1nm+bOZV+6Ss
+        Jl/VBTX5aN62q+bR3bvNKp/uNm1V09TujifUYDyt6nx8VSxn1VUzXubtXfQw
+        cz1s453LBWE+uZ/tZfvn27uzTx9s7+/O8u1sd2+6fW93tvNg99OHe5/uEWGp
+        8fZPfrE7vk3rcWNxHU8WK6aAMkR/enWY9N17TevQlL7/dG6eyod79+8d3Aum
+        UoYSxby6ymv0nN+d5VlZVlP61e/q1kiTbPoQpKHwy2+c/JL/B3Aw2gnQBAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:28 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/publicIp100?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4716,11 +5435,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4739,49 +5458,44 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"ae5753ad-843b-447c-ad44-b9866332d3f2"
+      - W/"33d6207d-2ebd-4c2d-88c4-13306af1a1b9"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9b89e9b4-130b-4dbf-85ae-1b194753a39c
+      - f17d8438-f80c-4177-a057-f90c9e4497a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14887'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 86c41dc2-313b-4b85-be1b-6f675c7782fa
+      - 271f6cbd-d436-4c13-b157-23fea58a0b9f
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192128Z:86c41dc2-313b-4b85-be1b-6f675c7782fa
+      - NORTHCENTRALUS:20160119T134948Z:271f6cbd-d436-4c13-b157-23fea58a0b9f
       Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
+      - Tue, 19 Jan 2016 13:49:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1GW339w/1422z7Y
-        vzfZ3t9/MN3OZvv725OHB59+eu/e3uze+d7v+5G+2F6veIi36FTfKKtphhHj
-        rTxr2rX5gkawyuu2oJaPUiagfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZumy
-        Fto+2Jnd37l/f297b+98d3v//qf59mS2d779cLJ7vpvf2z8/z3fsy8XqpFqe
-        FxfrmhFD99+Tr1KDBx47ncVqyu2VePL8v2lS73ZHRB/EUP66sy4P5qY3YfLg
-        q1tMmzzUuLikJmcvj2czogWgfbS7M8Z/+4NNS8NHX+TtvGLaP72mGSqmnVdo
-        QohU9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGU
-        VTZ7kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/q
-        gPBHSAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cVmMrg/
-        7Of6i6HQR7Nl8zpvW5JD0MIOXj6vLwkD+vh7pjl9ka1WZZHPnobfy9eGFz/K
-        l9mkJDF8VtVXWT0j6NTqPCub3LRQbv8im86LJcTfdf3N0fvLL15+9eb0J794
-        HaW3TocRPEVFKe5IyxSjf37J/wOqI1T/tQcAAA==
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWelMX0bLW7s/PR
+        iL8pZvj8brOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3d6afbj88n5xv7+wd
+        7O3Pdmez/YP7d+u8qdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb+8qAi+PZzN6v8kb84mHUt5mF0Dqu3d/34/u3Zt9urfzYLa9
+        l09m2/vTvdn2wcF0f3v33r2dT7Pz3Wx38vD3/UhfbK9XPMpbdKtvlNU0w5Dx
+        Vp417dp8QWNY5XVbUMtHKdNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1ox6E
+        MGsh7s6nBzv5DjDP9ve293fvz7Yfzu4Rce9P7j/Idw7uP7jvXi5WiiPe3N8Z
+        7+7ujw8ejj99YFvYsZQG+y/ydl5xV0+vaaaLqW1bzMr8TbHIq3V7tvyiWK5b
+        HtC+/X51Ui3Pi4t1zYDoKx0rvmOId39YnLGUn2fLNq/PsylxBuHa/v7LYkqc
+        cbeDaHN3UfwifH/2kr79SHD+JfhB//yS/wee5ic69AIAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/testprov100/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4791,11 +5505,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4818,114 +5532,39 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130913295648600367
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
       X-Ms-Request-Id:
-      - 6df2f525-3182-476f-bde7-11c04f04c0bb
+      - 09d59db5-ad0a-43fe-a030-2bbccb633bf5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14886'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 636c6230-426c-4524-8e54-ed59ba1394a5
+      - 2e41d2a1-0a2a-4343-a5dc-13cca3f55191
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:636c6230-426c-4524-8e54-ed59ba1394a5
+      - NORTHCENTRALUS:20160119T134948Z:2e41d2a1-0a2a-4343-a5dc-13cca3f55191
       Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
+      - Tue, 19 Jan 2016 13:49:47 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbu7vb
-        uztvdh8+2tt9tPfwk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
-        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
-        domzs/tmZ//R/oNH9x+Od/Ye7N7ffdAhEpHG/MqE0r+/z3A/mlRV+7TILpZV
-        0xZT4KFjptEum6rMX0/rPF8286p9UlaTr+qCmnw0b9tV8+ju3eV1ffFw92B/
-        PKHvxtOqzsdXxXJWXTXjZd7eBfCZA77dGNpvT2fnO9n5g4fb93b2Z9v7swf3
-        th9Op/e3D+7f353sPpxN850Hd/2pGt/mjXFjkR1PFismgfJF/q6lL4i4GKLO
-        sI6UvjXM8UUxraumOm/HZ9T4Yt4245/8wiPP67xtaXYahkyw8UMJ2WcgB/69
-        GGeIad6fYTYyy+7ezsOdh/sBswitophXV3mNnvO7szwry2pKv/pd3Rpp0gE+
-        BGkohPyNk1/y/wBRIBNE/QQAAA==
+        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
+        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
+        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
+        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrp3/5OdnUc7Ox+Zxr9Efvm+
+        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
+        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
+        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
+        OsD1LXDUebFk+QhI0OcfXc2JDAT+9599mt2/lz/ItqcPzvPt/en5bDvbfzjd
+        Pv9079O9871JvjvLx5dzj1BK7VAsvD7w/GyT3gebDkHssfjBm91PH+09fLR/
+        b7yz/2Dv/qe7HVYn+plfmZr6t7B+ZNx2zO833qGxvv84B8Z4b+fR/v54/+D+
+        w3sPwzEKf0Qxr67yGj3nd1WjeN3cGuGf/MLoI9MhfhAxf8n/A2uYcFGMBQAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"093cb4cf-7a11-4a39-b914-44c8f9b736b0"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 00034cd1-21fe-4c59-99d2-8e514d07308a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14890'
-      X-Ms-Correlation-Request-Id:
-      - e1b424c0-8206-478a-b084-ad377c4a64fb
-      X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:e1b424c0-8206-478a-b084-ad377c4a64fb
-      Date:
-      - Tue, 10 Nov 2015 19:21:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aOfhvelkf3q+/SDb
-        3d3ez+493J483N3f3t+fHpw/nDy49+lk5/f9SF9sr1c8zFv0rG+U1TTDgPFW
-        njXt2nxBw1jldVtQy0cpE1E+vCwaal4sL163WcudvV5Pp3k+y2fyJjWzZFkL
-        aSfZXj69/zDbnt27f7C9P9ufbdNgdrenu/m9B/d2Pp08nOzZl4vVSbU8Ly7W
-        NSOG7r8nX6UGDzx2SovVlNvvGgh4/l80p3e7A6IPYhh/3UmXB1PTmy958NUt
-        Zk0ealxcUpOzl8ezGZEC0D7a3RnvjXfGnw42LQ0bfZG384pJ//SaJqiYdl9Z
-        T8piSm9Y4AGq1OKHN3EdXGjiXtuJ++r12cuPfMx+STgOQo/mnTD9WUP/ZJ6f
-        b7+sq9nGMVwWdbvOSv3Tf4swIAybu7P8PFuXbTgY94f9VX/5vo7zo9myeZ23
-        LbFMMEvyeX1J6NDH3zPN6YtstSqLfPY0/F6+NtT7KF9mk5I45llVX2X1jKBT
-        q/OsbHLTgpDGUF7n03VdtNdMDWrjEPjmKFwtVus2/8kvmo0kjiFE7c5+Qt/f
-        VdLaMeqcfJFN58USsvazgPsgcytShjEUiZC1DcL4Qf/8kv8HyOZAZSMHAAA=
-    http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
@@ -4938,11 +5577,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -4965,20 +5604,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1e38e10f-4e45-48ac-ba5f-c14dd2e3bc31
+      - 42067839-ad65-4db9-9eff-99c1aad7b8c9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 2fa08fdd-5de8-4b71-9ce0-aa7f54e985e3
+      - eeeb1fb0-7667-408a-b585-062d68f4dab7
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192129Z:2fa08fdd-5de8-4b71-9ce0-aa7f54e985e3
+      - NORTHCENTRALUS:20160119T134949Z:eeeb1fb0-7667-408a-b585-062d68f4dab7
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Tue, 19 Jan 2016 13:49:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4995,7 +5634,80 @@ http_interactions:
         VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
         55f8P07bQ1vOAgAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:29 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      X-Ms-Request-Id:
+      - d0d19ece-0219-4150-91e8-0376d2e1ae9c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - b89c5080-b431-423e-b203-90e7df35cd33
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160119T134950Z:b89c5080-b431-423e-b203-90e7df35cd33
+      Date:
+      - Tue, 19 Jan 2016 13:49:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
+        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d3a3
+        dx++2b33aP/ho/u7n+zsPNrZ+cg0/iXyy/fx45cwCCD1FsgoAezwP1pmAvV1
+        VubNeVVP869eu26jtPNex7OBfs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoE
+        0SPO/e3dXaLPm539R/sPHt1/ON7Ze7B7f/dBh0hEGvMrE0r//j7D/WhSVe3T
+        IrtYVk1bTIGHjplGu2yqMn89rfN82cyr9klZTb6qC2ry0bxtV82ju3eX1/XF
+        w92D/fGEvhtPqzofXxXLWXXVjJd5exfAZw74dmNovz2dne9k5w8ebt/b2Z9t
+        788e3Nt+OJ3e3z64f393svtwNs13Htz1p2p8mzfGjUV2PFmsmATKF/m7lr4g
+        4mKIOsM6UvrWMMcXxbSumuq8HZ9R44t524x/8guPPK/ztqXZaRgywcYPJWSf
+        gRz492KcIaZ5f4bZyCy7ezsPdx7uB8witIpiXl3lNXrO787yrCyrKf3qd3Vr
+        pEkH+BCkoRDyN05+yf8DUzAquv0EAAA=
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -5008,11 +5720,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -5033,19 +5745,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14895'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192130Z:c2d2567f-afbf-456a-bff5-3a0de301a5c1
+      - NORTHCENTRALUS:20160119T134951Z:abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Tue, 19 Jan 2016 13:49:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5062,7 +5774,7 @@ http_interactions:
         9H2TTyuQ2X/7u7l5u6E31s2X5y+lB/ouu8yKEqh43742MILvCbE2uwDl8ZvM
         6Y289NEv+f4vSf4fxlUpaegCAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:30 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:51 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts/chefprod5120/listKeys?api-version=2015-05-01-preview
@@ -5075,11 +5787,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
       Content-Length:
       - '0'
   response:
@@ -5102,19 +5814,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - e930cd4e-6abb-4958-910f-4ddb6fc613d1
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - e930cd4e-6abb-4958-910f-4ddb6fc613d1
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192130Z:b9804bc6-acde-42d0-9eaa-543c5544d6b5
+      - NORTHCENTRALUS:20160119T134952Z:e930cd4e-6abb-4958-910f-4ddb6fc613d1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Tue, 19 Jan 2016 13:49:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5127,7 +5839,7 @@ http_interactions:
         Xv/U6ezdu/b3Xk0e/qJqXv7UT7av6x9cXM1/etLunX1n9nufn3y1u/ypqy8+
         P6Yefkny/wD0cfTdxgAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:30 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:52 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/?comp=list
@@ -5140,13 +5852,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Tue, 19 Jan 2016 13:49:52 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:wbgGtIeoc1ovC2HxePvE2aeO5NM4pJteZ6Ll3Rx4oCw=
+      - SharedKey chefprod5120:Wn/jS/g08ttfgc0WTrNy8M5EF7x2P2maxNQ0MKg56JE=
   response:
     status:
       code: 200
@@ -5159,38 +5871,120 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d30b6f0f-0001-0085-1fed-1b0615000000
+      - ced96114-0001-0084-39c0-5207e8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Tue, 19 Jan 2016 13:49:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
         bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jaGVm
         cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyI+PENvbnRhaW5lcnM+
-        PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3MtcG9zdGdyZXNkLWZj
-        ZjNkY2VjLWZiOGQtNDlmNS05ZDhjLWIxNWVkY2ZmNzA0YzwvTmFtZT48UHJv
-        cGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE1IFNlcCAyMDE1IDE1OjU4
-        OjIyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDJCREU2N0I5OTA3
-        MDUiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
-        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
-        cz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPnN5c3RlbTwvTmFtZT48
-        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDI1IFNlcCAyMDE1IDE5
-        OjE4OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDJDNURFMjg1
-        MTdEOTUiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
-        dGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+
-        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOCBBdWcgMjAxNSAx
-        OTozOToxNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQyQTgwNEIz
-        MEU1REJFIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1
-        cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRp
-        b24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29u
-        dGFpbmVyPjwvQ29udGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRp
-        b25SZXN1bHRzPg==
+        PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3MtY2hlZnByb2QtMzlj
+        NTMyMGMtMGIwMy00NmU5LTlmMGYtNDczZWFkNzY4ZmFiPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTIgSmFuIDIwMTYgMTc6NDc6
+        MjEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzFCNzg2QzM0MDc0
+        NSI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNz
+        LXBvc3RncmVzZC1mY2YzZGNlYy1mYjhkLTQ5ZjUtOWQ4Yy1iMTVlZGNmZjcw
+        NGM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNSBT
+        ZXAgMjAxNSAxNTo1ODoyMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4
+        OEQyQkRFNjdCOTkwNzA1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5t
+        YW5hZ2VpcTwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24s
+        IDA3IERlYyAyMDE1IDE2OjA5OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4iMHg4RDJGRjIwQjg2OUJEQkEiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0
+        ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1By
+        b3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5zeXN0ZW08
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyNSBTZXAg
+        MjAxNSAxOToxODo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQy
+        QzVERTI4NTE3RDk1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
+        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
+        L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT52aGRz
+        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTggQXVn
+        IDIwMTUgMTk6Mzk6MTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhE
+        MkE4MDRCMzBFNURCRSI8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFz
+        ZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGll
+        cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
+        dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:52 GMT
+- request:
+    method: get
+    uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-chefprod-39c5320c-0b03-46e9-9f0f-473ead768fab?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:52 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:vXmg5R9ZEAdJtGGP/DN4pkdXNYOFyIgEC8G5deIM2pI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7300f5e7-0001-000c-22c0-52bf31000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Tue, 19 Jan 2016 13:49:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jaGVm
+        cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
+        ZT0iYm9vdGRpYWdub3N0aWNzLWNoZWZwcm9kLTM5YzUzMjBjLTBiMDMtNDZl
+        OS05ZjBmLTQ3M2VhZDc2OGZhYiI+PEJsb2JzPjxCbG9iPjxOYW1lPkNoZWYt
+        UHJvZC4zOWM1MzIwYy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc2Ny
+        ZWVuc2hvdC5ibXA8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        VHVlLCAxOSBKYW4gMjAxNiAxMzo0OTowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDMyMEQ3NEE0MkY4MTU8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        PjYxNDkxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5pbWFnZS9i
+        bXA8L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
+        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1IC8+PENhY2hlLUNvbnRyb2wgLz48
+        Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjA8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
+        Z2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPkNoZWYtUHJvZC4zOWM1MzIw
+        Yy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc2VyaWFsY29uc29sZS5s
+        b2c8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxNSBK
+        YW4gMjAxNiAyMzoyMDo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMxRTAyODEwQUQ0MDI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjE4MjI3Mjwv
+        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZSAvPjxDb250ZW50LUVuY29k
+        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+MDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1h
+        cmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:53 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-postgresd-fcf3dcec-fb8d-49f5-9d8c-b15edcff704c?comp=list&restype=container
@@ -5203,13 +5997,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:49:53 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:xCJMkXlQDd2p0a8vLeFWt0I/iu1NxGqH1JyWwF0Gt3s=
+      - SharedKey chefprod5120:KIZkOAYamkyUfWn88ZF7NJpOUI6zMYi6d5rQf0VkZ6M=
   response:
     status:
       code: 200
@@ -5222,11 +6016,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4f8dc838-0001-0010-19ed-1b6726000000
+      - d46d0cd2-0001-0070-77c0-522204000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Tue, 19 Jan 2016 13:49:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5237,7 +6031,948 @@ http_interactions:
         ZjUtOWQ4Yy1iMTVlZGNmZjcwNGMiPjxCbG9icyAvPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:53 GMT
+- request:
+    method: get
+    uri: https://chefprod5120.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:53 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:3SwJfXwmrsTXN0I6GEf9R50j0CBD96FeDwu92KD//Fc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3a5d73ba-0001-0049-5bc0-5262a0000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Tue, 19 Jan 2016 13:49:53 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jaGVm
+        cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
+        ZT0ibWFuYWdlaXEiPjxCbG9icz48QmxvYj48TmFtZT5yZ3Rlc3QuYWUzMzFh
+        MTQtNWZmNi00MzE5LTg1MTQtMjc3ZTFmYTdhNTFhLnN0YXR1czwvTmFtZT48
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDEz
+        OjQ5OjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRDc2NzlE
+        MUIzNjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+TDJVK0tHVFVPalFnT0lCa0gwOVJ0UT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT5yZ3Rlc3QxMi45M2IzYzhmYS03Yjg1LTQ2NGQtOWRlYS0wZjY3MGIzOTFi
+        NTguc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
+        ZSwgMTkgSmFuIDIwMTYgMTM6NDk6NTMgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMjBENzY4NkQ2QUJDPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5hMFY3VUFMbnRB
+        aVlHYy9EVHBDYUNRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnJndGVzdDEyX2NhZDA5NWRiLThhYjItNGIz
+        YS1hMmRhLWY2OWQwYjlmZDkxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0OTo0OCBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEQ3NjVFNTQ5Rjc8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFz
+        ZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNl
+        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rl
+        c3QyLjM3M2UzNDkzLTA4MGYtNDFlYi04M2NmLTZhN2QxOTlkNGFjMC5zdGF0
+        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOSBK
+        YW4gMjAxNiAxMzo0OTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMyMEQ3NjA5MTQ2M0Q8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkRJOVQxcHBMZTRsSHVHK2VT
+        SW5GZ1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+cmd0ZXN0Ml84MDQ4OTM3Ni03OWZkLTQ0OTgtYjQ0NS05
+        MDc5MzZhZjkxYzQudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPlR1ZSwgMTkgSmFuIDIwMTYgMTM6NDk6NTAgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzMjBENzY2QzJCOTNCPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFz
+        ZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9u
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0X2EwODk3
+        M2MwLTU4M2MtNDlhYy05NzI0LThkNWY2ZTUzZDE5Yy52aGQ8L05hbWU+PFBy
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0
+        OTo1MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEQ3NjhFMzg5
+        Mjg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVu
+        dC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJl
+        YW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
+        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hs
+        dlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1E
+        aXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gt
+        bXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5m
+        aW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT5zZGZzZGYuNTIzOTk1MTQtNDBkZC00ZDgyLWI3MWEtMTIxZjQ1
+        NWRkZGRlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
+        ZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE1OjM5IEdNVDwvTGFzdC1Nb2RpZmll
+        ZD48RXRhZz4weDhEMzAwRTY0NTJBOTBCNDwvRXRhZz48Q29udGVudC1MZW5n
+        dGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
+        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
+        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+c1orZ1V2
+        dHluSzRMUC9YVE9CL3dPdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
+        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZGZzZGZfZmQwNDZiYTUtMmU1Yy00
+        NDhiLWFkNzktNjViNzI2ODEyMTE5LnZoZDwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE4OjE0IEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTZBMTgxNENDMzwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxM
+        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
+        b2I+PE5hbWU+dGVzdHByb3YxLjEwYjM5MjM1LTY4MjAtNDg2YS05ODA3LTI2
+        MmU2NGZkMjJjYi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+TW9uLCAwNyBEZWMgMjAxNSAxNzoxOToxNiBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDJGRjJBODkwNTk0REI8L0V0YWc+PENvbnRlbnQt
+        TGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkNH
+        MGtLYUk4eGpuVW92K09SaS83Rmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9j
+        a0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3YxLjc3Mzg5NGU4
+        LWM0M2YtNDc2Ni04NDk4LTMwMDM3Yzk0NzNlNS5zdGF0dXM8L05hbWU+PFBy
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAwNyBEZWMgMjAxNSAxNzo1
+        OTozMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJGRjMwMjg3RTIw
+        NTA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+
+        PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRl
+        bnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdl
+        IC8+PENvbnRlbnQtTUQ1Pmp0V3lLTDVPNXVNQ3FHYzI4YjVKcnc9PTwvQ29u
+        dGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlv
+        biAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        dGVzdHByb3YxMDAuYmI3ZTU0NzQtMDEwMS00OWQyLWFmODEtMDQ0ZTUyMzFm
+        MWZhLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5U
+        dWUsIDE5IEphbiAyMDE2IDEzOjQ5OjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMzIwRDc2NkYyQTQ4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MWtNUkU2SWlN
+        UklTV0V4eWQvT1Q4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjFfMTdkMjcwZGUtOWM3Yy00
+        YTQwLWFmYmEtMzAxNDUzNjBlODUyLnZoZDwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI4OjU4IEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUVGNzVFMjk4RTwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxM
+        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
+        b2I+PE5hbWU+dGVzdHByb3YxXzI3MGQ1ZDAzLWNmMjYtNDJiMC1hNGYxLWJl
+        YjEwNzc0ODMzMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+TW9uLCAwNyBEZWMgMjAxNSAxODowMTozNyBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDJGRjMwNzM4NjU1NUM8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
+        b2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+
+        dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwv
+        TGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRl
+        c3Rwcm92MV8yODFhZmEwMS04NjQ1LTRjMzMtOWY5YS0wOGIxN2QwZWMxZWQu
+        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkg
+        RGVjIDIwMTUgMTI6NDA6MDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMDA5NURGNzYxQTI0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
+        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
+        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjFfNzMx
+        N2QyZmMtNTVlYS00ZDM5LWFmMzUtZDkyNWIwMGE3YzYzLnZoZDwvTmFtZT48
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDEz
+        OjQ5OjQ1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRDc2NDFB
+        NjUzMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250
+        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
+        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBz
+        SGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+Mjwv
+        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8
+        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5p
+        bmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
+        bG9iPjxOYW1lPnRlc3Rwcm92MV9jMTMxMDAxZS00MWU5LTQ4NDEtYTJlMC0z
+        ZTBlMmEwM2E0MzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjg6NTMgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzMDAxRUY0MDZBM0RBPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50
+        ZXN0cHJvdjFfY2YxNjI2OTctZWY2NS00MDE4LWI5YzItYjk5YmNlYmM1ZjBl
+        LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA3
+        IERlYyAyMDE1IDE3OjIwOjM2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMkZGMkFCOEI2RENGRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3
+        MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
+        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
+        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lG
+        eStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
+        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5j
+        ZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5
+        cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3YyLmFl
+        YWM1YzI1LWJiYjctNDRmZC05OTI5LTg2OGFmODljODhiMS5zdGF0dXM8L05h
+        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAx
+        NSAyMjoyNzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFF
+        QzI4NkNENjI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1M
+        ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
+        L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
+        bmd1YWdlIC8+PENvbnRlbnQtTUQ1PmEyR0ZpMzR4SGhWaVdIeWhPOGdlUHc9
+        PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
+        b3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFz
+        ZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZh
+        aWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+
+        PE5hbWU+dGVzdHByb3YzLjA2ZTkxZWNlLTZmOTQtNDc5YS05ODMxLTkyZTU4
+        ZDNhMGVjNy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyNzoyMCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMwMDFFQkM5RTlCMUI8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkFrS3ox
+        M3Z3RUVReE0zSUh0WFlvQXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3Y0Ljg3MDdkOTkxLWU2
+        MTQtNGE3My04Y2RjLTljNmQ0NWJmNGQwNy5zdGF0dXM8L05hbWU+PFByb3Bl
+        cnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyOTow
+        MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRjhCOUNFMDU8
+        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PjhqdHNidy9Iayt6YXZtaXcvRERnOFE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        PjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
+        ZXN0MTEuMDMwNWUyZjctZDZjZC00NzA1LWI3NmItOTRiYjJkMDdmODI0LnN0
+        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4
+        IERlYyAyMDE1IDIyOjI3OjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMzAwMUVDNTU1QkQ4QTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
+        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
+        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+QlR2T2o1NDQ4SmtGNmNx
+        ZGZHMkdPQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
+        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
+        Yj48QmxvYj48TmFtZT52bXRlc3QxMV8zM2VmZmZkNS0wMzNmLTQ4NWEtYTAw
+        Ni04NzAxMWU2N2E3MWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjk6MDUgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMDAxRUZCMDkwMjYzPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT52bXRlc3QxMi5mMGY4Y2JhNS1jNGNkLTRhNDMtODNjNS03Mjg1ZGExYjMx
+        Yzkuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
+        ZSwgMDggRGVjIDIwMTUgMjI6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMDAxRUMyRDc2MTM2PC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5iUHZMaXBDSjdq
+        NGYyLytMK0JsTHhnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDEyX2QxN2FlZmFjLWZlZWMtNGM1
+        Yy1iYWY1LTM5NWRmYjRiODQ2NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyOTowOSBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRkRBMDhDRjM8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDEzLmVkNWIzYTVkLTc3ODYtNDJjNC1iZjBmLTExNWRl
+        YmU0MTE4My5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyODo1MCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMwMDFFRjIxQTUzNDI8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pm9Fd2s1
+        TnJrakIxR2MwSExnaktMaEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MTNfZDI1NTI0ZjYtOGZj
+        ZC00NjgwLWI0YmYtNWM4NzhmZTg1MmZjLnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjM0OjA2IEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUZBRThDQkM3QTwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0MTUuZTA3OGYyZWItZWY3Yy00MzAyLWIxOWMt
+        ZWNhOTc4NjA0MTM3LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDEyOjU1OjIyIEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzAwOTdGRkU0NDFDNzwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
+        cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
+        LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
+        WTRUbmw4Qjl2OXZWZnB5OElEdHJTZz09PC9Db250ZW50LU1ENT48Q2FjaGUt
+        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
+        b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
+        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QxNV81YThkNGQz
+        NS0wMmQ3LTQ3MzEtOWIwYy0zMzgyMDMyMzE3NmEudmhkPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMTI6NTY6
+        MjIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDA5ODIzOTE1MTEx
+        PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQt
+        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
+        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
+        YW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZR
+        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
+        cG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT52bXRlc3QxNi5iYWUzNDZlYi1hM2MwLTQ0NDYt
+        OTU4MC1jZTI0NzdlMzc5MDQuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMTU6Mjc6NDcgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBBRDRCMDcwNjU3PC9FdGFnPjxD
+        b250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5sQkhac1RBYWQ3a2JCVkxzVzl1R1lBPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5
+        cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE2X2Rk
+        YWM2YTM0LTRmYmYtNGIxOC05MmY1LWVjNTk1MDRkNjRmYS52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAx
+        NToyOTo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEFEOTc5
+        MDFDMjM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
+        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE3LjdmMjVhOTk5LTJmYjYt
+        NDBjNS05NGY4LTlkYjVlYTAwOGU3Yi5zdGF0dXM8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAxNToyNzo0OSBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEFENEM1REVGNjg8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1PnBVd2xtQTA1TnA2NTVISXB3VHBkY0E9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
+        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
+        MTdfMTZkNWQxYzktZTEwZS00ZmU0LTg1MGEtM2YxMDYxMmVhM2U5LnZoZDwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAy
+        MDE1IDE1OjI5OjUyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAw
+        QUQ5NTVENEE2NTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
+        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MTkuMTcxNzg3YjUt
+        NTI2OS00NTViLWFmMzQtOTU2MzU5MjIzMThhLnN0YXR1czwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDE1OjQ2
+        OjE3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwQUZFMDNCNUQ4
+        QTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+ekZIZ1hsSE02NnZoTk84WlhMbVUvUT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
+        bXRlc3QxOV81ZTE4Y2U1YS05NGIzLTQ1ZWItOGUxNS0yYTRkNzFlZjBhMTku
+        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkg
+        RGVjIDIwMTUgMTU6NDc6NTkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMDBCMDFENDkwRjE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
+        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
+        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyMS4xNmEx
+        NWQ5ZS1hMjI2LTRiOTYtYjNhNS01ZWFhZDEyNzZjODYuc3RhdHVzPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUg
+        MjE6MDA6MTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBEQkJE
+        QTcyNTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
+        Z3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9D
+        b250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5n
+        dWFnZSAvPjxDb250ZW50LU1ENT5YcTFHZTNXaWJrNnBpdlR6dlgrMGVBPT08
+        L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9z
+        aXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VT
+        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
+        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
+        YW1lPnZtdGVzdDIxX2VlZDBkNGUzLWIxZTktNDZmNS05YzMxLTNhNjllMjEz
+        ZjgwOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2Vk
+        LCAwOSBEZWMgMjAxNSAyMTowMjo1MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0
+        YWc+MHg4RDMwMERDMTk4RTI5Q0M8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEz
+        NjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pnlm
+        ckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
+        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDIy
+        LjY5MTU4OTJjLTRmYjEtNDkxYi04MThhLWFjY2M2YTQ1NDQ3OS5zdGF0dXM8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMg
+        MjAxNSAyMTowMDoyMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMw
+        MERCQkZCOTlCQjc8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVu
+        dC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJl
+        YW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
+        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnNkUEFTS21JMmRYRGJZcjkxd2Rw
+        RkE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1E
+        aXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxM
+        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
+        b2I+PE5hbWU+dm10ZXN0MjJfMGMzMTUzYzMtOWNlMC00ODE2LTljMjMtZjc5
+        NThkNWYyNTUyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
+        ZD5XZWQsIDA5IERlYyAyMDE1IDIxOjAyOjIyIEdNVDwvTGFzdC1Nb2RpZmll
+        ZD48RXRhZz4weDhEMzAwREMwODU1N0Q1MTwvRXRhZz48Q29udGVudC1MZW5n
+        dGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
+        ZXN0MjMuYmFkMzZkYTgtMjgzNi00NzVlLTlkMzAtMGFlNGNiYTk4N2M1LnN0
+        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5
+        IERlYyAyMDE1IDIxOjAwOjE2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMzAwREJCREEyQjgzMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
+        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
+        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WHExR2UzV2liazZwaXZU
+        enZYKzBlQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
+        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
+        Yj48QmxvYj48TmFtZT52bXRlc3QyM19lNDFjMTQ4Ny0wMDg3LTQ5ZDYtOTQ0
+        NS1lZTBlYTI5N2QyNzgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjE6MDI6MDcgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMDBEQkZGQkQ1OTZGPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT52bXRlc3QyNS5iMjY3ZmYwNS1jODEzLTQ1MmUtODc2YS04YmNiYjdiMTE0
+        OTEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldl
+        ZCwgMDkgRGVjIDIwMTUgMjI6MTU6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMDBFNjNFRUEyOTUxPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5CWEVEQzA5VkRD
+        NWdFSzFpbWVWdmdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI1XzY3N2ViMTE1LTdjZDYtNDU2
+        Yy1iYzc5LWNkNGU3MmE5MDYyMC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMjoxNzo1OCBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEU2OTg2Q0VCRDg8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDI2LjJlZDg2YTQ1LWZlMTQtNDAyMi05ZDk1LWFmNWFi
+        ODk4NTliMy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMjoxNToyNCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMwMEU2M0M5MUYzRkQ8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlFSdits
+        d25XNERGeWUxNDc0M1RSNEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjZfODExMjZlMTgtODdi
+        YS00ZmNiLWI3YzEtOWZlZmRkMDM0MDY1LnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE4OjA1IEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTY5QzY5MUJDMjwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0MjcuMmYxZjA2ZDItOTM2Mi00YTY5LWJjMTIt
+        YmE4OGNmMGQwZTdkLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5GcmksIDExIERlYyAyMDE1IDIxOjM5OjE0IEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzAyNzM4M0RBOTBENjwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
+        cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
+        LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
+        bkhRSGhjRkJmSTZYb3hMb2VPUjhLUT09PC9Db250ZW50LU1ENT48Q2FjaGUt
+        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
+        b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
+        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyNy5hMTRmMmMz
+        Ni0xNmNmLTRiODAtYjY0MC04MmMxNjcyYzAyYjcuc3RhdHVzPC9OYW1lPjxQ
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjI6
+        MTU6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBFNjNEOEY0
+        ODQxPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT5TdVNaY1ZQSmZzd2FudjhqN1o4RFVBPT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
+        PnZtdGVzdDI3XzFiNzJmZTdmLTM4MGMtNDliNy05NTU1LWEyZTI1NjVhN2Vk
+        YS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAw
+        OSBEZWMgMjAxNSAyMjoxODowMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
+        MHg4RDMwMEU2OUExNTUzNDE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2
+        NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJ
+        RnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVu
+        Y2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JU
+        eXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI3Xzk3
+        ZWUyZjViLTdiZmUtNDJjYi1hYmI1LTIzM2Q3YzdiYWUzOS52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxMSBEZWMgMjAxNSAy
+        MTo0MToyMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMjczQ0VB
+        Q0U2RTI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
+        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI4Ljg3MWEzMjIyLWMwZjYt
+        NGQ4YS04OWM2LTdhNzkyNDRkOGJhNi5zdGF0dXM8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNDowNiBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ1RURGRjVFNUY8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1Pkc3MDMrMTJkQUVGVExUcjJZVFRpMWc9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
+        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
+        MjhfYmU5YjFmY2UtNWEwNy00ZWI0LTg3ZTktNjQyY2E4NTg1M2UxLnZoZDwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEphbiAy
+        MDE2IDIwOjE2OjMyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzE2
+        RDY0NEFCRERFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
+        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjkuYzk3OTZmMzMt
+        NzRjNS00ZWE5LWJkNTMtZDJhYTNhMjBhMjQyLnN0YXR1czwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEphbiAyMDE2IDIwOjEz
+        OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzE2RDVFODEwOUVB
+        RjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+T2RUbFpjYkpyZTAwYTgzbHNtUHl6Zz09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
+        bXRlc3QyOV8wMTZmOTk5NC1jMDkwLTQwM2ItYjMxZi0zOThlMjg0ZTlmOTUu
+        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYg
+        SmFuIDIwMTYgMjA6MTY6MTMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMTZENjM5OURDMzc3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
+        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
+        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QzLjhmMWQ0
+        YTY3LTEyYWUtNDliYi1hZmY1LWVmNTdjZGYyNjI0Ny5zdGF0dXM8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAy
+        MjoyOTo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFGMTBE
+        Mzc0REI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5n
+        dGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0Nv
+        bnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1
+        YWdlIC8+PENvbnRlbnQtTUQ1PnFGeXBPNGFvUFpSQWFZQTBycHVDV0E9PTwv
+        Q29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3Np
+        dGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0
+        YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxh
+        YmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5h
+        bWU+dm10ZXN0MzIuNzkzNzMyMDQtNzMyMy00MThiLWEzYjctZGRmYzVmYjIz
+        ZWI5LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5X
+        ZWQsIDA2IEphbiAyMDE2IDIwOjE0OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMzE2RDVFREQyQTc3QTwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODdsVkNkZkRk
+        eWFxRk1UU2cyL1NaUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QzMl9iZGI0OThiYy0wZGZhLTRh
+        ZTAtYWEyYi0xNzUwMDA1NmRmZTMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTY6MjIgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENjNGMzlBNTc3PC9FdGFnPjxD
+        b250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxD
+        b250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50
+        LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAv
+        PjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRl
+        bnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24g
+        Lz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExl
+        YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
+        dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT52bXRlc3QzXzYzNWY0ZDc5LTNhYjctNDIyYi1hZDg2LTY0NDMz
+        Y2QxMWRjZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        VHVlLCAwOCBEZWMgMjAxNSAyMjozMTo0MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDMwMDFGNTkzRTc5REI8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        PjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
+        cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
+        dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
+        PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hl
+        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
+        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
+        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVz
+        dDQwLjAxY2U1ZWZmLWQ0NDgtNDY3NS04MzQxLWY3OTM0NGIxNWRkOC5zdGF0
+        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBK
+        YW4gMjAxNiAyMDoxNDo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMxNkQ2MDJCMjgxODA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmNveTVieDhnZW12QTA1eDk3
+        Z2d0ZVE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0NDBfMTgyZjQxMDQtMDRjMi00N2VjLWI1MTct
+        MTczMmMyODZmYjkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
+        ZmllZD5XZWQsIDA2IEphbiAyMDE2IDIwOjE2OjQ0IEdNVDwvTGFzdC1Nb2Rp
+        ZmllZD48RXRhZz4weDhEMzE2RDY0QzRDMDUzNDwvRXRhZz48Q29udGVudC1M
+        ZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
+        eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
+        b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
+        dC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48
+        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMt
+        YmxvYi1zZXF1ZW5jZS1udW1iZXI+NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51
+        bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        dm10ZXN0NDEuMjYzYmY4MWUtYWU5OC00ZjE2LTk0NGUtNzA0MTkzMjdiNjhi
+        LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQs
+        IDA2IEphbiAyMDE2IDIwOjE0OjA0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4weDhEMzE2RDVFQ0MwRTA2NjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eFVJMUNoRFlSZDg4
+        dW9hVmtyVDBFUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT52bXRlc3Q0MV8xYTcyMjFhMS03YzRjLTRmYjYt
+        ODI5OS1mN2Q5NWM0NGZjZTYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTU6NDggR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENjJBREY1MzcxPC9FdGFnPjxDb250
+        ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250
+        ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5
+        cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxD
+        b250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQt
+        TUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
+        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVu
+        Y2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNl
+        U3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFp
+        bGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48
+        TmFtZT52bXRlc3Q0Mi4wNjhiMjZiNS01MmRhLTRiMmYtYjljNC03NGM4OWZj
+        NjMzZmEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
+        PldlZCwgMDYgSmFuIDIwMTYgMjA6MTQ6NTUgR01UPC9MYXN0LU1vZGlmaWVk
+        PjxFdGFnPjB4OEQzMTZENjBBRTZENzRGPC9FdGFnPjxDb250ZW50LUxlbmd0
+        aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5xR1ErS1ZZ
+        VW1OOC81anErMTIwc0J3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQyXzRmZDk5YWExLTY0MGYt
+        NDc2Mi1iYmI0LWQwNDZlMDAwMmQ3NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+
+        PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNjozOSBHTVQ8
+        L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ2NDhGRDMzQzE8L0V0YWc+
+        PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+
+        PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRl
+        bnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdl
+        IC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29u
+        dGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlv
+        biAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1z
+        ZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48
+        TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
+        bG9iPjxOYW1lPnZtdGVzdDQ1LjFjYzY4NmZjLTRhYmEtNDdhNC1iMzdjLTAx
+        NDdlNDM1ZjMyZi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowODowNyBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDMxQUE5QzY4NkM3REY8L0V0YWc+PENvbnRlbnQt
+        TGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlU
+        aTQvaUhHNWloWHlwRHY0Sm5CK0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9j
+        a0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NDVfZDQ2YTM2MjQt
+        ZDA5Yi00NjM1LThiMTktMDg3MzkzNGM5ODcxLnZoZDwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA5OjM0
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlGQTg0NkU2Mjwv
+        RXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxl
+        bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
+        Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
+        Z3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09
+        PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
+        c2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NDwveC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JU
+        eXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNl
+        U3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Js
+        b2I+PEJsb2I+PE5hbWU+dm10ZXN0NDYuY2JlODcwOTEtZDk1NS00MzRmLTll
+        MzctMTE4NTk4ODdmMWY4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFz
+        dC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA4OjAxIEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlDMzZDOUNCODwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+Ny9mKy8zdlVGMUU1R1crUkdlZ2FSZz09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBl
+        PkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0Nl9iOTU4
+        Yjg0ZS01YjE2LTRmMjYtODZhOS00MDQxNzZhYzc5MTUudmhkPC9OYW1lPjxQ
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6
+        MDk6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFBQTA4Qzk2
+        NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRl
+        bnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3Ry
+        ZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVu
+        dC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNI
+        bHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQt
+        RGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94
+        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0Ny5jMmViN2ZiZS0xYWQxLTQ0
+        NDEtYWM4NS05ODA0N2NmZWFiYWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6MDc6NDUgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFBOUI5OTJFREI1PC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT5COXk3NmUzUmVWMXZLT09iL0VzK1lnPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48Qmxv
+        YlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQ3
+        XzU1YzQ3NmM4LTMyNDYtNDZjNC1hMTQxLWY3M2NiMWI4NTJjMS52aGQ8L05h
+        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBKYW4gMjAx
+        NiAxNzoxMDoyMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxQUFB
+        MTZCRUIxRDI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwv
+        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
+        dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
+        b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2
+        MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
+        dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
+        PjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VC
+        bG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3Bl
+        cnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDUuOTU5ZmFjMzItNzlk
+        Ni00OGQzLThkZGQtNzAzNzRlNWNkYzhlLnN0YXR1czwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI5OjE1
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUYwMTBBRDgxRDwv
+        RXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29u
+        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
+        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
+        Q29udGVudC1NRDU+bUtWclI1OTFYbDJLMG9qSXE2S3ZPdz09PC9Db250ZW50
+        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
+        PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
+        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
+        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRl
+        c3Q1NS5iMmM3NWNlYS0zYzNlLTRiNGEtYWI3Yi1jNzMyZGM1YzZiOTkuc3Rh
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEg
+        SmFuIDIwMTYgMTc6MDg6MDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMUFBOUM0QjY4Q0FEPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5MYjJ0MzJFM1IwcXJ4aDF5
+        VHl4bUdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjxCbG9iPjxOYW1lPnZtdGVzdDU1X2Q4MmMxYzEzLWYyMGMtNGI1My1hZGY5
+        LWVmOTZjNWI1MDRmMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowOToyOCBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDMxQUE5RjZCODJCOTY8L0V0YWc+PENvbnRlbnQt
+        TGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
+        PnZtdGVzdDVfMGQ2NGZkNzAtYTM4NS00OWQxLWE0OTktZTQyNTA2MDYxMzA0
+        LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4
+        IERlYyAyMDE1IDIyOjMwOjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMzAwMUYzNzY5NTZERDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3
+        MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
+        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
+        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lG
+        eStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
+        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5j
+        ZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5
+        cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0Ny4xYzAx
+        YWY2Yy1jNDdlLTQ3M2ItOThiMi00ZWE4MzcxODNkMTYuc3RhdHVzPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUg
+        MjI6Mjk6MzIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRjBC
+        Qjc0QzI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
+        Z3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9D
+        b250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5n
+        dWFnZSAvPjxDb250ZW50LU1ENT5pekd4c2FPY2plTTNvQnZuT2lSNm1nPT08
+        L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9z
+        aXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VT
+        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
+        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
+        YW1lPnZtdGVzdDdfODhjODlhZmMtMTZmNy00NmJmLWEyOTAtMGZjYmZmN2Jh
+        YTEwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUs
+        IDA4IERlYyAyMDE1IDIyOjMxOjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4weDhEMzAwMUY0QzQxQkZGNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2
+        MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxp
+        Y2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVu
+        Y29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZy
+        Q0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29u
+        dHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
+        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
+        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
+        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAv
+        PjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:54 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/system?comp=list&restype=container
@@ -5250,13 +6985,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:49:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Xh45YfOojfHpS9vPybOLRReme6kYfx1EA69yuR8P0oE=
+      - SharedKey chefprod5120:jq8u8LeebTB/a7Cei9RwEkI0Cpe0xiVjKxQbPyNiIIo=
   response:
     status:
       code: 200
@@ -5269,11 +7004,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 175acb5c-0001-0050-57ed-1b4ec8000000
+      - 5963d4a9-0001-0072-07c0-5220fe000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:29 GMT
+      - Tue, 19 Jan 2016 13:49:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5360,7 +7095,7 @@ http_interactions:
         cm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVt
         ZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:55 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5373,13 +7108,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:49:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:9B+LOUYDtfXxHG/9IixpVFI5svFqK4zjhG3LRuTmmvI=
+      - SharedKey chefprod5120:BRDrZ8t8cv3RDlmYRV4BT8+yL/pMfbatW3rC8ENjMl8=
   response:
     status:
       code: 200
@@ -5392,11 +7127,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d2491dff-0001-0011-1aed-1b66db000000
+      - 8f656615-0001-005f-5ac0-52a33e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:30 GMT
+      - Tue, 19 Jan 2016 13:49:55 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5405,56 +7140,2267 @@ http_interactions:
         cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
         ZT0idmhkcyI+PEJsb2JzPjxCbG9iPjxOYW1lPkNoZWYtUHJvZC4zOWM1MzIw
         Yy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc3RhdHVzPC9OYW1lPjxQ
-        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTggQXVnIDIwMTUgMTk6
-        Mzk6MTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQyQTgwNEIzMDUy
-        MTFBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4wPC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+MUIyTTJZOEFzZ1RwZ0FtWTdQaENmZz09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5D
-        aGVmLVByb2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
-        PlR1ZSwgMTAgTm92IDIwMTUgMTA6MTQ6MDIgR01UPC9MYXN0LU1vZGlmaWVk
-        PjxFdGFnPjB4OEQyRTlCN0E4NEY1M0JBPC9FdGFnPjxDb250ZW50LUxlbmd0
-        aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
-        cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
-        dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
-        PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hl
-        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
-        c2VxdWVuY2UtbnVtYmVyPjQ8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
-        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9j
-        a2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3Rh
-        dGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Q
-        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5Qb3N0Z3Jlcy1EZXYuZmNm
-        M2RjZWMtZmI4ZC00OWY1LTlkOGMtYjE1ZWRjZmY3MDRjLnN0YXR1czwvTmFt
-        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDI1IFNlcCAyMDE1
-        IDE3OjIyOjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkM1Q0RF
-        QTMyRjQyQjwvRXRhZz48Q29udGVudC1MZW5ndGg+ODA2PC9Db250ZW50LUxl
-        bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
-        Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
-        Z3VhZ2UgLz48Q29udGVudC1NRDU+cElhQ0xhZi9vS2ZVei96M1k1WW5zQT09
-        PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
-        c2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNl
-        U3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFp
-        bGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48
-        TmFtZT5Qb3N0Z3Jlcy1EZXYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
-        LU1vZGlmaWVkPkZyaSwgMjUgU2VwIDIwMTUgMTc6MjI6NTEgR01UPC9MYXN0
-        LU1vZGlmaWVkPjxFdGFnPjB4OEQyQzVDREYwRjJGMDhBPC9FdGFnPjxDb250
-        ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250
-        ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5
-        cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxD
-        b250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQt
-        TUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
-        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVu
-        Y2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNl
-        U3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2Vk
-        PC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1
-        cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtl
-        ciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMTMgSmFuIDIwMTYgMTI6
+        NTg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUMxOTQ4RTlE
+        RDc0PC9FdGFnPjxDb250ZW50LUxlbmd0aD40MzU8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT4wZ3Y2NmFuTzFTcktKYnIvQjNaV2Z3PT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
+        PkNoZWYtUHJvZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0Njo0NSBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMyMEQ2RjhCM0Q2Njc8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VT
+        dGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48
+        L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPlBvc3RncmVzLURldi5m
+        Y2YzZGNlYy1mYjhkLTQ5ZjUtOWQ4Yy1iMTVlZGNmZjcwNGMuc3RhdHVzPC9O
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjUgU2VwIDIw
+        MTUgMTc6MjI6NDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQyQzVD
+        REVBMzJGNDJCPC9FdGFnPjxDb250ZW50LUxlbmd0aD44MDY8L0NvbnRlbnQt
+        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
+        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
+        YW5ndWFnZSAvPjxDb250ZW50LU1ENT5wSWFDTGFmL29LZlV6L3ozWTVZbnNB
+        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
+        cG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPlBvc3RncmVzLURldi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+RnJpLCAyNSBTZXAgMjAxNSAxNzoyMjo1MSBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJDNUNERjBGMkYwOEE8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFz
+        ZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNl
+        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFy
+        a2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Tue, 19 Jan 2016 13:49:55 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/sdfsdf_fd046ba5-2e5c-448b-ad79-65b726812119.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:55 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:BVCLX5HRQNBLxWz3qrdZACc5k5uHlmuvjtoSwZ/IXug=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 22:18:14 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300E6A1814CC3"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - cea95837-0001-0087-5fc0-5204ef000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 3d846f20-0ebe-42c1-ad11-e3fdf6eaee7e
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5K89pQuNKK7a8Y4LldpVipoH4KpKUCYC0oFnJgNcZ6o%3D&st=2015-12-09T20%3A32%3A48Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 20:47:48 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:55 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:56 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_17d270de-9c7c-4a40-afba-30145360e852.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:56 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:B8qIH2VD+KPkXRB2NYFPw0RU7F5+6kLA6i8JqL0NAeM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:28:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001EF75E298E"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f7cb3bc8-0001-0023-1dc0-523e0b000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - a6f4659b-a1c8-41ff-b916-13700cb2eb0d
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=vcb%2Fb%2FZnnOandwg0LKqj83nl59sa589UyKWKji8fi34%3D&st=2015-12-07T17%3A45%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 07 Dec 2015 18:00:15 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:56 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:56 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_270d5d03-cf26-42b0-a4f1-beb107748332.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:56 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:pK3DwLyCbn1pw9UqU7uew8dayXZdAiqRvgadEIk7iYE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 07 Dec 2015 18:01:37 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D2FF307386555C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d7c49691-0001-0060-67c0-5214e2000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - c304e804-ca2a-4a99-91ad-df1f5012c0ec
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=drDSzIrz18NpBRDCuSUg9xYsRpesSHXthjl0mC3m1b8%3D&st=2015-12-07T17%3A06%3A27Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 07 Dec 2015 17:21:29 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:56 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_281afa01-8645-4c33-9f9a-08b17d0ec1ed.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:57 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:/SgePpSRDjF/aVr8x2N3B0Q0aYrw7OIX5SstEMOqT6g=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 12:40:08 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D30095DF761A24"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 8c343760-0001-0038-5ec0-521099000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - dec56065-3d49-45d2-bb4c-060e6c642202
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=l%2FXSrXQL2bVaC2MO9GJY7%2F6f3YPZaLsPw5zQmck4ejw%3D&st=2015-12-08T20%3A11%3A26Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 20:26:26 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:57 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_c131001e-41e9-4841-a2e0-3e0e2a03a432.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:57 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:73VV/hWV6bvCieHp/681+Zz3ku7kNRcAXvEzwlxPQjs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:28:53 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001EF406A3DA"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e4f2e680-0001-004c-03c0-5296df000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 23f2876b-42f1-4fbb-9223-b398ba9cd2a7
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=Ygeg1HmOQ4HzjGtpcxXlNapZ8C6fyoCpWnHdN5GJkaw%3D&st=2015-12-08T20%3A09%3A26Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 20:24:28 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:57 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_cf162697-ef65-4018-b9c2-b99bcebc5f0e.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:57 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:W4s/7orlkO/cox4VOfHNUzRtNFsufXhrSKWELrK3Bdo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 07 Dec 2015 17:20:36 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D2FF2AB8B6DCFF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - eb6df35d-0001-0024-6cc0-52c88e000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - e53c26d5-55a7-4a16-9d80-42c6b560bac7
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=Z9owrGbbsKE2lA2itp%2Bdl0RvgINCF05zSi5XCFRmozE%3D&st=2015-12-07T15%3A53%3A59Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 07 Dec 2015 16:09:03 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:58 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:58 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest11_33efffd5-033f-485a-a006-87011e67a71c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:58 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:YNkgD2Paq/87r852oNvMMYq+AfShkIPajGVcPIQlJf8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:29:05 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001EFB090263"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4c2903a8-0001-0088-75c0-52e919000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 64458afc-0ce5-4497-800a-79acbe081ac6
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=ujKuABV1IghJtny1F%2FBugcbYeocv%2BreVzGpH0dJAAg0%3D&st=2015-12-08T20%3A26%3A36Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 20:41:38 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:58 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest12_d17aefac-feec-4c5c-baf5-395dfb4b8465.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:58 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:KkJxr0o/oDIt9uGwFYgW2niUdfJC7OD0vWoVCGJC7pg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:29:09 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001EFDA08CF3"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 010266da-0001-0061-3dc0-52151f000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - ef7efb86-bb86-4e41-8d8d-d9c581002a4e
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=IkmKeQEnTkz%2FYn5kZK85IJ%2BE3e7hPiuHQPh4gxVfiX0%3D&st=2015-12-08T20%3A35%3A50Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 20:50:52 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:59 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest13_d25524f6-8fcd-4680-b4bf-5c878fe852fc.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:Okzq3NuV22OqGwv3H4/zHU7vVp3wFwAO99SKOJqQOLg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:34:06 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001FAE8CBC7A"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 85c659eb-0001-0075-60c0-52d67b000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 846a27b4-fa02-4493-a3cc-8a50df373a1a
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=xygq7agHNiTec4Qkzg%2Fwc8Bmp0HFM5WQf7E1kk%2B0Vrc%3D&st=2015-12-08T20%3A43%3A37Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 20:58:39 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:49:59 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest15_5a8d4d35-02d7-4731-9b0c-33820323176a.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:vZfai0u6TdZaO+Rs+P0MwpGMLCXjWDl3cqonx4F8Zxg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 12:56:22 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3009823915111"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d89c237d-0001-004d-67c0-529722000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 3627302d-275b-4fde-a196-e8c800dca40d
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=QXjqcV%2BfSzI7TBpywxkYszobHN%2FoK2%2F4REt2ZTUCcLY%3D&st=2015-12-09T12%3A28%3A35Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 12:43:35 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:49:59 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:00 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest16_ddac6a34-4fbf-4b18-92f5-ec59504d64fa.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:00 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:E5ewjmOXbqXajwtV9jSFeBLsWavAZQ5P4ngioet/5V8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 15:29:56 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300AD97901C23"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bb827bdd-0001-0039-16c0-521164000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - ce10df30-8aef-4323-98df-8b339be026c2
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=%2FZom%2Fp%2FRpa%2FVAS5IKXbL1JR9m7d4M8NPeqQj1SU4LHA%3D&st=2015-12-09T12%3A44%3A28Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 12:59:28 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:00 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:00 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest17_16d5d1c9-e10e-4fe4-850a-3f10612ea3e9.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:00 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:zIUryFCfolhQx6qoY3f7q9PLJsK6eYo9SO63rMLhrm0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 15:29:52 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300AD955D4A65"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d6e484a1-0001-0089-41c0-52e8e4000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 780593fa-f574-4196-9334-dedd3950e697
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=%2FIfF7Ax9XbdZQCpBmOT8fxVuqSNseMt5xmD9cVhUYD0%3D&st=2015-12-09T14%3A40%3A40Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 14:55:40 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:00 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:01 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest19_5e18ce5a-94b3-45eb-8e15-2a4d71ef0a19.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:01 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:qgUKAYW5IHvRldDbIueszd8ankOQIAZ9QkUWBmI6+f4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 15:47:59 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300B01D490F15"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - ef6fda14-0001-003a-28c0-521263000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - db1fc25a-e2fe-4fbb-bf15-37c1e27cfd06
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=k0Z0laUMGfMDhg641Npknm82YhhwlvZwJy2GLUi4GXo%3D&st=2015-12-09T15%3A21%3A52Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 15:36:54 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:01 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:01 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest21_eed0d4e3-b1e9-46f5-9c31-3a69e213f808.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:01 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:tTUQ8VaJOJrjNqoSKEFuOG+ReMUO/drq6SFq5Z84wEw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 21:02:51 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300DC198E29CC"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - a3e40ce1-0001-0076-5ac0-52d57c000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - f850a4ed-c743-41a4-8a00-f3fefcc501e5
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=1mpE9VSWbqDG7BqS3vH2ZGcJkkweThc2VDTzrLyLNVs%3D&st=2015-12-09T15%3A53%3A42Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 16:08:42 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:01 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest22_0c3153c3-9ce0-4816-9c23-f7958d5f2552.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:02 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:EVkBoCskM/g8pu1gEZlGcj1SdrgFUxDz4QYsYdu3zCM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 21:02:22 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300DC08557D51"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 8483e544-0001-0026-08c0-52ca74000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - b2a5455f-ec0f-4849-b2ab-b49b06179d84
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=DoK24GrEitLVi0lFOJodmBS0hUZ4vrdtNOfaa26D7X0%3D&st=2015-12-09T19%3A34%3A14Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 19:49:17 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:02 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest23_e41c1487-0087-49d6-9445-ee0ea297d278.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:02 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:Xyjz4VQzep/66xd3kgRIovhuCflqaNbHJxQNNGMaWrw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 21:02:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300DBFFBD596F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 254a33e3-0001-0012-22c0-5265dc000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - b2b07b0f-7362-481d-8d7b-bbc207859fe7
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=pj9up7Ms00l8eMhWbqObllZzJIOoD%2FickibkXpQP5uc%3D&st=2015-12-09T19%3A43%3A36Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 19:58:37 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:02 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest25_677eb115-7cd6-456c-bc79-cd4e72a90620.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:02 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:f1T2ld1mHldKBdcpKy7oxeE+RbV84ABKIjZkhEQhZ6A=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 22:17:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300E6986CEBD8"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 957b2fc8-0001-004e-3ac0-529425000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 2eb61cd1-1a1f-451b-aa72-5ecfc6a7732f
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=Bk5xnl5SM5nIPuCDsAN%2Ff4fkbiGiShFiON6wn0zzL10%3D&st=2015-12-09T20%3A39%3A01Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 20:54:00 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:03 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest26_81126e18-87ba-4fcb-b7c1-9fefdd034065.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:03 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:gmY10+HCIQG2QfGOb6h1zY/JjL9TcgF/GdT7XFB7/r8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 22:18:05 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300E69C691BC2"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d21f48df-0001-0062-55c0-521618000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 6c54a8ee-f6cb-4758-a663-86bd9dd5d8d7
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=whHlJGE5RPmR32ZF1ceXheXv%2Bw86gpUjCe8IJbIsOfk%3D&st=2015-12-09T20%3A59%3A03Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 21:14:04 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:03 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest27_1b72fe7f-380c-49b7-9555-a2e2565a7eda.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:03 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:JHJ4mQLP3RH6eFUTu/17UK/DtoKku13SHw4p1tYHcoQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 09 Dec 2015 22:18:01 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D300E69A155341"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 558b1ddf-0001-003b-4fc0-52139e000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 7bcb6ca3-9acd-4129-83af-ff074dda1d89
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=7ioLfwfljEvpt9dJF2OZnAhJSvqlvBLUTPC%2F6sRrcX4%3D&st=2015-12-09T21%3A20%3A40Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 21:35:44 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:04 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest27_97ee2f5b-7bfe-42cb-abb5-233d7c7bae39.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:04 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:beV05QK6xZxHqjEAP20kWbifQiGq1PMshuLhmnGj2go=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Fri, 11 Dec 2015 21:41:20 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D30273CEACE6E2"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - ec551915-0001-0027-7fc0-52cb89000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 1d8f191c-85ac-437a-ae82-87e27b83f6a9
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=3gsOQDWfxFyCPcTLS28IDuCZtIG%2BVR81KFzslaSs5mE%3D&st=2015-12-11T20%3A12%3A47Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 11 Dec 2015 20:27:49 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:04 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest28_be9b1fce-5a07-4eb4-87e9-642ca85853e1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:04 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:+Zc1hXQI43rcsvWDA7FJ7Pvrb3vZPR0zFTf9OzsPK+0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:16:32 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D644ABDDEF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 39660048-0001-0063-78c0-5217e5000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '6'
+      X-Ms-Copy-Id:
+      - c85e6e3a-026e-4919-9440-b09f423ed33a
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=%2FDF3qA1dMsXjVIbPfgYuMID%2FoetPxfqnfIOGuhM%2BA7o%3D&st=2015-12-09T22%3A00%3A09Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 09 Dec 2015 22:15:13 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:05 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest29_016f9994-c090-403b-b31f-398e284e9f95.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:05 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:WUylYhN12yeG1bDuChHb4iATMBWQO5MJ/v0EYrCsHsU=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:16:13 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D6399DC377"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 98840223-0001-0077-23c0-52d481000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '5'
+      X-Ms-Copy-Id:
+      - dc0e72ee-d359-46ef-924b-31a84c2c5551
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=Pm2q715OKNq1r9kWeIkHkOulC1ZPO4ydlOeyhvUtm3Q%3D&st=2015-12-11T21%3A24%3A50Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 11 Dec 2015 21:39:51 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:06 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:05 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest32_bdb498bc-0dfa-4ae0-aa2b-17500056dfe3.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:05 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:xa2l0SKt6nOG+IccgoXxgRyrScUIRZGAdKiaMWXB4uY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:16:22 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D63F39A577"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d1df53e8-0001-0013-7ac0-526421000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 05ffd2ac-0737-4893-b955-1b25214df860
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=RCdUFmgXKM65c3T5%2F30%2B8RsL2tKejV71iOJ8j%2BxKyzo%3D&st=2015-12-21T18%3A44%3A19Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Dec 2015 18:59:20 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:05 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:06 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest3_635f4d79-3ab7-422b-ad86-64433cd11dcd.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:06 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:quVE3hov+Sf1Mfc09IPYoHlMOkYNNFE0cptcoTk/o2Q=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:31:43 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001F593E79DB"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f2ab6c09-0001-004f-60c0-5295d8000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - cc959f61-94e4-4f16-a898-c5e38019a122
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=M7H6WAVO6hC0moA4aqh0lXP0INfF%2F4HvXkvWB3frOm4%3D&st=2015-12-07T23%3A05%3A07Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 07 Dec 2015 23:20:08 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:06 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:06 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest40_182f4104-04c2-47ec-b517-1732c286fb91.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:06 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:Lex2bmtN0pM+ZxQizD3klL+kBIZ7QJNQAkZEXhV0z34=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:16:44 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D64C4C0534"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - cbf7bf53-0001-0051-63c0-524f35000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - 04eb983e-be46-4339-9833-caf566d4e85b
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=9XWE7%2BFFJqMIiOe0IY3W03WTA0Wgr6TW%2BhiynrPFPzU%3D&st=2015-12-22T18%3A53%3A34Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 22 Dec 2015 19:08:35 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:06 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest41_1a7221a1-7c4c-4fb6-8299-f7d95c44fce6.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:hNTbIYf3VPp3t0SnhvS+6Q7tQQPYK33ZDv2POATr4ZE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:15:48 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D62ADF5371"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 60532bd2-0001-0065-7bc0-52e09d000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - b8daecdd-4684-417f-a3ed-ac70ad8fc8f9
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=6uC9DWQPmrvDitDZPbxY3AJhgaKdPP%2Fa7ugCtTcg5Es%3D&st=2015-12-23T16%3A09%3A43Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 23 Dec 2015 16:24:43 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest42_4fd99aa1-640f-4762-bbb4-d046e0002d75.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:jOsHDEyrTsC3+9cgDn3/4duuCghg9tN/9KHjBmcWU4c=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 06 Jan 2016 20:16:39 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D316D648FD33C1"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 38b69968-0001-0015-35c0-529359000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - f6440a34-59ae-4086-b761-e1209457cb5a
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=86HJrmFhqnKGAFKqvCJ%2BtpWSl8UUfLLhvKk3%2BlYyR2c%3D&st=2016-01-06T19%3A40%3A41Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 06 Jan 2016 19:55:45 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest45_d46a3624-d09b-4635-8b19-0873934c9871.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:bshjQGeDdDKMYahWX4OeNNMqEl++g0YtpOQN/YyG2vM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:09:34 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AA9FA846E62"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 8b9ecbc4-0001-0001-75c0-52503d000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - 990a3a70-59be-4aec-9632-abc92f0aa373
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=NgovbQ7%2Bz31TfKuzWqdumzQ4vtSZYPNAyXYlhONqN7c%3D&st=2016-01-06T20%3A10%3A43Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 06 Jan 2016 20:25:46 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:07 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:08 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest46_b958b84e-5b16-4f26-86a9-404176ac7915.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:08 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:VvsZ3zoOXSKsEpsmu2SkX0vnLJjW36h2029m4fLuvSk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:09:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AAA08C964B8"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 2f1ad670-0001-003d-68c0-52e4e6000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 7eb98240-c32f-4f36-8968-6a518019d276
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=wPIx3Ku0zD64lUWbSeuMo82dtzRKKnjo%2BlH7uTYviBY%3D&st=2016-01-08T14%3A57%3A22Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 08 Jan 2016 15:12:24 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:08 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:08 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest47_55c476c8-3246-46c4-a141-f73cb1b852c1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:08 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:F50e1PBRFoEZfvHPTOot08IYhirg78kVlljhteY4/vQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:10:21 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AAA16BEB1D2"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d85b51b3-0001-0029-14c0-522782000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - 3965c596-dfce-4815-87c1-cbf5d3a2b16f
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=SnK4smP8A%2BNtTwf3vEycliU4EGIns%2FRj6blkGCt5vIY%3D&st=2016-01-08T15%3A40%3A02Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 08 Jan 2016 15:55:03 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:08 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:09 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest55_d82c1c13-f20c-4b53-adf9-ef96c5b504f3.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:09 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:JowyoN8UT+Mm6J7EfeI0KjR5juhyWDOrQIk7VLnDhU0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:09:28 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AA9F6B82B96"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1f72fb94-0001-0079-71c0-52388a000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 3a7fc635-cf4b-43b3-86df-a99ee85a6e47
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=sVSvDRdxKlE7tBYdZiYIC%2FNYndVKnax4BHvKErlHpNQ%3D&st=2016-01-11T15%3A02%3A21Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 11 Jan 2016 15:17:24 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:09 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:09 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest5_0d64fd70-a385-49d1-a499-e42506061304.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:09 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:bbJJ8z4alIFQz9ldvMp+yjWHeEspmRzc6q0hPg7Zxw0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:30:46 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001F376956DD"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 466bc3fd-0001-0052-72c0-524c32000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 87c0db66-eb3b-4dff-917a-a93ae38a0de3
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=wrIrWP2aGVQuMnmBvGbPoCcrTJew0OVL%2BbBUlfBmwdo%3D&st=2015-12-08T19%3A02%3A39Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 19:17:42 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:09 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:10 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest7_88c89afc-16f7-46bf-a290-0fcbff7baa10.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:10 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:TjKr0ZhbxdsmIUvSXLEOKO7VSBMrYrO0+J/cS3H4vbg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 08 Dec 2015 22:31:21 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3001F4C41BFF7"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 2013ec8f-0001-003e-12c0-52e7e1000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - f61733c0-6026-46f8-9a8f-98f1f033f1ad
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=ZYmdcVS25Q0ygzhYyqmcoDpmnQo6TtowIzOkyWO4LsQ%3D&st=2015-12-08T19%3A18%3A32Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 08 Dec 2015 19:33:35 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:10 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5467,13 +9413,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:10 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:zF0gDzDVNEcJpAyrKvlBaVZSZPT+BfYiyRDi6R6fsAc=
+      - SharedKey chefprod5120:OH6Z7rZy+3SrDzitv/f9V1UYFnETnkqgmPzmzYnzxpg=
   response:
     status:
       code: 200
@@ -5494,7 +9440,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cd78618e-0001-0071-23ed-1b23f9000000
+      - d3e53076-0001-007a-17c0-523b8d000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5524,12 +9470,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:23:36 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:10 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:31 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:11 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psg/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5542,13 +9488,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:PCLFb7t0R+xKAZAZnNqEU3osge/CbNJYyCBfxApJ+38=
+      - SharedKey chefprod5120:ijFuqbIUlTmbIGOcXgVrfiJy+w9q/ZvcKWYUMg6BjEc=
   response:
     status:
       code: 200
@@ -5569,7 +9515,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c0a548dc-0001-005e-53ed-1ba2c3000000
+      - 2ae57e1d-0001-0002-01c0-52533a000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5599,12 +9545,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:18:59 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:11 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:11 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psgcont/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -5617,13 +9563,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Tue, 19 Jan 2016 13:50:11 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:5AS9zQdQrwuq2lN2U2JcQHiRxa3u6cyXf7/TrS6Ae3g=
+      - SharedKey chefprod5120:dZCzKmeTIJtC3HUVWNY78hCk36X2uMDIeOnBhLF7pnk=
   response:
     status:
       code: 200
@@ -5644,7 +9590,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4f1efffb-0001-0036-78ed-1bfc92000000
+      - 9a0813b5-0001-002a-38c0-522485000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5674,12 +9620,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:21:32 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:11 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -5692,11 +9638,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -5717,19 +9663,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - 3c4ee9f7-a175-47bf-840f-1b5124c09e86
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14880'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - 3c4ee9f7-a175-47bf-840f-1b5124c09e86
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192132Z:6aa71c26-c19e-445b-b5af-c0441f1b092e
+      - NORTHCENTRALUS:20160119T135017Z:3c4ee9f7-a175-47bf-840f-1b5124c09e86
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:16 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5748,7 +9694,7 @@ http_interactions:
         P3zwcOfhw4e3ZOwAl1vzdfgWvoy+xXw7+Bp/G32vZV4Yeo+/jbxHHKMD9tjS
         EZ+ovJmp6TMwZoxtCfTXYcvv/5Lk/wEjcGCNjAUAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:17 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/computevms1392/listKeys?api-version=2015-05-01-preview
@@ -5761,11 +9707,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
       Content-Length:
       - '0'
   response:
@@ -5788,19 +9734,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192132Z:04e5c9cf-55ab-4c5c-8b1b-f5923ad34611
+      - NORTHCENTRALUS:20160119T135018Z:e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:31 GMT
+      - Tue, 19 Jan 2016 13:50:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5813,7 +9759,7 @@ http_interactions:
         iydfXK+/mkx3f+LN3peftG9f/j6/1/zL5f6bt8/X7+59+eL3WZ3OL/euXp79
         oqf7F9TDL0n+H9NZ3UDGAAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:32 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:18 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/?comp=list
@@ -5826,13 +9772,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Tue, 19 Jan 2016 13:50:18 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:lw56fYr4qXY1L28H3fejbD3jMNx1f4WVb5zw/eARDrg=
+      - SharedKey computevms1392:ibrdH33UT0RGGsx265UcfPYtlYEzsVk0zILM4/yh7v4=
   response:
     status:
       code: 200
@@ -5845,31 +9791,131 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 21493640-0001-0041-7ded-1beef9000000
+      - cd008f14-0001-0084-02c0-5290c2000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Tue, 19 Jan 2016 13:50:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
         bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jb21w
         dXRldm1zMTM5Mi5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVy
-        cz48Q29udGFpbmVyPjxOYW1lPnN5c3RlbTwvTmFtZT48UHJvcGVydGllcz48
-        TGFzdC1Nb2RpZmllZD5Nb24sIDI4IFNlcCAyMDE1IDE0OjUzOjE2IEdNVDwv
-        TGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDJDODE0OEE3OEFCMTMiPC9FdGFn
-        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
-        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRh
-        aW5lcj48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+
-        PExhc3QtTW9kaWZpZWQ+RnJpLCAxNyBKdWwgMjAxNSAxNTo0NTozOSBHTVQ8
-        L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQyOEVCRUM0MUZCRUY0IjwvRXRh
-        Zz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
-        ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8
-        L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjwvQ29u
-        dGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+        cz48Q29udGFpbmVyPjxOYW1lPm1hbmFnZWlxPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPkZyaSwgMDggSmFuIDIwMTYgMTY6MTE6MTcgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzE4NDY1NkU5MUI2QyI8L0V0
+        YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29u
+        dGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQcm9wZXJ0
+        aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjggU2VwIDIwMTUgMTQ6NTM6MTYg
+        R01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMkM4MTQ4QTc4QUIxMyI8
+        L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        Q29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE3IEp1bCAyMDE1IDE1OjQ1OjM5
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDI4RUJFQzQxRkJFRjQi
+        PC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
+        ZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZp
+        bml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+
+        PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
+        dHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:19 GMT
+- request:
+    method: get
+    uri: https://computevms1392.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:19 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey computevms1392:uzglOr7gEznLJAQ/fDyBXOQZ89BRAGfHIQhY+6pZ+Ww=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - c37e038e-0001-006d-0bc0-526cc4000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Tue, 19 Jan 2016 13:50:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jb21w
+        dXRldm1zMTM5Mi5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJO
+        YW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPnZtdGVzdDQ4Ljk0
+        NDkyODZmLWRiZTYtNDczOS1hNDY1LWE0NzdhYjczNTE2Yi5zdGF0dXM8L05h
+        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBKYW4gMjAx
+        NiAxNzowNzo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxQUE5
+        QkYyNEYxQkU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjI3NzwvQ29udGVudC1M
+        ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
+        L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
+        bmd1YWdlIC8+PENvbnRlbnQtTUQ1Pkp2YWkvTmxVSHk3Y3B3cXlrYlJ5QVE9
+        PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
+        b3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFz
+        ZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZh
+        aWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+
+        PE5hbWU+dm10ZXN0NDhfZWZlZjQ0YTEtNzY3Ni00NjgxLTk3ZjEtMjUzNmIy
+        M2VmNTVmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5N
+        b24sIDExIEphbiAyMDE2IDE3OjA5OjU0IEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMzFBQUEwNjgzRTU3RjwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBw
+        bGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQt
+        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5o
+        S2RPamthdXA3c0IvbnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1D
+        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48
+        QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
+        NTMuNjAxZjFhYzktNTY0ZS00MmRlLWE0ZTgtMzEyNThiYTU5MDYxLnN0YXR1
+        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEph
+        biAyMDE2IDE3OjA4OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzFBQTlDMzMzMjAyNjwvRXRhZz48Q29udGVudC1MZW5ndGg+Mjc3PC9Db250
+        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
+        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+dTdTY1BBcDgwdUtITEUwZ1Yv
+        N1BRQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
+        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
+        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
+        QmxvYj48TmFtZT52bXRlc3Q1M185MWM1MGU4Yi0wNGIzLTQ5MzctYTZmYi00
+        NGQxMTZiYzAyNWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6MDk6NTggR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzMUFBQTA4Q0M4ODFDPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
+        b2Itc2VxdWVuY2UtbnVtYmVyPjExPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0
+        TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:19 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/system?comp=list&restype=container
@@ -5882,13 +9928,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Tue, 19 Jan 2016 13:50:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:b8QK6EGi14bs7z2eok+bz6I7sEaKvpfCN7J/HM8Fwn0=
+      - SharedKey computevms1392:1D0iZU4luZFHOfqboafTi7mr+3CksiK56jiG5PlA9No=
   response:
     status:
       code: 200
@@ -5901,11 +9947,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ea7937fb-0001-007d-0ced-1b5a22000000
+      - 441bf2ef-0001-007f-4fc0-5258d8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Tue, 19 Jan 2016 13:50:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5941,7 +9987,7 @@ http_interactions:
         UHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51
         bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:20 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5954,13 +10000,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Tue, 19 Jan 2016 13:50:20 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:LX/0YRvHuz4HB/1mWh0jXccRXOTepGW4C2lYUWYCRi4=
+      - SharedKey computevms1392:taqHzm3K7ALwIzc7iUW0huSV1AFfPM4Kgfks6U45G5o=
   response:
     status:
       code: 200
@@ -5973,11 +10019,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8c53abeb-0001-0067-3eed-1b754d000000
+      - e8d7d6f3-0001-0069-50c0-529946000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:32 GMT
+      - Tue, 19 Jan 2016 13:50:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6010,150 +10056,284 @@ http_interactions:
         c2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRp
         ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPk1JUTIuNjcwNjRjODctOGU5Ny00MGI5
         LWE5NjAtNjRjNWQ0YmJmZDEzLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48
-        TGFzdC1Nb2RpZmllZD5GcmksIDIxIEF1ZyAyMDE1IDE2OjE5OjE1IEdNVDwv
-        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkFBNDQ0MjFGQ0MyRTwvRXRhZz48
-        Q29udGVudC1MZW5ndGg+NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
-        eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
-        b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
-        dC1NRDU+VFZqMzBzTjJrWk53WkQ3UGtDZkVzdz09PC9Db250ZW50LU1ENT48
-        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JU
-        eXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2Vk
-        PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3Rh
-        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5NSVEyLnZoZDwv
-        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIxIEF1ZyAy
-        MDE1IDE1OjUxOjQxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkFB
-        NDA2ODJBMjM5RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8
-        L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0
-        ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
-        Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0Iv
-        bnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENv
-        bnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
-        cj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdl
-        QmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0
-        aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Js
-        b2I+PEJsb2I+PE5hbWU+TUlRQ29tcHV0ZTEuZDZlZmUwNzQtZDhlZS00ZmZm
-        LWJlYjktODQ2ZWYwNmQwYTIxLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48
-        TGFzdC1Nb2RpZmllZD5UaHUsIDI3IEF1ZyAyMDE1IDE4OjU0OjA4IEdNVDwv
-        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkFGMTBFM0QwRTkyQzwvRXRhZz48
-        Q29udGVudC1MZW5ndGg+ODA2PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
-        eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
-        b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
-        dC1NRDU+V05VN0J2T1FNMkN4ejY1c3dBcFpXQT09PC9Db250ZW50LU1ENT48
-        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JU
-        eXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2Vk
-        PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3Rh
-        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5NSVFDb21wdXRl
-        MS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAy
-        NyBBdWcgMjAxNSAxODo1NDozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
-        MHg4RDJBRjEwRjBCM0FDNDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2
-        NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
-        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
-        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmVVV3hM
-        Uks2RnlycldRSitmVFNwRVE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
-        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVu
-        Y2UtbnVtYmVyPjIyPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9i
-        VHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwv
-        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxM
-        ZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVy
-        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+TUlRQ29tcHV0ZTIuYzY1MTY5Njct
-        MTAwNS00YzcwLTk3MDQtY2Y1NmI4NDQ0MGVmLnN0YXR1czwvTmFtZT48UHJv
-        cGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE4IEF1ZyAyMDE1IDE5OjMz
-        OjIyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkE4MDNFMEE2QTA0
-        QTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODA2PC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+MzFpSmRMdTZOSzBMRlowKzlKcVZBZz09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5N
-        SVFDb21wdXRlMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+VHVlLCAxOCBBdWcgMjAxNSAxOTozNjowMSBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDJBODA0M0ZDMDExNkE8L0V0YWc+PENvbnRlbnQtTGVu
-        Z3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
-        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
-        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
-        TUQ1PkcySEZ1QlcrbmthLzRTcnhKNGhqcXc9PTwvQ29udGVudC1NRDU+PENh
-        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
-        b2Itc2VxdWVuY2UtbnVtYmVyPjIwPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
-        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5j
-        aGVmc2VydmVyMS44MTY3OTdjMC02YjNlLTRjMjEtOGUyMy00OGQyOTZkOGRl
-        MTIuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldl
-        ZCwgMTkgQXVnIDIwMTUgMTc6NDc6MzUgR01UPC9MYXN0LU1vZGlmaWVkPjxF
-        dGFnPjB4OEQyQThCRTQ0Njc4NDI1PC9FdGFnPjxDb250ZW50LUxlbmd0aD42
-        ODI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
-        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
-        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT4zVVQzVkVIL05M
-        eUVQU2xYOEhVdFJBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
-        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
-        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
-        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
-        PC9CbG9iPjxCbG9iPjxOYW1lPmNoZWZzZXJ2ZXIxLnZoZDwvTmFtZT48UHJv
-        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDE5IEF1ZyAyMDE1IDE3OjQ4
-        OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkE4QkU1NkIxQUEz
-        MzwvRXRhZz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8L0NvbnRlbnQt
-        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
-        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
-        YW5ndWFnZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0IvbnprV2V1aFdB
-        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
-        cG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yNDwveC1t
-        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Js
-        b2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
-        ZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZp
-        bml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
-        PjxOYW1lPmRhdGFkaXNrMS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
-        TW9kaWZpZWQ+VGh1LCAyNyBBdWcgMjAxNSAxODo1NjoxNyBHTVQ8L0xhc3Qt
-        TW9kaWZpZWQ+PEV0YWc+MHg4RDJBRjExMzA3ODE2RTc8L0V0YWc+PENvbnRl
-        bnQtTGVuZ3RoPjEwNzM3NDIzMzY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
-        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
-        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
-        ZW50LU1ENSAvPjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
-        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2It
-        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
-        PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
-        bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9M
-        ZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
-        ZGF0YWRpc2syLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
-        ZD5UaHUsIDI3IEF1ZyAyMDE1IDE4OjU2OjE3IEdNVDwvTGFzdC1Nb2RpZmll
-        ZD48RXRhZz4weDhEMkFGMTEzMDc1MDk3MjwvRXRhZz48Q29udGVudC1MZW5n
-        dGg+MzIyMTIyNTk4NDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
-        cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
-        dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
-        IC8+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4
-        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5j
-        ZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VT
-        dGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8
-        L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVy
-        YXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5wdWJ0ZXN0
-        LjczNTVlZmM5LWEzNGQtNGE2Mi04NWM5LTk3ZDNlYzVlYjJkYS5zdGF0dXM8
-        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMiBKdWwg
-        MjAxNSAxOTowODoxOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDI5
-        MkM4RTgwNjdBMkM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjA8L0NvbnRlbnQt
-        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
-        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
-        YW5ndWFnZSAvPjxDb250ZW50LU1ENT4xQjJNMlk4QXNnVHBnQW1ZN1BoQ2Zn
-        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
-        cG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVh
-        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
-        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
-        PjxOYW1lPnB1YnRlc3QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPlR1ZSwgMTggQXVnIDIwMTUgMTk6MzM6MTIgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQyQTgwM0RCMTRGMzQ4PC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD4xMzYzNzE1MDM2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
-        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
-        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
-        ZW50LU1ENT5VNDUxaHJJVGIzWjJqalZMamxYWnBRPT08L0NvbnRlbnQtTUQ1
-        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
-        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2Ut
-        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
-        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
-        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxO
-        ZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        TGFzdC1Nb2RpZmllZD5TYXQsIDE5IERlYyAyMDE1IDA2OjE4OjM4IEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzA4M0MzQzFCNTQ2MDwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+MTc0OTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1Pjg4a01Vb1hmaEZRVDM5T1M4U2JZdkE9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9i
+        VHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
+        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
+        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+TUlRMi52aGQ8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMyBKYW4g
+        MjAxNiAxNToxNDoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMx
+        QzJDMzgwMjExMDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NC
+        L256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
+        dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjxCbG9iPjxOYW1lPk1JUUNvbXB1dGUxLmQ2ZWZlMDc0LWQ4ZWUtNGZm
+        Zi1iZWI5LTg0NmVmMDZkMGEyMS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+
+        PExhc3QtTW9kaWZpZWQ+VGh1LCAyNyBBdWcgMjAxNSAxODo1NDowOCBHTVQ8
+        L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJBRjEwRTNEMEU5MkM8L0V0YWc+
+        PENvbnRlbnQtTGVuZ3RoPjgwNjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1PldOVTdCdk9RTTJDeHo2NXN3QXBaV0E9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9i
+        VHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
+        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
+        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+TUlRQ29tcHV0
+        ZTEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwg
+        MjcgQXVnIDIwMTUgMTg6NTQ6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFn
+        PjB4OEQyQUYxMEYwQjNBQzQzPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYz
+        NjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGlj
+        YXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5j
+        b2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5lVVd4
+        TFJLNkZ5cnJXUUorZlRTcEVRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250
+        cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
+        bmNlLW51bWJlcj4yMjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
+        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48
+        TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3Bl
+        cnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPk1JUUNvbXB1dGUyLmM2NTE2OTY3
+        LTEwMDUtNGM3MC05NzA0LWNmNTZiODQ0NDBlZi5zdGF0dXM8L05hbWU+PFBy
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOCBBdWcgMjAxNSAxOToz
+        MzoyMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJBODAzRTBBNkEw
+        NEE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjgwNjwvQ29udGVudC1MZW5ndGg+
+        PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRl
+        bnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdl
+        IC8+PENvbnRlbnQtTUQ1PjMxaUpkTHU2TkswTEZaMCs5SnFWQWc9PTwvQ29u
+        dGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlv
+        biAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        TUlRQ29tcHV0ZTIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPlR1ZSwgMTggQXVnIDIwMTUgMTk6MzY6MDEgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQyQTgwNDNGQzAxMTZBPC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5HMkhGdUJXK25rYS80U3J4SjRoanF3PT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj4yMDwveC1tcy1ibG9iLXNlcXVlbmNlLW51
+        bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        Y2hlZnNlcnZlcjEuODE2Nzk3YzAtNmIzZS00YzIxLThlMjMtNDhkMjk2ZDhk
+        ZTEyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5X
+        ZWQsIDE5IEF1ZyAyMDE1IDE3OjQ3OjM1IEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMkE4QkU0NDY3ODQyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        NjgyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+M1VUM1ZFSC9O
+        THlFUFNsWDhIVXRSQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT5jaGVmc2VydmVyMS52aGQ8L05hbWU+PFBy
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxOSBBdWcgMjAxNSAxNzo0
+        ODowNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJBOEJFNTZCMUFB
+        MzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50
+        LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVh
+        bTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQt
+        TGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhX
+        QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURp
+        c3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjQ8L3gt
+        bXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5m
+        aW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT5kYXRhZGlzazEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPlRodSwgMjcgQXVnIDIwMTUgMTg6NTY6MTcgR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPjB4OEQyQUYxMTMwNzgxNkU3PC9FdGFnPjxDb250
+        ZW50LUxlbmd0aD4xMDczNzQyMzM2PC9Db250ZW50LUxlbmd0aD48Q29udGVu
+        dC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBl
+        PjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29u
+        dGVudC1NRDUgLz48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwv
+        TGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
+        PmRhdGFkaXNrMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VGh1LCAyNyBBdWcgMjAxNSAxODo1NjoxNyBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDJBRjExMzA3NTA5NzI8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjMyMjEyMjU5ODQ8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+
+        YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRl
+        bnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1E
+        NSAvPjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
+        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVu
+        Y2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNl
+        U3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2Vk
+        PC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1
+        cmF0aW9uPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cHVidGVz
+        dC43MzU1ZWZjOS1hMzRkLTRhNjItODVjOS05N2QzZWM1ZWIyZGEuc3RhdHVz
+        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVs
+        IDIwMTUgMTk6MDg6MTkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQy
+        OTJDOEU4MDY3QTJDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4wPC9Db250ZW50
+        LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVh
+        bTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQt
+        TGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MUIyTTJZOEFzZ1RwZ0FtWTdQaENm
+        Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURp
+        c3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExl
+        YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
+        dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT5wdWJ0ZXN0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5UdWUsIDE4IEF1ZyAyMDE1IDE5OjMzOjEyIEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMkE4MDNEQjE0RjM0ODwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+MTM2MzcxNTAzNjE2PC9Db250ZW50LUxlbmd0aD48Q29udGVu
+        dC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBl
+        PjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29u
+        dGVudC1NRDU+VTQ1MWhySVRiM1oyampWTGpsWFpwUT09PC9Db250ZW50LU1E
+        NT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgt
+        bXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0
+        YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxh
+        YmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48
+        TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:33 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:20 GMT
+- request:
+    method: head
+    uri: https://computevms1392.blob.core.windows.net/manageiq/vmtest48_efef44a1-7676-4681-97f1-2536b23ef55f.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:20 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey computevms1392:pnwqB3M7FZZ0Vp15Wke+/9Oa0hhtsuxoDi+QJOlKhiU=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:09:54 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AAA0683E57F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - decfbe0f-0001-002a-23c0-52b3af000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '11'
+      X-Ms-Copy-Id:
+      - 00451abb-4056-4852-8cc4-70070127ce68
+      X-Ms-Copy-Source:
+      - https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=oRcSrPocFQZD1uHeoouJMb7pCdHLw5vcgKkFKEKZrF4%3D&st=2016-01-08T15%3A56%3A17Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Fri, 08 Jan 2016 16:11:20 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:21 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
+- request:
+    method: head
+    uri: https://computevms1392.blob.core.windows.net/manageiq/vmtest53_91c50e8b-04b3-4937-a6fb-44d116bc025c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Tue, 19 Jan 2016 13:50:21 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey computevms1392:7HM8jklpnuyOxbY+g1PPpxP7Y2lF1U4QxPfpPFGwHxk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Mon, 11 Jan 2016 17:09:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D31AAA08CC881C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 76cf4723-0001-0026-6dc0-525d5e000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '11'
+      X-Ms-Copy-Id:
+      - e37bc6c8-3f79-488b-995a-a5a9bb0ac745
+      X-Ms-Copy-Source:
+      - https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5HCnG18IWcHHIhO24KBiMjbXkHo22hMq2Bx8JG9kfNY%3D&st=2016-01-08T20%3A43%3A31Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Fri, 08 Jan 2016 20:58:35 GMT
+      Date:
+      - Tue, 19 Jan 2016 13:50:21 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd
@@ -6166,13 +10346,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:33 GMT
+      - Tue, 19 Jan 2016 13:50:21 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:2Wj09dP9EWNQ0GTltqYYjo8dy7SPo3Tdzfo2185DuCs=
+      - SharedKey computevms1392:BvTsIhSg1wV6A+79cX2+6ks9HQAjucmiV7icnaeLBcQ=
   response:
     status:
       code: 200
@@ -6193,7 +10373,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 611a3532-0001-0060-7eed-1b83c8000000
+      - ff7643f5-0001-0023-02c0-52a921000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -6223,12 +10403,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:53:18 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Tue, 19 Jan 2016 13:50:21 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/MIQCompute2.vhd
@@ -6241,13 +10421,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Tue, 19 Jan 2016 13:50:21 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:qu7EKW36gi674jWmHkZKKKqMAvmAJmnvK2qeO9Eg8s8=
+      - SharedKey computevms1392:2e6CCf8aE0a2TdMDHSqcHNpwCbxJ+RQqvzq+MLeyJek=
   response:
     status:
       code: 200
@@ -6268,7 +10448,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 81019259-0001-0062-0eed-1b8132000000
+      - 907481bb-0001-0070-55c0-52b52e000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -6290,12 +10470,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 18:38:50 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Tue, 19 Jan 2016 13:50:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:22 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/pubtest.vhd
@@ -6308,13 +10488,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Tue, 19 Jan 2016 13:50:22 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:7kxMuvbZMZbVVpHhJlrkOVkxfv3jFYvBfplrQ8og6DU=
+      - SharedKey computevms1392:YBmUpELcfB+cBxK5ZGVpWVqHD22/uvbp4Gv0f0gm+7k=
   response:
     status:
       code: 200
@@ -6335,7 +10515,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f5f2444e-0001-000e-2ded-1b2ae1000000
+      - bdb89821-0001-0082-0ec0-5267ba000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -6357,12 +10537,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 19:08:18 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:37 GMT
+      - Tue, 19 Jan 2016 13:50:22 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:38 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:23 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/spec1storage1/listKeys?api-version=2015-05-01-preview
@@ -6375,11 +10555,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
       Content-Length:
       - '0'
   response:
@@ -6402,19 +10582,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - 699e31ee-a303-4fe9-95d6-830248a6eae6
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - 699e31ee-a303-4fe9-95d6-830248a6eae6
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192139Z:13c6deb3-49fe-40a1-a446-23e7ddfbd444
+      - NORTHCENTRALUS:20160119T135023Z:699e31ee-a303-4fe9-95d6-830248a6eae6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:38 GMT
+      - Tue, 19 Jan 2016 13:50:23 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6427,7 +10607,7 @@ http_interactions:
         Nl88/fzs5f5Pvn795envdTXP3l5e59XznS9evdv9ielPPz9/+MnBF6ffvrtq
         L97eRQ+/JPl/AL0oAMzGAAAA
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:39 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:24 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/?comp=list
@@ -6440,13 +10620,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:24 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:6dy7gH0SHTFglwxbVmxyWYJMNHp+2alYEiIktJVhGr4=
+      - SharedKey spec1storage1:mfOPcbpfl6ybgiiuYFLGf8tc/0Zkwnc1Jy5UnBFI03o=
   response:
     status:
       code: 200
@@ -6459,11 +10639,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 93e009fc-0001-0000-69ed-1b5f42000000
+      - 397e3d20-0001-0065-20c0-52ee1f000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6491,7 +10671,7 @@ http_interactions:
         ZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:39 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:25 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm0-ea17ea24-adad-44c3-a889-0043fb2159f2?comp=list&restype=container
@@ -6504,13 +10684,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:6tiWlhUEAIhhVS1IujWbF7Kc5zvqxzjl9cFuY0Yo+II=
+      - SharedKey spec1storage1:NoGipI76Lb17zF4CsiPNnk+5auWJYM4M1ASdPViDn9A=
   response:
     status:
       code: 200
@@ -6523,11 +10703,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ddb5f435-0001-006f-71ed-1bf796000000
+      - 812b43b6-0001-0067-16c0-52ece5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6550,7 +10730,7 @@ http_interactions:
         cGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVy
         YXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:25 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm1-0b5a2a4f-1d67-41de-a12c-31d07169262e?comp=list&restype=container
@@ -6563,13 +10743,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Tue, 19 Jan 2016 13:50:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:XWHnlWbQAHteKVCCn/lzy6XHUtsE6fDG4g/JjmNO+fg=
+      - SharedKey spec1storage1:mS6JCA9crWU1lDmNX/wPXwuux5Ce6wVzYQvVR1bEQaY=
   response:
     status:
       code: 200
@@ -6582,11 +10762,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 91b7df6b-0001-0050-49ed-1b404a000000
+      - 5ec60d2c-0001-0054-51c0-52b5c8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6608,7 +10788,7 @@ http_interactions:
         PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:26 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6621,13 +10801,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Tue, 19 Jan 2016 13:50:26 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:LWLumiBG5P2d/INhQzla38vmBcR+KfdC3sIU60MorIM=
+      - SharedKey spec1storage1:yzUbUiXIfz+gk+bTF3ApyJehHn86VZ71wzuIiL30B9E=
   response:
     status:
       code: 200
@@ -6640,11 +10820,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ddb5f579-0001-006f-1eed-1bf796000000
+      - e57416bd-0001-006a-29c0-5203e9000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6702,7 +10882,7 @@ http_interactions:
         L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0Vu
         dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:26 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6715,11 +10895,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -6740,19 +10920,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - 485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14879'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - 485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192140Z:d15344ba-c3fd-4811-97f6-bc591ee6f19c
+      - NORTHCENTRALUS:20160119T135027Z:485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:39 GMT
+      - Tue, 19 Jan 2016 13:50:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6761,7 +10941,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:40 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6774,11 +10954,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -6799,19 +10979,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 130e7789-a40b-4ad4-af58-70e65ee1371b
+      - 65b2952f-d7fb-4b76-8531-abc2014c2fd3
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14879'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 130e7789-a40b-4ad4-af58-70e65ee1371b
+      - 65b2952f-d7fb-4b76-8531-abc2014c2fd3
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192140Z:130e7789-a40b-4ad4-af58-70e65ee1371b
+      - NORTHCENTRALUS:20160119T135027Z:65b2952f-d7fb-4b76-8531-abc2014c2fd3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:40 GMT
+      - Tue, 19 Jan 2016 13:50:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6820,7 +11000,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:41 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:28 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -6833,11 +11013,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -6858,19 +11038,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 243a7c73-c1f9-462e-9a12-63a7ba428402
+      - 224d0b45-f797-4cfb-88c6-fe2609ff16c4
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14878'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 243a7c73-c1f9-462e-9a12-63a7ba428402
+      - 224d0b45-f797-4cfb-88c6-fe2609ff16c4
       X-Ms-Routing-Request-Id:
-      - EASTUS2:20151110T192141Z:243a7c73-c1f9-462e-9a12-63a7ba428402
+      - NORTHCENTRALUS:20160119T135028Z:224d0b45-f797-4cfb-88c6-fe2609ff16c4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:41 GMT
+      - Tue, 19 Jan 2016 13:50:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6887,7 +11067,7 @@ http_interactions:
         vm/yaQVS+29/NzdvN/TGuvny/KX0QN9ll1lRAhXv29cGRvA9IdZmF6A+fpN5
         vZGjPvol3/8lyf8D6+XAwe4CAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:42 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:28 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts/miqazure15827/listKeys?api-version=2015-05-01-preview
@@ -6900,11 +11080,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
       Content-Length:
       - '0'
   response:
@@ -6927,19 +11107,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - 351d34d6-3adc-4e58-9563-3e817c14b47f
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - 351d34d6-3adc-4e58-9563-3e817c14b47f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192142Z:f2ea2cbc-8875-40e0-9f66-9bc90250bf8f
+      - NORTHCENTRALUS:20160119T135029Z:351d34d6-3adc-4e58-9563-3e817c14b47f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Tue, 19 Jan 2016 13:50:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6952,7 +11132,7 @@ http_interactions:
         NM93zy/eHM/qTz/ZefPJ3a8ud/dPLp/WT36f78ya79yb3H36iz6ffbLMJ+38
         6Zvru1fUwy9J/h+s9SVmxgAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:42 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:29 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/?comp=list
@@ -6965,13 +11145,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Tue, 19 Jan 2016 13:50:29 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:ipbIFnOeT+azlZ4+OoDvMAI01RETbC0vYC7eSOJr2Bs=
+      - SharedKey miqazure15827:JP8VSjPPcLiDjZT9gupLbiFw3R+bnAwXcxE4SdEsK7Q=
   response:
     status:
       code: 200
@@ -6984,11 +11164,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6b574251-0001-00af-29ed-1b0a6d000000
+      - 11899256-0001-0014-2dc0-52eb99000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Tue, 19 Jan 2016 13:50:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7003,7 +11183,7 @@ http_interactions:
         cj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVz
         dWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:30 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/vhds?comp=list&restype=container
@@ -7016,13 +11196,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Tue, 19 Jan 2016 13:50:30 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:dyOu5On23zwBh7bTI8023zuDvcKsW6hW+WM6Pozkbq8=
+      - SharedKey miqazure15827:9rlE2FpRDuJF/UDQC+MawgH+GQ8l+2dmiIfQzeWkyT0=
   response:
     status:
       code: 200
@@ -7035,11 +11215,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dfdef052-0001-0036-33ed-1b85af000000
+      - 743b49ee-0001-00a7-5bc0-52111e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Tue, 19 Jan 2016 13:50:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7095,7 +11275,7 @@ http_interactions:
         dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:31 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/ERP.vhd
@@ -7108,13 +11288,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Tue, 19 Jan 2016 13:50:31 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:8sgedD63p7C0YsIH1XiNcOViUOAS1upGKGsUgeVYAzU=
+      - SharedKey miqazure15827:2mzOrjwWxH6isfN9HD7Potzrx2D1Dy7IbIl7Z8TWGAU=
   response:
     status:
       code: 200
@@ -7135,7 +11315,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fea043b4-0001-003d-2fed-1b9ddb000000
+      - 64d20d38-0001-0072-63c0-5259c3000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7157,12 +11337,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:31:28 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Tue, 19 Jan 2016 13:50:30 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:43 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:31 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/MIQ.vhd
@@ -7175,13 +11355,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Tue, 19 Jan 2016 13:50:31 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:GZqIGwI86moCSLMYkM/kFOvK6V9vNevcylQsN8cTId4=
+      - SharedKey miqazure15827:nXfOn2+00JDaR+mBQ9no9dm5hiHzitLZF4G/QLjEFQY=
   response:
     status:
       code: 200
@@ -7202,7 +11382,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - dfd04c59-0001-006a-44ed-1b7456000000
+      - 46ed489a-0001-0035-03c0-5286a8000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7224,12 +11404,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:33:10 GMT
       Date:
-      - Tue, 10 Nov 2015 19:21:42 GMT
+      - Tue, 19 Jan 2016 13:50:31 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7242,11 +11422,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -7267,19 +11447,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - a807e2ff-f76f-44cc-83b4-bf0520677519
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - a807e2ff-f76f-44cc-83b4-bf0520677519
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:1931bdd8-e0e4-4585-aaff-f62fdc02d70c
+      - NORTHCENTRALUS:20160119T135032Z:a807e2ff-f76f-44cc-83b4-bf0520677519
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:43 GMT
+      - Tue, 19 Jan 2016 13:50:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7288,7 +11468,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7301,11 +11481,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -7326,19 +11506,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1b74c414-303c-45a3-8963-94ceab47a24a
+      - 485f6067-26e9-47ab-80bd-50c267eacf0e
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 1b74c414-303c-45a3-8963-94ceab47a24a
+      - 485f6067-26e9-47ab-80bd-50c267eacf0e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:1b74c414-303c-45a3-8963-94ceab47a24a
+      - NORTHCENTRALUS:20160119T135033Z:485f6067-26e9-47ab-80bd-50c267eacf0e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Tue, 19 Jan 2016 13:50:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7347,7 +11527,7 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
@@ -7360,11 +11540,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
   response:
     status:
       code: 200
@@ -7385,19 +11565,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - 56e540b0-d0f2-4607-8d39-1e902677a0b1
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - 56e540b0-d0f2-4607-8d39-1e902677a0b1
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192144Z:533f1471-34ca-4460-bd34-5a5f0af8fd95
+      - NORTHCENTRALUS:20160119T135034Z:56e540b0-d0f2-4607-8d39-1e902677a0b1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Tue, 19 Jan 2016 13:50:33 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7413,7 +11593,7 @@ http_interactions:
         iL7SZpN4J/xF5JVfYgf3PEZjouhl0dCnxfKCKNgC9uv1dJrns3xG3zf02br5
         8vylwKBvs8usKNEZQLfZBWiF32QWbpz1j37J939J8v8ApmXS5o0CAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:44 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:34 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts/nyrg9184/listKeys?api-version=2015-05-01-preview
@@ -7426,11 +11606,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDcxODI5NjUsIm5iZiI6MTQ0NzE4Mjk2NSwiZXhwIjoxNDQ3MTg2ODY1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Pdy8oDWo-umtO75hSX2iRJ8xlnqXLg0QIud27IAy8DJbY3js3LjsF2XQcU_aqdYnMdlFaieJW-b6ab1-H0Vs_6mbQoSHS6p-EVQCgZRcdTBPrSiLfJmkmHZrwajfmvwc7DWHh03_1_ZqTCYBaHoAtlgevATFO5MQ21Aunp7r9FilJBAAHubs-G1E67-3wbgOCNWy3vqBnzZxz2hV1nfn4bjyP2KvU5plApagdZU0Bcpf3u6BSeumNZPnXt4lEyRXvB3QK8r-IjC5IXY9ke3NQak-nXHuvdywYScquoZf0w2PN8yMLKRqA1T11uz1jZHz72iUxDK3TfB00ZHuHqaBYg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
       Content-Length:
       - '0'
   response:
@@ -7453,19 +11633,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4e772978-89c7-47b7-960e-c8550988b675
+      - e81325a4-06e5-4fd0-816e-67cdbc54ea8f
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 4e772978-89c7-47b7-960e-c8550988b675
+      - e81325a4-06e5-4fd0-816e-67cdbc54ea8f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151110T192145Z:4e772978-89c7-47b7-960e-c8550988b675
+      - NORTHCENTRALUS:20160119T135034Z:e81325a4-06e5-4fd0-816e-67cdbc54ea8f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 10 Nov 2015 19:21:44 GMT
+      - Tue, 19 Jan 2016 13:50:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7478,7 +11658,7 @@ http_interactions:
         ExeLVyfPPzm92rt+9vDz3/vdV7/o8tXDr3Z3fp/rez85+/zpt8vfq9mp2rNv
         n/wEevglyf8D3ICuGMYAAAA=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:45 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:35 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/?comp=list
@@ -7491,13 +11671,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Tue, 19 Jan 2016 13:50:35 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:7feVVPt4UN+oJs8ofTSGATDlhkt06chxRQHbkEdkZ0E=
+      - SharedKey nyrg9184:4QL2nLws8Yc9gAxlLpCJCfS+QPXHd5dspb6Dn4rScpQ=
   response:
     status:
       code: 200
@@ -7510,11 +11690,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - eeca8276-0001-006e-34ed-1b5337000000
+      - 908244c2-0001-0042-19c0-52d10a000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Tue, 19 Jan 2016 13:50:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7536,7 +11716,7 @@ http_interactions:
         PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
         dHM+
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:45 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:35 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/bootdiagnostics-salesforc-cdf0af79-304d-4d73-9cc5-8551b19dce07?comp=list&restype=container
@@ -7549,13 +11729,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Tue, 19 Jan 2016 13:50:35 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:v67PesFHtuZBivE6cNjiH2u99oqNYsYBXmEnoPAES/w=
+      - SharedKey nyrg9184:hSaVFNzwr8a6bsZt6KAp2rR6EDpqNh25S6FTphbEOYs=
   response:
     status:
       code: 200
@@ -7568,11 +11748,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a2071c53-0001-0032-64ed-1ba2ce000000
+      - 0cfd5f98-0001-0104-35c0-5249c9000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Tue, 19 Jan 2016 13:50:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7595,7 +11775,7 @@ http_interactions:
         b3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1l
         cmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:46 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:36 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/vhds?comp=list&restype=container
@@ -7608,13 +11788,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 10 Nov 2015 19:21:46 GMT
+      - Tue, 19 Jan 2016 13:50:36 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:+0zPdhWERhuNoCWtstpFLPLqEXsfZJpKT+30VxXy0UQ=
+      - SharedKey nyrg9184:mQIpGPZAhy+RGjIdPZ+Scllc4EfFxZbXmaZYFHUjvx0=
   response:
     status:
       code: 200
@@ -7627,11 +11807,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fbfed245-0001-0001-35ed-1bfbe3000000
+      - 4b6ad39d-0001-00fe-0ec0-52c67b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 10 Nov 2015 19:21:45 GMT
+      - Tue, 19 Jan 2016 13:50:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7665,5 +11845,5 @@ http_interactions:
         bj48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48
         L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 19:21:46 GMT
+  recorded_at: Tue, 19 Jan 2016 13:50:36 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
At the moment the get_vm_nics method is making one request per VM (per NIC) to get NIC information. This PR replaces all that with a single .list call that gets all NIC's up front, and then uses Ruby code internally to compare .id strings as needed.

The id strings already contain the resource group, too, so there's no need to parse that out and compare them separately.

I would like to get this in before doing more work on security groups because I can use the list of NIC's to more easily retrieve security groups.