### PR TITLE
Removed duplicate hash keys from HAML files

### DIFF
--- a/app/views/miq_policy/_export.html.haml
+++ b/app/views/miq_policy/_export.html.haml
@@ -82,7 +82,6 @@
           %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}
             = select_tag('choices_chosen[]',
               options_for_select(@sb[:new][:choices].sort),
-              :style             => "width:auto; min-width:375px; background-color:#fff; border: 0px;",
               :size              => 15,
               :style             => "width: 400px",
               :multiple          => true,

--- a/app/views/ops/_ap_form_file.html.haml
+++ b/app/views/ops/_ap_form_file.html.haml
@@ -46,7 +46,6 @@
               %td
                 = image_submit_tag("/images/toolbars/import.png",
                   :class => "rollover small",
-                  :id    => "accept",
                   :name  => "accept",
                   :alt   => t = _("Update this entry"),
                   :title => t,

--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -23,7 +23,6 @@
           %td
             = image_submit_tag("/images/toolbars/import.png",
               :class     => "rollover small",
-              :id        => "accept",
               :name      => "accept",
               :alt       => _("Add this entry"),
               :title     => _("Add this entry"),
@@ -62,7 +61,6 @@
               %td
                 = image_submit_tag("/images/toolbars/import.png",
                   :class      => "rollover small",
-                  :id         => "accept",
                   :name       => "accept",
                   :edit_entry => 'edit_registry',
                   :alt        => _("Update this entry"),

--- a/app/views/ops/_ap_form_registry.html.haml
+++ b/app/views/ops/_ap_form_registry.html.haml
@@ -21,7 +21,7 @@
           %td
             = image_submit_tag("/images/toolbars/import.png",
               :class => "rollover small",
-              :id => "accept", :name => "accept", :alt => _("Add this entry"), :title => _("Add this entry"), :item_type => "registry", :id => "#{@scan.id || "new"}")
+              :name => "accept", :alt => _("Add this entry"), :title => _("Add this entry"), :item_type => "registry", :id => "#{@scan.id || "new"}")
           %td
             = _("HKLM")
           %td
@@ -42,7 +42,7 @@
               %td
                 = image_submit_tag("/images/toolbars/import.png",
                   :class => "rollover small",
-                  :id => "accept", :name => "accept", :entry_id => i, :edit_entry => 'edit_registry', :alt => _("Update this entry"), :title => _("Update this entry"), :id => "#{@scan.id || "new"}")
+                  :name => "accept", :entry_id => i, :edit_entry => 'edit_registry', :alt => _("Update this entry"), :title => _("Update this entry"), :id => "#{@scan.id || "new"}")
               %td
                 = _("HKLM")
               %td

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -43,7 +43,6 @@
         = select_tag("chosen_parent",
                       options_for_select(@edit[:pchoices].sort, @edit[:new][:parent]),
                       :multiple => false,
-                      :class => "widthed",
                       "data-miq_sparkle_on" => true,
                       "data-miq_sparkle_off" => true,
                       :class    => "selectpicker")
@@ -64,7 +63,6 @@
           = select_tag('kids_chosen[]',
             options_for_select(@edit[:new][:kids].sort),
             :multiple => true,
-            :style => "width:auto; min-width:375px; border: 0px;",
             :size => 15,
             :style => "width: 400px",
             :id => "kids_chosen")


### PR DESCRIPTION
```                      
irb(main):001:0> {:a => 1, :a => 2, :b => 3}
(irb):1: warning: key :a is duplicated and overwritten on line 1
=> {:a=>2, :b=>3}
```