### PR TITLE
SCVMM: Implementation of the vm_destroy method required for VM retirement

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager.rb
@@ -100,6 +100,13 @@ class ManageIQ::Providers::Microsoft::InfraManager < ManageIQ::Providers::InfraM
     execute_power_operation("Resume", vm.uid_ems)
   end
 
+  def vm_destroy(vm, _options = {})
+    if vm.power_state == "on"
+      vm_stop(vm)
+    end
+    execute_power_operation("Remove", vm.uid_ems)
+  end
+
   def vm_create_evm_snapshot(vm, _options)
     log_prefix = "vm_create_evm_snapshot: vm=[#{vm.name}]"
 


### PR DESCRIPTION
A few points:
1) It is necessary to power off the VM first if running at the time of retirement. 
2) Consecutive operations (power off, then delete) run synchronously so there is no need to check if one operation has completed before starting the next.  
3) Saved VMs can be retired without powering them on first.

https://bugzilla.redhat.com/show_bug.cgi?id=1299069
https://bugzilla.redhat.com/show_bug.cgi?id=1299071