### PR TITLE
Added destination_image_locked? check to RHEV iso/pxe provisioning

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision/state_machine.rb
@@ -40,10 +40,13 @@ module ManageIQ::Providers::Redhat::InfraManager::Provision::StateMachine
       _log.info("#{message} #{for_destination}")
       update_and_notify_parent(:message => message)
       configure_container
-      configure_cloud_init
-
-      signal :poll_destination_powered_off_in_provider
+      configure_destination
     end
+  end
+
+  def configure_destination
+    configure_cloud_init
+    signal :poll_destination_powered_off_in_provider
   end
 
   def poll_destination_powered_on_in_provider

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_iso/state_machine.rb
@@ -1,12 +1,6 @@
 module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso::StateMachine
-  def customize_destination
-    message = "Starting New #{destination_type} Customization"
-    _log.info("#{message} #{for_destination}")
-    update_and_notify_parent(:message => message)
-
-    configure_container
+  def configure_destination
     attach_floppy_payload
-
     signal :boot_from_cdrom
   end
 

--- a/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine.rb
@@ -1,10 +1,5 @@
 module ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe::StateMachine
-  def customize_destination
-    message = "Starting New #{destination_type} Customization"
-    _log.info("#{message} #{for_destination}")
-    update_and_notify_parent(:message => message)
-    configure_container
-
+  def configure_destination
     signal :create_pxe_configuration_file
   end
 

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision/state_machine_spec.rb
@@ -97,10 +97,15 @@ describe ManageIQ::Providers::Redhat::InfraManager::Provision do
       allow(@task).to receive(:update_and_notify_parent)
 
       expect(@task).to receive(:configure_container)
-      expect(@task).to receive(:configure_cloud_init)
-      expect(@task).to receive(:poll_destination_powered_off_in_provider)
+      expect(@task).to receive(:configure_destination)
 
       @task.customize_destination
+    end
+
+    it "#configure_destination" do
+      expect(@task).to receive(:configure_cloud_init)
+      expect(@task).to receive(:poll_destination_powered_off_in_provider)
+      @task.configure_destination
     end
 
     it "#poll_destination_powered_off_in_provider" do

--- a/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/provision_via_pxe/state_machine_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
+describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe do
   context "::StateMachine" do
     before do
       ems      = FactoryGirl.create(:ems_redhat_with_authentication)
@@ -8,7 +8,8 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
       vm       = FactoryGirl.create(:vm_redhat)
       options  = {:src_vm_id => template.id}
 
-      @task = FactoryGirl.create(:miq_provision_redhat_via_iso, :source => template, :destination => vm, :state => 'pending', :status => 'Ok', :options => options)
+      @task = FactoryGirl.create(:miq_provision_redhat_via_pxe, :source => template, :destination => vm,
+                                 :state => 'pending', :status => 'Ok', :options => options)
     end
 
     it "#customize_destination" do
@@ -21,8 +22,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso do
     end
 
     it "#configure_destination" do
-      expect(@task).to receive(:attach_floppy_payload)
-      expect(@task).to receive(:boot_from_cdrom)
+      expect(@task).to receive(:create_pxe_configuration_file)
       @task.configure_destination
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1298748

The destination_image_locked? method was only being
called on native RHEV provisioning.  This change slightly
refactors the customize_destination method to enable
the destination_image_locked? check for all RHEV
provisioning types