### PR TITLE
[WIP] save_inventory_container: use metadata

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -75,4 +75,10 @@ class ContainerGroup < ApplicationRecord
       ([container_project, container_replicator] + container_services).compact
     end
   end
+
+  def disconnect_inv
+    _log.info "Disconnecting Container group [#{name}] id [#{id}]#{log_text}" +
+    " from EMS [#{ext_management_system.name}] id [#{ext_management_system.id}] "
+    self.ext_management_system = nil
+  end
 end

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -29,7 +29,7 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
-  def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [])
+  def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [], disconnect = false)
     deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
@@ -46,7 +46,7 @@ module EmsRefresh::SaveInventoryHelper
     unless deletes.blank?
       type = association.proxy_association.reflection.name
       _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
-      association.delete(deletes)
+      disconnect ? deletes.map(&:disconnect_inv) : association.delete(deletes)
     end
 
     # Add the new items

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -219,7 +219,7 @@ module ManageIQ::Providers::Kubernetes
         pc
       end
 
-      new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,
+      new_result[:container_project] = @data_index.fetch_path(:container_projects, :by_name,
                                                     service.metadata["table"][:namespace])
       new_result
     end
@@ -247,7 +247,7 @@ module ManageIQ::Providers::Kubernetes
           :container_nodes, :by_name, pod.spec.nodeName)
       end
 
-      new_result[:project] = @data_index.fetch_path(:container_projects, :by_name, pod.metadata["table"][:namespace])
+      new_result[:container_project] = @data_index.fetch_path(:container_projects, :by_name, pod.metadata["table"][:namespace])
 
       # TODO, map volumes
       # TODO, podIP
@@ -329,7 +329,7 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_quota(resource_quota)
       new_result = parse_base_item(resource_quota).except(:namespace)
-      new_result[:project] = @data_index.fetch_path(
+      new_result[:container_project] = @data_index.fetch_path(
         :container_projects,
         :by_name,
         resource_quota.metadata["table"][:namespace])
@@ -364,7 +364,7 @@ module ManageIQ::Providers::Kubernetes
 
     def parse_range(limit_range)
       new_result = parse_base_item(limit_range).except(:namespace)
-      new_result[:project] = @data_index.fetch_path(
+      new_result[:container_project] = @data_index.fetch_path(
         :container_projects,
         :by_name,
         limit_range.metadata["table"][:namespace])
@@ -427,7 +427,7 @@ module ManageIQ::Providers::Kubernetes
         :selector_parts   => parse_selector_parts(container_replicator)
       )
 
-      new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,
+      new_result[:container_project] = @data_index.fetch_path(:container_projects, :by_name,
                                                     container_replicator.metadata["table"][:namespace])
       new_result
     end

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -59,7 +59,7 @@ module ManageIQ::Providers
           :path      => route.path
         )
 
-        new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,
+        new_result[:container_project] = @data_index.fetch_path(:container_projects, :by_name,
                                                       route.metadata["table"][:namespace])
         new_result[:container_service] = @data_index.fetch_path(:container_services, :by_namespace_and_name,
                                                                 new_result[:namespace], get_service_name(route))
@@ -87,7 +87,7 @@ module ManageIQ::Providers
           :output_name                 => build.spec.try(:output).try(:to).try(:name)
         )
 
-        new_result[:project] = @data_index.fetch_path(:container_projects, :by_name,
+        new_result[:container_project] = @data_index.fetch_path(:container_projects, :by_name,
                                                       build.metadata["table"][:namespace])
         new_result
       end
@@ -105,7 +105,7 @@ module ManageIQ::Providers
           :start_timestamp               => status[:startTimestamp],
           :output_docker_image_reference => status[:outputDockerImageReference],
         )
-        new_result[:build_config] = @data_index.fetch_path(:container_builds, :by_name,
+        new_result[:container_build] = @data_index.fetch_path(:container_builds, :by_name,
                                                            build_pod.status.config.try(:name))
         new_result
       end

--- a/spec/models/ems_refresh/save_inventory_container_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_container_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe EmsRefresh::SaveInventoryContainer do
+  let(:dummy) { (Class.new { include EmsRefresh::SaveInventoryContainer }).new }
+
+  context 'with a simple descriptor' do
+    before(:each) do
+      stub_const("#{described_class}::DESCRIPTOR",
+                 :pizza   => {
+                   :links    => [:box],
+                   :children => [:toppings]
+                 },
+                 :topping => {})
+      stub_const("#{described_class}::ALWAYS_IGNORED", [])
+    end
+
+    it 'does not define unneeded methods' do
+      expect { dummy.make_pizza }.to raise_error(NoMethodError)
+    end
+
+    it 'does not define unneeded save_x_inventory methods' do
+      expect { dummy.save_falafel_inventory(:apples, :ems_ref, [], [], nil) }.to raise_error(
+        NoMethodError,
+        /undefined method `save_falafel_inventory'/
+      )
+    end
+
+    it 'calls save_inventory_single when given a single entity' do
+      parent = Object.new
+      hashes = [{}]
+      expect(dummy).to receive(:save_inventory_single).with('topping', parent, hashes, [], [])
+      dummy.save_topping_inventory(parent, hashes)
+    end
+
+    it 'calls save_inventory_multi when given a multiple entity' do
+      parent = double
+      new_hashes = [:a]
+      old_hashes = []
+      expect(parent).to receive(:toppings).exactly(3).times { old_hashes }
+      expect(dummy).to receive(:save_inventory_multi).with(old_hashes, new_hashes, old_hashes.dup, [:ems_ref], [], [])
+      expect(dummy).to receive(:store_ids_for_new_records)
+      dummy.save_toppings_inventory(parent, new_hashes)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -363,7 +363,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
                :ems_created_on        => '2015-08-17T09:16:46Z',
                :resource_version      => '165339',
-               :project               => nil,
+               :container_project     => nil,
                :container_quota_items => [
                  {
                    :resource       => "cpu",
@@ -391,7 +391,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
                :ems_created_on        => '2015-08-17T09:16:46Z',
                :resource_version      => '165339',
-               :project               => nil,
+               :container_project     => nil,
                :container_quota_items => [])
     end
 
@@ -413,7 +413,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
                :ems_created_on        => '2015-08-17T09:16:46Z',
                :resource_version      => '165339',
-               :project               => nil,
+               :container_project     => nil,
                :container_quota_items => [
                  {
                    :resource       => "cpu",
@@ -448,7 +448,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
         :ems_created_on        => '2015-08-17T09:16:46Z',
         :resource_version      => '2',
-        :project               => nil,
+        :container_project     => nil,
         :container_limit_items => [
           {
             :item_type               => "Container",
@@ -486,7 +486,7 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
                :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
                :ems_created_on        => '2015-08-17T09:16:46Z',
                :resource_version      => '2',
-               :project               => nil,
+               :container_project     => nil,
                :container_limit_items => [])
     end
   end


### PR DESCRIPTION
Replaces copy and pasted methods with metadata.

This is a requirement for container entity disconnects. It allowed writing tests for it and writing it only once for different entities.