### PR TITLE
Answering to ping requests with Rails instead of Apache

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,5 @@
+class PingController < ApplicationController
+  def index
+    render :text => 'pong', :status => 200
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2138,6 +2138,9 @@ Vmdb::Application.routes.draw do
   # pure-angular templates
   get '/static/*id' => 'static#show', :format => false
 
+  # ping response for load balancing
+  get '/ping' => 'ping#index'
+
   resources :ems_cloud, :as => :ems_clouds
   match "/auth/:provider/callback" => "sessions#create", :via => :get
 end

--- a/public/ping.html
+++ b/public/ping.html
@@ -1,7 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-   "http://www.w3.org/TR/html4/loose.dtd">
-<html>
-<body>
-EVM ping response
-</body>
-</html>


### PR DESCRIPTION
`ping.html` is no longer served through Rails after #6289