### PR TITLE
Automate UI Simulation support retry button

### DIFF
--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -164,7 +164,7 @@ module ApplicationController::Automate
     state_attrs = {'ae_state_retries' => ws.root['ae_state_retries'],
                    'ae_state'         => ws.root['ae_state']}
     state_attrs['ae_state_data'] = ws.persist_state_hash.to_yaml unless ws.persist_state_hash.empty?
-    state_attrs['ae_state_previous'] = ws.current_state_info unless ws.current_state_info.empty?
+    state_attrs['ae_state_previous'] = ws.current_state_info.to_yaml unless ws.current_state_info.empty?
     state_attrs
   end
 

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -131,7 +131,7 @@ module ApplicationController::Automate
     @right_cell_text = "Simulation"
 
     case params[:button]
-    when "throw","retry"    then resolve_button_throw
+    when "throw", "retry" then resolve_button_throw
     when "copy"     then resolve_button_copy
     when "paste"    then resolve_button_paste
     when "simulate" then resolve_button_simulate
@@ -162,7 +162,7 @@ module ApplicationController::Automate
 
   def state_attributes(ws)
     state_attrs = {'ae_state_retries' => ws.root['ae_state_retries'],
-                   'ae_state'         => ws.root['ae_state'] }
+                   'ae_state'         => ws.root['ae_state']}
     state_attrs['ae_state_data'] = ws.persist_state_hash.to_yaml unless ws.persist_state_hash.empty?
     state_attrs['ae_state_previous'] = ws.current_state_info unless ws.current_state_info.empty?
     state_attrs

--- a/app/controllers/application_controller/automate.rb
+++ b/app/controllers/application_controller/automate.rb
@@ -27,6 +27,7 @@ module ApplicationController::Automate
       if is_browser_ie? && browser_info(:version) == "7"
         page.redirect_to :action => 'resolve'
       else
+        page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         page.replace_html("main_div", :partial => "results_tabs")
         page << javascript_pf_toolbar_reload('center_tb', c_tb)
@@ -102,6 +103,7 @@ module ApplicationController::Automate
 
     if params[:simulate] == "simulate"
       @resolve = session[:resolve]
+      @resolve[:ae_result] = nil
     else
       @resolve = {} if params[:button] == "reset" || (@resolve && @resolve[:lastaction] == "simulate")
       @resolve[:lastaction] = nil if @resolve
@@ -129,7 +131,7 @@ module ApplicationController::Automate
     @right_cell_text = "Simulation"
 
     case params[:button]
-    when "throw"    then resolve_button_throw
+    when "throw","retry"    then resolve_button_throw
     when "copy"     then resolve_button_copy
     when "paste"    then resolve_button_paste
     when "simulate" then resolve_button_simulate
@@ -143,13 +145,27 @@ module ApplicationController::Automate
       :fqclass     => @resolve[:new][:starting_object],
       :message     => @resolve[:new][:object_message]
     }
-    @results = MiqAeEngine.resolve_automation_object(@sb[:name],
-                                                     User.current_user,
-                                                     @sb[:attrs],
-                                                     options,
-                                                     @resolve[:new][:readonly]).to_expanded_xml
+    @resolve[:state_attributes] = {} if params[:button] == 'throw'
+    automation_attrs = @sb[:attrs].reverse_merge(@resolve[:state_attributes])
+    ws = MiqAeEngine.resolve_automation_object(@sb[:name],
+                                               User.current_user,
+                                               automation_attrs,
+                                               options,
+                                               @resolve[:new][:readonly])
+    ws.root['ae_result'] ||= 'ok'
+    @results = ws.to_expanded_xml
     @resolve[:uri] = options[:uri]
+    @resolve[:ae_result] = ws.root['ae_result']
+    @resolve[:state_attributes] = ws.root['ae_result'] == 'retry' ? state_attributes(ws) : {}
     @json_tree = ws_tree_from_xml(@results)
+  end
+
+  def state_attributes(ws)
+    state_attrs = {'ae_state_retries' => ws.root['ae_state_retries'],
+                   'ae_state'         => ws.root['ae_state'] }
+    state_attrs['ae_state_data'] = ws.persist_state_hash.to_yaml unless ws.persist_state_hash.empty?
+    state_attrs['ae_state_previous'] = ws.current_state_info unless ws.current_state_info.empty?
+    state_attrs
   end
 
   def ready_to_throw
