### PR TITLE
Fix RBAC on catalog items toolbar actions

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -768,6 +768,20 @@ class ApplicationHelper::ToolbarBuilder
       when "log_download", "refresh_logs", "log_collect", "log_reload", "logdepot_edit", "processmanager_restart", "refresh_workers"
         return true
       end
+    when "MiqTemplate"
+      case id
+      when "miq_template_clone"
+        return true unless @record.is_available?(:clone)
+      when "miq_template_policy_sim", "miq_template_protect"
+        return true if @record.host && @record.host.vmm_product.downcase == "workstation"
+      when "miq_template_refresh"
+        return true if @record && !@record.ext_management_system && !(@record.host && @record.host.vmm_product.downcase == "workstation")
+      when "miq_template_scan", "image_scan"
+        return true unless @record.is_available?(:smartstate_analysis) || @record.is_available_now_error_message(:smartstate_analysis)
+        return true unless @record.has_proxy?
+      when "miq_template_refresh", "miq_template_reload"
+        return true unless @perf_options[:typ] == "realtime"
+      end
     when "ScanItemSet"
       case id
       when "scan_delete"
@@ -828,20 +842,6 @@ class ApplicationHelper::ToolbarBuilder
         return true unless @record.is_available?(:smartstate_analysis) || @record.is_available_now_error_message(:smartstate_analysis)
         return true unless @record.has_proxy?
       when "perf_refresh", "perf_reload", "vm_perf_refresh", "vm_perf_reload"
-        return true unless @perf_options[:typ] == "realtime"
-      end
-    when "MiqTemplate"
-      case id
-      when "miq_template_clone"
-        return true unless @record.is_available?(:clone)
-      when "miq_template_policy_sim", "miq_template_protect"
-        return true if @record.host && @record.host.vmm_product.downcase == "workstation"
-      when "miq_template_refresh"
-        return true if @record && !@record.ext_management_system && !(@record.host && @record.host.vmm_product.downcase == "workstation")
-      when "miq_template_scan", "image_scan"
-        return true unless @record.is_available?(:smartstate_analysis) || @record.is_available_now_error_message(:smartstate_analysis)
-        return true unless @record.has_proxy?
-      when "miq_template_refresh", "miq_template_reload"
         return true unless @perf_options[:typ] == "realtime"
       end
     when "OrchestrationTemplate", "OrchestrationTemplateCfn", "OrchestrationTemplateHot", "OrchestrationTemplateAzure"

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -665,6 +665,16 @@ class ApplicationHelper::ToolbarBuilder
       when "condition_remove"
         return true if x_active_tree == :condition_tree || !role_allows(:feature => "condition_delete")
       end
+    when "CustomButton"
+      case id
+      when "ab_button_edit", "ab_button_delete", "ab_button_simulate"
+        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
+      end
+    when "CustomButtonSet"
+      case id
+      when "ab_group_edit", "ab_group_delete", "ab_button_new"
+        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
+      end
     when "Host"
       case id
       when "host_protect"
@@ -796,6 +806,15 @@ class ApplicationHelper::ToolbarBuilder
       end
     when "Service", "ServiceOrchestration"
       return build_toolbar_hide_button_service(id)
+    when "ServiceTemplate"
+      case id
+      when "ab_group_new", "ab_button_new"
+        return !role_allows_button_manipulation
+      when /^history_\d*/
+        return false
+      else
+        return !role_allows(:feature => id)
+      end
     when "Vm"
       case id
       when "vm_clone"
@@ -848,6 +867,8 @@ class ApplicationHelper::ToolbarBuilder
       return true unless role_allows(:feature => id)
     when "NilClass"
       case id
+      when "ab_group_new", "ab_button_new", "ab_group_reorder"
+        return !role_allows_button_manipulation if x_active_tree == :sandt_tree
       when "action_new"
         return true unless role_allows(:feature => "action_new")
       when "alert_profile_new"
