### PR TITLE
[WIP] [api] filter service requests

### DIFF
--- a/app/controllers/api_controller/service_requests.rb
+++ b/app/controllers/api_controller/service_requests.rb
@@ -1,5 +1,11 @@
 class ApiController
   module ServiceRequests
+    def show_service_requests
+      params["filter"] ||= []
+      params["filter"] << "requester_id=#{@auth_user_obj.id}"
+      show_generic(:service_requests)
+    end
+
     #
     # Service Requests Subcollection Supporting Methods
     #

--- a/config/api.yml
+++ b/config/api.yml
@@ -672,6 +672,10 @@
     :subcollections:
     - :request_tasks
     - :tasks
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: miq_request_show_list
   :service_templates:
     :description: Service Templates
     :options:

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -100,5 +100,27 @@ describe ApiController do
 
       expect_request_forbidden
     end
+
+    it "does not show another user's requests" do
+      other_user = FactoryGirl.create(:user)
+      FactoryGirl.create(:service_template_provision_request,
+                         :requester   => other_user,
+                         :source_id   => template.id,
+                         :source_type => template.class.name)
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url
+      expect_query_result(:service_requests, 0, 0)
+    end
+
+    it "a user can see their own requests" do
+      service_request
+      api_basic_authorize collection_action_identifier(:service_requests, :read, :get)
+
+      run_get service_requests_url
+      expect_query_result(:service_requests, 1, 1)
+    end
+
+    it "an admin can see all the requests"
   end
 end

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -91,4 +91,14 @@ describe ApiController do
       expect_result_to_have_user_email(@user.email)
     end
   end
+
+  context "authorization" do
+    it "is forbidden for a user without appropriate role" do
+      api_basic_authorize
+
+      run_get service_requests_url
+
+      expect_request_forbidden
+    end
+  end
 end


### PR DESCRIPTION
To resolve https://bugzilla.redhat.com/show_bug.cgi?id=1297974

@abellotti: not sure this is the way to go WRT filtering request results by requester. In any case, https://github.com/imtayadeway/manageiq/blob/e79330f5c16f96fb66e670e5f8e68aa84d860a93/spec/requests/api/service_requests_spec.rb#L104-L114 is currently failing because `Rbac` will return the count of all objects (it does filter the results though, but I'm unhappy about having to insert that filter to get that). Any thoughts?

I've left the last spec pending - perhaps we can talk about that too if you have time this week. Thanks!

/cc @AparnaKarve @gtanzillo 
@miq-bot add-label wip