### PR TITLE
Fixed schema sequencing issue.

### DIFF
--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -2330,7 +2330,7 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:fields] = @ae_class.ae_fields.deep_clone
     @edit[:new][:fields_list] = @edit[:new][:fields]
                                 .sort_by { |f| f.priority.to_i }
-                                .collect { |f| "#{f.display_name} (#{f.name})" }
+                                .collect { |f| f.display_name ? "#{f.display_name} (#{f.name})" : "(#{f.name})" }
     @edit[:key] = "fields_edit__seq"
     @edit[:current] = copy_hash(@edit[:new])
     @right_cell_text = "Edit of Class Schema Sequence '#{@ae_class.name}'"

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -535,4 +535,41 @@ describe MiqAeClassController do
       expect(priorities).to eq([1, 2, 3])
     end
   end
+
+  context "#fields_seq_field_changed" do
+    before do
+      ns = FactoryGirl.create(:miq_ae_namespace, :name => 'foo')
+      @cls = FactoryGirl.create(:miq_ae_class, :namespace_id => ns.id)
+      FactoryGirl.create(:miq_ae_field,
+                         :aetype   => "attribute",
+                         :datatype => "string",
+                         :name     => "name01",
+                         :class_id => @cls.id,
+                         :priority => 1)
+      FactoryGirl.create(:miq_ae_field,
+                         :aetype   => "attribute",
+                         :datatype => "string",
+                         :name     => "name02",
+                         :class_id => @cls.id,
+                         :priority => 2)
+    end
+
+    it "moves selected field down" do
+      controller.send(:fields_seq_edit_screen, @cls.id)
+      expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name01)", "(name02)"])
+      controller.instance_variable_set(:@_params, :button => 'down', :id => 'seq', :seq_fields => "['(name01)']")
+      expect(controller).to receive(:render)
+      controller.fields_seq_field_changed
+      expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name02)", "(name01)"])
+    end
+
+    it "moves selected field up" do
+      controller.send(:fields_seq_edit_screen, @cls.id)
+      expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name01)", "(name02)"])
+      controller.instance_variable_set(:@_params, :button => 'up', :id => 'seq', :seq_fields => "['(name02)']")
+      expect(controller).to receive(:render)
+      controller.fields_seq_field_changed
+      expect(assigns(:edit)[:new][:fields_list]).to match_array(["(name02)", "(name01)"])
+    end
+  end
 end


### PR DESCRIPTION
Issue is caused by whitespace on the left of all items in list when schema fields do not have display name, when sending up selected fields from the form jquery serialize method trims whitespace around the fields which causes an issue when comparing these fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1299965
https://bugzilla.redhat.com/show_bug.cgi?id=1300034

@dclarizio please review.