### PR TITLE
UI - Fix paging replace style breakage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -406,7 +406,8 @@ class ApplicationController < ActionController::Base
 
     render :update do |page|
       page.replace("report_html_div", :partial => "layouts/report_html")
-      page.replace_html("paging_div", :partial => 'layouts/saved_report_paging_bar', :locals => {:pages => @sb[:pages]})
+      page.replace_html("paging_div", :partial => 'layouts/saved_report_paging_bar',
+                                      :locals  => {:pages => @sb[:pages]})
       page << javascript_hide_if_exists("form_buttons_div")
       page << javascript_show_if_exists("rpb_div_1")
       page << "miqSparkle(false)"
@@ -1976,7 +1977,11 @@ class ApplicationController < ActionController::Base
         page.replace_html("main_div", :partial => "layouts/gtl")
         page << "$('#adv_div').slideUp(0.3);" if params[:entry]
       end
-      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => action_url, :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                      :locals  => {:pages      => @pages,
+                                                   :action_url => action_url,
+                                                   :db         => @view.db,
+                                                   :headers    => @view.headers})
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1976,7 +1976,7 @@ class ApplicationController < ActionController::Base
         page.replace_html("main_div", :partial => "layouts/gtl")
         page << "$('#adv_div').slideUp(0.3);" if params[:entry]
       end
-      page.replace("pc_div_1", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => action_url, :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => action_url, :db => @view.db, :headers => @view.headers})
     end
   end
 

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -397,7 +397,11 @@ class MiqRequestController < ApplicationController
                                                  :js_options => js_options})
       page << "miqGridOnCheck();"           # Reset the center buttons
 
-      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => "show_list", :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                      :locals  => {:pages      => @pages,
+                                                   :action_url => "show_list",
+                                                   :db         => @view.db,
+                                                   :headers    => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -397,7 +397,7 @@ class MiqRequestController < ApplicationController
                                                  :js_options => js_options})
       page << "miqGridOnCheck();"           # Reset the center buttons
 
-      page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => "show_list", :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => "show_list", :db => @view.db, :headers => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/miq_request_controller.rb
+++ b/app/controllers/miq_request_controller.rb
@@ -397,7 +397,7 @@ class MiqRequestController < ApplicationController
                                                  :js_options => js_options})
       page << "miqGridOnCheck();"           # Reset the center buttons
 
-      page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => "show_list", :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => "show_list", :db => @view.db, :headers => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -73,7 +73,11 @@ class MiqTaskController < ApplicationController
       get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
         page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
-        page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+        page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                        :locals  => {:pages      => @pages,
+                                                     :action_url => @lastaction,
+                                                     :db         => @view.db,
+                                                     :headers    => @view.headers})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
     else                      # Came in from non-ajax, just get the jobs
@@ -273,7 +277,11 @@ class MiqTaskController < ApplicationController
         else
           page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace_html("main_div", :partial => @refresh_partial)
-          page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+          page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                          :locals  => {:pages      => @pages,
+                                                       :action_url => @lastaction,
+                                                       :db         => @view.db,
+                                                       :headers    => @view.headers})
         end
       end
     end
