### PR TITLE
FIX: Approve Vm provisioning in UI

### DIFF
--- a/app/controllers/application_controller/miq_request_methods.rb
+++ b/app/controllers/application_controller/miq_request_methods.rb
@@ -742,7 +742,7 @@ module ApplicationController::MiqRequestMethods
     if @miq_request.workflow_class
       options = {}
       begin
-        options[:wf] = @miq_request.workflow_class.new(@options, current_user)
+        options[:wf] = @miq_request.workflow(@options)
       rescue MiqException::MiqVmError => bang
         @no_wf_msg = _("Cannot create Request Info, error: ") << bang.message
       end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -57,7 +57,11 @@ class MiqRequestWorkflow
     @values       = values
     @filters      = {}
     @requester    = requester.kind_of?(User) ? requester : User.lookup_by_identity(requester)
-    @requester.miq_group_description = values[:requester_group]
+    group_description = values[:requester_group]
+    if group_description && group_description != @requester.miq_group_description
+      @requester = @requester.clone
+      @requester.miq_group_description = group_description
+    end
     @values.merge!(options) unless options.blank?
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1301631

The workflow requester is set to the current_user.
The group context for the request was then being set in the the
current_user, corrupting it.

Changes:

1. MiqRequestWorkflow#requester = MiqRequest#requester
so the correct dialogs will be displayed.
2. Requester is cloned before setting the group as a precaution.

This assumes the viewer and administrator can see the resources that
the requester has access to view as well.

/cc @gmcculloug Think this is all of it.

I did see another [`workflow_class.new`]( https://github.com/ManageIq/manageiq/blob/master/app/controllers/application_controller/miq_request_methods.rb#L931) but I think that is creating a whole new request. I'm guessing that in this case it should change the user (and the group?)