### PR TITLE
Use cpu_total_cores for vm cpu right_size

### DIFF
--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -90,7 +90,7 @@ module VmOrTemplate::RightSizing
 
   RIGHT_SIZING_MODES.each do |mode, meth|
     define_method("#{mode}_recommended_vcpus") do
-      base_recommended(send(meth[:cpu]), num_cpu, self.class.cpu_recommendation_minimum)  unless num_cpu.nil?
+      base_recommended(send(meth[:cpu]), cpu_total_cores, self.class.cpu_recommendation_minimum)  unless cpu_total_cores.nil?
     end
 
     define_method("#{mode}_recommended_mem") do
@@ -98,7 +98,7 @@ module VmOrTemplate::RightSizing
     end
 
     define_method("#{mode}_vcpus_recommended_change_pct") do
-      base_change_percentage(send("#{mode}_recommended_vcpus"), num_cpu) unless num_cpu.nil?
+      base_change_percentage(send("#{mode}_recommended_vcpus"), cpu_total_cores) unless cpu_total_cores.nil?
     end
 
     define_method("#{mode}_mem_recommended_change_pct") do
@@ -106,7 +106,7 @@ module VmOrTemplate::RightSizing
     end
 
     define_method("#{mode}_vcpus_recommended_change") do
-      base_change(send("#{mode}_recommended_vcpus"), num_cpu) unless num_cpu.nil?
+      base_change(send("#{mode}_recommended_vcpus"), cpu_total_cores) unless cpu_total_cores.nil?
     end
 
     define_method("#{mode}_mem_recommended_change") do

--- a/spec/factories/hardware.rb
+++ b/spec/factories/hardware.rb
@@ -12,6 +12,12 @@ FactoryGirl.define do
       cpu_total_cores      4
     end
 
+    trait(:cpu1x2) do
+      cpu_sockets          1
+      cpu_cores_per_socket 2
+      cpu_total_cores      2
+    end
+
     trait(:ram1GB) { memory_mb 1024 }
   end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -427,7 +427,7 @@ describe Metric do
     context "with a small environment and time_profile" do
       before(:each) do
         @vm1 = FactoryGirl.create(:vm_vmware)
-        @vm2 = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :memory_mb => 4096, :cpu_sockets => 2))
+        @vm2 = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 4096))
         @host1 = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
         @host2 = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576))
 


### PR DESCRIPTION
CPU right size recommendation was reporting a VM with 1 socket
and 4 cores as having 1 total CPU.  Use cpu_total_cores instead
of num_cpu to correctly report the total number of logical CPUs.

https://bugzilla.redhat.com/show_bug.cgi?id=1299809