### PR TITLE
Refactor: containers entities summary helper

### DIFF
--- a/app/helpers/container_group_helper/textual_summary.rb
+++ b/app/helpers/container_group_helper/textual_summary.rb
@@ -70,10 +70,6 @@ module ContainerGroupHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
   def textual_phase
     @record.phase
   end
@@ -84,14 +80,6 @@ module ContainerGroupHelper::TextualSummary
 
   def textual_reason
     @record.reason
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
   end
 
   def textual_restart_policy

--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -22,10 +22,6 @@ module ContainerHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
   def textual_state
     @record.state
   end

--- a/app/helpers/container_image_helper/textual_summary.rb
+++ b/app/helpers/container_image_helper/textual_summary.rb
@@ -25,10 +25,6 @@ module ContainerImageHelper
     # Items
     #
 
-    def textual_name
-      @record.name
-    end
-
     def textual_tag
       @record.tag
     end

--- a/app/helpers/container_node_helper/textual_summary.rb
+++ b/app/helpers/container_node_helper/textual_summary.rb
@@ -36,18 +36,6 @@ module ContainerNodeHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
-  end
-
   def textual_num_cpu_cores
     {:label => "Number of CPU Cores",
      :value => @record.hardware.nil? ? "N/A" : @record.hardware.cpu_total_cores}

--- a/app/helpers/container_project_helper/textual_summary.rb
+++ b/app/helpers/container_project_helper/textual_summary.rb
@@ -66,19 +66,7 @@ module ContainerProjectHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
   def textual_display_name
     @record.display_name
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
   end
 end

--- a/app/helpers/container_replicator_helper/textual_summary.rb
+++ b/app/helpers/container_replicator_helper/textual_summary.rb
@@ -21,18 +21,6 @@ module ContainerReplicatorHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
-  end
-
   def textual_replicas
     {:label => "Requested pods", :value => @record.replicas}
   end

--- a/app/helpers/container_route_helper/textual_summary.rb
+++ b/app/helpers/container_route_helper/textual_summary.rb
@@ -20,18 +20,6 @@ module ContainerRouteHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
-  end
-
   def textual_host_name
     @record.host_name
   end

--- a/app/helpers/container_service_helper/textual_summary.rb
+++ b/app/helpers/container_service_helper/textual_summary.rb
@@ -42,18 +42,6 @@ module ContainerServiceHelper::TextualSummary
   # Items
   #
 
-  def textual_name
-    @record.name
-  end
-
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
-  def textual_resource_version
-    @record.resource_version
-  end
-
   def textual_session_affinity
     @record.session_affinity
   end

--- a/app/helpers/container_summary_helper.rb
+++ b/app/helpers/container_summary_helper.rb
@@ -71,6 +71,18 @@ module ContainerSummaryHelper
     textual_link(@record.container_images)
   end
 
+  def textual_name
+    @record.name
+  end
+
+  def textual_resource_version
+    @record.resource_version
+  end
+
+  def textual_creation_timestamp
+    format_timezone(@record.creation_timestamp)
+  end
+
   def textual_guest_applications
     textual_link(@record.guest_applications, :feature => "container_image_show",
                                              :label   => "Packages",


### PR DESCRIPTION
Moves the following repeated methods from individual container entity textual_summary to container_summary_helper:
* textual_name
* textual_resource_version
* textual_creation_timestamp