### PR TITLE
Simplify MiqPolicyController::Conditions#condition_build_edit_screen a bit

### DIFF
--- a/app/controllers/miq_policy_controller/conditions.rb
+++ b/app/controllers/miq_policy_controller/conditions.rb
@@ -156,8 +156,8 @@ module MiqPolicyController::Conditions
     @edit[:current] = {}
 
     if params[:copy]  # If copying, create a new condition based on the original
-      c = Condition.find(params[:id])
-      @condition = Condition.new(c.attributes.merge(:name => nil, :id => nil))
+      cond = Condition.find(params[:id])
+      @condition = cond.dup.tap { |c| c.name = nil }
     else
       @condition = params[:id] && params[:typ] != "new" ? Condition.find(params[:id]) : Condition.new     # Get existing or new record
     end


### PR DESCRIPTION
This is a follow up on https://github.com/ManageIQ/manageiq/pull/6226/files#r50049052

`ActiveRecord`'s `#dup` clones all attributes except `id`.