### PR TITLE
Load the session store, UI constants and other UI things in console.

### DIFF
--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -17,6 +17,11 @@ module Vmdb
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update_attributes(:status => "started")
       end
+
+      # Rails console needs session store configured
+      if defined?(Rails::Console)
+        MiqUiWorker.preload_for_worker_role
+      end
     end
   end
 end


### PR DESCRIPTION
Draper was added in #5946.

It provides helpers in rails console, which depend on
ActionController::TestRequest.new, which requires a session store.