### PR TITLE
Switch from hide_action to private controller methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,6 +104,7 @@ class ApplicationController < ActionController::Base
 
     render_exception(msg)
   end
+  private :error_handler
 
   def render_exception(msg)
     respond_to do |format|
@@ -122,6 +123,7 @@ class ApplicationController < ActionController::Base
       format.any { render :nothing => true, :status => 404 }  # Anything else, just send 404
     end
   end
+  private :render_exception
 
   def change_tab
     redirect_to(:action => params[:tab], :id => params[:id])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,7 +104,6 @@ class ApplicationController < ActionController::Base
 
     render_exception(msg)
   end
-  hide_action :error_handler
 
   def render_exception(msg)
     respond_to do |format|
@@ -123,7 +122,6 @@ class ApplicationController < ActionController::Base
       format.any { render :nothing => true, :status => 404 }  # Anything else, just send 404
     end
   end
-  hide_action :render_exception
 
   def change_tab
     redirect_to(:action => params[:tab], :id => params[:id])

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1,6 +1,10 @@
 module ApplicationController::CiProcessing
   extend ActiveSupport::Concern
 
+  included do
+    private(:process_elements)
+  end
+
   # Set Ownership selected db records
   def set_ownership(klass = "VmOrTemplate")
     assert_privileges(params[:pressed])

--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1,10 +1,6 @@
 module ApplicationController::CiProcessing
   extend ActiveSupport::Concern
 
-  included do
-    hide_action(:process_elements)
-  end
-
   # Set Ownership selected db records
   def set_ownership(klass = "VmOrTemplate")
     assert_privileges(params[:pressed])

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -5,6 +5,7 @@ module ApplicationController::CurrentUser
     helper_method :current_user,  :current_userid
     helper_method :current_group, :current_group_id
     helper_method :admin_user?, :super_admin_user?
+    private :clear_current_user
   end
 
   def clear_current_user

--- a/app/controllers/application_controller/current_user.rb
+++ b/app/controllers/application_controller/current_user.rb
@@ -5,9 +5,6 @@ module ApplicationController::CurrentUser
     helper_method :current_user,  :current_userid
     helper_method :current_group, :current_group_id
     helper_method :admin_user?, :super_admin_user?
-    hide_action :clear_current_user, :current_user=
-    hide_action :admin_user?, :super_admin_user?
-    hide_action :current_user, :current_userid, :current_group_id
   end
 
   def clear_current_user

--- a/app/controllers/application_controller/tenancy.rb
+++ b/app/controllers/application_controller/tenancy.rb
@@ -3,9 +3,6 @@ module ApplicationController::Tenancy
 
   included do
     helper_method :current_tenant
-    hide_action :set_session_tenant
-    hide_action :current_tenant
-    hide_action :refresh_session_tenant
   end
 
   def current_tenant

--- a/app/controllers/application_controller/timezone.rb
+++ b/app/controllers/application_controller/timezone.rb
@@ -5,9 +5,6 @@ class ApplicationController
     included do
       helper_method :get_timezone_abbr, :get_timezone_offset
       helper_method :server_timezone
-
-      hide_action :get_timezone_abbr, :get_timezone_offset
-      hide_action :server_timezone
     end
 
     # return timezone abbreviation

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -532,7 +532,6 @@ class CatalogController < ApplicationController
     when 'reconfigure' then :reconfigure_fqname
     end
   end
-  hide_action :get_ae_tree_edit_key
 
   def ae_tree_select_toggle
     @edit = session[:edit]
@@ -679,7 +678,6 @@ class CatalogController < ApplicationController
       end
     end
   end
-  hide_action :process_sts
 
   def template_to_node_name(object)
     ORCHESTRATION_TEMPLATES_NODES[object.class.name]

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -532,6 +532,7 @@ class CatalogController < ApplicationController
     when 'reconfigure' then :reconfigure_fqname
     end
   end
+  private :get_ae_tree_edit_key
 
   def ae_tree_select_toggle
     @edit = session[:edit]
@@ -678,6 +679,7 @@ class CatalogController < ApplicationController
       end
     end
   end
+  private :process_sts
 
   def template_to_node_name(object)
     ORCHESTRATION_TEMPLATES_NODES[object.class.name]

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -654,6 +654,7 @@ class ConfigurationController < ApplicationController
     end
     settings
   end
+  private :merge_in_user_settings
 
   # * start with DEFAULT_SETTINGS
   # * merge in current session changes