@@ -891,6 +912,12 @@ class ApplicationHelper::ToolbarBuilder
       end
     end
     false  # No reason to hide, allow the button to show
+  end
+
+  def role_allows_button_manipulation
+    %w(catalogitem_new catalogitem_edit atomic_catalogitem_new atomic_catalogitem_edit).any? do |feature|
+      role_allows(:feature => feature)
+    end
   end
 
   # Determine if a button should be disabled

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1904,8 +1904,13 @@
           :feature_type: admin
           :hidden: true
           :identifier: ab_group_new
+        - :name: Edit
+          :description: Edit Button Group
+          :feature_type: admin
+          :hidden: true
+          :identifier: ab_group_edit
         - :name: Delete
-          :description: Delete Buttons
+          :description: Delete Button Group
           :feature_type: admin
           :hidden: true
           :identifier: ab_group_delete
@@ -1935,7 +1940,7 @@
           :description: Edit Button
           :feature_type: admin
           :hidden: true
-          :identifier: ab_group_edit
+          :identifier: ab_button_edit
         - :name: Delete
           :description: Delete Buttons
           :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -168,10 +168,6 @@
         :description: Add Atomic Catalog Item
         :feature_type: admin
         :identifier: atomic_catalogitem_new
-      - :name: Edit Button
-        :description: Edit Button
-        :feature_type: admin
-        :identifier: ab_button_edit
     - :name: Operate
       :description: Perform Operations on Catalog Items
       :feature_type: control

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -710,6 +710,20 @@ describe ApplicationHelper do
       end
     end
 
+    context "CustomButtonSet" do
+      before do
+        @record = CustomButtonSet.new
+        @sb = {:active_tree => :sandt_tree}
+      end
+
+      %w(ab_button_new ab_group_edit ab_group_delete).each do |id|
+        it "hides #{id} action from toolbar when user has view permission only" do
+          @id = id
+          expect(subject).to be_truthy
+        end
+      end
+    end
+
     context "when with EmsCluster" do
       before do
         @record = EmsCluster.new
@@ -1091,6 +1105,20 @@ describe ApplicationHelper do
       it "otherwise" do
         @id = 'xx'
         expect(subject).to be_falsey
+      end
+    end
+
+    context "ServiceTemplate" do
+      before do
+        @record = ServiceTemplate.new
+        @sb = {:active_tree => :sandt_tree}
+      end
+
+      %w(ab_button_new ab_group_new catalogitem_edit catalogitem_delete).each do |id|
+        it "hides #{id} action from toolbar when user has view permission only" do
+          @id = id
+          expect(subject).to be_truthy
+        end
       end
     end
 
@@ -1586,6 +1614,20 @@ describe ApplicationHelper do
             @report = ''
             expect(subject).to be_falsey
           end
+        end
+      end
+    end
+
+    context "NilClass" do
+      before do
+        @record = nil
+        @sb = {:active_tree => :sandt_tree}
+      end
+
+      %w(ab_button_new ab_group_new ab_group_reorder).each do |id|
+        it "hides #{id} action from toolbar when user has view permission only" do
+          @id = id
+          expect(subject).to be_truthy
         end
       end
     end

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 998 }
+  let(:expected_feature_count) { 997 }
 
   # - container_dashboard
   # - miq_report_widget_editor

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 997 }
+  let(:expected_feature_count) { 998 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
This PR is fixing more issues on Catalog item toolbars' actions. It's fixing also identifiers of the product features already defined, and add some new ones. Then it's merging New/Edit/Delete Button and Button Groups actions to the one action for Button/Button Group.

I created this PR after removing duplicated product features in https://github.com/jrafanie/manageiq/commit/2fcae9692072d286cf2a975a24202fdb275b511d and basically it's reworked https://github.com/ManageIQ/manageiq/pull/3987 + completed RBAC fixes for all toolbars in Catalog Items.