### PR TITLE
Remove ServiceTemplate from direct RBAC

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -23,7 +23,6 @@ module Rbac
     ResourcePool
     SecurityGroup
     Service
-    ServiceTemplate
     Storage
     VmOrTemplate
   )

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,28 @@
 describe ApplicationController do
+  context "Service Templates" do
+    before :each do
+      EvmSpecHelper.local_miq_server
+      child_tenant = FactoryGirl.create(:tenant)
+      tenant_role = FactoryGirl.create(:miq_user_role, :settings => {:restrictions => {:vms => :user_or_group}})
+      user_with_child_tenant = FactoryGirl.create(:user_with_group)
+      user_with_child_tenant.current_group.miq_user_role = tenant_role
+      user_with_child_tenant.current_group.tenant = child_tenant
+      user_with_child_tenant.current_group.save
+      FactoryGirl.create(:user_admin)
+
+      FactoryGirl.create(:service_template) # created with root tenant
+      @service_template_with_child_tenant = FactoryGirl.create(:service_template, :tenant => child_tenant)
+      login_as user_with_child_tenant
+    end
+
+    it "returns all catalog items related to current tenant and root tenant" do
+      controller.instance_variable_set(:@settings, {})
+      allow_any_instance_of(ApplicationController).to receive(:fetch_path)
+      view, _pages = controller.send(:get_view, ServiceTemplate, {})
+      expect(view.table.data.count).to eq(2)
+    end
+  end
+
   context "#find_by_id_filtered" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1296671
Important part of scenario is point 2 "‘VM and Template Access Restriction" in role.

In scenario from BZ we should see all service templates which are related to current tenant and parent's tenants (https://github.com/ManageIQ/manageiq/pull/4425) (not just  ServiceTemplate (service catalog menu) based on template as decribed in BZ)

the reason that we can removed it is : we are not using belongs to and managed filters, group and user/tenant ownership (this is not presented in UI), neither tags(ServiceTemplate model is not taggable)

cc @gtanzillo 