@@ -661,6 +662,7 @@ class ConfigurationController < ApplicationController
   def init_settings
     merge_in_user_settings(copy_hash(DEFAULT_SETTINGS))
   end
+  private :init_settings
 
   def set_form_vars
     case @tabform

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -654,7 +654,6 @@ class ConfigurationController < ApplicationController
     end
     settings
   end
-  hide_action :merge_in_user_settings
 
   # * start with DEFAULT_SETTINGS
   # * merge in current session changes
@@ -662,7 +661,6 @@ class ConfigurationController < ApplicationController
   def init_settings
     merge_in_user_settings(copy_hash(DEFAULT_SETTINGS))
   end
-  hide_action :init_settings
 
   def set_form_vars
     case @tabform

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -32,7 +32,6 @@ class ContainerController < ApplicationController
     end
     send_action
   end
-  hide_action :whitelisted_action
 
   def x_button
     @explorer = true

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -32,6 +32,7 @@ class ContainerController < ApplicationController
     end
     send_action
   end
+  private :whitelisted_action
 
   def x_button
     @explorer = true

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -22,10 +22,26 @@ module OpsController::Settings::RHN
   end
 
   included do
+    private(:rhn_subscription_map)
+    private(:rhn_update_information)
+    private(:rhn_subscription)
+    private(:rhn_save_subscription)
+    private(:rhn_credentials_from_edit)
+    private(:rhn_fire_available_organizations)
+    private(:rhn_load_session)
+    private(:rhn_gather_checks)
+
     helper_method(:rhn_subscription_types)
+    private(:rhn_subscription_types)
+
     helper_method(:rhn_address_string)
+    private(:rhn_address_string)
+
     helper_method(:rhn_account_info_string)
+    private(:rhn_account_info_string)
+
     helper_method(:rhn_default_enabled)
+    private(:rhn_default_enabled)
   end
 
   def rhn_address_string

--- a/app/controllers/ops_controller/settings/rhn.rb
+++ b/app/controllers/ops_controller/settings/rhn.rb
@@ -22,26 +22,10 @@ module OpsController::Settings::RHN
   end
 
   included do
-    hide_action(:rhn_subscription_map)
-    hide_action(:rhn_update_information)
-    hide_action(:rhn_subscription)
-    hide_action(:rhn_save_subscription)
-    hide_action(:rhn_credentials_from_edit)
-    hide_action(:rhn_fire_available_organizations)
-    hide_action(:rhn_load_session)
-    hide_action(:rhn_gather_checks)
-
     helper_method(:rhn_subscription_types)
-    hide_action(:rhn_subscription_types)
-
     helper_method(:rhn_address_string)
-    hide_action(:rhn_address_string)
-
     helper_method(:rhn_account_info_string)
-    hide_action(:rhn_account_info_string)
-
     helper_method(:rhn_default_enabled)
-    hide_action(:rhn_default_enabled)
   end
 
   def rhn_address_string

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -32,7 +32,6 @@ class ServiceController < ApplicationController
     end
     send_action
   end
-  hide_action :whitelisted_action
 
   def x_button
     @explorer = true

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -32,6 +32,7 @@ class ServiceController < ApplicationController
     end
     send_action
   end
+  private :whitelisted_action
 
   def x_button
     @explorer = true

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,10 @@
 # used to serve static angular templates from under app/views/static/
 
 class StaticController < ApplicationController
+  # hide_action is gone in Rails, but high_voltage is still using it.
+  # https://github.com/thoughtbot/high_voltage/pull/214
+  def self.hide_action(*)
+  end
+
   include HighVoltage::StaticPage
 end

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -6,9 +6,6 @@ describe ApplicationHelper do
     self.class.send(:include, ApplicationController::CurrentUser)
   end
 
-  def self.hide_action(*_args)
-  end
-
   def method_missing(sym, *args)
     b = _toolbar_builder
     if b.respond_to?(sym, true)


### PR DESCRIPTION
`hide_action` is going away in Rails 5 -- it's mostly obviated these days by explicit route definitions: Rails no longer defaults to allowing the client to call any non-"hidden" controller method via URL manipulation.

Some of these methods can't be private, because they need to be called with a receiver. In those cases, I've just dropped the `hide_action` without replacement. They're all safe, because either they're pure query methods with no side effects, or they require parameters, or both.

The rest are made private just because we can, moreso than out of any real concern that the router may be subverted.