### PR TITLE
Make display names checkbox label clickable in topology

### DIFF
--- a/app/views/container_topology/show.html.haml
+++ b/app/views/container_topology/show.html.haml
@@ -3,8 +3,9 @@
     .col-md-12
       .toolbar-pf-actions
         .form-group.text
-          %input#box{'ng-change' => "show_hide_names(checkboxModel.value)",  'ng-model' => "checkboxModel.value", :type => "checkbox", 'ng-true-value' => 'true', 'ng-false-value' => 'false'}
-          = _("Display Names")
+          %label.checkbox-inline
+            %input#box{'ng-change' => "show_hide_names(checkboxModel.value)",  'ng-model' => "checkboxModel.value", :type => "checkbox", 'ng-true-value' => 'true', 'ng-false-value' => 'false'}
+            = _("Display Names")
         .form-group
           %button.btn.btn-default
             %i{'ng-click' => "refresh()", :class => "fa fa-refresh fa-lg"}


### PR DESCRIPTION
@miq-bot add_label bug, ui, providers/containers

@epwinchell @martinpovolny 

![displaynameslabeltopology](https://cloud.githubusercontent.com/assets/6277245/12536153/de027ea2-c2a4-11e5-943d-edee1919c326.png)
