### PR TITLE
Add validation for dialog text box with integer type

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -38,10 +38,12 @@ class DialogFieldTextBox < DialogField
 
     return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is required" if required? && value.blank?
 
-    case validator_type
-    when 'regex'
-      return "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.match(/#{validator_rule}/)
-    end
+    # currently only regex is supported
+    rule = validator_rule if validator_type == 'regex'
+    rule ||= "^[0-9]+$" if data_type == "integer"
+
+    return unless rule
+    "#{dialog_tab.label}/#{dialog_group.label}/#{label} is invalid" unless value.match(/#{rule}/)
   end
 
   def script_error_values


### PR DESCRIPTION
A built-in all numeric regex is used for validation if there is no other regex provided. A `nil` value is still allowed if the field is optional.

https://bugzilla.redhat.com/show_bug.cgi?id=1278170