### PR TITLE
Introduce ApplicationRecord

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1585,7 +1585,7 @@ class ApplicationController < ActionController::Base
   end
 
   def filter_ids_in_region(ids, label)
-    in_reg, out_reg = ActiveRecord::Base.partition_ids_by_remote_region(ids)
+    in_reg, out_reg = ApplicationRecord.partition_ids_by_remote_region(ids)
     if ids.length == 1
       add_flash(_("The selected %s is not in the current region") % label, :error) if in_reg.empty?
     elsif in_reg.empty?

--- a/app/controllers/mixins/compressed_ids.rb
+++ b/app/controllers/mixins/compressed_ids.rb
@@ -5,10 +5,10 @@ module CompressedIds
   #
 
   def to_cid(id)
-    ActiveRecord::Base.compress_id(id)
+    ApplicationRecord.compress_id(id)
   end
 
   def from_cid(cid)
-    ActiveRecord::Base.uncompress_id(cid)
+    ApplicationRecord.uncompress_id(cid)
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,4 +1,4 @@
-class Account < ActiveRecord::Base
+class Account < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :host
 

--- a/app/models/advanced_setting.rb
+++ b/app/models/advanced_setting.rb
@@ -1,4 +1,4 @@
-class AdvancedSetting < ActiveRecord::Base
+class AdvancedSetting < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   include ReportableMixin

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/assigned_server_role.rb
+++ b/app/models/assigned_server_role.rb
@@ -1,4 +1,4 @@
-class AssignedServerRole < ActiveRecord::Base
+class AssignedServerRole < ApplicationRecord
   belongs_to :miq_server
   belongs_to :server_role
 

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,4 +1,4 @@
-class AuditEvent < ActiveRecord::Base
+class AuditEvent < ApplicationRecord
   include ReportableMixin
 
   validates_presence_of     :event, :status, :message, :severity

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,4 +1,4 @@
-class Authentication < ActiveRecord::Base
+class Authentication < ApplicationRecord
   include NewWithTypeStiMixin
   def self.new(*args, &block)
     if self == Authentication

--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -1,4 +1,4 @@
-class AvailabilityZone < ActiveRecord::Base
+class AvailabilityZone < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
   include Metric::CiMixin

--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -1,4 +1,4 @@
-class BinaryBlob < ActiveRecord::Base
+class BinaryBlob < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   has_many :binary_blob_parts, -> { order(:id) }, :dependent => :delete_all
 

--- a/app/models/binary_blob_part.rb
+++ b/app/models/binary_blob_part.rb
@@ -1,4 +1,4 @@
-class BinaryBlobPart < ActiveRecord::Base
+class BinaryBlobPart < ApplicationRecord
   def self.default_part_size
     @default_part_size ||= 1.megabyte
   end

--- a/app/models/blacklisted_event.rb
+++ b/app/models/blacklisted_event.rb
@@ -1,4 +1,4 @@
-class BlacklistedEvent < ActiveRecord::Base
+class BlacklistedEvent < ApplicationRecord
   belongs_to        :ext_management_system, :foreign_key => "ems_id"
 
   default_value_for :enabled, true

--- a/app/models/bottleneck_event.rb
+++ b/app/models/bottleneck_event.rb
@@ -1,4 +1,4 @@
-class BottleneckEvent < ActiveRecord::Base
+class BottleneckEvent < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   include ReportableMixin

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -1,4 +1,4 @@
-class ChargebackRate < ActiveRecord::Base
+class ChargebackRate < ApplicationRecord
   include UuidMixin
   include ReportableMixin
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -1,4 +1,4 @@
-class ChargebackRateDetail < ActiveRecord::Base
+class ChargebackRateDetail < ApplicationRecord
   belongs_to :chargeback_rate
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
 

--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -1,4 +1,4 @@
-class ChargebackRateDetailMeasure < ActiveRecord::Base
+class ChargebackRateDetailMeasure < ApplicationRecord
   serialize :units, Array
   serialize :units_display, Array
   validates :name, :presence => true, :length => {:maximum => 100}

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,4 +1,4 @@
-class Classification < ActiveRecord::Base
+class Classification < ApplicationRecord
   acts_as_tree
 
   belongs_to :tag

--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -1,4 +1,4 @@
-class CloudNetwork < ActiveRecord::Base
+class CloudNetwork < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -1,4 +1,4 @@
-class CloudObjectStoreContainer < ActiveRecord::Base
+class CloudObjectStoreContainer < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
   has_many   :cloud_object_store_objects

--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -1,4 +1,4 @@
-class CloudObjectStoreObject < ActiveRecord::Base
+class CloudObjectStoreObject < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
   belongs_to :cloud_tenant
   belongs_to :cloud_object_store_container

--- a/app/models/cloud_resource_quota.rb
+++ b/app/models/cloud_resource_quota.rb
@@ -1,4 +1,4 @@
-class CloudResourceQuota < ActiveRecord::Base
+class CloudResourceQuota < ApplicationRecord
   include ReportableMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -1,4 +1,4 @@
-class CloudSubnet < ActiveRecord::Base
+class CloudSubnet < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -1,4 +1,4 @@
-class CloudTenant < ActiveRecord::Base
+class CloudTenant < ApplicationRecord
   include ReportableMixin
   include NewWithTypeStiMixin
 

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -1,4 +1,4 @@
-class CloudVolume < ActiveRecord::Base
+class CloudVolume < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -1,4 +1,4 @@
-class CloudVolumeSnapshot < ActiveRecord::Base
+class CloudVolumeSnapshot < ApplicationRecord
   include NewWithTypeStiMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"

--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -1,4 +1,4 @@
-class Compliance < ActiveRecord::Base
+class Compliance < ApplicationRecord
   belongs_to  :resource,  :polymorphic => true
   has_many    :compliance_details, :dependent => :destroy
 

--- a/app/models/compliance_detail.rb
+++ b/app/models/compliance_detail.rb
@@ -1,4 +1,4 @@
-class ComplianceDetail < ActiveRecord::Base
+class ComplianceDetail < ApplicationRecord
   belongs_to  :compliance
   belongs_to  :condition
   belongs_to  :miq_policy

--- a/app/models/computer_system.rb
+++ b/app/models/computer_system.rb
@@ -1,4 +1,4 @@
-class ComputerSystem < ActiveRecord::Base
+class ComputerSystem < ApplicationRecord
   include ReportableMixin
 
   belongs_to :managed_entity, :polymorphic => true

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,4 +1,4 @@
-class Condition < ActiveRecord::Base
+class Condition < ApplicationRecord
   include UuidMixin
   before_validation :default_name_to_guid, :on => :create
 

--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -1,3 +1,3 @@
-class ConditionSet < ActiveRecord::Base
+class ConditionSet < ApplicationRecord
   acts_as_miq_set
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,4 +1,4 @@
-class Configuration < ActiveRecord::Base
+class Configuration < ApplicationRecord
   belongs_to                :miq_server, :foreign_key => "miq_server_id"
   serialize                 :settings,   Vmdb::ConfigurationEncoder
 

--- a/app/models/configuration_location.rb
+++ b/app/models/configuration_location.rb
@@ -1,4 +1,4 @@
-class ConfigurationLocation < ActiveRecord::Base
+class ConfigurationLocation < ApplicationRecord
   belongs_to :provisioning_manager
   belongs_to :parent, :class_name => 'ConfigurationLocation'
   has_and_belongs_to_many :configuration_profiles, :join_table => :configuration_locations_configuration_profiles

--- a/app/models/configuration_organization.rb
+++ b/app/models/configuration_organization.rb
@@ -1,4 +1,4 @@
-class ConfigurationOrganization < ActiveRecord::Base
+class ConfigurationOrganization < ApplicationRecord
   belongs_to :provisioning_manager
   belongs_to :parent, :class_name => 'ConfigurationOrganization'
   has_and_belongs_to_many :configuration_profiles, :join_table => :configuration_organizations_configuration_profiles

--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -1,4 +1,4 @@
-class ConfigurationProfile < ActiveRecord::Base
+class ConfigurationProfile < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/configuration_tag.rb
+++ b/app/models/configuration_tag.rb
@@ -1,4 +1,4 @@
-class ConfigurationTag < ActiveRecord::Base
+class ConfigurationTag < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -1,4 +1,4 @@
-class ConfiguredSystem < ActiveRecord::Base
+class ConfiguredSystem < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,4 +1,4 @@
-class Container < ActiveRecord::Base
+class Container < ApplicationRecord
   include ReportableMixin
   include NewWithTypeStiMixin
 

--- a/app/models/container_component_status.rb
+++ b/app/models/container_component_status.rb
@@ -1,4 +1,4 @@
-class ContainerComponentStatus < ActiveRecord::Base
+class ContainerComponentStatus < ApplicationRecord
   include ReportableMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/container_condition.rb
+++ b/app/models/container_condition.rb
@@ -1,4 +1,4 @@
-class ContainerCondition < ActiveRecord::Base
+class ContainerCondition < ApplicationRecord
   include ReportableMixin
   belongs_to :container_entity, :polymorphic => true
 end

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -1,4 +1,4 @@
-class ContainerDefinition < ActiveRecord::Base
+class ContainerDefinition < ApplicationRecord
   # :name, :image, :image_pull_policy, :memory, :cpu
   belongs_to :container_group
   has_many :container_port_configs, :dependent => :destroy

