### PR TITLE
Upgrade acts_as_list to 0.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "ziya",                           "=2.3.0",    :require => false, :git => "g
 
 # Not vendored, but required
 gem "mime-types",                     "~>2.6.1",   :require => "mime/types/columnar"
-gem "acts_as_list",                   "~>0.1.4"
+gem "acts_as_list",                   "~>0.7.2"
 gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be required so that it loads before ancestry
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.

--- a/app/models/miq_cim_derived_metric.rb
+++ b/app/models/miq_cim_derived_metric.rb
@@ -1,4 +1,7 @@
 class MiqCimDerivedMetric < ActiveRecord::Base
   belongs_to    :miq_storage_metric
+
+  # acts_as_list was blindly upgraded from "~>0.1.4" to "~>0.7.2" to fix
+  # a rails 4.x issue.  Keep this in mind when we try using acts_as_list.
   acts_as_list  :scope => :miq_storage_metric
 end


### PR DESCRIPTION
Fixes #3501

Fixes loading MiqCimDerivedMetric on rails 4.2.x and has probably been broken
since we upgraded from rails 3.2, maybe earlier:

```
irb(main):001:0> MiqCimDerivedMetric
NameError: undefined local variable or method `accessible_attributes' for #<Class:0x007ff34df30820>
  from /Users/joerafaniello/.gem/ruby/2.2.4/gems/acts_as_list-0.1.9/lib/acts_as_list/active_record/acts/list.rb:61:in `class_eval'
```

It appears that we only use acts_as_list to define a scope in MiqCimDerivedMetric:
`acts_as_list  :scope => :miq_storage_metric`

I'd rather just remove this dependency but I have no idea what to test after
removing it.