### PR TITLE
Disable ApplicationController error handling in most specs

### DIFF
--- a/app/controllers/api_controller/error_handler.rb
+++ b/app/controllers/api_controller/error_handler.rb
@@ -8,6 +8,7 @@ class ApiController
       def rescue_from_api_errors
         ERROR_MAPPING.each do |error, type|
           rescue_from error do |e|
+            raise e unless ApplicationController.handle_exceptions?
             api_exception_type(type, e)
           end
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,7 +90,17 @@ class ApplicationController < ActionController::Base
   # This will rescue any un-handled exceptions
   rescue_from StandardError, :with => :error_handler
 
+  def self.handle_exceptions?
+    Thread.current[:application_controller_handles_exceptions] != false
+  end
+
+  def self.handle_exceptions=(v)
+    Thread.current[:application_controller_handles_exceptions] = v
+  end
+
   def error_handler(e)
+    raise e unless ApplicationController.handle_exceptions?
+
     logger.fatal "Error caught: [#{e.class.name}] #{e.message}\n#{e.backtrace.join("\n")}"
 
     msg = case e

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,11 @@ Vmdb::Application.configure do
     end
   end
 
+  # Any exception that gets past our ApplicationController's rescue_from
+  # should just be raised intact
+  config.middleware.delete ::ActionDispatch::ShowExceptions
+  config.middleware.delete ::ActionDispatch::DebugExceptions
+
   # Raise exceptions in transactional callbacks
   config.active_record.raise_in_transactional_callbacks = true
 

--- a/spec/controllers/application_controller/tenancy_spec.rb
+++ b/spec/controllers/application_controller/tenancy_spec.rb
@@ -1,6 +1,8 @@
 describe DashboardController do
   before do
     Tenant.seed
+
+    ApplicationController.handle_exceptions = true
   end
 
   describe "#current_tenant" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -13,6 +13,10 @@ describe CatalogController do
   end
 
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       CatalogController::CATALOG_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, actual_method|
         it "calls the appropriate method: '#{actual_method}' for action '#{action_name}'" do
@@ -122,6 +126,8 @@ describe CatalogController do
 
   context "#st_upload_image" do
     before do
+      ApplicationController.handle_exceptions = true
+
       controller.instance_variable_set(:@sb, {})
       controller.instance_variable_set(:@_params, :button => "save")
       @st = FactoryGirl.create(:service_template)

--- a/spec/controllers/cloud_tenant_controller_spec.rb
+++ b/spec/controllers/cloud_tenant_controller_spec.rb
@@ -3,6 +3,8 @@ describe CloudTenantController do
     before(:each) do
       set_user_privileges
       EvmSpecHelper.create_guid_miq_server_zone
+
+      ApplicationController.handle_exceptions = true
     end
 
     it "when Instance Retire button is pressed" do

--- a/spec/controllers/container_image_controller_spec.rb
+++ b/spec/controllers/container_image_controller_spec.rb
@@ -5,6 +5,8 @@ describe ContainerImageController do
   end
 
   it "when Smart Analysis is pressed" do
+    ApplicationController.handle_exceptions = true
+
     expect(controller).to receive(:scan_images)
     post :button, :pressed => 'container_image_scan', :format => :js
     expect(controller.send(:flash_errors?)).not_to be_truthy

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -3,6 +3,8 @@ describe EmsInfraController do
     before(:each) do
       set_user_privileges
       EvmSpecHelper.create_guid_miq_server_zone
+
+      ApplicationController.handle_exceptions = true
     end
 
     it "when VM Right Size Recommendations is pressed" do

--- a/spec/controllers/host_controller_spec.rb
+++ b/spec/controllers/host_controller_spec.rb
@@ -5,6 +5,8 @@ describe HostController do
     before(:each) do
       set_user_privileges
       EvmSpecHelper.create_guid_miq_server_zone
+
+      ApplicationController.handle_exceptions = true
     end
 
     it "doesn't break" do

--- a/spec/controllers/miq_ae_customization_controller_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller_spec.rb
@@ -122,6 +122,8 @@ describe MiqAeCustomizationController do
     before(:each) do
       allow_any_instance_of(described_class).to receive(:set_user_time_zone)
       allow(controller).to receive(:check_privileges).and_return(true)