--- a/app/models/container_env_var.rb
+++ b/app/models/container_env_var.rb
@@ -1,2 +1,2 @@
-class ContainerEnvVar < ActiveRecord::Base
+class ContainerEnvVar < ApplicationRecord
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -1,4 +1,4 @@
-class ContainerGroup < ActiveRecord::Base
+class ContainerGroup < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
   include NewWithTypeStiMixin

--- a/app/models/container_groups_container_services.rb
+++ b/app/models/container_groups_container_services.rb
@@ -1,2 +1,2 @@
-class ContainerGroupsContainerServices < ActiveRecord::Base
+class ContainerGroupsContainerServices < ApplicationRecord
 end

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -1,4 +1,4 @@
-class ContainerImage < ActiveRecord::Base
+class ContainerImage < ApplicationRecord
   include ReportableMixin
   include ScanningMixin
 

--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -1,4 +1,4 @@
-class ContainerImageRegistry < ActiveRecord::Base
+class ContainerImageRegistry < ApplicationRecord
   include ReportableMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/container_limit.rb
+++ b/app/models/container_limit.rb
@@ -1,4 +1,4 @@
-class ContainerLimit < ActiveRecord::Base
+class ContainerLimit < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
 

--- a/app/models/container_limit_item.rb
+++ b/app/models/container_limit_item.rb
@@ -1,3 +1,3 @@
-class ContainerLimitItem < ActiveRecord::Base
+class ContainerLimitItem < ApplicationRecord
   belongs_to :container_limit
 end

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -1,4 +1,4 @@
-class ContainerNode < ActiveRecord::Base
+class ContainerNode < ApplicationRecord
   include ReportableMixin
   include NewWithTypeStiMixin
 

--- a/app/models/container_port_config.rb
+++ b/app/models/container_port_config.rb
@@ -1,3 +1,3 @@
-class ContainerPortConfig < ActiveRecord::Base
+class ContainerPortConfig < ApplicationRecord
   # :port, :host_port, :protocol
 end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -1,4 +1,4 @@
-class ContainerProject < ActiveRecord::Base
+class ContainerProject < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/container_quota.rb
+++ b/app/models/container_quota.rb
@@ -1,4 +1,4 @@
-class ContainerQuota < ActiveRecord::Base
+class ContainerQuota < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
 

--- a/app/models/container_quota_item.rb
+++ b/app/models/container_quota_item.rb
@@ -1,3 +1,3 @@
-class ContainerQuotaItem < ActiveRecord::Base
+class ContainerQuotaItem < ApplicationRecord
   belongs_to :container_quota
 end

--- a/app/models/container_replicator.rb
+++ b/app/models/container_replicator.rb
@@ -1,4 +1,4 @@
-class ContainerReplicator < ActiveRecord::Base
+class ContainerReplicator < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
 

--- a/app/models/container_route.rb
+++ b/app/models/container_route.rb
@@ -1,4 +1,4 @@
-class ContainerRoute < ActiveRecord::Base
+class ContainerRoute < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
 

--- a/app/models/container_service.rb
+++ b/app/models/container_service.rb
@@ -1,4 +1,4 @@
-class ContainerService < ActiveRecord::Base
+class ContainerService < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
   # :name, :uid, :creation_timestamp, :resource_version, :namespace

--- a/app/models/container_service_port_config.rb
+++ b/app/models/container_service_port_config.rb
@@ -1,3 +1,3 @@
-class ContainerServicePortConfig < ActiveRecord::Base
+class ContainerServicePortConfig < ApplicationRecord
   belongs_to :container_service
 end

--- a/app/models/container_volume.rb
+++ b/app/models/container_volume.rb
@@ -1,3 +1,3 @@
-class ContainerVolume < ActiveRecord::Base
+class ContainerVolume < ApplicationRecord
   belongs_to :parent, :polymorphic => true
 end

--- a/app/models/custom_attribute.rb
+++ b/app/models/custom_attribute.rb
@@ -1,4 +1,4 @@
-class CustomAttribute < ActiveRecord::Base
+class CustomAttribute < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   include ReportableMixin

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -1,4 +1,4 @@
-class CustomButton < ActiveRecord::Base
+class CustomButton < ApplicationRecord
   has_one       :resource_action, :as => :resource, :dependent => :destroy, :autosave => true
 
   serialize :options

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -1,4 +1,4 @@
-class CustomButtonSet < ActiveRecord::Base
+class CustomButtonSet < ApplicationRecord
   acts_as_miq_set
 
   def self.find_all_by_class_name(class_name, class_id = nil)

--- a/app/models/customization_script.rb
+++ b/app/models/customization_script.rb
@@ -1,4 +1,4 @@
-class CustomizationScript < ActiveRecord::Base
+class CustomizationScript < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/customization_spec.rb
+++ b/app/models/customization_spec.rb
@@ -1,4 +1,4 @@
-class CustomizationSpec < ActiveRecord::Base
+class CustomizationSpec < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   serialize :spec

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -1,4 +1,4 @@
-class CustomizationTemplate < ActiveRecord::Base
+class CustomizationTemplate < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -1,4 +1,4 @@
-class DatabaseBackup < ActiveRecord::Base
+class DatabaseBackup < ApplicationRecord
   SUPPORTED_DEPOTS = {
     'smb' => 'Samba',
     'nfs' => 'Network File System'

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -1,4 +1,4 @@
-class Dialog < ActiveRecord::Base
+class Dialog < ApplicationRecord
   DIALOG_DIR = Rails.root.join("product/dialogs/service_dialogs")
 
   # The following gets around a glob symbolic link issue

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -1,4 +1,4 @@
-class DialogField < ActiveRecord::Base
+class DialogField < ApplicationRecord
   include NewWithTypeStiMixin
   attr_accessor :value
   attr_accessor :dialog

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -1,4 +1,4 @@
-class DialogGroup < ActiveRecord::Base
+class DialogGroup < ApplicationRecord
   include DialogMixin
   has_many   :dialog_fields, -> { order(:position) }, :dependent => :destroy
   belongs_to :dialog_tab

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -1,4 +1,4 @@
-class DialogTab < ActiveRecord::Base
+class DialogTab < ApplicationRecord
   include DialogMixin
   has_many   :dialog_groups, -> { order(:position) }, :dependent => :destroy
   belongs_to :dialog

--- a/app/models/disk.rb
+++ b/app/models/disk.rb
@@ -1,4 +1,4 @@
-class Disk < ActiveRecord::Base
+class Disk < ApplicationRecord
   belongs_to :hardware
   belongs_to :storage
   belongs_to :backing, :polymorphic => true

--- a/app/models/drift_state.rb
+++ b/app/models/drift_state.rb
@@ -1,4 +1,4 @@
-class DriftState < ActiveRecord::Base
+class DriftState < ApplicationRecord
   include_concern 'Purging'
 
   belongs_to :resource, :polymorphic => true

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -1,4 +1,4 @@
-class EmsCluster < ActiveRecord::Base
+class EmsCluster < ApplicationRecord
   include NewWithTypeStiMixin
   include_concern 'CapacityPlanning'
   include ReportableMixin

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -1,4 +1,4 @@
-class EmsFolder < ActiveRecord::Base
+class EmsFolder < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   include ReportableMixin

--- a/app/models/event_log.rb
+++ b/app/models/event_log.rb
@@ -1,4 +1,4 @@
-class EventLog < ActiveRecord::Base
+class EventLog < ApplicationRecord
   belongs_to :operating_system
 
   include ReportableMixin

--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -1,4 +1,4 @@
-class EventStream < ActiveRecord::Base
+class EventStream < ApplicationRecord
   serialize :full_data
 
   belongs_to :target, :polymorphic => true

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -1,4 +1,4 @@
-class ExtManagementSystem < ActiveRecord::Base
+class ExtManagementSystem < ApplicationRecord
   def self.types
     leaf_subclasses.collect(&:ems_type)
   end

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -1,4 +1,4 @@
-class FileDepot < ActiveRecord::Base
+class FileDepot < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin
   has_many              :miq_schedules, :dependent => :nullify

--- a/app/models/filesystem.rb
+++ b/app/models/filesystem.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "metadata/linux")
 require 'LinuxUtils'
 
-class Filesystem < ActiveRecord::Base
+class Filesystem < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :miq_set    # ScanItemSet
   belongs_to :scan_item

--- a/app/models/firewall_rule.rb
+++ b/app/models/firewall_rule.rb
@@ -1,4 +1,4 @@
-class FirewallRule < ActiveRecord::Base
+class FirewallRule < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :source_security_group, :class_name => "SecurityGroup"
 

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -1,4 +1,4 @@
-class Flavor < ActiveRecord::Base
+class Flavor < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -1,4 +1,4 @@
-class FloatingIp < ActiveRecord::Base
+class FloatingIp < ApplicationRecord
   include NewWithTypeStiMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"

--- a/app/models/guest_application.rb
+++ b/app/models/guest_application.rb
@@ -1,4 +1,4 @@
-class GuestApplication < ActiveRecord::Base
+class GuestApplication < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :host
   belongs_to :container_image

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -1,4 +1,4 @@
-class GuestDevice < ActiveRecord::Base
+class GuestDevice < ApplicationRecord
   belongs_to :hardware
   has_one :vm_or_template, :through => :hardware
   has_one :vm,             :through => :hardware

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -1,4 +1,4 @@
-class Hardware < ActiveRecord::Base
+class Hardware < ApplicationRecord
   belongs_to  :vm_or_template
   belongs_to  :vm,            :foreign_key => :vm_or_template_id
   belongs_to  :miq_template,  :foreign_key => :vm_or_template_id

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -12,7 +12,7 @@ require 'LinuxUtils'
 $LOAD_PATH << File.join(GEMS_PENDING_ROOT, "metadata/ScanProfile")
 require 'HostScanProfiles'
 