@@ -316,7 +324,11 @@ class MiqTaskController < ApplicationController
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
-      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols',
+                                      :locals  => {:pages      => @pages,
+                                                   :action_url => @lastaction,
+                                                   :db         => @view.db,
+                                                   :headers    => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -73,7 +73,7 @@ class MiqTaskController < ApplicationController
       get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
         page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
-        page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+        page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
     else                      # Came in from non-ajax, just get the jobs
@@ -273,7 +273,7 @@ class MiqTaskController < ApplicationController
         else
           page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace_html("main_div", :partial => @refresh_partial)
-          page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+          page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         end
       end
     end
@@ -316,7 +316,7 @@ class MiqTaskController < ApplicationController
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
-      page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => 'layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/controllers/miq_task_controller.rb
+++ b/app/controllers/miq_task_controller.rb
@@ -73,7 +73,7 @@ class MiqTaskController < ApplicationController
       get_jobs(tasks_condition(@tasks_options[@tabform]))
       render :update do |page|
         page.replace_html("gtl_div", :partial => "layouts/gtl", :locals => {:action_url => @lastaction})
-        page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+        page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         page << "miqSparkle(false);"  # Need to turn off sparkle in case original ajax element gets replaced
       end
     else                      # Came in from non-ajax, just get the jobs
@@ -273,7 +273,7 @@ class MiqTaskController < ApplicationController
         else
           page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
           page.replace_html("main_div", :partial => @refresh_partial)
-          page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+          page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
         end
       end
     end
@@ -316,7 +316,7 @@ class MiqTaskController < ApplicationController
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSetButtons(0, 'center_tb');"                             # Reset the center toolbar
       page.replace("main_div", :partial => "layouts/tasks")
-      page.replace("pc_div_1", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
+      page.replace_html("paging_div", :partial => '/layouts/pagingcontrols', :locals => {:pages => @pages, :action_url => @lastaction, :db => @view.db, :headers => @view.headers})
       page << "miqSparkle(false);"
     end
   end

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -41,12 +41,11 @@
               .col-md-12
                 = yield
         .row.toolbar-pf#paging_div
-          .col-md-12
-            .toolbar-pf-actions
-              - if saved_report_paging?
-                = render(:partial => 'layouts/saved_report_paging_bar', :locals => {:pages => @sb[:pages]})
-              - else
-                = render(:partial => 'layouts/x_pagingcontrols')
+          - if saved_report_paging?
+            = render(:partial => 'layouts/saved_report_paging_bar',
+                     :locals  => {:pages => @sb[:pages]})
+          - else
+            = render(:partial => 'layouts/x_pagingcontrols')
 
         - unless simulate
           .resizer.hidden-xs
@@ -88,16 +87,12 @@
                   = yield
           - unless @in_a_form
             .row.toolbar-pf#paging_div
-              .col-md-12
-                .toolbar-pf-actions
-                  - unless @embedded
-                    - if @pages && @items_per_page != ONE_MILLION
-                      = render(:partial => 'layouts/pagingcontrols',
-                              :locals => {:pages      => @pages,
-                                           :action_url => action_url_for_views,
-                                           :db         => @view.db,
-                                           :headers    => @view.headers,
-                                           :button_div => 'center_tb'})
+              = render(:partial => 'layouts/pagingcontrols',
+                       :locals  => {:pages      => @pages,
+                                    :action_url => action_url_for_views,
+                                    :db         => @view.db,
+                                    :headers    => @view.headers,
+                                    :button_div => 'center_tb'})
 
         .col-md-2.col-md-pull-10.sidebar-pf.sidebar-pf-left
           = render :partial => "layouts/listnav"
@@ -141,16 +136,12 @@
                   = yield
           - if layout_uses_paging? && !@in_a_form
             .row.toolbar-pf#paging_div
-              .col-md-12
-                .toolbar-pf-actions
-                  - unless @embedded
-                    - if @pages && @items_per_page != ONE_MILLION
-                      = render(:partial => 'layouts/pagingcontrols',
-                               :locals  => {:pages      => @pages,
-                                            :action_url => action_url_for_views,
-                                            :db         => @view.db,
-                                            :headers    => @view.headers,
-                                            :button_div => 'center_tb'})
+              = render(:partial => 'layouts/pagingcontrols',
+                       :locals  => {:pages      => @pages,
+                                    :action_url => action_url_for_views,
+                                    :db         => @view.db,
+                                    :headers    => @view.headers,
+                                    :button_div => 'center_tb'})
 
 - if show_advanced_search?
   :javascript

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -46,7 +46,7 @@
               - if saved_report_paging?
                 = render(:partial => 'layouts/saved_report_paging_bar', :locals => {:pages => @sb[:pages]})
               - else
-                = render(:partial => '/layouts/x_pagingcontrols')
+                = render(:partial => 'layouts/x_pagingcontrols')
 
         - unless simulate
           .resizer.hidden-xs
@@ -92,7 +92,7 @@
                 .toolbar-pf-actions
                   - unless @embedded
                     - if @pages && @items_per_page != ONE_MILLION
-                      = render(:partial => '/layouts/pagingcontrols',
+                      = render(:partial => 'layouts/pagingcontrols',
                               :locals => {:pages      => @pages,
                                            :action_url => action_url_for_views,
                                            :db         => @view.db,
@@ -115,7 +115,7 @@
               .row
                 .col-md-12
                   %br
-                  = render :partial => '/layouts/tabs'
+                  = render :partial => 'layouts/tabs'
             .col-md-12
               .row
                 .col-md-12
@@ -145,12 +145,12 @@
                 .toolbar-pf-actions
                   - unless @embedded
                     - if @pages && @items_per_page != ONE_MILLION
-                      = render(:partial => '/layouts/pagingcontrols',
-                              :locals => {:pages      => @pages,
-                                           :action_url => action_url_for_views,
-                                           :db         => @view.db,
-                                           :headers    => @view.headers,
-                                           :button_div => 'center_tb'})
+                      = render(:partial => 'layouts/pagingcontrols',
+                               :locals  => {:pages      => @pages,
+                                            :action_url => action_url_for_views,
+                                            :db         => @view.db,
+                                            :headers    => @view.headers,
+                                            :button_div => 'center_tb'})
 
 - if show_advanced_search?
   :javascript

--- a/app/views/layouts/_content.html.haml
+++ b/app/views/layouts/_content.html.haml
@@ -90,8 +90,8 @@
               = render(:partial => 'layouts/pagingcontrols',
                        :locals  => {:pages      => @pages,
                                     :action_url => action_url_for_views,
-                                    :db         => @view.db,
-                                    :headers    => @view.headers,
+                                    :db         => @view.try(:db),
+                                    :headers    => @view.try(:headers),
                                     :button_div => 'center_tb'})
 
         .col-md-2.col-md-pull-10.sidebar-pf.sidebar-pf-left
@@ -139,8 +139,8 @@
               = render(:partial => 'layouts/pagingcontrols',
                        :locals  => {:pages      => @pages,
                                     :action_url => action_url_for_views,
-                                    :db         => @view.db,
-                                    :headers    => @view.headers,
+                                    :db         => @view.try(:db),
+                                    :headers    => @view.try(:headers),
                                     :button_div => 'center_tb'})
 
 - if show_advanced_search?

--- a/app/views/layouts/_pagingcontrols.html.haml
+++ b/app/views/layouts/_pagingcontrols.html.haml
@@ -52,9 +52,9 @@
                     %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
                                                       :complete => "miqSparkle(false);",
                                                       :url      => update_paging_url_parms(action_url, :page => pages[:current] - 1)),
-                            :class   => "fa fa-angle-left",
-                            :alt     => "Previous",
-                            :title   => "Previous"}
+                          :class   => "fa fa-angle-left",
+                          :alt     => "Previous",
+                          :title   => "Previous"}
                 - elsif action_id
                   %li.first
                     %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1, :id => action_id)}')",

