### PR TITLE
Fix: VimPerfDaily report throwing exceptions

### DIFF
--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -24,9 +24,13 @@ class VimPerformanceDaily < MetricRollup
 
   def self.find(cnt, *args)
     raise "Unsupported finder value #{cnt}" unless cnt == :all
-
     Vmdb::Deprecation.deprecation_warning(:find, :find_entries, caller(1))
 
+    all(*args)
+  end
+
+  def self.all(*args)
+    Vmdb::Deprecation.deprecation_warning(:all, :find_entries, caller(1))
     options = args.last.kind_of?(Hash) ? args.last : {}
     ext_options = options.delete(:ext_options) || {}
     find_entries(ext_options)

--- a/product/charts/miq_reports/vim_perf_daily.yaml
+++ b/product/charts/miq_reports/vim_perf_daily.yaml
@@ -77,7 +77,6 @@ cols:
 
 # Included tables (joined, has_one, has_many) and columns
 include:
-include:
   resource:
     columns:
     - cpu_usagemhz_rate_average_high_over_time_period


### PR DESCRIPTION
Introduced in 397851a83bb7d804cff9f1e1136724d946350f38

Could not run generate_table for VimPerfDaily reports

```ruby
report = MiqReport.new(YAML.load(File.open("./product/charts/miq_reports/vim_perf_daily.yaml")))
report.generate_table(:userid => "admin")

manageiq/app/models/rbac.rb:530:in `method_with_scope'
manageiq/app/models/rbac.rb:299:in `find_targets_without_rbac'
manageiq/app/models/rbac.rb:295:in `find_targets_with_rbac'
manageiq/app/models/rbac.rb:489:in `search'
manageiq/app/models/miq_report/generator.rb:273:in `_generate_table'
manageiq/app/models/miq_report/generator.rb:176:in `block in generate_table'
manageiq/app/models/user.rb:304:in `with_user'
```


/cc @martinpovolny thanks for coming up with the test case.