### PR TITLE
When logging, mask LDAP credentials in nested hashes

### DIFF
--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -7,14 +7,17 @@ module VMDB
 
     require_relative 'configuration_encoder'
 
+
+    PASSWORD_KEYS = [:bind_pwd, :amazon_secret]
+
     def self.deep_clean_auth_for_log(log_auth)
       log_auth.each do |key, val|
         log_auth[key] = deep_clean_auth_for_log(val) if val.kind_of?(Hash)
 
-        log_auth[key] = "********" if [:bind_pwd, :amazon_secret].include? key
+        log_auth[key] = "********" if PASSWORD_KEYS.include? key
 
         log_auth[key].each do |p|
-          p.each { |key2, _val2| p[key2] = "********" if [:bind_pwd, :amazon_secret].include? key2 }
+          p.each { |key2, _val2| p[key2] = "********" if PASSWORD_KEYS.include? key2 }
         end if [:user_proxies].include? key
       end
       log_auth

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -7,17 +7,14 @@ module VMDB
 
     require_relative 'configuration_encoder'
 
-
-    PASSWORD_KEYS = [:bind_pwd, :amazon_secret]
-
     def self.deep_clean_auth_for_log(log_auth)
       log_auth.each do |key, val|
         log_auth[key] = deep_clean_auth_for_log(val) if val.kind_of?(Hash)
 
-        log_auth[key] = "********" if PASSWORD_KEYS.include? key
+        log_auth[key] = "********" if Vmdb::ConfigurationEncoder::PASSWORD_FIELDS.include?(key.to_s)
 
         log_auth[key].each do |p|
-          p.each { |key2, _val2| p[key2] = "********" if PASSWORD_KEYS.include? key2 }
+          p.keys.each { |key2| p[key2] = "********" if Vmdb::ConfigurationEncoder::PASSWORD_FIELDS.include?(key2.to_s) }
         end if [:user_proxies].include? key
       end
       log_auth

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -7,17 +7,21 @@ module VMDB
 
     require_relative 'configuration_encoder'
 
-    def self.clone_auth_for_log(auth)
-      log_auth = auth.deep_clone
-      [:bind_pwd, :amazon_secret].each do |key|
-        log_auth[key] = '********' if log_auth.key?(key)
-        if log_auth.key?(:user_proxies)
-          log_auth[:user_proxies].each do |p|
-            p[key] = '********' if p.key?(key)
-          end
-        end
+    def self.deep_clean_auth_for_log(log_auth)
+      log_auth.each do |key, val|
+        log_auth[key] = deep_clean_auth_for_log(val) if val.kind_of?(Hash)
+
+        log_auth[key] = "********" if [:bind_pwd, :amazon_secret].include? key
+
+        log_auth[key].each do |p|
+          p.each { |key2, _val2| p[key2] = "********" if [:bind_pwd, :amazon_secret].include? key2 }
+        end if [:user_proxies].include? key
       end
       log_auth
+    end
+
+    def self.clone_auth_for_log(auth)
+      deep_clean_auth_for_log(auth.deep_clone)
     end
 
     def self.invalidate(name)

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -85,7 +85,7 @@ describe VMDB::Config do
     options = {:host => "16.1.2.119",
                :port => "389",
                :auth => {:basedn                      => "OU=Users,OU=Developers,OU=Manageiq,DC=manageiq,DC=com",
-                         :bind_dn                     => "CN=Joe Vlcek,OU=Users,OU=Developers,OU=ManageIQ,DC=manageiq,DC=com",
+                         :bind_dn                     => "CN=David Robert Jones,OU=Users,OU=Developers,OU=ManageIQ,DC=manageiq,DC=com",
                          :bind_pwd                    => "top_secret_bind_pwd",
                          :get_direct_groups           => true,
                          :group_memberships_max_depth => 2,
@@ -106,25 +106,25 @@ describe VMDB::Config do
                         }
               }
 
-    it "masks_passwors_in_log_auth" do
+    it "masks passwords in log auth" do
       log_auth = VMDB::Config.clone_auth_for_log(options)
       expect(log_auth[:auth][:bind_pwd]).to eql("********")
       expect(log_auth[:auth][:amazon_secret]).to eql("********")
     end
 
-    it "leaves_source_passwords_unaltered" do
+    it "leaves source passwords unaltered" do
       VMDB::Config.clone_auth_for_log(options)
       expect(options[:auth][:bind_pwd]).to eql("top_secret_bind_pwd")
       expect(options[:auth][:amazon_secret]).to eql("top_secret_secret")
     end
 
-    it "masks_user_proxies_passwors_in_log_auth" do
+    it "masks user proxies passwords in log auth" do
       log_auth = VMDB::Config.clone_auth_for_log(options)
       expect(log_auth[:auth][:user_proxies][0][:bind_pwd]).to eql("********")
       expect(log_auth[:auth][:user_proxies][0][:amazon_secret]).to eql("********")
     end
 
-    it "leaves_source_user_proxies_unaltered" do
+    it "leaves source user proxies unaltered" do
       VMDB::Config.clone_auth_for_log(options)
       expect(options[:auth][:user_proxies][0][:bind_pwd]).to eql("user_proxy_bind_pwd")
       expect(options[:auth][:user_proxies][0][:amazon_secret]).to eql("user_proxy_amazon_secret")

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -89,7 +89,7 @@ describe VMDB::Config do
                          :bind_pwd                    => "top_secret_bind_pwd",
                          :get_direct_groups           => true,
                          :group_memberships_max_depth => 2,
-                         :ldaphost                    => ["16.1.2.119"],
+                         :ldaphost                    => ["192.0.2.255"],
                          :ldapport                    => "389",
                          :mode                        => "ldap",
                          :user_suffix                 => "manageiq.com",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1297576

Credentials maintained in nested hashes were not being masked for logging
if they were not in the top level hash.

This fix is a generic approach and will `deep` mask the credentials.