-class Host < ActiveRecord::Base
+class Host < ApplicationRecord
   include NewWithTypeStiMixin
 
   VENDOR_TYPES = {

--- a/app/models/host_service_group.rb
+++ b/app/models/host_service_group.rb
@@ -1,4 +1,4 @@
-class HostServiceGroup < ActiveRecord::Base
+class HostServiceGroup < ApplicationRecord
   has_many :filesystems, :dependent => :nullify
   has_many :system_services, :dependent => :nullify
   belongs_to :host

--- a/app/models/hosts_storage.rb
+++ b/app/models/hosts_storage.rb
@@ -1,3 +1,3 @@
-class HostsStorage < ActiveRecord::Base
+class HostsStorage < ApplicationRecord
   self.table_name = "host_storages"
 end

--- a/app/models/hosts_storages.rb
+++ b/app/models/hosts_storages.rb
@@ -1,3 +1,3 @@
-class HostsStorages < ActiveRecord::Base
+class HostsStorages < ApplicationRecord
   self.table_name = "host_storages"
 end

--- a/app/models/import_file_upload.rb
+++ b/app/models/import_file_upload.rb
@@ -1,4 +1,4 @@
-class ImportFileUpload < ActiveRecord::Base
+class ImportFileUpload < ApplicationRecord
   has_one :binary_blob, :as => :resource, :dependent => :destroy
 
   def policy_import_data

--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -1,4 +1,4 @@
-class IsoDatastore < ActiveRecord::Base
+class IsoDatastore < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :iso_datastore
   has_many   :iso_images, :dependent => :destroy
 

--- a/app/models/iso_image.rb
+++ b/app/models/iso_image.rb
@@ -1,4 +1,4 @@
-class IsoImage < ActiveRecord::Base
+class IsoImage < ApplicationRecord
   belongs_to :iso_datastore
   belongs_to :pxe_image_type
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,4 +1,4 @@
-class Job < ActiveRecord::Base
+class Job < ApplicationRecord
   include_concern 'StateMachine'
   include UuidMixin
   include ReportableMixin

--- a/app/models/lan.rb
+++ b/app/models/lan.rb
@@ -1,4 +1,4 @@
-class Lan < ActiveRecord::Base
+class Lan < ApplicationRecord
   belongs_to :switch
 
   has_many :guest_devices

--- a/app/models/ldap_domain.rb
+++ b/app/models/ldap_domain.rb
@@ -1,4 +1,4 @@
-class LdapDomain < ActiveRecord::Base
+class LdapDomain < ApplicationRecord
   belongs_to :ldap_region
 
   has_many :ldap_servers, :dependent => :destroy

--- a/app/models/ldap_group.rb
+++ b/app/models/ldap_group.rb
@@ -1,4 +1,4 @@
-class LdapGroup < ActiveRecord::Base
+class LdapGroup < ApplicationRecord
   belongs_to :ldap_domain
 
   # acts_as_miq_taggable

--- a/app/models/ldap_management.rb
+++ b/app/models/ldap_management.rb
@@ -1,4 +1,4 @@
-class LdapManagement < ActiveRecord::Base
+class LdapManagement < ApplicationRecord
   belongs_to :ldap_user
   belongs_to :manager, :class_name => "LdapUser"
 end

--- a/app/models/ldap_region.rb
+++ b/app/models/ldap_region.rb
@@ -1,4 +1,4 @@
-class LdapRegion < ActiveRecord::Base
+class LdapRegion < ApplicationRecord
   include ReportableMixin
 
   validates_presence_of   :name

--- a/app/models/ldap_server.rb
+++ b/app/models/ldap_server.rb
@@ -1,4 +1,4 @@
-class LdapServer < ActiveRecord::Base
+class LdapServer < ApplicationRecord
   belongs_to :ldap_domain
 
   default_value_for :mode, "ldaps"

--- a/app/models/ldap_user.rb
+++ b/app/models/ldap_user.rb
@@ -1,4 +1,4 @@
-class LdapUser < ActiveRecord::Base
+class LdapUser < ApplicationRecord
   belongs_to :ldap_domain
 
   has_many   :ldap_managements, :dependent => :destroy

--- a/app/models/lifecycle_event.rb
+++ b/app/models/lifecycle_event.rb
@@ -1,4 +1,4 @@
-class LifecycleEvent < ActiveRecord::Base
+class LifecycleEvent < ApplicationRecord
   belongs_to :vm_or_template
 
   include UuidMixin

--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -2,7 +2,7 @@ require 'net/ftp'
 require 'uri'
 require 'mount/miq_generic_mount_session'
 
-class LogFile < ActiveRecord::Base
+class LogFile < ApplicationRecord
   belongs_to :resource,    :polymorphic => true
   belongs_to :file_depot
   belongs_to :miq_task

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,4 +1,4 @@
-class Metric < ActiveRecord::Base
+class Metric < ApplicationRecord
   BASE_COLS = ["id", "timestamp", "capture_interval_name", "resource_type", "resource_id", "resource_name", "tag_names", "parent_host_id", "parent_ems_cluster_id", "parent_ems_id", "parent_storage_id"]
 
   include Metric::Common

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -1,4 +1,4 @@
-class MetricRollup < ActiveRecord::Base
+class MetricRollup < ApplicationRecord
   include Metric::Common
 
   def self.find_all_by_interval_and_time_range(interval, start_time, end_time)

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1,6 +1,6 @@
 require 'awesome_spawn'
 
-class MiqAction < ActiveRecord::Base
+class MiqAction < ApplicationRecord
   include UuidMixin
   before_validation :default_name_to_guid, :on => :create
   before_destroy    :check_policy_contents_empty_on_destroy

--- a/app/models/miq_action_set.rb
+++ b/app/models/miq_action_set.rb
@@ -1,3 +1,3 @@
-class MiqActionSet < ActiveRecord::Base
+class MiqActionSet < ApplicationRecord
   acts_as_miq_set
 end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -1,4 +1,4 @@
-class MiqAlert < ActiveRecord::Base
+class MiqAlert < ApplicationRecord
   include UuidMixin
 
   serialize :expression

--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -1,4 +1,4 @@
-class MiqAlertSet < ActiveRecord::Base
+class MiqAlertSet < ApplicationRecord
   acts_as_miq_set
 
   before_validation :default_name_to_guid, :on => :create

--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,4 +1,4 @@
-class MiqAlertStatus < ActiveRecord::Base
+class MiqAlertStatus < ApplicationRecord
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
 end

--- a/app/models/miq_approval.rb
+++ b/app/models/miq_approval.rb
@@ -1,4 +1,4 @@
-class MiqApproval < ActiveRecord::Base
+class MiqApproval < ApplicationRecord
   belongs_to :approver, :polymorphic => true
   belongs_to :stamper,  :class_name => "User"
   belongs_to :miq_request

--- a/app/models/miq_cim_association.rb
+++ b/app/models/miq_cim_association.rb
@@ -1,6 +1,6 @@
 require 'miq_storage_defs'
 
-class MiqCimAssociation < ActiveRecord::Base
+class MiqCimAssociation < ApplicationRecord
   belongs_to  :result_instance,
               :class_name  => "MiqCimInstance",
               :foreign_key => "result_instance_id"

--- a/app/models/miq_cim_derived_metric.rb
+++ b/app/models/miq_cim_derived_metric.rb
@@ -1,4 +1,4 @@
-class MiqCimDerivedMetric < ActiveRecord::Base
+class MiqCimDerivedMetric < ApplicationRecord
   belongs_to    :miq_storage_metric
   acts_as_list  :scope => :miq_storage_metric
 end

--- a/app/models/miq_cim_instance.rb
+++ b/app/models/miq_cim_instance.rb
@@ -4,7 +4,7 @@ require 'miq_storage_defs'
 require 'wbem'
 require 'net_app_manageability/types'
 
-class MiqCimInstance < ActiveRecord::Base
+class MiqCimInstance < ApplicationRecord
   has_many  :miq_cim_associations,
             :dependent    => :destroy
 

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -1,6 +1,6 @@
 require 'util/postgres_admin'
 
-class MiqDatabase < ActiveRecord::Base
+class MiqDatabase < ApplicationRecord
   REGISTRATION_DEFAULT_VALUES = {
     :registration_type   => "sm_hosted",
     :registration_server => "subscription.rhn.redhat.com"

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -1,4 +1,4 @@
-class MiqDialog < ActiveRecord::Base
+class MiqDialog < ApplicationRecord
   validates_presence_of   :name, :description
   validates_uniqueness_of :name, :scope => :dialog_type, :case_sensitive => false
 

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -1,4 +1,4 @@
-class MiqEnterprise < ActiveRecord::Base
+class MiqEnterprise < ApplicationRecord
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource  # Destroy will be handled by purger

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -1,4 +1,4 @@
-class MiqEventDefinition < ActiveRecord::Base
+class MiqEventDefinition < ApplicationRecord
   include UuidMixin
 
   validates_presence_of     :name

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -1,4 +1,4 @@
-class MiqEventDefinitionSet < ActiveRecord::Base
+class MiqEventDefinitionSet < ApplicationRecord
   acts_as_miq_set
 
   def self.seed

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -1,4 +1,4 @@
-class MiqGroup < ActiveRecord::Base
+class MiqGroup < ApplicationRecord
   USER_GROUP   = "user"
   SYSTEM_GROUP = "system"
   TENANT_GROUP = "tenant"

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,6 +1,6 @@
 # TODO: Import/Export support
 
-class MiqPolicy < ActiveRecord::Base
+class MiqPolicy < ApplicationRecord
   acts_as_miq_taggable
   acts_as_miq_set_member
   include_concern 'ImportExport'

--- a/app/models/miq_policy_content.rb
+++ b/app/models/miq_policy_content.rb
@@ -1,4 +1,4 @@
-class MiqPolicyContent < ActiveRecord::Base
+class MiqPolicyContent < ApplicationRecord
   belongs_to :miq_policy
   belongs_to :miq_event_definition
   belongs_to :miq_action

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -1,4 +1,4 @@
-class MiqPolicySet < ActiveRecord::Base
+class MiqPolicySet < ApplicationRecord
   acts_as_miq_set
 
   before_validation :default_name_to_guid, :on => :create

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -1,4 +1,4 @@
-class MiqProductFeature < ActiveRecord::Base
+class MiqProductFeature < ApplicationRecord
   acts_as_tree
 
   has_and_belongs_to_many :miq_user_roles, :join_table => :miq_roles_features

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -17,7 +17,7 @@ require 'digest'
 #     put: Default to "generic" to be performed by the generic worker.
 #     get: Defaults to "generic" but is typically overridden by the caller (a worker)
 #
-class MiqQueue < ActiveRecord::Base
+class MiqQueue < ApplicationRecord
   belongs_to :handler, :polymorphic => true
 
   attr_accessor :last_exception

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,4 +1,4 @@
-class MiqRegion < ActiveRecord::Base
+class MiqRegion < ApplicationRecord
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -1,4 +1,4 @@
-class MiqRegionRemote < ActiveRecord::Base
+class MiqRegionRemote < ApplicationRecord
   def self.db_ping(host, port, username, password, database = nil, adapter = nil)
     database, adapter = prepare_default_fields(database, adapter)
     with_remote_connection(host, port, username, password, database, adapter) do |conn|

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -1,4 +1,4 @@
-class MiqReport < ActiveRecord::Base
+class MiqReport < ApplicationRecord
   include ActiveRecord::AttributeAccessorThatYamls
 
   include_concern 'Formatting'

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -1,4 +1,4 @@
-class MiqReportResult < ActiveRecord::Base
+class MiqReportResult < ApplicationRecord
   include_concern 'Purging'
 
   belongs_to :miq_report

--- a/app/models/miq_report_result_detail.rb
+++ b/app/models/miq_report_result_detail.rb
@@ -1,3 +1,3 @@
-class MiqReportResultDetail < ActiveRecord::Base
+class MiqReportResultDetail < ApplicationRecord
   belongs_to  :miq_report_result
 end

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -1,4 +1,4 @@
-class MiqRequest < ActiveRecord::Base
+class MiqRequest < ApplicationRecord
   ACTIVE_STATES = %w(active queued)
 
   belongs_to :source,            :polymorphic => true

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -1,4 +1,4 @@
-class MiqRequestTask < ActiveRecord::Base
+class MiqRequestTask < ApplicationRecord
   include_concern 'Dumping'
   include_concern 'PostInstallCallback'
   include_concern 'StateMachine'

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -1,4 +1,4 @@
-class MiqSchedule < ActiveRecord::Base
+class MiqSchedule < ApplicationRecord
   validates_uniqueness_of :name, :scope => [:userid, :towhat]
   validates_presence_of   :name, :description, :towhat, :run_at
   validate                :validate_run_at, :validate_file_depot

--- a/app/models/miq_scsi_lun.rb
+++ b/app/models/miq_scsi_lun.rb
@@ -1,4 +1,4 @@
-class MiqScsiLun < ActiveRecord::Base
+class MiqScsiLun < ApplicationRecord
   belongs_to :miq_scsi_target
 
   include ReportableMixin

--- a/app/models/miq_scsi_target.rb
+++ b/app/models/miq_scsi_target.rb
@@ -1,4 +1,4 @@
-class MiqScsiTarget < ActiveRecord::Base
+class MiqScsiTarget < ApplicationRecord
   serialize :address
 
   belongs_to :guest_device

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -1,4 +1,4 @@
-class MiqSearch < ActiveRecord::Base
+class MiqSearch < ApplicationRecord
   serialize :options
   serialize :filter
 

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -1,4 +1,4 @@
-class MiqServer < ActiveRecord::Base
+class MiqServer < ApplicationRecord
   include_concern 'WorkerManagement'
   include_concern 'ServerMonitor'
   include_concern 'ServerSmartProxy'

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -1,4 +1,4 @@
-class MiqShortcut < ActiveRecord::Base
+class MiqShortcut < ApplicationRecord
   has_many :miq_widget_shortcuts, :dependent => :destroy
   has_many :miq_widgets, :through => :miq_widget_shortcuts
 

--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -1,6 +1,6 @@
 require 'net_app_manageability/types'
 
-class MiqStorageMetric < ActiveRecord::Base
+class MiqStorageMetric < ApplicationRecord
   has_one   :miq_cim_instance,
             :foreign_key => "metric_id"
 

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -1,4 +1,4 @@
-class MiqTask < ActiveRecord::Base
+class MiqTask < ApplicationRecord
   serialize :context_data
   STATE_INITIALIZED = 'Initialized'.freeze
   STATE_QUEUED      = 'Queued'.freeze

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -1,4 +1,4 @@
-class MiqUserRole < ActiveRecord::Base
+class MiqUserRole < ApplicationRecord
   SUPER_ADMIN_ROLE_NAME = "EvmRole-super_administrator"
   ADMIN_ROLE_NAME       = "EvmRole-administrator"
   DEFAULT_TENANT_ROLE_NAME = "EvmRole-tenant_administrator"

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -2,7 +2,7 @@
 #
 require 'simple-rss'
 
-class MiqWidget < ActiveRecord::Base
+class MiqWidget < ApplicationRecord
   default_value_for :enabled, true
   default_value_for :read_only, false
 

--- a/app/models/miq_widget_content.rb
+++ b/app/models/miq_widget_content.rb
@@ -1,4 +1,4 @@
-class MiqWidgetContent < ActiveRecord::Base
+class MiqWidgetContent < ApplicationRecord
   belongs_to  :miq_widget
   belongs_to  :miq_report_result
 end

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -1,4 +1,4 @@
-class MiqWidgetSet < ActiveRecord::Base
+class MiqWidgetSet < ApplicationRecord
   acts_as_miq_set
 
   before_destroy :destroy_user_versions

--- a/app/models/miq_widget_shortcut.rb
+++ b/app/models/miq_widget_shortcut.rb
@@ -1,4 +1,4 @@
-class MiqWidgetShortcut < ActiveRecord::Base
+class MiqWidgetShortcut < ApplicationRecord
   belongs_to :miq_widget
   belongs_to :miq_shortcut
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -1,6 +1,6 @@
 require 'io/wait'
 
-class MiqWorker < ActiveRecord::Base
+class MiqWorker < ApplicationRecord
   include UuidMixin
   include ReportableMixin
 
@@ -182,7 +182,7 @@ class MiqWorker < ActiveRecord::Base
   # Grab all the classes in the hierarchy below ActiveRecord::Base
   def self.path_to_my_worker_settings
     @path_to_my_worker_settings ||=
-      ancestors.grep(Class).select { |c| c < ActiveRecord::Base }.reverse.collect(&:settings_name)
+      ancestors.grep(Class).select { |c| c <= MiqWorker }.reverse.collect(&:settings_name)
   end
 
   def self.fetch_worker_settings_from_server(miq_server, options = {})

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,4 +1,4 @@
-class Network < ActiveRecord::Base
+class Network < ApplicationRecord
   belongs_to :hardware
   belongs_to :guest_device, :foreign_key => "device_id", :inverse_of => :network
 

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -1,4 +1,4 @@
-class NetworkPort < ActiveRecord::Base
+class NetworkPort < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -1,4 +1,4 @@
-class NetworkRouter < ActiveRecord::Base
+class NetworkRouter < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/ontap_aggregate_derived_metric.rb
+++ b/app/models/ontap_aggregate_derived_metric.rb
@@ -1,4 +1,4 @@
-class OntapAggregateDerivedMetric < ActiveRecord::Base
+class OntapAggregateDerivedMetric < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_aggregate_metrics_rollup.rb
+++ b/app/models/ontap_aggregate_metrics_rollup.rb
@@ -1,4 +1,4 @@
-class OntapAggregateMetricsRollup < ActiveRecord::Base
+class OntapAggregateMetricsRollup < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_disk_derived_metric.rb
+++ b/app/models/ontap_disk_derived_metric.rb
@@ -1,4 +1,4 @@
-class OntapDiskDerivedMetric < ActiveRecord::Base
+class OntapDiskDerivedMetric < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_disk_metrics_rollup.rb
+++ b/app/models/ontap_disk_metrics_rollup.rb
@@ -1,4 +1,4 @@
-class OntapDiskMetricsRollup < ActiveRecord::Base
+class OntapDiskMetricsRollup < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_lun_derived_metric.rb
+++ b/app/models/ontap_lun_derived_metric.rb
@@ -1,4 +1,4 @@
-class OntapLunDerivedMetric < ActiveRecord::Base
+class OntapLunDerivedMetric < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_lun_metrics_rollup.rb
+++ b/app/models/ontap_lun_metrics_rollup.rb
@@ -1,4 +1,4 @@
-class OntapLunMetricsRollup < ActiveRecord::Base
+class OntapLunMetricsRollup < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_system_derived_metric.rb
+++ b/app/models/ontap_system_derived_metric.rb
@@ -1,4 +1,4 @@
-class OntapSystemDerivedMetric < ActiveRecord::Base
+class OntapSystemDerivedMetric < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_system_metrics_rollup.rb
+++ b/app/models/ontap_system_metrics_rollup.rb
@@ -1,4 +1,4 @@
-class OntapSystemMetricsRollup < ActiveRecord::Base
+class OntapSystemMetricsRollup < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_volume_derived_metric.rb
+++ b/app/models/ontap_volume_derived_metric.rb
@@ -1,4 +1,4 @@
-class OntapVolumeDerivedMetric < ActiveRecord::Base
+class OntapVolumeDerivedMetric < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/ontap_volume_metrics_rollup.rb
+++ b/app/models/ontap_volume_metrics_rollup.rb
@@ -1,4 +1,4 @@
-class OntapVolumeMetricsRollup < ActiveRecord::Base
+class OntapVolumeMetricsRollup < ApplicationRecord
   include ReportableMixin
 
   belongs_to    :miq_cim_instance

--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -1,6 +1,6 @@
 require 'miq-encode'
 
-class OperatingSystem < ActiveRecord::Base
+class OperatingSystem < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :vm,           :foreign_key => :vm_or_template_id
   belongs_to :miq_template, :foreign_key => :vm_or_template_id

--- a/app/models/operating_system_flavor.rb
+++ b/app/models/operating_system_flavor.rb
@@ -1,4 +1,4 @@
-class OperatingSystemFlavor < ActiveRecord::Base
+class OperatingSystemFlavor < ApplicationRecord
   include ReportableMixin
 
   acts_as_miq_taggable

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -1,5 +1,5 @@
 require 'ancestry'
-class OrchestrationStack < ActiveRecord::Base
+class OrchestrationStack < ApplicationRecord
   require_nested :Status
 
   include NewWithTypeStiMixin

--- a/app/models/orchestration_stack_output.rb
+++ b/app/models/orchestration_stack_output.rb
@@ -1,4 +1,4 @@
-class OrchestrationStackOutput < ActiveRecord::Base
+class OrchestrationStackOutput < ApplicationRecord
   include ReportableMixin
 
   belongs_to :stack, :class_name => "OrchestrationStack"

--- a/app/models/orchestration_stack_parameter.rb
+++ b/app/models/orchestration_stack_parameter.rb
@@ -1,4 +1,4 @@
-class OrchestrationStackParameter < ActiveRecord::Base
+class OrchestrationStackParameter < ApplicationRecord
   include ReportableMixin
 
   belongs_to :stack, :class_name => "OrchestrationStack"

--- a/app/models/orchestration_stack_resource.rb
+++ b/app/models/orchestration_stack_resource.rb
@@ -1,4 +1,4 @@
-class OrchestrationStackResource < ActiveRecord::Base
+class OrchestrationStackResource < ApplicationRecord
   include ReportableMixin
 
   belongs_to :stack, :class_name => "OrchestrationStack"

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -1,5 +1,5 @@
 require 'digest/md5'
-class OrchestrationTemplate < ActiveRecord::Base
+class OrchestrationTemplate < ApplicationRecord
   TEMPLATE_DIR = Rails.root.join("product/orchestration_templates")
 
   include NewWithTypeStiMixin

--- a/app/models/os_process.rb
+++ b/app/models/os_process.rb
@@ -1,4 +1,4 @@
-class OsProcess < ActiveRecord::Base
+class OsProcess < ApplicationRecord
   belongs_to :operating_system
 
   include ReportableMixin

--- a/app/models/partition.rb
+++ b/app/models/partition.rb
@@ -1,4 +1,4 @@
-class Partition < ActiveRecord::Base
+class Partition < ApplicationRecord
   belongs_to :disk
   belongs_to :hardware
   has_many :volumes,

--- a/app/models/patch.rb
+++ b/app/models/patch.rb
@@ -1,4 +1,4 @@
-class Patch < ActiveRecord::Base
+class Patch < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :host
 

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,4 +1,4 @@
-class Picture < ActiveRecord::Base
+class Picture < ApplicationRecord
   has_one :binary_blob, :as => :resource, :dependent => :destroy, :autosave => true
   include ReportableMixin
 

--- a/app/models/policy_event.rb
+++ b/app/models/policy_event.rb
@@ -1,4 +1,4 @@
-class PolicyEvent < ActiveRecord::Base
+class PolicyEvent < ApplicationRecord
   include_concern 'Purging'
 
   belongs_to  :miq_event_definition

--- a/app/models/policy_event/purging.rb
+++ b/app/models/policy_event/purging.rb
@@ -1,4 +1,4 @@
-class PolicyEvent < ActiveRecord::Base
+class PolicyEvent < ApplicationRecord
   module Purging
     extend ActiveSupport::Concern
     include PurgingMixin

--- a/app/models/policy_event_content.rb
+++ b/app/models/policy_event_content.rb
@@ -1,4 +1,4 @@
-class PolicyEventContent < ActiveRecord::Base
+class PolicyEventContent < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :policy_event
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,4 +1,4 @@
-class Provider < ActiveRecord::Base
+class Provider < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin
   include ReportableMixin

--- a/app/models/pxe_image.rb
+++ b/app/models/pxe_image.rb
@@ -1,4 +1,4 @@
-class PxeImage < ActiveRecord::Base
+class PxeImage < ApplicationRecord
   belongs_to :pxe_image_type
   belongs_to :pxe_server
   belongs_to :pxe_menu

--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -1,4 +1,4 @@
-class PxeImageType < ActiveRecord::Base
+class PxeImageType < ApplicationRecord
   include ReportableMixin
   has_many :customization_templates
   has_many :pxe_images

--- a/app/models/pxe_menu.rb
+++ b/app/models/pxe_menu.rb
@@ -1,4 +1,4 @@
-class PxeMenu < ActiveRecord::Base
+class PxeMenu < ApplicationRecord
   belongs_to :pxe_server
 
   def self.class_from_contents(contents)

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -1,4 +1,4 @@
-class PxeServer < ActiveRecord::Base
+class PxeServer < ApplicationRecord
   autoload :WimParser, "win32/wim_parser" # via gems/pending
 
   include FileDepotMixin

--- a/app/models/registry_item.rb
+++ b/app/models/registry_item.rb
@@ -1,4 +1,4 @@
-class RegistryItem < ActiveRecord::Base
+class RegistryItem < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :miq_set    # ScanItemSet
   belongs_to :scan_item

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,6 +1,6 @@
 require 'ancestry'
 
-class Relationship < ActiveRecord::Base
+class Relationship < ApplicationRecord
   has_ancestry
 
   belongs_to :resource, :polymorphic => true

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,4 +1,4 @@
-class Repository < ActiveRecord::Base
+class Repository < ApplicationRecord
   belongs_to :storage
 
   validates_presence_of     :name, :relative_path

--- a/app/models/reserve.rb
+++ b/app/models/reserve.rb
@@ -1,4 +1,4 @@
-class Reserve < ActiveRecord::Base
+class Reserve < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   serialize :reserved

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -1,4 +1,4 @@
-class ResourceAction < ActiveRecord::Base
+class ResourceAction < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   belongs_to :dialog
 

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -1,2 +1,2 @@
-class ResourceGroup < ActiveRecord::Base
+class ResourceGroup < ApplicationRecord
 end

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,4 +1,4 @@
-class ResourcePool < ActiveRecord::Base
+class ResourcePool < ApplicationRecord
   include ReportableMixin
   acts_as_miq_taggable
 

--- a/app/models/rr_pending_change.rb
+++ b/app/models/rr_pending_change.rb
@@ -1,4 +1,4 @@
-class RrPendingChange < ActiveRecord::Base
+class RrPendingChange < ApplicationRecord
   RR_TABLE_NAME_SUFFIX = "pending_changes"
   include RrModelCore
 

--- a/app/models/rr_sync_state.rb
+++ b/app/models/rr_sync_state.rb
@@ -1,4 +1,4 @@
-class RrSyncState < ActiveRecord::Base
+class RrSyncState < ApplicationRecord
   RR_TABLE_NAME_SUFFIX = "sync_state"
   include RrModelCore
 end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,5 +1,5 @@
 require 'resource_feeder/common'
-class RssFeed < ActiveRecord::Base
+class RssFeed < ApplicationRecord
   include ResourceFeeder
   validates_presence_of     :name
   validates_uniqueness_of   :name

--- a/app/models/scan_history.rb
+++ b/app/models/scan_history.rb
@@ -1,4 +1,4 @@
-class ScanHistory < ActiveRecord::Base
+class ScanHistory < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :vm,           :foreign_key => :vm_or_template_id
   belongs_to :miq_template, :foreign_key => :vm_or_template_id

--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -1,4 +1,4 @@
-class ScanItem < ActiveRecord::Base
+class ScanItem < ApplicationRecord
   serialize :definition
   acts_as_miq_set_member
   include UuidMixin

--- a/app/models/scan_item_set.rb
+++ b/app/models/scan_item_set.rb
@@ -1,3 +1,3 @@
-class ScanItemSet < ActiveRecord::Base
+class ScanItemSet < ApplicationRecord
   acts_as_miq_set
 end

--- a/app/models/schema_migration.rb
+++ b/app/models/schema_migration.rb
@@ -1,4 +1,4 @@
-class SchemaMigration < ActiveRecord::Base
+class SchemaMigration < ApplicationRecord
   def self.up_to_date?
     begin
       migrations = missing_db_migrations

--- a/app/models/security_context.rb
+++ b/app/models/security_context.rb
@@ -1,3 +1,3 @@
-class SecurityContext < ActiveRecord::Base
+class SecurityContext < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 end

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -1,4 +1,4 @@
-class SecurityGroup < ActiveRecord::Base
+class SecurityGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include ReportableMixin
 

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -1,4 +1,4 @@
-class ServerRole < ActiveRecord::Base
+class ServerRole < ApplicationRecord
   has_many :assigned_server_roles
   has_many :miq_servers, :through => :assigned_server_roles
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,4 @@
-class Service < ActiveRecord::Base
+class Service < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
 
   belongs_to :tenant

--- a/app/models/service_resource.rb
+++ b/app/models/service_resource.rb
@@ -1,4 +1,4 @@
-class ServiceResource < ActiveRecord::Base
+class ServiceResource < ApplicationRecord
   belongs_to :service_template
   belongs_to :service
   belongs_to :resource, :polymorphic => true

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -1,4 +1,4 @@
-class ServiceTemplate < ActiveRecord::Base
+class ServiceTemplate < ApplicationRecord
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
   include ServiceMixin
   include OwnershipMixin

--- a/app/models/service_template_catalog.rb
+++ b/app/models/service_template_catalog.rb
@@ -1,4 +1,4 @@
-class ServiceTemplateCatalog < ActiveRecord::Base
+class ServiceTemplateCatalog < ApplicationRecord
   include ReportableMixin
   include TenancyMixin
   validates_presence_of     :name

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,4 +1,4 @@
-class Session < ActiveRecord::Base
+class Session < ApplicationRecord
   @@timeout = 3600 # session time to live in seconds
   @@interval = 30 # how often to purge in seconds
   @@job ||= nil

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -1,6 +1,6 @@
 require 'time'
 
-class Snapshot < ActiveRecord::Base
+class Snapshot < ApplicationRecord
   acts_as_tree
 
   belongs_to :vm_or_template

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -1,4 +1,4 @@
-class Storage < ActiveRecord::Base
+class Storage < ApplicationRecord
   has_many :repositories
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"
   has_many :miq_templates,     :foreign_key => :storage_id

--- a/app/models/storage_file.rb
+++ b/app/models/storage_file.rb
@@ -1,4 +1,4 @@
-class StorageFile < ActiveRecord::Base
+class StorageFile < ApplicationRecord
   belongs_to :storage
   belongs_to :vm_or_template
   belongs_to :vm,           :foreign_key => :vm_or_template_id

--- a/app/models/storage_manager.rb
+++ b/app/models/storage_manager.rb
@@ -1,6 +1,6 @@
 require 'miq_storage_defs'
 
-class StorageManager < ActiveRecord::Base
+class StorageManager < ApplicationRecord
   include AuthenticationMixin
   include FilterableMixin
   include RelationshipMixin

--- a/app/models/storage_metrics_metadata.rb
+++ b/app/models/storage_metrics_metadata.rb
@@ -1,4 +1,4 @@
-class StorageMetricsMetadata < ActiveRecord::Base
+class StorageMetricsMetadata < ApplicationRecord
   serialize :counter_info
   validates_uniqueness_of :type
 end

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -1,4 +1,4 @@
-class Switch < ActiveRecord::Base
+class Switch < ApplicationRecord
   belongs_to :host
 
   has_many :guest_devices

--- a/app/models/system_service.rb
+++ b/app/models/system_service.rb
@@ -1,4 +1,4 @@
-class SystemService < ActiveRecord::Base
+class SystemService < ApplicationRecord
   belongs_to :vm_or_template
   belongs_to :vm,           :foreign_key => :vm_or_template_id
   belongs_to :miq_template, :foreign_key => :vm_or_template_id

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
   has_many :taggings, :dependent => :destroy
   has_one :classification
   virtual_has_one :category,       :class_name => "Classification"

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,4 +1,4 @@
-class Tagging < ActiveRecord::Base
+class Tagging < ApplicationRecord
   belongs_to :tag
   belongs_to :taggable, :polymorphic => true
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,6 +1,6 @@
 require 'ancestry'
 
-class Tenant < ActiveRecord::Base
+class Tenant < ApplicationRecord
   HARDCODED_LOGO = "custom_logo.png"
   HARDCODED_LOGIN_LOGO = "custom_login_logo.png"
   DEFAULT_URL = nil

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -1,4 +1,4 @@
-class TenantQuota < ActiveRecord::Base
+class TenantQuota < ApplicationRecord
   belongs_to :tenant
 
   QUOTA_BASE = {

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -1,4 +1,4 @@
-class TimeProfile < ActiveRecord::Base
+class TimeProfile < ApplicationRecord
   ALL_DAYS  = (0...7).to_a.freeze
   ALL_HOURS = (0...24).to_a.freeze
   DEFAULT_TZ = "UTC"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   include RelationshipMixin
   acts_as_miq_taggable
   include RegionMixin

--- a/app/models/vim_performance_operating_range.rb
+++ b/app/models/vim_performance_operating_range.rb
@@ -1,4 +1,4 @@
-class VimPerformanceOperatingRange < ActiveRecord::Base
+class VimPerformanceOperatingRange < ApplicationRecord
   belongs_to  :resource, :polymorphic => true
   belongs_to  :time_profile
 

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -1,4 +1,4 @@
-class VimPerformanceState < ActiveRecord::Base
+class VimPerformanceState < ApplicationRecord
   serialize :state_data
 
   belongs_to :resource, :polymorphic => true

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -1,4 +1,4 @@
-class VimPerformanceTagValue < ActiveRecord::Base
+class VimPerformanceTagValue < ApplicationRecord
   belongs_to :metric, :polymorphic => true
 
   serialize :assoc_ids

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -2,7 +2,7 @@ require 'ostruct'
 require 'cgi'
 require 'uri'
 
-class VmOrTemplate < ActiveRecord::Base
+class VmOrTemplate < ApplicationRecord
   include NewWithTypeStiMixin
   include ScanningMixin
 
@@ -472,7 +472,7 @@ class VmOrTemplate < ActiveRecord::Base
   end
 
   def self.invoke_tasks_remote(options)
-    ids_by_region = options[:ids].group_by { |id| ActiveRecord::Base.id_to_region(id.to_i) }
+    ids_by_region = options[:ids].group_by { |id| ApplicationRecord.id_to_region(id.to_i) }
     ids_by_region.each do |region, ids|
       remote_options = options.merge(:ids => ids)
       hostname = MiqRegion.find_by_region(region).remote_ws_address

--- a/app/models/vmdb_database.rb
+++ b/app/models/vmdb_database.rb
@@ -1,4 +1,4 @@
-class VmdbDatabase < ActiveRecord::Base
+class VmdbDatabase < ApplicationRecord
   has_many :vmdb_tables,           :dependent => :destroy
   has_many :evm_tables,            :class_name => 'VmdbTableEvm'
   has_many :vmdb_database_metrics, :dependent => :destroy

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -1,4 +1,4 @@
-class VmdbDatabaseConnection < ActiveRecord::Base
+class VmdbDatabaseConnection < ApplicationRecord
   self.table_name = 'pg_stat_activity'
   self.primary_key = nil
 

--- a/app/models/vmdb_database_lock.rb
+++ b/app/models/vmdb_database_lock.rb
@@ -1,4 +1,4 @@
-class VmdbDatabaseLock < ActiveRecord::Base
+class VmdbDatabaseLock < ApplicationRecord
   self.table_name = 'pg_locks'
   self.primary_key = nil
 

--- a/app/models/vmdb_database_metric.rb
+++ b/app/models/vmdb_database_metric.rb
@@ -1,4 +1,4 @@
-class VmdbDatabaseMetric < ActiveRecord::Base
+class VmdbDatabaseMetric < ApplicationRecord
   belongs_to :vmdb_database
 
   VmdbMetric # Eager load VmdbMetric class to allow access to VmdbMetric::Purging

--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -1,4 +1,4 @@
-class VmdbDatabaseSetting < ActiveRecord::Base
+class VmdbDatabaseSetting < ApplicationRecord
   self.table_name = 'pg_settings'
   self.primary_key = nil
 

--- a/app/models/vmdb_index.rb
+++ b/app/models/vmdb_index.rb
@@ -1,4 +1,4 @@
-class VmdbIndex < ActiveRecord::Base
+class VmdbIndex < ApplicationRecord
   belongs_to :vmdb_table
 
   has_many :vmdb_metrics,          :as => :resource  # Destroy will be handled by purger

--- a/app/models/vmdb_metric.rb
+++ b/app/models/vmdb_metric.rb
@@ -1,4 +1,4 @@
-class VmdbMetric < ActiveRecord::Base
+class VmdbMetric < ApplicationRecord
   belongs_to :resource, :polymorphic => true
 
   include_concern 'Purging'

--- a/app/models/vmdb_table.rb
+++ b/app/models/vmdb_table.rb
@@ -1,4 +1,4 @@
-class VmdbTable < ActiveRecord::Base
+class VmdbTable < ApplicationRecord
   belongs_to :vmdb_database
 
   has_many :vmdb_indexes,                            :dependent => :destroy

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,4 +1,4 @@
-class Volume < ActiveRecord::Base
+class Volume < ApplicationRecord
   belongs_to :hardware
   has_many :partitions, lambda { |_|
     p = Partition.quoted_table_name

--- a/app/models/windows_image.rb
+++ b/app/models/windows_image.rb
@@ -1,4 +1,4 @@
-class WindowsImage < ActiveRecord::Base
+class WindowsImage < ApplicationRecord
   belongs_to :pxe_server
   belongs_to :pxe_image_type
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,4 +1,4 @@
-class Zone < ActiveRecord::Base
+class Zone < ApplicationRecord
   DEFAULT_NTP_SERVERS = {:server => %w(0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org)}.freeze
 
   validates_presence_of   :name, :description

--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -283,8 +283,8 @@ class TreeNodeBuilder
         policy_id = parent_id.split('_')[2].split('-').last
         event_id  = parent_id.split('_').last.split('-').last
       end
-      p  = MiqPolicy.find_by_id(ActiveRecord::Base.uncompress_id(policy_id))
-      ev = MiqEventDefinition.find_by_id(ActiveRecord::Base.uncompress_id(event_id))
+      p  = MiqPolicy.find_by_id(ApplicationRecord.uncompress_id(policy_id))
+      ev = MiqEventDefinition.find_by_id(ApplicationRecord.uncompress_id(event_id))
       image = p.action_result_for_event(object, ev) ? "check" : "x"
     else
       image = object.action_type == "default" ? "miq_action" : "miq_action_#{object.action_type}"
@@ -343,7 +343,7 @@ class TreeNodeBuilder
       base_class = object.class.base_model.name           # i.e. Vm or MiqTemplate
       base_class = "Datacenter" if base_class == "EmsFolder" && object.is_datacenter
       prefix = TreeBuilder.get_prefix_for_model(base_class)
-      cid = ActiveRecord::Base.compress_id(object.id)
+      cid = ApplicationRecord.compress_id(object.id)
       "#{format_parent_id}#{prefix}-#{cid}"
     end
   end

--- a/app/views/miq_ae_class/_class_instances.html.haml
+++ b/app/views/miq_ae_class/_class_instances.html.haml
@@ -12,7 +12,7 @@
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
           - @record.ae_instances.each do |record|
             - next if record.name == '$'
-            - cls_cid = "#{class_prefix(record.class)}-#{ActiveRecord::Base.compress_id(record.id)}"
+            - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}
               %td.narrow.noclick
                 %input{:type => 'checkbox', :value => cls_cid}

--- a/app/views/miq_ae_class/_class_methods.html.haml
+++ b/app/views/miq_ae_class/_class_methods.html.haml
@@ -12,7 +12,7 @@
         %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
           - @record.ae_methods.each do |record|
             - next if record.name == '$'
-            - cls_cid = "#{class_prefix(record.class)}-#{ActiveRecord::Base.compress_id(record.id)}"
+            - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
             %tr{'data-click-id' => cls_cid}
               %td.narrow.noclick
                 %input{:type => 'checkbox', :value => cls_cid}

--- a/app/views/miq_ae_class/_ns_details.html.haml
+++ b/app/views/miq_ae_class/_ns_details.html.haml
@@ -11,7 +11,7 @@
       %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
         - @records.each do |record|
           - next if record.name == '$'
-          - cls_cid = "#{class_prefix(record.class)}-#{ActiveRecord::Base.compress_id(record.id)}"
+          - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
           %tr{'data-click-id' => cls_cid}
             %td.narrow.noclick
               %input{:type => 'checkbox', :value => cls_cid}

--- a/app/views/miq_ae_class/_ns_list.html.haml
+++ b/app/views/miq_ae_class/_ns_list.html.haml
@@ -15,7 +15,7 @@
       %tbody{'data-click-url' => '/miq_ae_class/tree_select/'}
         - @grid_data.each do |record|
           - next if record.name == '$'
-          - cls_cid = "#{class_prefix(record.class)}-#{ActiveRecord::Base.compress_id(record.id)}"
+          - cls_cid = "#{class_prefix(record.class)}-#{ApplicationRecord.compress_id(record.id)}"
           %tr{'data-click-id' => cls_cid}
             %td.narrow.noclick
               %input{:type => 'checkbox', :value => cls_cid}

--- a/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
+++ b/db/migrate/20131216214850_fix_replication_on_upgrade_from_version_four.rb
@@ -136,7 +136,7 @@ class FixReplicationOnUpgradeFromVersionFour < ActiveRecord::Migration
     end
 
     if RrSyncState.table_exists?
-      prefix = "rr#{ActiveRecord::Base.my_region_number}"
+      prefix = "rr#{ApplicationRecord.my_region_number}"
       RENAMED_TABLES.each do |old_name, new_name|
         drop_trigger(new_name, "#{prefix}_#{old_name}")
       end

--- a/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
+++ b/db/migrate/20150921204114_add_vmware_ro_datastores_to_hosts_storages.rb
@@ -9,7 +9,7 @@ class AddVmwareRoDatastoresToHostsStorages < ActiveRecord::Migration
 
     # Find the sequence_start value for our region, if the region is
     # 0 then start at 1
-    seq_start_value = ActiveRecord::Base.rails_sequence_start
+    seq_start_value = ApplicationRecord.rails_sequence_start
     seq_start_value = 1 if seq_start_value == 0
 
     # add_column ... :primary_key was adding ids to all existing rows before

--- a/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
+++ b/db/migrate/20151208150956_fix_host_storage_replication_on_upgrade.rb
@@ -30,7 +30,7 @@ class FixHostStorageReplicationOnUpgrade < ActiveRecord::Migration
   def run_for_replication_source
     return unless RrSyncState.table_exists?
 
-    prefix = "rr#{ActiveRecord::Base.my_region_number}"
+    prefix = "rr#{ApplicationRecord.my_region_number}"
     old_name = "hosts_storages"
     new_name = "host_storages"
 

--- a/gems/pending/spec/appliance_console/key_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/key_configuration_spec.rb
@@ -3,7 +3,7 @@ require "appliance_console/key_configuration"
 
 describe ApplianceConsole::KeyConfiguration do
   context "#ask_questions" do
-    subject { Class.new(described_class).tap { |c| c.send(:include, ApplianceConsole::Prompts) }.new }
+    subject { Class.new(described_class).tap { |c| c.include(ApplianceConsole::Prompts) }.new }
 
     context "creating" do
       it "asks for nothing else" do

--- a/lib/extensions/ar_lock.rb
+++ b/lib/extensions/ar_lock.rb
@@ -35,4 +35,4 @@ module ArLock
   end
 end
 
-ActiveRecord::Base.send(:include, ArLock)
+ApplicationRecord.include ArLock

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -5,7 +5,7 @@ module ActiveRecord
       super
       return if options[:id] == false
 
-      value = ActiveRecord::Base.rails_sequence_start
+      value = ApplicationRecord.rails_sequence_start
       set_pk_sequence!(table_name, value) unless value == 0
     end
   end

--- a/lib/extensions/ar_nested_count_by.rb
+++ b/lib/extensions/ar_nested_count_by.rb
@@ -17,4 +17,4 @@ module ArNestedCountBy
   end
 end
 
-ActiveRecord::Base.send(:include, ArNestedCountBy)
+ApplicationRecord.include ArNestedCountBy

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -9,7 +9,7 @@ module ArRegion
 
   module ClassMethods
     def inherited(other)
-      if other.superclass == ActiveRecord::Base
+      if other == other.base_class
         other.class_eval do
           virtual_column :region_number,      :type => :integer
           virtual_column :region_description, :type => :string
@@ -150,4 +150,4 @@ module ArRegion
   end
 end
 
-ActiveRecord::Base.send(:include, ArRegion)
+ActiveRecord::Base.include ArRegion

--- a/lib/extensions/ar_table_lock.rb
+++ b/lib/extensions/ar_table_lock.rb
@@ -26,4 +26,4 @@ module ArTableLock
   end
 end
 
-ActiveRecord::Base.send(:extend, ArTableLock)
+ApplicationRecord.extend ArTableLock

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -135,7 +135,8 @@ module VirtualFields
   end
 
   def virtual_fields_base?
-    @virtual_fields_base
+    @virtual_fields_base ||
+      respond_to?(:abstract_class?) && abstract_class?
   end
 
   #

--- a/lib/extensions/as_include_concern.rb
+++ b/lib/extensions/as_include_concern.rb
@@ -53,7 +53,7 @@ module ActiveSupport
           to_include = mod
           require_dependency to_include.underscore
         end
-        send(:include, to_include.constantize)
+        include to_include.constantize
       end
     end
   end

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -17,4 +17,4 @@ module RequireNested
   end
 end
 
-Module.send(:include, RequireNested)
+Module.include RequireNested

--- a/lib/migration_helper/shared_stubs/rr_logged_event.rb
+++ b/lib/migration_helper/shared_stubs/rr_logged_event.rb
@@ -2,7 +2,7 @@ require Rails.root.join("lib/rr_model_core")
 require_relative "../stub_cache_mixin"
 
 module MigrationHelper::SharedStubs
-  class RrLoggedEvent < ActiveRecord::Base
+  class RrLoggedEvent < ApplicationRecord
     extend MigrationHelper::StubCacheMixin
 
     RR_TABLE_NAME_SUFFIX = "logged_events"

--- a/lib/migration_helper/shared_stubs/rr_pending_change.rb
+++ b/lib/migration_helper/shared_stubs/rr_pending_change.rb
@@ -2,7 +2,7 @@ require Rails.root.join("lib/rr_model_core")
 require_relative "../stub_cache_mixin"
 
 module MigrationHelper::SharedStubs
-  class RrPendingChange < ActiveRecord::Base
+  class RrPendingChange < ApplicationRecord
     extend MigrationHelper::StubCacheMixin
 
     RR_TABLE_NAME_SUFFIX = "pending_changes"

--- a/lib/migration_helper/shared_stubs/rr_sync_state.rb
+++ b/lib/migration_helper/shared_stubs/rr_sync_state.rb
@@ -2,7 +2,7 @@ require Rails.root.join("lib/rr_model_core")
 require_relative "../stub_cache_mixin"
 
 module MigrationHelper::SharedStubs
-  class RrSyncState < ActiveRecord::Base
+  class RrSyncState < ApplicationRecord
     extend MigrationHelper::StubCacheMixin
 
     RR_TABLE_NAME_SUFFIX = "sync_state"

--- a/lib/miq_automation_engine/engine/miq_ae_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_workspace.rb
@@ -1,6 +1,6 @@
 require_relative 'miq_ae_state_info'
 module MiqAeEngine
-  class MiqAeWorkspace < ActiveRecord::Base
+  class MiqAeWorkspace < ApplicationRecord
     serialize :workspace
     serialize :setters
     include UuidMixin

--- a/lib/miq_automation_engine/models/miq_ae_class.rb
+++ b/lib/miq_automation_engine/models/miq_ae_class.rb
@@ -1,4 +1,4 @@
-class MiqAeClass < ActiveRecord::Base
+class MiqAeClass < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 

--- a/lib/miq_automation_engine/models/miq_ae_field.rb
+++ b/lib/miq_automation_engine/models/miq_ae_field.rb
@@ -1,4 +1,4 @@
-class MiqAeField < ActiveRecord::Base
+class MiqAeField < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 

--- a/lib/miq_automation_engine/models/miq_ae_instance.rb
+++ b/lib/miq_automation_engine/models/miq_ae_instance.rb
@@ -1,4 +1,4 @@
-class MiqAeInstance < ActiveRecord::Base
+class MiqAeInstance < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -1,6 +1,6 @@
 require 'miq-syntax-checker'
 
-class MiqAeMethod < ActiveRecord::Base
+class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
 

--- a/lib/miq_automation_engine/models/miq_ae_namespace.rb
+++ b/lib/miq_automation_engine/models/miq_ae_namespace.rb
@@ -1,4 +1,4 @@
-class MiqAeNamespace < ActiveRecord::Base
+class MiqAeNamespace < ApplicationRecord
   acts_as_tree
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin

--- a/lib/miq_automation_engine/models/miq_ae_value.rb
+++ b/lib/miq_automation_engine/models/miq_ae_value.rb
@@ -1,4 +1,4 @@
-class MiqAeValue < ActiveRecord::Base
+class MiqAeValue < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
   belongs_to :ae_field,    :class_name => "MiqAeField",    :foreign_key => :field_id

--- a/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_methods.rb
@@ -148,7 +148,7 @@ module MiqAeMethodService
 
     def self.drb_undumped(klass)
       _log.info "Entered: klass=#{klass.name}"
-      klass.send(:include, DRbUndumped) unless klass.ancestors.include?(DRbUndumped)
+      klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)
     end
 
     def self.ar_method

--- a/lib/miq_rubyrep.rb
+++ b/lib/miq_rubyrep.rb
@@ -35,7 +35,7 @@ class MiqRubyrep
       config.options[setting] = value unless value.nil?
     end
 
-    config.options[:rep_prefix] = "rr#{ActiveRecord::Base.my_region_number}"
+    config.options[:rep_prefix] = "rr#{ApplicationRecord.my_region_number}"
 
     config.options[:replicator]                    = :one_way
     config.options[:syncer]                        = :one_way

--- a/lib/report_formatter/timeline.rb
+++ b/lib/report_formatter/timeline.rb
@@ -49,7 +49,7 @@ module ReportFormatter
     # Methods to convert record id (id, fixnum, 12000000000056) to/from compressed id (cid, string, "12c56")
     #   for use in UI controls (i.e. tree node ids, pulldown list items, etc)
     def to_cid(id)
-      ActiveRecord::Base.compress_id(id)
+      ApplicationRecord.compress_id(id)
     end
 
     def tl_event(tl_xml, row, col)

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -60,7 +60,7 @@ describe EmsInfraController do
       ems_infra = FactoryGirl.create(:ext_management_system)
       post :button, :pressed => "vm_right_size", :id => ems_infra.id, :display => 'vms', :check_10r839 => '1'
       expect(controller.send(:flash_errors?)).not_to be_truthy
-      expect(response.body).to include("/vm/right_size/#{ActiveRecord::Base.uncompress_id('10r839')}")
+      expect(response.body).to include("/vm/right_size/#{ApplicationRecord.uncompress_id('10r839')}")
     end
 
     it "when Host Analyze then Check Compliance is pressed" do

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -287,9 +287,9 @@ describe OpsController do
       allow(controller).to receive(:check_privileges).and_return(true)
       allow(controller).to receive(:assert_privileges).and_return(true)
       allow(controller).to receive(:x_active_tree).and_return(:diagnostics_tree)
-      allow(controller).to receive(:x_node).and_return("z-#{ActiveRecord::Base.compress_id(@zone.id)}")
+      allow(controller).to receive(:x_node).and_return("z-#{ApplicationRecord.compress_id(@zone.id)}")
       post :change_tab, :tab_id => "diagnostics_collect_logs"
-      allow(controller).to receive(:x_node).and_return("svr-#{ActiveRecord::Base.compress_id(@miq_server.id)}")
+      allow(controller).to receive(:x_node).and_return("svr-#{ApplicationRecord.compress_id(@miq_server.id)}")
     end
     it "does not render toolbar buttons when edit is clicked" do
       post :x_button, :id => @miq_server.id, :pressed => 'log_depot_edit', :format => :js

--- a/spec/controllers/provider_foreman_controller_spec.rb
+++ b/spec/controllers/provider_foreman_controller_spec.rb
@@ -126,7 +126,7 @@ describe ProviderForemanController do
     end
 
     it "renders the edit page when the configuration manager id is selected from a grid/tile" do
-      post :edit, "check_#{ActiveRecord::Base.compress_id(@config_mgr.id)}" => "1"
+      post :edit, "check_#{ApplicationRecord.compress_id(@config_mgr.id)}" => "1"
       expect(response.status).to eq(200)
     end
   end
@@ -425,12 +425,12 @@ describe ProviderForemanController do
 
   def ems_key_for_provider(provider)
     ems = ExtManagementSystem.where(:provider_id => provider.id).first
-    "e-" + ActiveRecord::Base.compress_id(ems.id)
+    "e-" + ApplicationRecord.compress_id(ems.id)
   end
 
   def config_profile_key(config_profile)
     cp = ConfigurationProfile.where(:id => config_profile.id).first
-    "cp-" + ActiveRecord::Base.compress_id(cp.id)
+    "cp-" + ApplicationRecord.compress_id(cp.id)
   end
 
   def ems_id_for_provider(provider)

--- a/spec/lib/extensions/ar_merge_conditions_spec.rb
+++ b/spec/lib/extensions/ar_merge_conditions_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecord::Base do
+describe ApplicationRecord do
   context "calling apply_legacy_finder_options" do
     before(:each) do
       @vm = FactoryGirl.create(:vm_vmware)

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -704,8 +704,8 @@ describe VirtualFields do
   end
 end
 
-describe "ActiveRecord::Base class" do
-  context "class immediately under ActiveRecord::Base" do
+describe "ApplicationRecord class" do
+  context "class immediately under ApplicationRecord" do
     it ".virtual_column_names" do
       result = Host.virtual_column_names
       expect(result.count("region_number")).to eq(1)
@@ -717,7 +717,7 @@ describe "ActiveRecord::Base class" do
     end
   end
 
-  context "class not immediately under ActiveRecord::Base" do
+  context "class not immediately under ApplicationRecord" do
     it ".virtual_column_names" do
       result = MiqTemplate.virtual_column_names
       expect(result.count("region_number")).to eq(1)


### PR DESCRIPTION
Ultimately, all our patches should be on ApplicationRecord, instead of directly mutilating ActiveRecord::Base.

For now, I've changed the inheritance on all our models, and made the first tentative steps to relocating some extensions.

Most notably, while I've changed all the in-app callers to ask ApplicationRecord for region details, ArRegion remains on AR::Base because rubyrep expects it.