--- a/app/views/layouts/_pagingcontrols.html.haml
+++ b/app/views/layouts/_pagingcontrols.html.haml
@@ -1,149 +1,152 @@
-- button_div ||= "center_tb"
-- db ||= nil
-- action_id    = action_url.split("/").last if action_url.include?("/")
+.col-md-12
+  .toolbar-pf-actions
+    - if !@embedded && @pages && @items_per_page != ONE_MILLION
+      - button_div ||= "center_tb"
+      - db ||= nil
+      - action_id    = action_url.split("/").last if action_url.include?("/")
 
-- @pc_occ ||= 0
-- @pc_occ += 1
+      - @pc_occ ||= 0
+      - @pc_occ += 1
 
-%div{:id => "pc_div_#{@pc_occ}"}
-  - if @pc_occ == 1
-    .form-group
-      - if !@no_checkall && !@no_checkboxes
-        %input{:id => 'masterToggle', :type => 'checkbox', :name => 'masterToggle', :onclick => "miqUpdateAllCheckboxes('#{button_div}', null);"}
-        = _("(Check All)")
-  - if @gtl_type != "list" && @view
-    .form-group{:style => "border-right: 0"}
-      = _('Sorted by: ')
-      = select_tag("sort_choice",
-                       options_for_select(@view.headers),
-                       :class => "selectpicker dropup")
-      :javascript
-        miqSelectPickerEvent("sort_choice", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
-  - else
-    - if @bottom_msg
-      = h(@bottom_msg)
-  - unless db.blank?
-    - if %w(EmsInfra EmsCloud EmsCluster ResourcePool OntapStorageSystem OntapLogicalDisk CimBaseStorageExtent OntapStorageVolume StorageManager OntapFileShare SniaLocalFileSystem).include?(db)
-      - @db = db.underscore
-  - if @pc_occ == 1
-    .form-group
-      - unless @embedded
-        - if @sortdir == "ASC"
-          = _("Asc. by:")
+      %div{:id => "pc_div_#{@pc_occ}"}
+        - if @pc_occ == 1
+          .form-group
+            - if !@no_checkall && !@no_checkboxes
+              %input{:id => 'masterToggle', :type => 'checkbox', :name => 'masterToggle', :onclick => "miqUpdateAllCheckboxes('#{button_div}', null);"}
+              = _("(Check All)")
+        - if @gtl_type != "list" && @view
+          .form-group{:style => "border-right: 0"}
+            = _('Sorted by: ')
+            = select_tag("sort_choice",
+                            options_for_select(@view.headers),
+                            :class => "selectpicker dropup")
+            :javascript
+              miqSelectPickerEvent("sort_choice", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
         - else
-          = _("Desc. by:")
-      = @view.headers[@sortcol]
-
-    .form-group.pull-right{:style => "border-right: 0"}
-      %ul.pagination
-        - if pages[:current] > 1
-          - if @ajax_paging_buttons
-            %li.first
-              %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                :complete => "miqSparkle(false);",
-                                                :url      => update_paging_url_parms(action_url, :page => 1)),
-                    :class   => "fa fa-angle-double-left",
-                    :alt     => "First",
-                    :title   => "First"}
-            %li.prev
-              %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                :complete => "miqSparkle(false);",
-                                                :url      => update_paging_url_parms(action_url, :page => pages[:current] - 1)),
-                      :class   => "fa fa-angle-left",
-                      :alt     => "Previous",
-                      :title   => "Previous"}
-          - elsif action_id
-            %li.first
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1, :id => action_id)}')",
-                    :class   => "fa fa-angle-double-left",
-                    :alt     => "First",
-                    :title   => "First"}
-            %li.prev
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1, :id => action_id)}')",
-                    :class   => "fa fa-angle-left",
-                    :alt     => "Previous",
-                    :title   => "Previous"}
-          - else
-            %li.first
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1)}')",
-                    :class   => "fa fa-angle-double-left",
-                    :alt     => "First",
-                    :title   => "First"}
-            %li.prev
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1)}')",
-                    :class   => "fa fa-angle-left",
-                    :alt     => "Previous",
-                    :title   => "Previous"}
-        - else
-          %li.first.disabled
-            %span{:class => "fa fa-angle-double-left"}
-          %li.prev.disabled
-            %span{:class => "fa fa-angle-left"}
-
-        %li
-          %span
-            - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
-            - end_number = pages[:perpage] * pages[:current]
-            - if start_number == pages[:items]
-              = "(Item #{start_number} of #{pages[:items]})"
-            - else
-              - if end_number > pages[:items]
-                = "(Items #{start_number}-#{pages[:items]} of #{pages[:items]})"
+          - if @bottom_msg
+            = h(@bottom_msg)
+        - unless db.blank?
+          - if %w(EmsInfra EmsCloud EmsCluster ResourcePool OntapStorageSystem OntapLogicalDisk CimBaseStorageExtent OntapStorageVolume StorageManager OntapFileShare SniaLocalFileSystem).include?(db)
+            - @db = db.underscore
+        - if @pc_occ == 1
+          .form-group
+            - unless @embedded
+              - if @sortdir == "ASC"
+                = _("Asc. by:")
               - else
