### PR TITLE
Refactor MiqPolicy

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -76,7 +76,7 @@ class MiqPolicy < ActiveRecord::Base
     @@built_in_policies.each do|bp|
       p = OpenStruct.new(bp)
       p.attributes = {"name" => "(Built-in) " + bp[:name], "description" => "(Built-in) " + bp[:description], :applies_to? => true}
-      p.events = [MiqEventDefinition.find_by_name(p.event)]
+      p.events = [MiqEventDefinition.find_by(:name => p.event)]
       p.conditions = []
       if p.condition
         p.conditions = [Condition.new(
@@ -87,14 +87,14 @@ class MiqPolicy < ActiveRecord::Base
           :towhat      => "Vm"
         )]
       end
-      p.actions_for_event = [MiqAction.find_by_name(p.action)]
+      p.actions_for_event = [MiqAction.find_by(:name => p.action)]
       result.push(p)
     end
     @@built_ins = result
     @@built_ins.dup
   end
 
-  CLEAN_ATTRS = ["id", "guid", "name", "created_on", "updated_on", "miq_policy_id"]
+  CLEAN_ATTRS = %w(id guid name created_on updated_on miq_policy_id description)
   def self.clean_attrs(attrs)
     CLEAN_ATTRS.each { |a| attrs.delete(a) }
     attrs
@@ -106,8 +106,7 @@ class MiqPolicy < ActiveRecord::Base
     npolicy.miq_policy_contents = miq_policy_contents.collect do |pc|
       MiqPolicyContent.new(self.class.clean_attrs(pc.attributes))
     end
-    npolicy.save!
-    npolicy
+    npolicy.tap(&:save!)
   end
 
   def miq_event_definitions
@@ -122,23 +121,23 @@ class MiqPolicy < ActiveRecord::Base
 
   def actions_for_event(event, on = :failure)
     order = on == :success ? "success_sequence" : "failure_sequence"
-    miq_policy_contents.where(:miq_event_definition_id => event.id).order(order).collect do |pe|
+    miq_policy_contents.where(:miq_event_definition => event).order(order).collect do |pe|
       next unless pe.qualifier == on.to_s
       pe.get_action(on)
     end.compact
   end
 
   def action_result_for_event(action, event)
-    pe = miq_policy_contents.find_by(:miq_action_id => action.id, :miq_event_definition_id => event.id)
+    pe = miq_policy_contents.find_by(:miq_action => action, :miq_event_definition => event)
     pe.qualifier == "success"
   end
 
   def delete_event(event)
-    MiqPolicyContent.destroy_all(["miq_policy_id = ? and miq_event_definition_id = ?", id, event.id])
+    MiqPolicyContent.destroy_all(:miq_policy => self, :miq_event_definition => event)
   end
 
   def add_event(event)
-    MiqPolicyContent.create(:miq_policy_id => id, :miq_event_definition_id => event.id)
+    MiqPolicyContent.create(:miq_policy => self, :miq_event_definition => event)
   end
 
   def sync_events(events)
@@ -165,56 +164,55 @@ class MiqPolicy < ActiveRecord::Base
   def self.enforce_policy(target, event, inputs = {})
     return unless target.respond_to?(:get_policies)
 
-    mode = event.ends_with?("compliance_check") ? "compliance" : "control"
     result = {:result => true, :details => []}
 
-    # find event record
-    unless event == "rsop" # rsop event doesn't exist. It's used to run rsop without taking any actions
-      erec = MiqEventDefinition.find_by_name(event)
-      # raise "unable to find event named '#{event}'" if erec.nil?
-      if erec.nil?
-        logger.info("MIQ(policy-enforce_policy): Event: [#{event}], not defined, skipping policy enforcement")
-        return result
-      end
+    erec = find_event_def(event)
+    if erec.nil?
+      logger.info("MIQ(policy-enforce_policy): Event: [#{event}], not defined, skipping policy enforcement")
+      return result
     end
 
     logger.info("MIQ(policy-enforce_policy): Event: [#{event}], To: [#{target.name}]")
 
