### PR TITLE
toolbar images to font icons #2

### DIFF
--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -6,6 +6,23 @@ $(document).ready(function () {
     return miqCheckForChanges();
   });
 
+  $(document).on('click', 'button[data-click_url]', function () {
+    var el = $(this);
+    var parms = $.parseJSON(el.attr('data-click_url'));
+    var url = parms.url;
+    var options = {};
+    if (el.attr('data-miq_sparkle_on')) {
+      options.beforeSend = true;
+    }
+    if (el.attr('data-miq_sparkle_off')) {
+      options.complete = true;
+    }
+    submit = el.attr('data-submit');
+    if (typeof submit != "undefined")
+      miqJqueryRequest(url, {data: miqSerializeForm(submit)});
+    else
+      miqJqueryRequest(url, options);
+  });
   // Bind call to check/display text area max length on keyup
   $(document).on('keyup', 'textarea[data-miq_check_max_length]', function () {
     miqCheckMaxLength(this);

--- a/app/views/layouts/_tag_edit_assignments.html.haml
+++ b/app/views/layouts/_tag_edit_assignments.html.haml
@@ -26,9 +26,8 @@
                 :loading  => "miqSparkle(true);",
                 :complete => "miqSparkle(false);")
               %td{:onclick => cl, :title => t = _("Click to remove this assignment")}
-                = image_tag(image_path('toolbars/delete.png'),
-                  :class       => "rollover small pointer",
-                  :alt         => t)
+                %button.btn.btn-default
+                  %i.pficon.pficon-close.fa-lg
             - else
               %td
                 %ul#list

--- a/app/views/report/_menu_form2.html.haml
+++ b/app/views/report/_menu_form2.html.haml
@@ -1,112 +1,129 @@
 #menu_div2
   - if @selected && @selected[1] && (!@edit[:selected_reports].blank? || !@edit[:available_reports].blank?)
-    = form_tag({:action => 'menu_update',
-                :id     => "report_menu_form2"},
-               :method => :post) do
-      %fieldset{:style => "height: 450px;"}
-        %h3
-          = _('Manage Reports')
-        #column_lists
-          %table.admintable
-            %tr
-              %td{:align => "left"}
-                = _('Selected Reports:')
-              %td
-              %td{:align => "left"}
-                = _('Available Reports:')
-              %td
-            %tr
-              %td{:align => "right"}
-                = select_tag('selected_reports[]',
-                  options_for_select(@edit[:selected_reports], @selected_reps),
-                  :multiple => true,
-                  :style    => "width: 280px; height: 310px;",
-                  :id       => "selected_reports")
-              %td{:width => "20", :valign => "middle"}
+    - url = url_for(:action => 'menu_field_changed')
+    %fieldset{:style => "height: 450px;"}
+      %h3
+        = _('Manage Reports')
+      #column_lists
+        %table
+          %tr
+            %td{:align => "left"}
+              = _('Selected Reports:')
+            %td
+            %td{:align => "left"}
+              = _('Available Reports:')
+            %td
+          %tr
+            %td{:align => "right"}
+              = select_tag('selected_reports[]',
+                options_for_select(@edit[:selected_reports], @selected_reps),
+                :multiple => true,
+                :style    => "width: 280px; height: 310px;",
+                :id       => "selected_reports")
+
+            %td.text-center{:width => "40"}
+              .btn-group-vertical
                 - if @edit[:available_reports].length == 0
-                  = image_tag(image_path('toolbars/left.png'), :class => "rollover small", :border => "0")
+                  %button.btn.btn-default.disabled
+                    %i.fa.fa-angle-left.fa-lg
                 - else
                   - t = _("Move selected reports left")
-                  = link_to(image_tag(image_path('toolbars/left.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'left'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => t)
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=left"}.to_json}
+                    %i.fa.fa-angle-left.fa-lg
+
                 - if @edit[:selected_reports].length == 0
-                  = image_tag(image_path('toolbars/right.png'), :class => "rollover small", :border => "0")
                 - else
                   - t = _("Move selected reports right")
-                  = link_to(image_tag(image_path('toolbars/right.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'right'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => t)
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=right"}.to_json}
+                    %i.fa.fa-angle-right.fa-lg
+
                 - if @edit[:selected_reports].length < 2
-                  = image_tag(image_path('toolbars/top.png'), :class => "rollover small", :border => "0")
+                  %button.btn.btn-default
+                    %i.fa.fa-angle-double-up.fa-lg
                 - else
                   - t = _("Move selected reports to top")
-                  = link_to(image_tag(image_path('toolbars/top.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'top'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => t)
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=top"}.to_json}
+                    %i.fa.fa-angle-double-up.fa-lg
+
                 - if @edit[:selected_reports].length < 2
-                  = image_tag(image_path('toolbars/up.png'), :class => "rollover small", :border => "0")
+                  %button.btn.btn-default
+                    %i.fa.fa-angle-up.fa-lg
                 - else
                   - t = _("Move selected reports up")
-                  = link_to(image_tag(image_path('toolbars/up.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'up'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => t)
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=up"}.to_json}
+                    %i.fa.fa-angle-up.fa-lg
+
                 - if @edit[:selected_reports].length < 2
-                  = image_tag(image_path('toolbars/down.png'), :class => "rollover small", :border => "0")
+                  %button.btn.btn-default
+                    %i.fa.fa-angle-down.fa-lg
                 - else
                   - t = _("Move selected reports down")
-                  = link_to(image_tag(image_path('toolbars/down.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'down'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => t)
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=down"}.to_json}
+                    %i.fa.fa-angle-down.fa-lg
+
                 - if @edit[:selected_reports].length < 2
-                  = image_tag(image_path('toolbars/bottom.png'), :class => "rollover small", :border => "0")
+                  %button.btn.btn-default
+                    %i.fa.fa-angle-double-down.fa-lg
                 - else
                   - t = _("Move selected reports to bottom")
-                  = link_to(image_tag(image_path('toolbars/bottom.png'), :border => "0", :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :button => 'bottom'},
-                    "data-submit" => "column_lists",
-                    :remote       => true,
-                    "data-method" => :post,
-                    :title        => 'Move selected reports to bottom')
-              %td{:align => "left"}
-                = select_tag('available_reports[]',
-                  options_for_select(@edit[:available_reports].sort),
-                  :multiple => true,
-                  :style    => "width: 280px; height: 310px;",
-                  :id       => "available_reports")
-            %tr
-              %td{:colspan => "3", :align => "right"}
-                %div{:style => "width: 67px; float: right; margin-bottom: 2px;"}
-                  - t = _('Commit report management changes')
-                  = link_to(image_tag(image_path('toolbars/commit.png'), :class => "rollover small", :alt => t),
-                    {:action => 'menu_field_changed', :pressed => 'commit'},
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :title                 => t)
-                  - t = _("Discard report management changes")
-                  = link_to(image_tag(image_path('toolbars/discard.png'), :class => "rollover small", :alt => t),
-                    {:action => 'discard_changes', :pressed => 'discard_reports'},
-                    "data-miq_sparkle_on"  => true,
-                    "data-miq_sparkle_off" => true,
-                    :remote                => true,
-                    "data-method"          => :post,
-                    :title                 => t)
-      - unless @edit[:user_typ]
-        = _('* Report is not owned by your group so it cannot be removed')
+                  %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?button=bottom"}.to_json}
+                    %i.fa.fa-angle-double-down.fa-lg
+
+            %td{:align => "left"}
+              = select_tag('available_reports[]',
+                options_for_select(@edit[:available_reports].sort),
+                :multiple => true,
+                :style    => "width: 280px; height: 310px;",
+                :id       => "available_reports")
+          %tr
+            %td{:colspan => "3", :align => "right"}
+              .form-group.pull-right
+                - t = _('Commit report management changes')
+                %button.btn.btn-primary{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url}?pressed=commit"}.to_json}
+                  = _('Commit')
+                - t = _("Discard report management changes")
+                - url2 = url_for(:action => 'discard_changes')
+                %button.btn.btn-default{:title => t,
+                    "data-submit"         => 'column_lists',
+                    "data-miq_sparkle_on" => true,
+                    :remote               => true,
+                    "data-method"         => :post,
+                    'data-click_url'      => {:url => "#{url2}?pressed=discard_reports"}.to_json}
+                  = _('Discard')
+    - unless @edit[:user_typ]
+      = _('* Report is not owned by your group so it cannot be removed')

--- a/app/views/vm_common/_form.html.haml
+++ b/app/views/vm_common/_form.html.haml
@@ -66,45 +66,32 @@
             :size => 15,
             :style => "width: 400px",
             :id => "kids_chosen")
-      %td{:width => "20"}
-        = link_to(image_tag(image_path('toolbars/right.png'),
-            :class => "rollover small",
-            :style => "width: 28px; height: 28px",
-            :alt => (t = _("Move selected VMs to right"))),
-          {:action => 'form_field_changed',
-           :button => 'right',
-           :id     => @record.id || "new"},
-          "data-submit"         => 'main_div',
-          "data-miq_sparkle_on" => true,
-          :remote               => true,
-          "data-method"         => :post,
-          :title                => t)
-
-        = link_to(image_tag(image_path('toolbars/allright.png'),
-            :class => "rollover small",
-            :style => "width: 28px; height: 28px",
-            :alt => (t = _("Move all VMs to right"))),
-          {:action => 'form_field_changed',
-           :button => 'allright',
-           :id     => @record.id || "new"},
-          "data-submit"         => 'main_div',
-          "data-miq_sparkle_on" => true,
-          :remote               => true,
-          "data-method"         => :post,
-          :title                => t)
-
-        = link_to(image_tag(image_path('toolbars/left.png'),
-            :class => "rollover small",
-            :style => "width: 28px; height: 28px",
-            :alt   => (t = _("Move selected VMs to left"))),
-          {:action => 'form_field_changed',
-           :button => 'left',
-           :id     => @record.id || "new"},
-          "data-submit"         => 'main_div',
-          "data-miq_sparkle_on" => true,
-          :remote               => true,
-          "data-method"         => :post,
-          :title                => t)
+      %td.text-center{:width => "40"}
+        .btn-group-vertical
+          %button.btn.btn-default{:title => _("Move selected VMs to right"),
+            "data-submit"         => 'main_div',
+            "data-miq_sparkle_on" => true,
+            :remote               => true,
+            "data-method"         => :post,
+            'data-click_url' => {:url => "#{url}?button=right"}.to_json,
+            :id     => @record.id || "new"}
+            %i.fa.fa-angle-right.fa-lg
+          %button.btn.btn-default{:title => _("Move all VMs to right"),
+            "data-submit"         => 'main_div',
+            "data-miq_sparkle_on" => true,
+            :remote               => true,
+            "data-method"         => :post,
+            'data-click_url' => {:url => "#{url}?button=allright"}.to_json,
+            :id     => @record.id || "new"}
+            %i.fa.fa-angle-double-right.fa-lg
+          %button.btn.btn-default{:title => _("Move selected VMs to left"),
+            "data-submit"         => 'main_div',
+            "data-miq_sparkle_on" => true,
+            :remote               => true,
+            "data-method"         => :post,
+            'data-click_url' => {:url => "#{url}?button=left"}.to_json,
+            :id     => @record.id || "new"}
+            %i.fa.fa-angle-left.fa-lg
 
       %td{:align => "left", :valign => "top"}
         %div{:style => "overflow: auto; width: 400px; border: 1px solid #999999;"}


### PR DESCRIPTION
replace toolbar buttons with font icons in forms, etc

Old
<img width="631" alt="screen shot 2016-01-20 at 1 49 10 pm" src="https://cloud.githubusercontent.com/assets/1287144/12459412/a08fc672-bf7c-11e5-84c1-d2f3a3eccb2d.png">
New
<img width="650" alt="screen shot 2016-01-20 at 1 47 11 pm" src="https://cloud.githubusercontent.com/assets/1287144/12459414/a0c541f8-bf7c-11e5-8c7b-e764ddc4b038.png">
Old
<img width="843" alt="screen shot 2016-01-20 at 1 48 31 pm" src="https://cloud.githubusercontent.com/assets/1287144/12459415/a0c54f5e-bf7c-11e5-8040-f1fa12ff8e45.png">
New
<img width="873" alt="screen shot 2016-01-20 at 1 47 50 pm" src="https://cloud.githubusercontent.com/assets/1287144/12459413/a0c161fa-bf7c-11e5-9877-b17039e961e5.png">