-                = "(Items #{start_number}-#{end_number} of #{pages[:items]})"
-            %input{:type => 'hidden', :name => 'limitstart', :value => '0'}
+                = _("Desc. by:")
+            = @view.headers[@sortcol]
 
-        - if pages[:current] < pages[:total]
-          - if @ajax_paging_buttons
-            %li.next
-              %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                :complete => "miqSparkle(false);",
-                                                :url      => update_paging_url_parms(action_url, :page => pages[:current] + 1)),
-                    :class   => "fa fa-angle-right",
-                    :alt     => "Next",
-                    :title   => "Next"}
-            %li.last
-              %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                :complete => "miqSparkle(false);",
-                                                :url      => update_paging_url_parms(action_url, :page => pages[:total])),
-                    :class   => "fa fa-angle-double-right",
-                    :alt     => "Last",
-                    :title   => "Last"}
-          - elsif action_id
-            %li.next
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1, :id => action_id)}')",
-                    :class   => "fa fa-angle-right",
-                    :alt     => "Next",
-                    :title   => "Next"}
-            %li.last
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total], :id => action_id)}')",
-                    :class   => "fa fa-angle-double-right",
-                    :alt     => "Last",
-                    :title   => "Last"}
-          - else
-            %li.next
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1)}')",
-                    :class   => "fa fa-angle-right",
-                    :alt     => "Next",
-                    :title   => "Next"}
-            %li.last
-              %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total])}')",
-                    :class   => "fa fa-angle-double-right",
-                    :alt     => "Last",
-                    :title   => "Last"}
-        - else
-          %li.next.disabled
-            %span{:class => "fa fa-angle-right"}
-          %li.last.disabled
-            %span{:class => "fa fa-angle-double-right"}
+          .form-group.pull-right{:style => "border-right: 0"}
+            %ul.pagination
+              - if pages[:current] > 1
+                - if @ajax_paging_buttons
+                  %li.first
+                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => update_paging_url_parms(action_url, :page => 1)),
+                          :class   => "fa fa-angle-double-left",
+                          :alt     => "First",
+                          :title   => "First"}
+                  %li.prev
+                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => update_paging_url_parms(action_url, :page => pages[:current] - 1)),
+                            :class   => "fa fa-angle-left",
+                            :alt     => "Previous",
+                            :title   => "Previous"}
+                - elsif action_id
+                  %li.first
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1, :id => action_id)}')",
+                          :class   => "fa fa-angle-double-left",
+                          :alt     => "First",
+                          :title   => "First"}
+                  %li.prev
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1, :id => action_id)}')",
+                          :class   => "fa fa-angle-left",
+                          :alt     => "Previous",
+                          :title   => "Previous"}
+                - else
+                  %li.first
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => 1)}')",
+                          :class   => "fa fa-angle-double-left",
+                          :alt     => "First",
+                          :title   => "First"}
+                  %li.prev
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] - 1)}')",
+                          :class   => "fa fa-angle-left",
+                          :alt     => "Previous",
+                          :title   => "Previous"}
+              - else
+                %li.first.disabled
+                  %span{:class => "fa fa-angle-double-left"}
+                %li.prev.disabled
+                  %span{:class => "fa fa-angle-left"}
 
-    .form-group.pull-right
-      = _('Items per page:')
-      = select_tag("ppsetting",
-                   options_for_select(@pp_choices, pages[:perpage]),
-                   "data-width" => "auto",
-                   :class       => "selectpicker dropup")
+              %li
+                %span
+                  - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
+                  - end_number = pages[:perpage] * pages[:current]
+                  - if start_number == pages[:items]
+                    = "(Item #{start_number} of #{pages[:items]})"
+                  - else
+                    - if end_number > pages[:items]
+                      = "(Items #{start_number}-#{pages[:items]} of #{pages[:items]})"
+                    - else
+                      = "(Items #{start_number}-#{end_number} of #{pages[:items]})"
+                  %input{:type => 'hidden', :name => 'limitstart', :value => '0'}
+
+              - if pages[:current] < pages[:total]
+                - if @ajax_paging_buttons
+                  %li.next
+                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => update_paging_url_parms(action_url, :page => pages[:current] + 1)),
+                          :class   => "fa fa-angle-right",
+                          :alt     => "Next",
+                          :title   => "Next"}
+                  %li.last
+                    %span{:onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => update_paging_url_parms(action_url, :page => pages[:total])),
+                          :class   => "fa fa-angle-double-right",
+                          :alt     => "Last",
+                          :title   => "Last"}
+                - elsif action_id
+                  %li.next
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1, :id => action_id)}')",
+                          :class   => "fa fa-angle-right",
+                          :alt     => "Next",
+                          :title   => "Next"}
+                  %li.last
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total], :id => action_id)}')",
+                          :class   => "fa fa-angle-double-right",
+                          :alt     => "Last",
+                          :title   => "Last"}
+                - else
+                  %li.next
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:current] + 1)}')",
+                          :class   => "fa fa-angle-right",
+                          :alt     => "Next",
+                          :title   => "Next"}
+                  %li.last
+                    %span{:onclick => "DoNav('#{update_paging_url_parms(action_url, :page => pages[:total])}')",
+                          :class   => "fa fa-angle-double-right",
+                          :alt     => "Last",
+                          :title   => "Last"}
+              - else
+                %li.next.disabled
+                  %span{:class => "fa fa-angle-right"}
+                %li.last.disabled
+                  %span{:class => "fa fa-angle-double-right"}
+
+          .form-group.pull-right
+            = _('Items per page:')
+            = select_tag("ppsetting",
+                        options_for_select(@pp_choices, pages[:perpage]),
+                        "data-width" => "auto",
+                        :class       => "selectpicker dropup")
+            :javascript
+              miqSelectPickerEvent("ppsetting", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
       :javascript
-        miqSelectPickerEvent("ppsetting", "#{update_paging_url_parms(action_url, {}, true)}", {beforeSend: true, complete: true})
-:javascript
-  miqInitSelectPicker();
+        miqInitSelectPicker();

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -10,8 +10,14 @@
                 :items   => @sb[:pages][:items]}
 
     %div{:id => "rpb_div_#{@pb_occ}"}
