### PR TITLE
Include rails environment in update_start task

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -28,8 +28,13 @@ namespace :evm do
     EvmApplication.status
   end
 
+  # update_start can be called in an environment where the database configuration is
+  # not set, so we need to give it a dummy config
   task :update_start do
-    EvmApplication.update_start
+    EvmRakeHelper.with_dummy_database_url_configuration do
+      Rake::Task["environment"].invoke
+      EvmApplication.update_start
+    end
   end
 
   task :update_stop => :environment do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1301164

**The Issue:**

The EvmApplication.update_start leverages MiqServer which was not being loaded
without this change.

**The Testing:**

We have no spec tests for rake tasks so I reproduced the failure on a live test environment,
where I manually injected this fix and confirmed it was successful.