### PR TITLE
make some checks for vm and host more generic in topology service

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -80,26 +80,22 @@ class ContainerTopologyService
           "Container" # the container entity itself
         end
       else
-        if name.eql? "Vm"
-          'VM'
+        if entity.kind_of?(Vm)
+          name.upcase # turn Vm to VM because it's an abbreviation
         else
-          name # non container entities such as Host, Vm
+          name # non container entities such as Host
         end
       end
     end
   end
 
   def entity_id(entity)
-    type = entity_type(entity)
     if entity.kind_of?(ManageIQ::Providers::ContainerManager)
       id = entity.id.to_s
+    elsif entity.kind_of?(Host) || entity.kind_of?(Vm)
+      id = entity.uid_ems
     else
-      id = case type
-             when 'Vm', 'Host'
-               entity.uid_ems
-             else
-               entity.ems_ref
-           end
+      id = entity.ems_ref
     end
     id
   end
@@ -107,7 +103,6 @@ class ContainerTopologyService
   def build_entity_data(entity)
     type = entity_type(entity)
     status = entity_status(entity, type)
-
     data = {:id           => entity_id(entity),
             :name         => entity.name,
             :status       => status,
@@ -115,7 +110,7 @@ class ContainerTopologyService
             :display_kind => entity_display_type(entity),
             :miq_id       => entity.id}
 
-    if %w(Vm Host).include? type
+    if entity.kind_of?(Host) || entity.kind_of?(Vm)
       data.merge!(:provider => entity.ext_management_system.name)
     end
 

--- a/spec/services/container_topology_service_spec.rb
+++ b/spec/services/container_topology_service_spec.rb
@@ -47,7 +47,7 @@ describe ContainerTopologyService do
     it "topology contains the expected structure and content" do
       # vm and host test cross provider correlation to infra provider
       hardware = FactoryGirl.create(:hardware, :cpu_sockets => 2, :cpu_cores_per_socket => 4, :cpu_total_cores => 8)
-      host = FactoryGirl.create(:host,
+      host = FactoryGirl.create(:host_redhat,
                                 :uid_ems => "abcd9a08-7b13-11e5-8546-129aa6621999",
                                 :ext_management_system => ems_rhev,
                                 :hardware => hardware)


### PR DESCRIPTION
@miq-bot add_label refactor, providers/containers

@jrafanie per one of your comments in #6266, I've started generalizing some types vs strings. 
it was really not the purpose of that PR, so I'm doing it here.