-      %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :width => "100%",
-            :style => "height: 30px; border: 1px solid #BAB9BA; border-width: 1px 1px 0px 1px; background: url(#{image_path('layout/teaserbarlg.png')}) repeat-x left bottom;"}
+      %table{:border => "0",
+             :cellpadding => "0",
+             :cellspacing => "0",
+             :width => "100%",
+             :style => ['height: 30px',
+                        'border: 1px solid #BAB9BA',
+                        'border-width: 1px 1px 0px 1px',
+                        "background: url(#{image_path('layout/teaserbarlg.png')}) repeat-x left bottom"].join('; ')}
         %tr
           %td{:valign => "middle"}
           %td{:valign => "middle", :align => "right"}

--- a/app/views/layouts/_saved_report_paging_bar.html.haml
+++ b/app/views/layouts/_saved_report_paging_bar.html.haml
@@ -1,81 +1,83 @@
-- action = "saved_report_paging"
-- url = url_for(:action => action)
-- @pb_occ ||= 0
-- @pb_occ += 1
-- pages ||= {:perpage => @settings[:perpage][:reports],
-             :current => 1,
-             :total   => @sb[:pages][:total],
-             :items   => @sb[:pages][:items]}
+.col-md-12
+  .toolbar-pf-actions
+    - action = "saved_report_paging"
+    - url = url_for(:action => action)
+    - @pb_occ ||= 0
+    - @pb_occ += 1
+    - pages ||= {:perpage => @settings[:perpage][:reports],
+                :current => 1,
+                :total   => @sb[:pages][:total],
+                :items   => @sb[:pages][:items]}
 
