### PR TITLE
Moved favicon into the asset pipeline

### DIFF
--- a/app/assets/images/favicon.ico
+++ b/app/assets/images/favicon.ico
@@ -1,0 +1,1 @@
+../../../public/favicon.ico


### PR DESCRIPTION
1. Currently the browser will always ask for `/favicon.ico`. So we need to respond to that url. Instead of using an apache rewrite filter, just have the file on the filesystem.
2. Currently we reference `asset_tag_link` from our layouts. The `favicon` is not in our assets directory. so this causes errors. This PR symbolically links it into assets so the build will work correctly.