-    profiles, plist = get_policies_for_target(target, mode, event, inputs)
+    mode = event.ends_with?("compliance_check") ? "compliance" : "control"
+
+    profiles, plist = get_policies_for_target(target, mode, erec, inputs)
     return result if plist.blank?
 
-    # evaluate conditions
+    failed, succeeded = evaluate_conditions(plist, target, mode, inputs, result)
+
+    # inject policy results into errors attribute of "target" object
+    target.errors.clear
+    # TODO: If we need this validation on the object, create a real/virtual attribute so ActiveModel doesn't yell
+    target.errors.add(:smart, result[:result])
+
+    action = invoke_actions(target, mode, profiles, succeeded, failed, inputs.merge(:event => erec))
+    result[:action] = action if action
+    result
+  end
+
+  def self.find_event_def(event)
+    # rsop event doesn't exist. It's used to run rsop without taking any actions
+    if event == 'rsop'
+      MiqEventDefinition.new(:name => event)
+    else
+      MiqEventDefinition.find_by(:name => event)
+    end
+  end
+  private_class_method :find_event_def
+
+  def self.evaluate_conditions(plist, target, mode, inputs, result)
     failed = []
     succeeded = []
     plist.each do|p|
       logger.info("MIQ(policy-enforce_policy): Resolving policy [#{p.description}]...")
-      cond_result = "allow"
       if p.conditions.empty?
         succeeded.push(p)
         next
       end
 
-      clist = []
-      p.conditions.uniq.each do|c|
-        # we'll hard code the "always" condition for now until we have full support for
-        # defining actions for both successful and failed policies
-        if c.name == "always"
-          succeeded.push(p)
-          next
-        end
+      cond_result, clist = evaluate_conditions_for_policy(target, p, mode, inputs)
 
-        unless c.applies_to?(target, inputs)
-          # skip conditions that do not apply based on applies_to_exp
-          logger.info("MIQ(policy-enforce_policy): Resolving policy [#{p.description}], Condition: [#{c.description}] does not apply, skipping...")
-          next
-        end
-
-        eval_result = eval_condition(c, target, inputs)
-        cond_result = eval_result if eval_result == "deny"
-        clist.push(c.attributes.merge("result" => eval_result))
-
-        break if eval_result == "deny" && mode == "control"
-      end
       if cond_result == "deny"
         result[:result] = false
         result[:details].push(p.attributes.merge("result" => false, "conditions" => clist))
@@ -224,27 +222,42 @@ class MiqPolicy < ActiveRecord::Base
         succeeded.push(p)
       end
     end
-
-    # inject policy results into errors attribute of "target" object
-    target.errors.clear
-    # TODO: If we need this validation on the object, create a real/virtual attribute so ActiveModel doesn't yell
-    target.errors.add(:smart, result[:result])
-
-    unless event == "rsop" # don't create policy events or invoke actions if we're doing rsop
-      if mode == "control"
-        pevent = build_results(failed, profiles, erec, :failure) + build_results(succeeded, profiles, erec, :success)
-        PolicyEvent.create_events(target, event, pevent)
-      end
-      result[:actions] = MiqAction.invoke_actions(
-        target,
-        inputs.merge(:event => erec),
-        succeeded,
-        failed
-      )
-    end
-
-    result
+    [succeeded, failed]
   end
