### PR TITLE
Resolve inconsistent dialog auto refresh

### DIFF
--- a/app/assets/javascripts/dialog_field_refresh.js
+++ b/app/assets/javascripts/dialog_field_refresh.js
@@ -9,7 +9,7 @@ var dialogFieldRefresh = {
 
   initializeDialogSelectPicker: function(fieldName, fieldId, selectedValue, url) {
     miqInitSelectPicker();
-    $('.selectpicker').selectpicker('val', selectedValue);
+    $('#' + fieldName).selectpicker('val', selectedValue);
     miqSelectPickerEvent(fieldName, url);
     $('#' + fieldName).on('change', function(){
       dialogFieldRefresh.triggerAutoRefresh(fieldId, "true");

--- a/spec/javascripts/dialog_field_refresh_spec.js
+++ b/spec/javascripts/dialog_field_refresh_spec.js
@@ -106,6 +106,11 @@ describe('dialogFieldRefresh', function() {
       expect($.fn.selectpicker).toHaveBeenCalledWith('val', 'selectedValue');
     });
 
+    it('uses the correct selector', function() {
+      dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
+      expect($.fn.selectpicker.calls.mostRecent().object.selector).toEqual('#fieldName');
+    });
+
     it('sets up the select picker event', function() {
       dialogFieldRefresh.initializeDialogSelectPicker(fieldName, fieldId, selectedValue, url);
       expect(window.miqSelectPickerEvent).toHaveBeenCalledWith('fieldName', 'url');


### PR DESCRIPTION
Change a call to selectpicker that
attempted to refresh all the dynamic
dropdowns via classname and now
only update for the correct dom id.
Resolves issues found in the following
two BZ's
https://bugzilla.redhat.com/show_bug.cgi?id=1289643

https://bugzilla.redhat.com/show_bug.cgi?id=1300411