+
+      ApplicationController.handle_exceptions = true
     end
 
     describe 'corresponding methods are called for allowed actions' do

--- a/spec/controllers/miq_policy_controller_spec.rb
+++ b/spec/controllers/miq_policy_controller_spec.rb
@@ -224,6 +224,10 @@ describe MiqPolicyController do
   end
 
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       MiqPolicyController::POLICY_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -21,6 +21,8 @@ describe ReportController do
       end
 
       it "should save the selected time zone with a chargeback report" do
+        ApplicationController.handle_exceptions = true
+
         user = FactoryGirl.create(:user)
         login_as user
         rep = FactoryGirl.create(
@@ -72,6 +74,8 @@ describe ReportController do
 
     context "#miq_report_edit" do
       it "should build tabs with correct tab id after reset button is pressed to prevent error when changing tabs" do
+        ApplicationController.handle_exceptions = true
+
         user = FactoryGirl.create(:user)
         login_as user
         rep = FactoryGirl.create(

--- a/spec/controllers/miq_report_controller/trees_spec.rb
+++ b/spec/controllers/miq_report_controller/trees_spec.rb
@@ -87,6 +87,8 @@ describe ReportController do
       end
 
       it 'renders show of Dashboards in Dashboards tree' do
+        ApplicationController.handle_exceptions = true
+
         MiqWidgetSet.seed
         user = FactoryGirl.create(:user_with_group)
         login_as user
@@ -107,6 +109,8 @@ describe ReportController do
       end
 
       it 'renders show of Dashboard Widget in Widgets tree' do
+        ApplicationController.handle_exceptions = true
+
         widget = FactoryGirl.create(:miq_widget)
         post :tree_select, :id => "xx-r_-#{widget.id}", :format => :js, :accord => 'widgets'
         expect(response).to render_template('report/_widget_show')

--- a/spec/controllers/ontap_file_share_controller_spec.rb
+++ b/spec/controllers/ontap_file_share_controller_spec.rb
@@ -3,6 +3,8 @@ describe OntapFileShareController do
     before(:each) do
       set_user_privileges
       EvmSpecHelper.create_guid_miq_server_zone
+
+      ApplicationController.handle_exceptions = true
     end
 
     it "when VM Right Size Recommendations is pressed" do

--- a/spec/controllers/ops_controller_spec.rb
+++ b/spec/controllers/ops_controller_spec.rb
@@ -6,6 +6,10 @@ describe OpsController do
   end
 
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       OpsController::OPS_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do
@@ -22,6 +26,8 @@ describe OpsController do
   end
 
   it 'can view the db_settings tab' do
+    ApplicationController.handle_exceptions = true
+
     session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
                                      :active_tab  => 'db_settings',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
@@ -30,6 +36,8 @@ describe OpsController do
   end
 
   it 'can view the db_connections tab' do
+    ApplicationController.handle_exceptions = true
+
     session[:sandboxes] = {"ops" => {:active_tree => :vmdb_tree,
                                      :active_tab  => 'db_connections',
                                      :trees       => {:vmdb_tree => {:active_node => 'root'}}}}
@@ -43,6 +51,10 @@ describe OpsController do
   #
   # def rbac_user_set_record_vars(user)
   describe 'rbac_user_edit' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     it 'can add a user w/ group' do
       session[:settings] = {:views => {}, :perpage => {:list => 10}}
       session[:edit] = {

--- a/spec/controllers/pxe_controller_spec.rb
+++ b/spec/controllers/pxe_controller_spec.rb
@@ -4,6 +4,10 @@ describe PxeController do
   end
 
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       PxeController::PXE_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -857,6 +857,7 @@ describe ReportController do
   describe 'x_button' do
     before(:each) do
       set_user_privileges
+      ApplicationController.handle_exceptions = true
     end
 
     describe 'corresponding methods are called for allowed actions' do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -31,6 +31,10 @@ describe ServiceController do
   end
 
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       ServiceController::SERVICE_X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         it "calls the appropriate method: '#{method}' for action '#{action_name}'" do

--- a/spec/controllers/vm_cloud_controller_spec.rb
+++ b/spec/controllers/vm_cloud_controller_spec.rb
@@ -12,6 +12,10 @@ describe VmCloudController do
   # So we need a test for each possible value of 'presses' until all this is
   # converted into proper routes and test is changed to test the new routes.
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     context 'for allowed actions' do
       ApplicationController::Explorer::X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         prefixes = ["image", "instance"]
@@ -57,6 +61,8 @@ describe VmCloudController do
       subject { controller.instance_variable_get(:@breadcrumbs) }
 
       it 'skips dropping a breadcrumb when a button action is executed' do
+        ApplicationController.handle_exceptions = true
+
         post :x_button, :id => nil, :pressed => 'instance_ownership'
         expect(subject).to eq([{:name => "Instances", :url => "/vm_cloud/explorer"}])
       end

--- a/spec/controllers/vm_infra_controller_spec.rb
+++ b/spec/controllers/vm_infra_controller_spec.rb
@@ -24,6 +24,8 @@ describe VmInfraController do
 
   # http://localhost:3000/vm_infra/show/10000000001403?display=vmtree_info
   it 'can render the genealogy tree' do
+    ApplicationController.handle_exceptions = true
+
     seed_session_trees('vm_infra', 'vms_instances_filter_tree')
     xhr :post, :show, :id => vm_vmware.id, :display => 'vmtree_info'
     expect(response.status).to eq(200)

--- a/spec/controllers/vm_or_template_controller_spec.rb
+++ b/spec/controllers/vm_or_template_controller_spec.rb
@@ -12,6 +12,10 @@ describe VmOrTemplateController do
   # So we need a test for each possible value of 'presses' until all this is
   # converted into proper routes and test is changed to test the new routes.
   describe 'x_button' do
+    before do
+      ApplicationController.handle_exceptions = true
+    end
+
     describe 'corresponding methods are called for allowed actions' do
       ApplicationController::Explorer::X_BUTTON_ALLOWED_ACTIONS.each_pair do |action_name, method|
         actual_action = 'vm_' + action_name
@@ -56,6 +60,8 @@ describe VmOrTemplateController do
     end
 
     it 'skips dropping a breadcrumb when a button action is executed' do
+      ApplicationController.handle_exceptions = true
+
       post :x_button, :id => nil, :pressed => 'miq_template_ownership'
       breadcrumbs = controller.instance_variable_get(:@breadcrumbs)
       expect(breadcrumbs).to eq([{:name => "VMs and Instances", :url => "/vm_or_template/explorer"}])

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -2819,6 +2819,10 @@ describe ApplicationHelper do
   end
 
   describe "update_url_parms", :type => :request do
+    before do
+      MiqServer.seed
+    end
+
     context "when the given parameter exists in the request query string" do
       before do
         get("/vm/show_list/100", "type=grid")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1245,6 +1245,10 @@ describe ApplicationHelper do
   end
 
   describe "update_paging_url_parms", :type => :request do
+    before do
+      MiqServer.seed
+    end
+
     context "when the given parameter is a hash" do
       before do
         get("/vm/show_list/100", "bc=VMs+running+on+2014-08-25&menu_click=Display-VMs-on_2-6-5"\

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,7 +86,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     EmsRefresh.debug_failures = true
-    ApplicationController.handle_exceptions = true
+    ApplicationController.handle_exceptions = false
   end
   config.after(:each) do
     EvmSpecHelper.clear_caches

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     EmsRefresh.debug_failures = true
+    ApplicationController.handle_exceptions = true
   end
   config.after(:each) do
     EvmSpecHelper.clear_caches

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -109,6 +109,8 @@ module ApiSpecHelper
     define_entrypoint_url_methods
     define_url_methods(collections)
     define_user
+
+    ApplicationController.handle_exceptions = true
   end
 
   def define_entrypoint_url_methods


### PR DESCRIPTION
Unless the spec is deliberately causing an exception to see the resulting 500 response, it's much more useful for it to hit RSpec directly: we get a descriptive failure message and a nice backtrace.