### PR TITLE
Restrict the list of e-mails by current user's groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -756,11 +756,12 @@ class ApplicationController < ActionController::Base
   # Build the user_emails hash for edit screens needing the edit_email view
   def build_user_emails_for_edit
     @edit[:user_emails] = {}
-    User.all.sort_by { |u| u.name.downcase }.each do |u|
-      unless u.email.blank? ||
-             (@edit[:new][:email][:to] && @edit[:new][:email][:to].include?(u.email))
-        @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
-      end
+    to_email = @edit[:new][:email][:to] || []
+    users_in_current_groups = User.with_current_user_groups.uniq.sort_by { |u| u.name.downcase }
+    users_in_current_groups.each do |u|
+      next if u.email.blank?
+      next if to_email.include?(u.email)
+      @edit[:user_emails][u.email] = "#{u.name} (#{u.email})"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -320,4 +320,8 @@ class User < ActiveRecord::Base
   def self.current_user
     Thread.current[:user] ||= find_by_userid(current_userid)
   end
+
+  def self.with_current_user_groups
+    includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1287216
Logged user can belongs to a few groups.
This list of emails contains only emails from these groups not all
emails.

Replacing https://github.com/ManageIQ/manageiq/pull/5758

cc @gtanzillo 