-%div{:id => "rpb_div_#{@pb_occ}"}
-  %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :width => "100%",
-         :style => "height: 30px; border: 1px solid #BAB9BA; border-width: 1px 1px 0px 1px; background: url(#{image_path('layout/teaserbarlg.png')}) repeat-x left bottom;"}
-    %tr
-      %td{:valign => "middle"}
-      %td{:valign => "middle", :align => "right"}
-        %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :align => "right"}
-          %tr
-            %td{:style => "padding: 4px 2px 4px 2px;", :nowrap => true}= _("Per page:")
-            %td{:style => "padding: 4px 2px 4px 2px;"}
-              = select_tag("perpage_setting#{@pb_occ}",
-                           options_for_select(@pp_choices, pages[:perpage]),
-                           "data-miq_sparkle_on"  => true,
-                           "data-miq_sparkle_off" => true,
-                           "data-miq_observe"     => {:url => url}.to_json)
-            %td{:nowrap => true}
-              - if pages[:current] > 1
-                = link_to(image_tag(image_path('toolbars/first.png'), :border => "0", :class => "rollover small"),
-                          {:action => action,
-                           :page   => 1},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :remote                => true,
-                          "data-method"          => :post,
-                          :title                 => "")
-                = link_to(image_tag(image_path('toolbars/previous.png'), :border => "0", :class => "rollover small"),
-                          {:action => action,
-                           :page   => pages[:current] - 1},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :remote                => true,
-                          "data-method"          => :post,
-                          :title                 => "")
-              - else
-                = image_tag(image_path('toolbars/first.png'), :class => "dimmed small")
-                = image_tag(image_path('toolbars/previous.png'), :class => "dimmed small")
-              - if pages[:current] < pages[:total]
-                = link_to(image_tag(image_path('toolbars/next.png'), :class => "rollover small"),
-                          {:action => action,
-                           :page   => pages[:current] + 1},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :remote                => true,
-                          "data-method"          => :post,
-                          :title                 => "")
-                = link_to(image_tag(image_path('toolbars/last.png'), :class => "rollover small"),
-                          {:action  => action,
-                           :page    => pages[:total]},
-                          "data-miq_sparkle_on"  => true,
-                          "data-miq_sparkle_off" => true,
-                          :remote                => true,
-                          "data-method"          => :post,
-                          :title                 => "")
-              - else
-                = image_tag(image_path('toolbars/next.png'), :class => "dimmed small")
-                = image_tag(image_path('toolbars/last.png'), :class => "dimmed small")
-            %td{:valign => "middle", :style => "padding: 4px"}
-              - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
-              - end_number = pages[:perpage] * pages[:current]
-              - if start_number == pages[:items]
-                = _("(Row %{start_number} of %{pages})") % {:start_number => start_number,
-                                                            :pages        => pages[:items]}
-              - else
-                - if end_number > pages[:items]
-                  = _("(Rows %{start_number}-%{pages_items} of %{pages_items})") % {:start_number => start_number,
-                                                                                    :pages_items  => pages[:items]}
-                - else
-                  = _("(Rows %{start_number}-%{end_number} of %{pages_items})") % {:start_number => start_number,
-                                                                                   :end_number   => end_number,
-                                                                                   :pages_items  => pages[:items]}
-              %input{:type => "hidden", :name => 'limitstart', :value => '0'}
-= render(:partial => '/layouts/x_form_buttons')
+    %div{:id => "rpb_div_#{@pb_occ}"}
+      %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :width => "100%",
+            :style => "height: 30px; border: 1px solid #BAB9BA; border-width: 1px 1px 0px 1px; background: url(#{image_path('layout/teaserbarlg.png')}) repeat-x left bottom;"}
+        %tr
+          %td{:valign => "middle"}
+          %td{:valign => "middle", :align => "right"}
+            %table{:border => "0", :cellpadding => "0", :cellspacing => "0", :align => "right"}
+              %tr
+                %td{:style => "padding: 4px 2px 4px 2px;", :nowrap => true}= _("Per page:")
+                %td{:style => "padding: 4px 2px 4px 2px;"}
+                  = select_tag("perpage_setting#{@pb_occ}",
+                              options_for_select(@pp_choices, pages[:perpage]),
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              "data-miq_observe"     => {:url => url}.to_json)
+                %td{:nowrap => true}
+                  - if pages[:current] > 1
+                    = link_to(image_tag(image_path('toolbars/first.png'), :border => "0", :class => "rollover small"),
+                              {:action => action,
+                              :page   => 1},
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :remote                => true,
+                              "data-method"          => :post,
+                              :title                 => "")
+                    = link_to(image_tag(image_path('toolbars/previous.png'), :border => "0", :class => "rollover small"),
+                              {:action => action,
+                              :page   => pages[:current] - 1},
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :remote                => true,
+                              "data-method"          => :post,
+                              :title                 => "")
+                  - else
+                    = image_tag(image_path('toolbars/first.png'), :class => "dimmed small")
+                    = image_tag(image_path('toolbars/previous.png'), :class => "dimmed small")
+                  - if pages[:current] < pages[:total]
+                    = link_to(image_tag(image_path('toolbars/next.png'), :class => "rollover small"),
+                              {:action => action,
+                              :page   => pages[:current] + 1},
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :remote                => true,
+                              "data-method"          => :post,
+                              :title                 => "")
+                    = link_to(image_tag(image_path('toolbars/last.png'), :class => "rollover small"),
+                              {:action  => action,
+                              :page    => pages[:total]},
+                              "data-miq_sparkle_on"  => true,
+                              "data-miq_sparkle_off" => true,
+                              :remote                => true,
+                              "data-method"          => :post,
+                              :title                 => "")
+                  - else
+                    = image_tag(image_path('toolbars/next.png'), :class => "dimmed small")
+                    = image_tag(image_path('toolbars/last.png'), :class => "dimmed small")
+                %td{:valign => "middle", :style => "padding: 4px"}
+                  - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
+                  - end_number = pages[:perpage] * pages[:current]
+                  - if start_number == pages[:items]
+                    = _("(Row %{start_number} of %{pages})") % {:start_number => start_number,
+                                                                :pages        => pages[:items]}
+                  - else
+                    - if end_number > pages[:items]
+                      = _("(Rows %{start_number}-%{pages_items} of %{pages_items})") % {:start_number => start_number,
+                                                                                        :pages_items  => pages[:items]}
+                    - else
+                      = _("(Rows %{start_number}-%{end_number} of %{pages_items})") % {:start_number => start_number,
+                                                                                      :end_number   => end_number,
+                                                                                      :pages_items  => pages[:items]}
+                  %input{:type => "hidden", :name => 'limitstart', :value => '0'}
+    = render(:partial => '/layouts/x_form_buttons')