@@ -159,6 +175,7 @@ module ApplicationController::Automate
   def resolve_reset
     c_tb = build_toolbar(center_toolbar_filename)
     render :update do |page|
+      page.replace("left_cell_bottom", :partial => "resolve_form_buttons")
       page.replace("resolve_form_div", :partial => "resolve_form") unless params[:tab_id]
       page.replace("results_tabs",     :partial => "results_tabs")
       page << javascript_pf_toolbar_reload('center_tb', c_tb)

--- a/app/views/miq_ae_tools/_resolve_form_buttons.html.haml
+++ b/app/views/miq_ae_tools/_resolve_form_buttons.html.haml
@@ -9,6 +9,15 @@
       :remote               => true,
       "data-method"         => :post,
       :title                => t)
+    - if @resolve[:ae_result] == 'retry'
+      - t = _("Retry state machine simulation, with preserved attributes")
+      = link_to(_("Retry"),
+      {:action => "resolve", :button => "retry"},
+      :class                => "btn btn-primary",
+      :alt                  => t,
+      "data-miq_sparkle_on" => true,
+      :remote               => true,
+      :title                => t)
     = link_to(_("Reset"),
       {:action => "resolve", :button => "reset"},
       :class                 => "btn btn-default",

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -21,3 +21,62 @@ describe MiqAeCustomizationController, "ApplicationController::Automate" do
     end
   end
 end
+
+describe MiqAeToolsController, "ApplicationController::Automate" do
+  context "#build_results" do
+    let(:custom_button) { FactoryGirl.create(:custom_button, :applies_to_class => "Host") }
+    let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
+    before(:each) do
+      set_user_privileges
+    end
+
+    def resolve_hash(button)
+      target_classes = {}
+      CustomButton.button_classes.each { |db| target_classes[db] = ui_lookup(:model => db) }
+      {
+        :new            => {:target_class => button.applies_to_class},
+        :target_classes => target_classes
+      }
+    end
+
+    context 'submit' do
+      let(:options) { {'ae_result' => 'ok'} }
+      it 'ok' do
+        resolve = resolve_hash(custom_button)
+        session[:resolve] = resolve
+        sb = {:name => 'test', :vmdb_object => nil, :attrs => {'a' => 1}}
+        controller.instance_variable_set(:@resolve, resolve)
+        controller.instance_variable_set(:@sb, sb)
+        controller.instance_variable_set(:@_params, :button => 'throw')
+        allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(workspace)
+        allow(workspace).to receive(:to_expanded_xml).and_return("<A/>")
+        allow(MiqAeToolsController).to receive(:ws_tree_from_xml).and_return(nil)
+        controller.build_results
+        expect(resolve[:ae_result]).to eql('ok')
+        expect(resolve[:state_attributes]).to be_empty
+      end
+    end
+
+    context 'state machine' do
+      let(:options) { {'ae_result' => 'retry', 'ae_state' => 'state1'} }
+      it "retry" do
+        state_hash = {'var1' => 1, 'var2' => 2}
+        resolve = resolve_hash(custom_button)
+        resolve[:state_attributes] = {'ae_state' => 'state3'}
+        session[:resolve] = resolve
+        sb = {:name => 'test', :vmdb_object => nil, :attrs => {'a' => 1}}
+        controller.instance_variable_set(:@resolve, resolve)
+        controller.instance_variable_set(:@sb, sb)
+        controller.instance_variable_set(:@_params, :button => 'retry')
+        allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(workspace)
+        allow(workspace).to receive(:to_expanded_xml).and_return("<A/>")
+        allow(workspace).to receive(:persist_state_hash).and_return(state_hash)
+        allow(workspace).to receive(:current_state_info).and_return({})
+        allow(MiqAeToolsController).to receive(:ws_tree_from_xml).and_return(nil)
+        controller.build_results
+        expect(resolve[:ae_result]).to eql('retry')
+        expect(resolve[:state_attributes]['ae_state']).to eql('state1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1299579

When a user runs Automate Simulation if there is a state machine
that returns a 'retry'. The UI would show a Retry button in addition
to the 'Submit' and 'Reset' button.