### PR TITLE
Make ArRegion smarter at discovering the region

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -20,7 +20,7 @@ module ArRegion
 
     def my_region_number(force_reload = false)
       clear_region_cache if force_reload
-      @@my_region_number ||= File.read(File.join(Rails.root, "REGION")).to_i rescue 0
+      @@my_region_number ||= discover_my_region_number
     end
 
     def rails_sequence_factor
@@ -116,6 +116,18 @@ module ArRegion
     # Partition the passed ids into local and remote sets
     def partition_ids_by_remote_region(ids)
       ids.partition { |id| self.id_in_current_region?(id) }
+    end
+
+    private
+
+    def discover_my_region_number
+      region_file = File.join(Rails.root, "REGION")
+      region_num = File.read(region_file) if File.exist?(region_file)
+      region_num ||= ENV.fetch("REGION", nil)
+      region_num ||= id_to_region(connection.select_value("select last_value from miq_databases_id_seq"))
+      region_num.to_i
+    rescue ActiveRecord::StatementInvalid # sequence does not exist yet
+      0
     end
   end
 

--- a/spec/lib/ws_proxy_spec.rb
+++ b/spec/lib/ws_proxy_spec.rb
@@ -4,7 +4,7 @@ describe WsProxy do
       :server => {
         :websocket => {
           :cert => 'non-existent-foo-bar',
-          :key  => 'REGION' # file existing under Rails root
+          :key  => 'Gemfile' # file existing under Rails root
         }
       }
     )
@@ -22,7 +22,7 @@ describe WsProxy do
           :idle_timeout= => 120,
           :timeout=      => 120,
           :cert          => WsProxy::DEFAULT_CERT_FILE,
-          :key           => 'REGION',
+          :key           => 'Gemfile',
           nil            => [port, "0.0.0.0:5900"],
         }
       )


### PR DESCRIPTION
**Story:**

A bug was introduced (fixed: #6239) because the migrations depended upon the presence of a `REGION` file. Many developers do not have this file on their machine. I have also had issues with the dependence of a `REGION` file and the incorrect determination of the region when the file was not present.

I wanted the application to be smarter when determining the region. So my environment would not depend upon the `REGION` file and have me constantly updating it.

In the long term, it would be great if this file were not needed in development or production, but this PR does not have such lofty aspirations.

**Before:**

- In production, users need to backup and restore a `REGION` file.
- In development, users need to change the `REGION` file when ever switching their database.

**After:**

- In production, the `REGION` file is optional. But it will be present since all the infrastructure currently creates one.
- In development, the local `REGION` file is optional. When it is missing, it will properly determine the region rather than assume it is 0.

**What this PR addresses:**

- This makes the `REGION` file optional.
- It will mostly be leveraged in development, thought it could be leveraged in production if we want to go the route of removing that file.

**How does this work:**

The database has the region number embedded in the sequence of every table. This is necessary because every time a record is created, it needs to be assigned an id for the correct region.

If the `REGION` file is not present, it looks at the sequence of the very first table created (`miq_databases`) and uses that to determine the correct region. If that table does not exist, then it falls back to region 0 as it always has.

This also adds the provision of reading the region number from an environment variable `REGION`.

/cc @jrafanie @carbonin This is what I had in mind. think this may help with #6239
/cc @Fryguy Easier for me to just throw code together than explain
/cc @matthewd FYI