+  private_class_method :evaluate_conditions
+
+  def self.evaluate_conditions_for_policy(target, policy, mode, inputs)
+    cond_result = "allow"
+    clist = []
+    policy.conditions.uniq.each do|c|
+      unless c.applies_to?(target, inputs)
+        # skip conditions that do not apply based on applies_to_exp
+        logger.info("MIQ(policy-enforce_policy): Resolving policy [#{policy.description}], Condition: [#{c.description}] does not apply, skipping...")
+        next
+      end
+
+      eval_result = eval_condition(c, target, inputs)
+      cond_result = eval_result if eval_result == "deny"
+      clist.push(c.attributes.merge("result" => eval_result))
+
+      break if eval_result == "deny" && mode == "control"
+    end
+    [cond_result, clist]
+  end
+  private_class_method :evaluate_conditions_for_policy
+
+  def self.invoke_actions(target, mode, profiles, succeeded, failed, inputs)
+    # don't create policy events or invoke actions if we're doing rsop
+    event = inputs[:event]
+    return if event.name == 'rsop'
+
+    if mode == 'control'
+      pevent = build_results(failed, profiles, event, :failure) + build_results(succeeded, profiles, event, :success)
+      PolicyEvent.create_events(target, event, pevent)
+    end
+    MiqAction.invoke_actions(target, inputs, succeeded, failed)
+  end
+  private_class_method :invoke_actions
 
   def self.build_results(policies, profiles, event, status)
     # [
@@ -259,57 +272,69 @@ class MiqPolicy < ActiveRecord::Base
         :miq_policy      => p,
         :result          => status.to_s,
         :miq_actions     => p.actions_for_event(event, status).uniq,
-        :miq_policy_sets => p.memberof.collect { |ps| ps if profiles.include?(ps) }.compact
+        :miq_policy_sets => p.memberof.select { |ps| profiles.include?(ps) }
       }
     end.compact
   end
+  private_class_method :build_results
 
   def self.resolve(rec, list = nil, event = nil)
     # list is expected to be a list of policies, not profiles.
     policies = list.nil? ? all : where(:name => list)
-    result = []
-    policies.each do|p|
+    policies.collect do |p|
       next if event && !p.events.include?(event)
 
-      policy_hash = {"result" => "allow", "conditions" => [], "actions" => []}
+      policy_hash = {"result" => "N/A", "conditions" => [], "actions" => []}
       policy_hash["scope"] = MiqExpression.evaluate_atoms(p.expression, rec) unless p.expression.nil?
-      if policy_hash["scope"] && policy_hash["scope"]["result"] == false
-        policy_hash["result"] = "N/A"
-        result.push(p.attributes.merge(policy_hash))
-        next
-      end
+      if policy_hash["scope"].nil? || policy_hash["scope"]["result"]
+        policy_hash['result'], policy_hash['conditions'] = resolve_policy_conditions(p, rec)
 
-      p.conditions.each do|c|
+        action_on = policy_hash["result"] == "deny" ? :failure : :success
+        policy_hash["actions"] =
+          p.actions_for_event(event, action_on).uniq.collect do |a|
+            {"id" => a.id, "name" => a.name, "description" => a.description, "result" => policy_hash["result"]}
+          end unless event.nil?
+      end
+      p.attributes.merge(policy_hash)
+    end.compact
+  end
+
+  def self.resolve_policy_conditions(policy, rec)
+    policy_result = 'allow'
+    conditions =
+      policy.conditions.collect do |c|
         rec_model = rec.class.base_model.name
         rec_model = "Vm" if rec_model.downcase.match("template")
         next unless rec_model == c["towhat"]
 
-        cond_hash = {"id" => c.id}
-        cond_hash["scope"] = MiqExpression.evaluate_atoms(c.applies_to_exp, rec) unless c.applies_to_exp.nil?
-        unless cond_hash["scope"] && cond_hash["scope"]["result"] == false
-          cond_hash["result"] = eval_condition(c, rec)
-          policy_hash["result"] = cond_hash["result"] if cond_hash["result"] == "deny"
-          cond_hash["expression"] = MiqExpression.evaluate_atoms(c.expression, rec)
-        else
-          cond_hash["result"] = "N/A"
-          cond_hash["expression"] = c.expression.exp
+        resolve_condition(c, rec).tap do |cond_hash|
+          policy_result = cond_hash["result"] if cond_hash["result"] == "deny"
         end
