### PR TITLE
Add _missing_instance attribute

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_object.rb
@@ -80,6 +80,7 @@ module MiqAeEngine
           if @aei.nil?
             $miq_ae_logger.info("Instance [#{@object_name}] not found in MiqAeDatastore - trying [#{MISSING_INSTANCE}]")
             # Try the .missing instance, if the requested one was not found
+            @attributes['_missing_instance'] = @instance
             @instance = MISSING_INSTANCE
             @aei      = fetch_instance(@instance)
           end

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -743,4 +743,22 @@ module MiqAeEngineSpec
       expect(my_objects_array).to eq([])
     end
   end
+
+  describe MiqAeEngine do
+    include AutomationSpecHelper
+    before do
+      @user = FactoryGirl.create(:user_with_group)
+      ae_fields = {'var1' => {:aetype => 'attribute', :datatype => 'string'}}
+      ae_instances = {'.missing' => {'var1' => {:value => "${#_missing_instance}"}}}
+      create_ae_model(:name => 'DOM1', :ae_namespace => 'NS1', :ae_class => 'CLASS1',
+                      :instance_name => '.missing', :ae_fields => ae_fields,
+                      :ae_instances => ae_instances)
+    end
+
+    it "check _missing_instance" do
+      ws = MiqAeEngine.instantiate("/DOM1/NS1/CLASS1/FRED", @user)
+      expect(ws.root['var1']).to eq('FRED')
+      expect(ws.root['_missing_instance']).to eq('FRED')
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1301717

If the .missing instance is being used for an instance, preserve
the original name in an attribute called _missing_instance in the
MiqAeObject.
This attribute can be used in substitution.