### PR TITLE
Added the activerecord-session_store gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
 gem "rails",                           "~>4.2.5"
+gem "activerecord-session_store",      "~>0.1.2"
 
 # Local gems
 path "gems/" do


### PR DESCRIPTION
As of https://github.com/rails/rails/commit/0ffe19056c8e8b2f9ae9d487b896cad2ce9387ad the session store was extracted into a gem. We need it for the `session_store: sql` functionality.

https://bugzilla.redhat.com/show_bug.cgi?id=1300018