-        policy_hash["conditions"].push(cond_hash.merge(
-                                         "name"        => c.name,
-                                         "description" => c.description
-        ))
-      end
-      result_list = policy_hash["conditions"].collect { |c| c["result"] }.uniq
-      policy_hash["result"] = result_list.first if result_list.length == 1 && result_list.first == "N/A"
-      policy_hash["result"] = "N/A" unless p.active == true  # Ignore condition result if policy is inactive
-      action_on = policy_hash["result"] == "deny" ? :failure : :success
-      policy_hash["actions"] = p.actions_for_event(event, action_on).uniq.collect do|a|
-        {"id" => a.id, "name" => a.name, "description" => a.description, "result" => policy_hash["result"]}
-      end unless event.nil?
-      result.push(p.attributes.merge(policy_hash))
+      end.compact
+
+    if policy.active == true
+      result_list = conditions.collect { |c| c["result"] }.uniq
+      policy_result = result_list.first if result_list.length == 1 && result_list.first == "N/A"
+    else
+      policy_result = "N/A" # Ignore condition result if policy is inactive
     end
-    result
+    [policy_result, conditions]
   end
+  private_class_method :resolve_policy_conditions
+
+  def self.resolve_condition(cond, rec)
+    cond_hash = {"id" => cond.id, "name" => cond.name, "description" => cond.description}
+    cond_hash["scope"] = MiqExpression.evaluate_atoms(cond.applies_to_exp, rec) unless cond.applies_to_exp.nil?
+    if cond_hash["scope"].nil? || cond_hash["scope"]["result"]
+      cond_hash["result"] = eval_condition(cond, rec)
+      cond_hash["expression"] = MiqExpression.evaluate_atoms(cond.expression, rec)
+    else
+      cond_hash["result"] = "N/A"
+      cond_hash["expression"] = cond.expression.exp
+    end
+    cond_hash
+  end
+  private_class_method :resolve_condition
 
   def applies_to?(rec, inputs = {})
     rec_model = rec.class.base_model.name
@@ -322,21 +347,15 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def self.eval_condition(c, rec, inputs = {})
+    possible_results = c['modifier'] == 'allow' ? %w(allow deny) : %w(deny allow)
     begin
-      if Condition.evaluate(c, rec, inputs)
-        result = c["modifier"]
-      else
-        if c["modifier"] == "deny"
-          result = "allow"
-        else
-          result = "deny"
-        end
-      end
+      index = Condition.evaluate(c, rec, inputs) ? 0 : 1
+      possible_results[index]
     rescue => err
-      MiqPolicy.logger.log_backtrace(err)
+      logger.log_backtrace(err)
     end
-    result
   end
+  private_class_method :eval_condition
 
   EVENT_GROUPS_EXCLUDED = ["evm_operations", "ems_operations"]
   def self.all_policy_events
@@ -348,13 +367,11 @@ class MiqPolicy < ActiveRecord::Base
   end
 
   def last_event
-    event = policy_events.last
-    event.nil? ? nil : event.created_on
+    policy_events.last.try(:created_on)
   end
 
   def first_event
-    event = policy_events.first
-    event.nil? ? nil : event.created_on
+    policy_events.first.try(:created_on)
   end
 
   def first_and_last_event
@@ -367,73 +384,87 @@ class MiqPolicy < ActiveRecord::Base
       attrs[:towhat] = "Vm"      if p.towhat.nil?
       attrs[:active] = true      if p.active.nil?
       attrs[:mode]   = "control" if p.mode.nil?
-      unless attrs.empty?
-        _log.info("Updating [#{p.name}]")
-        p.update_attributes(attrs)
-      end
+      next if attrs.empty?
+      _log.info("Updating [#{p.name}]")
+      p.update_attributes(attrs)
     end
   end
 
-  private
-
   def self.get_policies_for_target(target, mode, event, inputs = {})
