### PR TITLE
Cleanup configure_secret_token

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -23,12 +23,14 @@ module MiqWebServerWorkerMixin
     end
 
     def self.configure_secret_token
+      return if Rails.application.config.secret_token
+
       Rails.application.config.secret_token = MiqDatabase.first.session_secret_token
 
-      # To set a secret token after the Rails.application is initialized?,
+      # To set a secret token after the Rails.application is initialized,
       # we need to reset the secrets since they are cached:
       # https://github.com/rails/rails/blob/4-2-stable/railties/lib/rails/application.rb#L386-L401
-      Rails.application.secrets = nil if Rails.application.initialized?
+      Rails.application.secrets = nil
     end
 
     def self.rails_server

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -23,12 +23,12 @@ module MiqWebServerWorkerMixin
     end
 
     def self.configure_secret_token
-      Vmdb::Application.config.secret_token = MiqDatabase.first.session_secret_token
+      Rails.application.config.secret_token = MiqDatabase.first.session_secret_token
 
-      # To set a secret token after the Vmdb::Application is initialized?,
+      # To set a secret token after the Rails.application is initialized?,
       # we need to reset the secrets since they are cached:
       # https://github.com/rails/rails/blob/4-2-stable/railties/lib/rails/application.rb#L386-L401
-      Vmdb::Application.secrets = nil if Vmdb::Application.initialized?
+      Rails.application.secrets = nil if Rails.application.initialized?
     end
 
     def self.rails_server
@@ -159,7 +159,7 @@ module MiqWebServerWorkerMixin
       params = {
         :Host        => self.class.binding_address,
         :environment => Rails.env.to_s,
-        :app         => Vmdb::Application
+        :app         => Rails.application
       }
 
       params[:Port] = port.kind_of?(Numeric) ? port : 3000

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -14,7 +14,7 @@ describe MiqWebServerWorkerMixin do
       :Port        => 3000,
       :Host        => w.class.binding_address,
       :environment => Rails.env.to_s,
-      :app         => Vmdb::Application
+      :app         => Rails.application
     )
   end
 end

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -8,6 +8,39 @@ describe MiqWebServerWorkerMixin do
     expect(test_class.build_uri(123)).to eq "http://[::1]:123"
   end
 
+  let(:test_class) do
+    Class.new do
+      include MiqWebServerWorkerMixin
+    end
+  end
+
+  before do
+    @token   = Rails.application.config.secret_token
+    @secrets = Rails.application.secrets
+    MiqDatabase.seed
+  end
+
+  after do
+    Rails.application.config.secret_token = @token
+    Rails.application.secrets = @secrets
+  end
+
+  it ".configure_secret_token resets secrets when token unconfigured" do
+    Rails.application.config.secret_token = nil
+
+    test_class.configure_secret_token
+    expect(Rails.application.secrets[:secret_token]).to eq(MiqDatabase.first.session_secret_token)
+  end
+
+  it ".configure_secret_token does not reset secrets when token configured" do
+    Rails.application.config.secret_token = SecureRandom.hex(64)
+    Rails.application.secrets = nil
+    Rails.application.secrets
+
+    test_class.configure_secret_token
+    expect(Rails.application.secrets[:secret_token]).to eq(Rails.application.config.secret_token)
+  end
+
   it "#rails_server_options" do
     w = FactoryGirl.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
     expect(w.rails_server_options).to have_attributes(


### PR DESCRIPTION
* Use Rails.application instead of the class Vmdb::Application.
* Don't reset the token and secrets if the token is already set