### PR TITLE
Appliance console region

### DIFF
--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -98,7 +98,7 @@ module ApplianceConsole
   ip = eth0.address
   # Because it takes a few seconds, get the database information once in the outside loop
   configured = ApplianceConsole::DatabaseConfiguration.configured?
-  dbhost, dbtype, database = ApplianceConsole::Utilities.db_host_type_database if configured
+  dbhost, database = ApplianceConsole::Utilities.db_host_type_database if configured
 
   clear_screen
 
@@ -138,7 +138,7 @@ module ApplianceConsole
         "MAC Address:", mac,
         "Timezone:", timezone,
         "Local Database:", ApplianceConsole::Utilities.pg_status,
-        "#{I18n.t("product.name")} Database:", configured ? "#{dbtype} @ #{dbhost}" : "not configured",
+        "#{I18n.t("product.name")} Database:", configured ? "postgres @ #{dbhost}" : "not configured",
         "Database/Region:", configured ? "#{database} / #{region || 0}" : "not configured",
         "External Auth:", ExternalHttpdAuthentication.config_status,
         "#{I18n.t("product.name")} Version:", version,
@@ -481,7 +481,7 @@ Date and Time Configuration
         if database_configuration.activate
           database_configuration.post_activation
           say("\nConfiguration activated successfully.\n")
-          dbhost, dbtype, database = ApplianceConsole::Utilities.db_host_type_database
+          dbhost, database = ApplianceConsole::Utilities.db_host_type_database
           press_any_key
         else
           say("\nConfiguration activation failed!\n")

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -138,7 +138,7 @@ module ApplianceConsole
         "MAC Address:", mac,
         "Timezone:", timezone,
         "Local Database:", ApplianceConsole::Utilities.pg_status,
-        "#{I18n.t("product.name")} Database:", configured ? "postgres @ #{dbhost}" : "not configured",
+        "#{I18n.t("product.name")} Database:", configured ? "postgres @ #{dbhost || "localhost"}" : "not configured",
         "Database/Region:", configured ? "#{database} / #{region || 0}" : "not configured",
         "External Auth:", ExternalHttpdAuthentication.config_status,
         "#{I18n.t("product.name")} Version:", version,

--- a/gems/pending/appliance_console.rb
+++ b/gems/pending/appliance_console.rb
@@ -39,7 +39,6 @@ require 'appliance_console/errors'
 
 [:INT, :TERM, :ABRT, :TSTP].each { |s| trap(s) { raise MiqSignalError } }
 
-REGION_FILE   = RAILS_ROOT.join("REGION")
 VERSION_FILE  = RAILS_ROOT.join("VERSION")
 LOGFILE       = RAILS_ROOT.join("log", "appliance_console.log")
 DB_RESTORE_FILE = "/tmp/evm_db.backup"
@@ -98,7 +97,7 @@ module ApplianceConsole
   ip = eth0.address
   # Because it takes a few seconds, get the database information once in the outside loop
   configured = ApplianceConsole::DatabaseConfiguration.configured?
-  dbhost, database = ApplianceConsole::Utilities.db_host_type_database if configured
+  dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region if configured
 
   clear_screen
 
@@ -123,7 +122,6 @@ module ApplianceConsole
       dns1, dns2 = dns.nameservers
       order      = dns.search_order.join(' ')
       timezone   = LinuxAdmin::TimeDate.system_timezone
-      region     = File.read(REGION_FILE).chomp  if File.exist?(REGION_FILE)
       version    = File.read(VERSION_FILE).chomp if File.exist?(VERSION_FILE)
       configured = ApplianceConsole::DatabaseConfiguration.configured?
 
@@ -481,7 +479,7 @@ Date and Time Configuration
         if database_configuration.activate
           database_configuration.post_activation
           say("\nConfiguration activated successfully.\n")
-          dbhost, database = ApplianceConsole::Utilities.db_host_type_database
+          dbhost, database, region = ApplianceConsole::Utilities.db_host_database_region
           press_any_key
         else
           say("\nConfiguration activation failed!\n")

--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -73,11 +73,7 @@ module ApplianceConsole
 
     def create_region
       log_and_feedback(__method__) do
-        AwesomeSpawn.run!(
-          "script/rails runner script/rake",
-          :params => ["evm:db:region", "--", {:region => region}],
-          :chdir  => RAILS_ROOT
-        )
+        ApplianceConsole::Utilities.rake("evm:db:region", ["--", {:region => region}])
       end
     end
 

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -29,13 +29,14 @@ module ApplianceConsole
       end
     end
 
-    def self.db_host_type_database
-      result = AwesomeSpawn.run("bin/rails runner",
-                                :params => ["puts MiqDbConfig.current.options.values_at(:host, :database)"],
-                                :chdir  => RAILS_ROOT
-                               )
+    def self.db_host_database_region
+      result = AwesomeSpawn.run(
+        "bin/rails runner",
+        :params => ["puts MiqDbConfig.current.options.values_at(:host, :database), ActiveRecord::Base.my_region_number"],
+        :chdir  => RAILS_ROOT
+      )
 
-      host, database = result.output.split("\n").last(2)
+      host, database, region = result.output.split("\n").last(3)
 
       if database.blank?
         logger = ApplianceConsole::Logging.logger
@@ -44,7 +45,7 @@ module ApplianceConsole
         logger.error "Error:  #{result.error.inspect}"  unless result.error.blank?
       end
 
-      return host.presence, database
+      return host.presence, database, region
     end
 
     def self.pg_status

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -36,7 +36,6 @@ module ApplianceConsole
                                )
 
       host, database = result.output.split("\n").last(2)
-      host = "localhost" if host.blank?
 
       if database.blank?
         logger = ApplianceConsole::Logging.logger
@@ -45,7 +44,7 @@ module ApplianceConsole
         logger.error "Error:  #{result.error.inspect}"  unless result.error.blank?
       end
 
-      return host, database
+      return host.presence, database
     end
 
     def self.pg_status

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -31,21 +31,21 @@ module ApplianceConsole
 
     def self.db_host_type_database
       result = AwesomeSpawn.run("bin/rails runner",
-                                :params => ["puts MiqDbConfig.current.options.values_at(:host, :adapter, :database)"],
+                                :params => ["puts MiqDbConfig.current.options.values_at(:host, :database)"],
                                 :chdir  => RAILS_ROOT
                                )
 
-      host, type, database = result.output.split("\n").last(3)
+      host, database = result.output.split("\n").last(2)
       host = "localhost" if host.blank?
 
-      if [type, database].any?(&:blank?)
+      if database.blank?
         logger = ApplianceConsole::Logging.logger
         logger.error "db_host_type_database: Failed to detect some/all DB configuration"
         logger.error "Output: #{result.output.inspect}" unless result.output.blank?
         logger.error "Error:  #{result.error.inspect}"  unless result.error.blank?
       end
 
-      return host, type, database
+      return host, database
     end
 
     def self.pg_status


### PR DESCRIPTION
Move looking up the database region into into appliance console utilities.
Appliance console no longer cares about the region file (rake task takes care of it)

Change: If there is no database, `appliance_console` won't know the region of the database.
But that seems ok since if there is no database, there is no database region yet.

This relates to #6248 - but is independent.

/cc @jrafanie @carbonin for your review