-    erec = MiqEventDefinition.find_by_name(event)
+    event = find_event_def(event) if event.kind_of?(String)
+
     # collect policies expand profiles (sets)
+    profiles, plist = get_expanded_profiles_and_policies(target)
+    plist = built_in_policies.concat(plist).uniq
+
+    towhat = target.class.base_model.name
+    towhat = "Vm" if towhat.downcase.match("template")
+    plist.keep_if do |p|
+      p.mode == mode &&
+      p.towhat == towhat &&
+      policy_for_event?(p, event) &&
+      policy_active?(p) &&
+      policy_applicable?(p, target, inputs)
+    end
+
+    [profiles, plist]
+  end
+
+  def self.policy_for_event?(policy, event)
+    event.name == 'rsop' || policy.events.include?(event)
+  end
+  private_class_method :policy_for_event?
+
+  def self.policy_active?(policy)
+    return true if policy.active
+
+    logger.info("MIQ(policy-enforce_policy): Policy [#{policy.description}] is not active, skipping...")
+    false
+  end
+  private_class_method :policy_active?
+
+  def self.policy_applicable?(policy, target, inputs)
+    return true if policy.kind_of?(MiqPolicy) ? policy.applies_to?(target, inputs) : policy.applies_to?
+
+    logger.info("MIQ(policy-enforce_policy): Policy [#{policy.description}] does not apply, skipping...")
+    false
+  end
+  private_class_method :policy_applicable?
+
+  def self.get_expanded_profiles_and_policies(target)
+    # get profiles and policies from target object
+    target_policies = target.get_policies
+    target_profiles = separate_profiles_from_policies(target_policies)
+
+    # get profiles and policies from associations
+    assoc_policies =
+      @@associations_to_get_policies.collect do |assoc|
+        next unless target.respond_to?(assoc)
+
+        obj = target.send(assoc)
+        next unless obj
+
+        obj.get_policies
+      end.compact.flatten
+    assoc_profiles = separate_profiles_from_policies(assoc_policies)
+
+    [target_profiles.concat(assoc_profiles), target_policies.concat(assoc_policies).flatten.compact.uniq]
+  end
+  private_class_method :get_expanded_profiles_and_policies
+
+  def self.separate_profiles_from_policies(policies)
     profiles = []
-    plist = built_in_policies
-    plist = plist.concat(target.get_policies.collect do|p|
+    policies.collect! do |p|
       if p.kind_of?(MiqPolicySet)
         profiles.push(p)
         p = p.members
       end
       p
-    end.compact.flatten).uniq # get policies from target object
-    @@associations_to_get_policies.each do|assoc|
-      next unless target.respond_to?(assoc)
-
-      obj = target.send(assoc)
-      next unless obj
-      plist = plist.concat(obj.get_policies.collect do|p|
-        if p.kind_of?(MiqPolicySet)
-          profiles.push(p)
-          p = p.members.sort { |a, b| a.name <=> b.name }
-        end
-        p
-      end.compact.flatten).uniq
     end
 
-    towhat = target.class.base_model.name
-    towhat = "Vm" if towhat.downcase.match("template")
-
-    # Filter out policies that are not for the target class or the requested mode
-    plist = plist.find_all { |p| p.mode == mode && p.towhat == towhat }
-
-    # collect only policies that include event unless we're doing rsop
-    plist.collect! do|p|
-      if p.kind_of?(MiqPolicy)
-        # p if p.contains?(erec)
-        p if p.events.include?(erec)
-      else
-        # built-in policies are OpenStructs
-        p if p.events.include?(erec)
-      end
-    end.compact! unless event == "rsop"
-
-    plist.collect! do|p|
-      unless p.active == true
-        logger.info("MIQ(policy-enforce_policy): Policy [#{p.description}] is not active, skipping...")
-        next
-      end
-
-      applies = p.kind_of?(MiqPolicy) ? p.applies_to?(target, inputs) : p.applies_to?
-      unless applies
-        logger.info("MIQ(policy-enforce_policy): Policy [#{p.description}] does not apply, skipping...")
-        next
-      end
-      p
-    end.compact!
-    return profiles, plist
+    profiles
   end