--- a/app/views/layouts/_x_pagingcontrols.html.haml
+++ b/app/views/layouts/_x_pagingcontrols.html.haml
@@ -1,107 +1,109 @@
-- if @pages && @items_per_page != ONE_MILLION && @pages[:items] > 0
-  - button_div ||= "center_tb"
-  - action_url ||= "explorer"
-  - pages = @pages
-  - if action_url.include?("/")
-    - action_method = action_url.split("/").first
-    - action_id = action_url.split("/").last
-  - url = action_id ? url_for(:action => action_method, :id => action_id) : url_for(:action => action_url)
-  - @pc_occ ||= 0
-  - @pc_occ += 1
-  %div{:id => "pc_div_#{@pc_occ}"}
-    - if @pc_occ == 1
-      .form-group
-        - if ! @no_checkall && ! @no_checkboxes
-          %input#masterToggle{:name    => "masterToggle",
-                              :onclick => "miqUpdateAllCheckboxes('#{button_div}', null);",
-                              :type    => "checkbox"}
-          (Check All)
-      .form-group{:style => "border-right: 0"}
-        = _('Sorted by: ')
-        - sort_text = "#{@view.headers[@sortcol]} (#{@sortdir == "ASC" ? "Asc." : "Desc."})"
-        - if @gtl_type != "list" && @view
-          = select_tag("sort_choice",
-                       options_for_select([sort_text] + @view.headers),
-                       :class => "selectpicker dropup")
-          :javascript
-            miqSelectPickerEvent("sort_choice", "#{url}", {beforeSend: true, complete: true})
-        - elsif @gtl_type == "list" && @view
-          = h(sort_text)
-    - else
-      - if @bottom_msg
-        = h(@bottom_msg)
+.col-md-12
+  .toolbar-pf-actions
+    - if @pages && @items_per_page != ONE_MILLION && @pages[:items] > 0
+      - button_div ||= "center_tb"
+      - action_url ||= "explorer"
+      - pages = @pages
+      - if action_url.include?("/")
+        - action_method = action_url.split("/").first
+        - action_id = action_url.split("/").last
+      - url = action_id ? url_for(:action => action_method, :id => action_id) : url_for(:action => action_url)
+      - @pc_occ ||= 0
+      - @pc_occ += 1
+      %div{:id => "pc_div_#{@pc_occ}"}
+        - if @pc_occ == 1
+          .form-group
+            - if ! @no_checkall && ! @no_checkboxes
+              %input#masterToggle{:name    => "masterToggle",
+                                  :onclick => "miqUpdateAllCheckboxes('#{button_div}', null);",
+                                  :type    => "checkbox"}
+              (Check All)
+          .form-group{:style => "border-right: 0"}
+            = _('Sorted by: ')
+            - sort_text = "#{@view.headers[@sortcol]} (#{@sortdir == "ASC" ? "Asc." : "Desc."})"
+            - if @gtl_type != "list" && @view
+              = select_tag("sort_choice",
+                          options_for_select([sort_text] + @view.headers),
+                          :class => "selectpicker dropup")
+              :javascript
+                miqSelectPickerEvent("sort_choice", "#{url}", {beforeSend: true, complete: true})
+            - elsif @gtl_type == "list" && @view
+              = h(sort_text)
+        - else
+          - if @bottom_msg
+            = h(@bottom_msg)
 
-    .form-group.pull-right{:style => "border-right: 0"}
-      %ul.pagination
-        %li.first
-          / first button
-          - if pages[:current] > 1
-            %span{:type    => "button",
-                  :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                :complete => "miqSparkle(false);",
-                                                :url      => "#{action_url}?page=1&id=#{action_id}"),
-                    :class   => "fa fa-angle-double-left",
-                    :alt     => "First",
-                    :title   => "First"}
-            %li.prev
-              %span{:type    => "button",
-                    :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                  :complete => "miqSparkle(false);",
-                                                  :url      => "#{action_url}?page=#{pages[:current] - 1}&id=#{action_id}"),
-                      :class   => "fa fa-angle-left",
-                      :alt     => "Previous",
-                      :title   => "Previous"}
-          - else
-            %li.first.disabled
-              %span{:class => "i fa fa-angle-double-left"}
-            %li.prev.disabled
-              %span{:class => "i fa fa-angle-left"}
-
-          %li
-            %span
-              - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
-              - end_number = pages[:perpage] * pages[:current]
-              - if start_number == pages[:items]
-                = "Showing #{start_number} of #{pages[:items]} items"
+        .form-group.pull-right{:style => "border-right: 0"}
+          %ul.pagination
+            %li.first
+              / first button
+              - if pages[:current] > 1
+                %span{:type    => "button",
+                      :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => "#{action_url}?page=1&id=#{action_id}"),
+                        :class   => "fa fa-angle-double-left",
+                        :alt     => "First",
+                        :title   => "First"}
+                %li.prev
+                  %span{:type    => "button",
+                        :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => "#{action_url}?page=#{pages[:current] - 1}&id=#{action_id}"),
+                          :class   => "fa fa-angle-left",
+                          :alt     => "Previous",
+                          :title   => "Previous"}
               - else
-                - if end_number > pages[:items]
-                  = "Showing #{start_number}-#{pages[:items]} of #{pages[:items]} items"
-                - else
-                  = "Showing #{start_number}-#{end_number} of #{pages[:items]} items"
-              %input{:name => "limitstart", :type => "hidden", :value => "0"}/
+                %li.first.disabled
+                  %span{:class => "i fa fa-angle-double-left"}
+                %li.prev.disabled
+                  %span{:class => "i fa fa-angle-left"}
 
-          - if pages[:current] < pages[:total]
-            %li.next
-              %span{:type    => "button",
-                      :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                  :complete => "miqSparkle(false);",
-                                                  :url      => "#{action_url}?page=#{pages[:current] +1}&id=#{action_id}"),
-                      :class   => "i fa fa-angle-right",
-                      :alt     => "Next",
-                      :title   => "Next"}
-            %li.last
-              %span{:type    => "button",
-                      :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                  :complete => "miqSparkle(false);",
-                                                  :url      => "#{action_url}?page=#{pages[:total]}&id=#{action_id}"),
-                      :class   => "i fa fa-angle-double-right",
-                      :alt     => "Last",
-                      :title   => "Last"}
-          - else
-            %li.next.disabled
-              %span{:class => "i fa fa-angle-right"}
-            %li.last.disabled
-              %span{:class => "i fa fa-angle-double-right"}
+              %li
+                %span
+                  - start_number = (pages[:perpage] * pages[:current]) - pages[:perpage] + 1
+                  - end_number = pages[:perpage] * pages[:current]
+                  - if start_number == pages[:items]
+                    = "Showing #{start_number} of #{pages[:items]} items"
+                  - else
+                    - if end_number > pages[:items]
+                      = "Showing #{start_number}-#{pages[:items]} of #{pages[:items]} items"
+                    - else
+                      = "Showing #{start_number}-#{end_number} of #{pages[:items]} items"
+                  %input{:name => "limitstart", :type => "hidden", :value => "0"}/
 
