### PR TITLE
Use RewriteRule instead of ProxyPass

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Vmdb::Application.configure do
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
   # TODO: enable static asset server for now so rails serves the images/css, etc.
-  config.serve_static_files = true
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -38,15 +38,12 @@ describe MiqApache::Conf do
       output = MiqApache::Conf.create_redirects_config(@default_options).lines.to_a
       expect(output).to include("ProxyPass /api/ balancer://evmcluster_ui/api/\n")
       expect(output).to include("ProxyPassReverse /api/ balancer://evmcluster_ui/api/\n")
-      expect(output).to include("ProxyPass /proxy_pages !\n")
-      expect(output).to include("ProxyPass /self_service !\n")
-      expect(output).to include("ProxyPass / balancer://evmcluster_ui/\n")
-      expect(output).to include("ProxyPassReverse / balancer://evmcluster_ui/\n")
-    end
 
-    it "should write two lines per redirect" do
-      output = MiqApache::Conf.create_redirects_config(@default_options).lines.to_a
-      expect(output.length).to be(Array(@default_options[:redirects]).length * 2 + 2)
+      expect(output).to include("RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts)) /self_service/index.html [L]\n")
+      expect(output).to include("RewriteCond \%{REQUEST_URI} !^/proxy_pages\n")
+      expect(output).to include("RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n")
+      expect(output).to include("RewriteRule ^/ balancer://evmcluster_ui\%{REQUEST_URI} [P,QSA,L]\n")
+      expect(output).to include("ProxyPassReverse / balancer://evmcluster_ui/\n")
     end
   end
 


### PR DESCRIPTION
Worked with @skateman to serve assets from apache.

The solution is to only proxy if the file does not exist.
This required `RewriteCond -f` and `RewriteRule [P]` combo.

We were serving up assets from rails, we are now serving from apache. And it has been disabled from rails.
Since `ProxyPass` is preferred, that has been kept for the api.

The ui is noticeably faster (~2x) and has less load on rails.

---

Bug fix. Refreshing self_service ui brought a user to the home page. repro steps:

1. go to `/self_service`
2. login
3. go to `/self_service/services`
4. click refresh
5. uri is now `/self_service`, expecting `/self_service/services`

This is part of ManageIQ/manageiq-appliance#47

/cc @bdunne @Fryguy @matthewd @jrafanie 
/cc @carbonin @abellotti FYI