### PR TITLE
Allow migration to run if REGION file is missing

### DIFF
--- a/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
+++ b/db/migrate/20160115142023_remove_replicated_rows_from_newly_excluded_tables.rb
@@ -14,7 +14,7 @@ class RemoveReplicatedRowsFromNewlyExcludedTables < ActiveRecord::Migration
 
   def up
     say_with_time("Removing rows from newly excluded tables") do
-      region_cond = ActiveRecord::Base.region_to_conditions(Rails.root.join("REGION").read.to_i)
+      region_cond = ActiveRecord::Base.region_to_conditions(ActiveRecord::Base.my_region_number)
       MiqEventDefinition.where.not(region_cond).delete_all
       ScanItem.where.not(region_cond).delete_all
     end

--- a/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
+++ b/spec/migrations/20160115142023_remove_replicated_rows_from_newly_excluded_tables_spec.rb
@@ -8,10 +8,7 @@ describe RemoveReplicatedRowsFromNewlyExcludedTables do
 
   migration_context :up do
     before do
-      path_double = double
-      allow(Rails).to receive(:root).and_return(path_double)
-      allow(path_double).to receive(:join).and_return(path_double)
-      allow(path_double).to receive(:read).and_return("99")
+      allow(ActiveRecord::Base).to receive(:my_region_number).and_return(99)
     end
 
     it "removes the rows from the tables" do


### PR DESCRIPTION
Use the ActiveRecord extensions to retrieve region number.
This will default to region 0 if the file doesn't exist.

Follow up to #6206
Fixes #6239