### PR TITLE
remove aar_columns and aar_options

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -630,8 +630,6 @@ module MiqReport::Generator
   def build_reportable_data(entry, options = {})
     rec = entry[:obj]
     data_records = [build_get_attributes_with_options(rec, options)]
-    rec.class.aar_columns |= data_records.first.keys
-
     data_records = build_add_includes(data_records, entry, options["include"]) if options["include"]
     data_records
   end
@@ -713,7 +711,6 @@ module MiqReport::Generator
             association_records.each do |assoc_record|
               data_records << existing_record.merge(assoc_record)
             end
-            entry[:obj].class.aar_columns |= data_records.last.keys
           end
         end
       end

--- a/app/models/mixins/reportable_mixin.rb
+++ b/app/models/mixins/reportable_mixin.rb
@@ -1,9 +1,5 @@
 module ReportableMixin
   extend ActiveSupport::Concern
-  included do
-    cattr_accessor :aar_options, :aar_columns
-  end
-
   module ClassMethods
     def sortable?
       true

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -1,9 +1,4 @@
 class VmdbDatabaseConnection < ActiveRecord::Base
-  class << self
-    attr_accessor :aar_columns
-  end
-  self.aar_columns = []
-
   self.table_name = 'pg_stat_activity'
   self.primary_key = nil
 

--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -1,9 +1,4 @@
 class VmdbDatabaseSetting < ActiveRecord::Base
-  class << self
-    attr_accessor :aar_columns
-  end
-  self.aar_columns = []
-
   self.table_name = 'pg_settings'
   self.primary_key = nil
 

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -88,22 +88,6 @@ class ActsAsArModel
   # Acts As Reportable methods
   #
 
-  class << self
-    attr_reader :aar_options
-  end
-
-  class << self
-    attr_writer :aar_options
-  end
-
-  def self.aar_columns
-    @aar_columns ||= []
-  end
-
-  class << self
-    attr_writer :aar_columns
-  end
-
   #
   # Virtual columns and reflections
   #

--- a/spec/lib/acts_as_ar_model_spec.rb
+++ b/spec/lib/acts_as_ar_model_spec.rb
@@ -28,8 +28,6 @@ describe ActsAsArModel do
 
     it { expect(base_class).to respond_to(:virtual_columns) }
 
-    it { expect(base_class).to respond_to(:aar_columns) }
-
     it { expect(base_class.columns_hash.values[0]).to be_kind_of(ActsAsArModelColumn) }
     it { expect(base_class.columns_hash.keys).to      match_array(col_names_strs) }
     it { expect(base_class.column_names).to           match_array(col_names_strs) }


### PR DESCRIPTION
We no longer reference or use these in report generation or anywhere else.

~~This was missing from `MiqEnterprise` and throwing exceptions in report generation.~~

/cc @gtanzillo @h-kataria @dclarizio 