+  private_class_method :separate_profiles_from_policies
 
   def add_action_for_event(event, action, opt_hash = nil)
     # we now expect an options hash provided by the UI, merge the qualifier with the options_hash
@@ -466,4 +497,5 @@ class MiqPolicy < ActiveRecord::Base
 
     self.save!
   end
+  private :add_action_for_event
 end

--- a/app/models/policy_event.rb
+++ b/app/models/policy_event.rb
@@ -11,7 +11,7 @@ class PolicyEvent < ActiveRecord::Base
   virtual_has_many :miq_policy_sets, :uses => {:contents => :resource}
 
   def self.create_events(target, event, result)
-    event = MiqEventDefinition.find_by_name(event)
+    event = MiqEventDefinition.find_by(:name => event) if event.kind_of?(String)
     chain_id = nil
     result.each do |r|
       miq_policy_id = r[:miq_policy].kind_of?(MiqPolicy) ? r[:miq_policy].id : nil # handle built-in policies too

--- a/config/built_in_policies.yml
+++ b/config/built_in_policies.yml
@@ -1,0 +1,44 @@
+---
+- :name: Stop Newly Retired Running VM
+  :description: Stop Newly Retired Running VM
+  :towhat: Vm
+  :event: vm_retired
+  :applies_to?: true
+  :active: true
+  :condition:
+    and:
+    - "=":
+        field: Vm-retired
+        value: true
+    - "=":
+        field: Vm-power_state
+        value: 'on'
+  :modifier: deny
+  :mode: control
+  :action: vm_stop
+- :name: Prevent Retired VM from Starting
+  :description: Prevent Retired VM from starting
+  :towhat: Vm
+  :event: request_vm_start
+  :applies_to?: true
+  :active: true
+  :condition:
+    "=":
+      field: Vm-retired
+      value: true
+  :modifier: deny
+  :mode: control
+  :action: prevent
+- :name: Stop Retired VM
+  :description: Stop Retired VM
+  :towhat: Vm
+  :event: vm_start
+  :applies_to?: true
+  :active: true
+  :condition:
+    "=":
+      field: Vm-retired
+      value: true
+  :modifier: deny
+  :mode: control
+  :action: vm_stop

--- a/spec/factories/miq_action.rb
+++ b/spec/factories/miq_action.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :miq_action do
-    sequence(:name)  { |num| "action_#{num}" }
-    description      "Test Action"
-    action_type      "Test"
+    sequence(:name)        { |num| "action_#{seq_padded_for_sorting(num)}" }
+    sequence(:description) { |num| "Test Action_#{seq_padded_for_sorting(num)}" }
+    action_type            "Test"
   end
 end

--- a/spec/factories/miq_policy.rb
+++ b/spec/factories/miq_policy.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :miq_policy do
-    description "Test Policy"
+    sequence(:name)        { |num| "policy_#{seq_padded_for_sorting(num)}" }
+    sequence(:description) { |num| "Test Policy_#{seq_padded_for_sorting(num)}" }
+    towhat                 "Vm"
   end
 end

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -42,7 +42,6 @@ describe MiqPolicy do
 
     context "when fields(towhat, active, mode) are not yet set in database" do
       it "should be filled up by default values" do
-        # be sure that we have not values in those fields
         miq_policy_instance.towhat = nil
         miq_policy_instance.active = nil
         miq_policy_instance.mode = nil
@@ -52,7 +51,6 @@ describe MiqPolicy do
 
         updated_miq_policy = MiqPolicy.find(miq_policy_instance.id)
 
-        # testing against default values from app/models/miq_policy.rb:366
         expect(updated_miq_policy.towhat).to eq("Vm")
         expect(updated_miq_policy.active).to eq(true)
         expect(updated_miq_policy.mode).to eq("control")
