### PR TITLE
use tenant name, don't look it up in config

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -1092,7 +1092,6 @@ class MiqExpression
       :include_model => true,
       :include_table => true
     }.merge(options)
-    @company ||= VMDB::Config.new("vmdb").config[:server][:company]
     tables, col = val.split("-")
     first = true
     val_is_a_tag = false
@@ -1101,7 +1100,7 @@ class MiqExpression
       friendly = tables.split(".").collect do|t|
         if t.downcase == "managed"
           val_is_a_tag = true
-          @company + " Tags"
+          "#{Tenant.root_tenant.name} Tags"
         elsif t.downcase == "user_tag"
           "My Tags"
         else

--- a/lib/report_formatter/text.rb
+++ b/lib/report_formatter/text.rb
@@ -171,7 +171,7 @@ module ReportFormatter
         unless mri.user_categories.blank?
           user_filters = mri.user_categories.flatten
           unless user_filters.blank?
-            customer_name = VMDB::Config.new("vmdb").config[:server][:company]
+            customer_name = Tenant.root_tenant.name
             user_filter = "User assigned " + customer_name + " Tag filters:"
             t = user_filter + " " * (@line_len - 2 - user_filter.length)
             output << fit_to_width("|#{t}|" + CRLF)
@@ -186,7 +186,7 @@ module ReportFormatter
         unless mri.categories.blank?
           categories = mri.categories.flatten
           unless categories.blank?
-            customer_name = VMDB::Config.new("vmdb").config[:server][:company]
+            customer_name = Tenant.root_tenant.name
             customer_name_title = "Report based " + customer_name + " Tag filters:"
             t = customer_name_title + " " * (@line_len - customer_name_title.length - 2)
             output << fit_to_width("|#{t}|" + CRLF)

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -381,6 +381,9 @@ describe MiqExpression do
     end
 
     it "should not contain duplicate tag fields" do
+      # tags contain the root tenant's name
+      Tenant.seed
+
       category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
       FactoryGirl.create(:classification, :parent_id => category.id, :name => 'prod', :description => 'Production')
       tags = MiqExpression.model_details('Host',
@@ -849,7 +852,9 @@ describe MiqExpression do
       end
 
       it "TAG type" do
-        # Create tag category and tag for the next 2 tests
+        # tags contain the root tenant's name
+        Tenant.seed
+
         category = FactoryGirl.create(:classification, :name => 'environment', :description => 'Environment')
         FactoryGirl.create(:classification, :parent_id => category.id, :name => 'prod', :description => 'Production')
 

--- a/spec/models/miq_expression/model_details_spec.rb
+++ b/spec/models/miq_expression/model_details_spec.rb
@@ -1,6 +1,9 @@
 describe MiqExpression do
   describe ".model_details" do
     before do
+      # tags contain the root tenant's name
+      Tenant.seed
+
       cat = FactoryGirl.create(:classification,
                                :description  => "Auto Approve - Max CPU",
                                :name         => "prov_max_cpu",


### PR DESCRIPTION
Remove more `VMDB::Config.new("vmdb").config[:server]` references

`tenant#name` is the new location for the `vmdb.yml server value`. Most of the references have moved across but a few are hidden around.

The specs did need to be tweaked to set the `current_user`, so miq expression would be able to detect the current user's tenant. Note: before, we just used the default tenant's name for all tag descriptions.

/cc @gtanzillo @gmcculloug I had this kicking around (August 14th) and thought I'd send across
/cc @dclarizio FYI