### PR TITLE
Use config/secrets.yml and auto-filter credentials information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 BUILD
 ca/root
 certs/v2_key
+config/secrets.yml*
 coverage/
 Gemfile.dev.rb
 Gemfile.lock*

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -1,0 +1,21 @@
+development:
+  azure:
+    client_id: xxxxx
+    client_secret: yyyyy
+    tenant_id: zzzzz
+
+  amazon:
+    client_id: xxxxx
+    client_secret: yyyyy
+    tenant_id: zzzzz
+
+test:
+  azure:
+    client_id: xxxxx
+    client_secret: yyyyy
+    tenant_id: zzzzz
+
+  amazon:
+    client_id: xxxxx
+    client_secret: yyyyy
+    tenant_id: zzzzz

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'application_helper'
 
 require 'rspec/rails'
 require 'vcr'
+require 'cgi'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -111,6 +112,20 @@ VCR.configure do |c|
   c.default_cassette_options = {
     :allow_unused_http_interactions => false
   }
+
+  # Set your config/secrets.yml file
+  secrets = Rails.application.secrets
+
+  # Looks for provider subkeys you set in secrets.yml. Replace the values of
+  # those keys (both escaped or unescaped) with some placeholder text.
+  secrets.keys.each do |provider|
+    next if [:secret_key_base, :secret_token].include?(provider) # Defaults
+    cred_hash = secrets.public_send(provider)
+    cred_hash.each do |key, value|
+      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { CGI.escape(value) }
+      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { value }
+    end
+  end
 
   # c.debug_logger = File.open(Rails.root.join("log", "vcr_debug.log"), "w")
 end


### PR DESCRIPTION
With this PR, you can put credentials information in your config/secrets.yml file, which has been added to the .gitignore file. The format of your secrets.yml file should be subdivided by provider, like so:

```
development:
  azure:
    client_id: xxxxxxxxxx
    client_secret: yyyyyyyyyy
    tenant_id: zzzzzzzzzz

test:
  azure:
    client_id: xxxxxxxxxx
    client_secret: yyyyyyyyyy
    tenant_id: zzzzzzzzzz
```

Within your specs, you can then refer back to this information like so:

```
Rails.application.secrets.azure
Rails.application.secrets.amazon
# and so on
```

With that in place, I added logic into the spec_helper to automatically filter on any subkeys you create under any particular provider. So, for the example above, it will filter "client_id", "client_secret" and "tenant_id".

When you run your tests and generate a new VCR cassette, the actual values for those keys inside the refresher.yml file will be replaced with e.g. ```<AZURE_CLIENT_ID>```, ```<AZURE_CLIENT_SECRET>``` and ```<AZURE_TENANT_ID>```, with "AZURE" replaced with whatever the provider name is.

This way you don't have to hand edit your test file(s) and the refresher.yml file every time you want to submit a PR.

~~As part of the PR, I modified the Azure refresher spec, too.~~