@@ -70,7 +68,6 @@ describe MiqPolicy do
 
         miq_policy = MiqPolicy.find(miq_policy_instance.id)
 
-        # testing against default values from app/models/miq_policy.rb:366
         expect(miq_policy.towhat).not_to eq("Vm")
         expect(miq_policy.active).not_to eq(true)
         expect(miq_policy.mode).not_to eq("control")
@@ -79,6 +76,181 @@ describe MiqPolicy do
         expect(miq_policy.towhat).to eq("Host")
         expect(miq_policy.active).to eq(false)
         expect(miq_policy.mode).to eq("compliance")
+      end
+    end
+  end
+
+  context "instance methods" do
+    let(:event)  { FactoryGirl.create(:miq_event_definition) }
+    let(:action) { FactoryGirl.create(:miq_action) }
+
+    let(:policy) do
+      cond = FactoryGirl.create(:condition)
+      FactoryGirl.create(:miq_policy, :conditions => [cond]).tap do |p|
+        p.replace_actions_for_event(event, [[action, {:qualifier => :success}]])
+      end
+    end
+
+    describe "#events" do
+      it "lists miq_event_definition assigned to the policy" do
+        expect(policy.events).to eq([event])
+      end
+    end
+
+    describe "#sync_events, #add_event, #delete_event" do
+      let(:new_events) { [FactoryGirl.create(:miq_event_definition), FactoryGirl.create(:miq_event_definition)] }
+
+      it 'synchronizes with new list of events' do
+        policy.sync_events(new_events)
+        policy.reload
+        expect(policy.events).to eq(new_events)
+      end
+    end
+
+    describe "#actions #actions_for_event, #replace_actions_for_event" do
+      let(:new_action)    { FactoryGirl.create(:miq_action) }
+      let(:another_event) { FactoryGirl.create(:miq_event_definition) }
+
+      it "lists all actions for the policy" do
+        policy.replace_actions_for_event(another_event, [[new_action, {:qualifier => :success}]])
+        expect(policy.actions).to match_array([action, new_action])
+      end
+
+      it "lists actions for an event" do
+        expect(policy.actions_for_event(event, :success)).to eq([action])
+      end
+
+      it "replaces actions for an event" do
+        policy.replace_actions_for_event(event, [[new_action, {:qualifier => :success}]])
+        expect(policy.actions_for_event(event, :success)).to eq([new_action])
+      end
+    end
+
+    describe "#action_result_for_event" do
+      it "finds the action result to be true or false" do
+        expect(policy.action_result_for_event(action, event)).to be true
+      end
+    end
+
+    describe "#copy, .clean_attrs" do
+      it "creates new instance based on the existing one" do
+        new_policy = policy.copy(:name => 'newname', :description => 'newdesc')
+        expect(new_policy.name).to        eq('newname')
+        expect(new_policy.description).to eq('newdesc')
+
+        expect(new_policy.id).not_to   eq(policy.id)
+        expect(new_policy.guid).not_to eq(policy.guid)
+
+        expect(new_policy.events).to     eq(policy.events)
+        expect(new_policy.actions).to    eq(policy.actions)
+        expect(new_policy.conditions).to eq(policy.conditions)
+      end
+    end
+
+    describe "#applies_to?" do
+      let(:target_vm)       { FactoryGirl.create(:vm_amazon) }
+      let(:target_template) { FactoryGirl.create(:template_infra) }
+      let(:target_host)     { FactoryGirl.create(:host) }
+
+      it "applies to target with matched type" do
+        expect(policy.applies_to?(target_vm)).to       be_truthy
+        expect(policy.applies_to?(target_template)).to be_truthy
+        expect(policy.applies_to?(target_host)).to     be_falsey
+      end
+
+      context "policy has expression" do
+        before do
+          policy.expression = "expression"
+        end
+
+        it "applies to target when expression evaluates true" do
+          expect(Condition).to receive(:evaluate).and_return(true)
+          expect(policy.applies_to?(target_vm)).to be_truthy
+        end
+
+        it "does not apply to target when expression evaluates false" do
+          expect(Condition).to receive(:evaluate).and_return(false)
+          expect(policy.applies_to?(target_vm)).to be_falsey
+        end
+      end
+    end
+  end
+
+  context "class methods" do
+    let(:events)  { [FactoryGirl.create(:miq_event_definition), FactoryGirl.create(:miq_event_definition)] }
+    let(:actions) { [FactoryGirl.create(:miq_action), FactoryGirl.create(:miq_action)] }
+    let(:conds)   { [FactoryGirl.create(:condition), FactoryGirl.create(:condition)] }
+    let(:target)  { FactoryGirl.create(:vm) }
+
+    let(:policies) do
+      [
+        FactoryGirl.create(:miq_policy, :conditions => [conds[0]], :active => true, :mode => 'control').tap do |p|
+          p.replace_actions_for_event(events[0], [[actions[0], {:qualifier => :success}]])
+        end,
+        FactoryGirl.create(:miq_policy, :conditions => [conds[1]], :active => false).tap do |p|
+          p.replace_actions_for_event(events[1], [[actions[1], {:qualifier => :success}]])
+        end
+      ]
+    end
+
+    let(:profiles) do
+      [
+        FactoryGirl.create(:miq_policy_set).tap { |pf| pf.add_member(policies[0]) },
+        FactoryGirl.create(:miq_policy_set).tap { |pf| pf.add_member(policies[1]) },
+      ]
+    end
+
+    before { policies }
+
+    describe ".resolve" do
+      it "resolves all policies" do
+        results = described_class.resolve(FactoryGirl.create(:vm))
+        expect(results.size).to eq(2)
+      end
+
+      it "resolves policies by event" do
+        results = described_class.resolve(FactoryGirl.create(:vm), policies.collect(&:name), events[1])
+        expect(results.size).to eq(1)
+        result = results[0]
+        expect(result).to include(
+          'name'        => policies[1].name,
+          'description' => policies[1].description,
+          'towhat'      => policies[1].towhat,
+          'expression'  => policies[1].expression,
+          'result'      => 'N/A'
+        )
+        expect(result['conditions'][0]).to include(
+          'name'        => conds[1].name,
+          'description' => conds[1].description,
+          'result'      => 'deny',
+          'expression'  => conds[1].expression.exp.merge('result' => false)
+        )
+        expect(result['actions'][0]).to include(
+          'name'        => actions[1].name,
+          'description' => actions[1].description,
+          'result'      => 'N/A'
+        )
+      end
+    end
+
+    describe ".get_policies_for_target" do
+      it 'gets profiles and policies for a target' do
+        allow(target).to receive(:get_policies).and_return(profiles)
+        prof_list, pol_list = described_class.get_policies_for_target(target, 'control', events[0].name)
+        expect(prof_list.size).to eq(2)
+        expect(pol_list.size).to  eq(1)
+        expect(pol_list[0]).to    eq(policies[0])
+      end
+    end
+
+    describe ".enforce_policy" do
+      it 'executes policies for a target' do
+        allow(target).to receive(:get_policies).and_return(profiles)
+        res = described_class.enforce_policy(target, events[0].name)
+        expect(res[:result]).to be false
+        expect(res[:details][0]).to include(policies[0].attributes.merge('result' => false))
+        expect(res[:details][0]['conditions'][0])
+          .to include(conds[0].attributes.merge('result' => 'deny').except('expression'))
       end
     end
   end


### PR DESCRIPTION
Refactored a few fat methods into multiple simpler private methods.
Added missing spec tests for all instance and class methods.
Initialized built in policies from a yaml file on disk

Removed the special handling of `always` condition. A search finds there is no longer such condition.