### PR TITLE
Return empty command lines for permission issues or already exited pids

### DIFF
--- a/gems/pending/spec/util/miq-process_spec.rb
+++ b/gems/pending/spec/util/miq-process_spec.rb
@@ -1,0 +1,19 @@
+require 'util/miq-process'
+
+describe MiqProcess do
+  context ".command_line" do
+    it "exited process" do
+      allow(Sys::ProcTable).to receive(:ps).and_return nil
+      expect(described_class.command_line(123)).to eq ""
+    end
+
+    it "no permissions to proctable info" do
+      allow(Sys::ProcTable).to receive(:ps).and_return(double(:cmdline => nil))
+      expect(described_class.command_line(123)).to eq ""
+    end
+
+    it "normal case" do
+      expect(described_class.command_line(Process.pid)).not_to be_empty
+    end
+  end
+end

--- a/gems/pending/util/miq-process.rb
+++ b/gems/pending/util/miq-process.rb
@@ -127,7 +127,9 @@ class MiqProcess
   end
 
   def self.command_line(pid)
-    Sys::ProcTable.ps(pid).cmdline
+    # Already exited pids, or permission errors cause ps or ps.cmdline to be nil,
+    # so the best we can do is return an empty string.
+    Sys::ProcTable.ps(pid).try(:cmdline) || ""
   end
 
   def self.alive?(pid)


### PR DESCRIPTION
We should consistently return strings so the best we can do is return an empty
string for these unhappy paths.

We can't take action for empty command lines, so in the case of exited pids, this
should be ok.  Permission issues are only a problem on development environments
but not for appliances.

```
[NoMethodError]: undefined method `include?' for nil:NilClass  Method:[rescue in monitor]
../gems/pending/util/miq-process.rb:163:in `is_worker?'
```