-    .form-group.pull-right
-      = _('Items per page:')
-      = select_tag("ppsetting",
-                   options_for_select(@pp_choices, pages[:perpage]),
-                   "data-width" => "auto",
-                   :class       => "selectpicker dropup")
-      :javascript
-        miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
+              - if pages[:current] < pages[:total]
+                %li.next
+                  %span{:type    => "button",
+                          :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => "#{action_url}?page=#{pages[:current] +1}&id=#{action_id}"),
+                          :class   => "i fa fa-angle-right",
+                          :alt     => "Next",
+                          :title   => "Next"}
+                %li.last
+                  %span{:type    => "button",
+                          :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                      :complete => "miqSparkle(false);",
+                                                      :url      => "#{action_url}?page=#{pages[:total]}&id=#{action_id}"),
+                          :class   => "i fa fa-angle-double-right",
+                          :alt     => "Last",
+                          :title   => "Last"}
+              - else
+                %li.next.disabled
+                  %span{:class => "i fa fa-angle-right"}
+                %li.last.disabled
+                  %span{:class => "i fa fa-angle-double-right"}
 
-= render(:partial => '/layouts/x_form_buttons')
-:javascript
-  miqInitSelectPicker();
+        .form-group.pull-right
+          = _('Items per page:')
+          = select_tag("ppsetting",
+                      options_for_select(@pp_choices, pages[:perpage]),
+                      "data-width" => "auto",
+                      :class       => "selectpicker dropup")
+          :javascript
+            miqSelectPickerEvent("ppsetting", "#{url}", {beforeSend: true, complete: true})
+
+    = render(:partial => '/layouts/x_form_buttons')
+    :javascript
+      miqInitSelectPicker();

--- a/app/views/layouts/_x_pagingcontrols.html.haml
+++ b/app/views/layouts/_x_pagingcontrols.html.haml
@@ -40,19 +40,19 @@
               - if pages[:current] > 1
                 %span{:type    => "button",
                       :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                    :complete => "miqSparkle(false);",
-                                                    :url      => "#{action_url}?page=1&id=#{action_id}"),
-                        :class   => "fa fa-angle-double-left",
-                        :alt     => "First",
-                        :title   => "First"}
+                                                  :complete => "miqSparkle(false);",
+                                                  :url      => "#{action_url}?page=1&id=#{action_id}"),
+                      :class   => "fa fa-angle-double-left",
+                      :alt     => "First",
+                      :title   => "First"}
                 %li.prev
                   %span{:type    => "button",
                         :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => "#{action_url}?page=#{pages[:current] - 1}&id=#{action_id}"),
-                          :class   => "fa fa-angle-left",
-                          :alt     => "Previous",
-                          :title   => "Previous"}
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => "#{action_url}?page=#{pages[:current] - 1}&id=#{action_id}"),
+                        :class   => "fa fa-angle-left",
+                        :alt     => "Previous",
+                        :title   => "Previous"}
               - else
                 %li.first.disabled
                   %span{:class => "i fa fa-angle-double-left"}
@@ -75,20 +75,20 @@
               - if pages[:current] < pages[:total]
                 %li.next
                   %span{:type    => "button",
-                          :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => "#{action_url}?page=#{pages[:current] +1}&id=#{action_id}"),
-                          :class   => "i fa fa-angle-right",
-                          :alt     => "Next",
-                          :title   => "Next"}
+                        :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => "#{action_url}?page=#{pages[:current] +1}&id=#{action_id}"),
+                        :class   => "i fa fa-angle-right",
+                        :alt     => "Next",
+                        :title   => "Next"}
                 %li.last
                   %span{:type    => "button",
-                          :onclick => remote_function(:loading  => "miqSparkle(true);",
-                                                      :complete => "miqSparkle(false);",
-                                                      :url      => "#{action_url}?page=#{pages[:total]}&id=#{action_id}"),
-                          :class   => "i fa fa-angle-double-right",
-                          :alt     => "Last",
-                          :title   => "Last"}
+                        :onclick => remote_function(:loading  => "miqSparkle(true);",
+                                                    :complete => "miqSparkle(false);",
+                                                    :url      => "#{action_url}?page=#{pages[:total]}&id=#{action_id}"),
+                        :class   => "i fa fa-angle-double-right",
+                        :alt     => "Last",
+                        :title   => "Last"}
               - else
                 %li.next.disabled
                   %span{:class => "i fa fa-angle-right"}


### PR DESCRIPTION
There's a lot of places that do `replace_html('paging_div', ...)`, but since the patternfly change, the content layout includes paging like

```haml
.row.toolbar-pf#paging_div
  .col-md-12
    .toolbar-pf-actions
      = render(:partial => 'layouts/pagingcontrols', ...)
```

So any replace would lose that `col-md-12` and `toolbar-pf-actions`.

This fixes that by moving these 2 elements (and a condition when needed) inside those paging partials (`layouts/pagingcontrols`, `layouts/saved_report_paging_bar` and `layouts/x_pagingcontrols`).

Also changes *every* paging replacement invocation to always reference `paging_div` (a few references to `pc_div_1` have cropped in since, since that behaved correctly) and always use `replace_html` (not `replace`).

Closes #5582.