### PR TITLE
Update gettext and more_core_extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem "sshkey",                         "~>1.8.0",   :require => false
 #
 unless ENV['APPLIANCE']
   group :development do
-    gem "gettext",          "3.1.4",    :require => false  # Used for finding translations
+    gem "gettext",          "3.1.9",    :require => false  # Used for finding translations
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
   end
 

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -30,7 +30,7 @@ gem "linux_admin",             "~>0.14.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false
-gem "more_core_extensions",    "~>1.2.0",           :require => false
+gem "more_core_extensions",    "~>2.0.0",           :require => false
 gem "net-sftp",                "~>2.1.2",           :require => false
 gem "net-scp",                 "~>1.2.1",           :require => false
 gem "nokogiri",                "~>1.6.0",           :require => false

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -26,7 +26,7 @@ gem "httpclient",              "~>2.5.3",           :require => false
 gem "image-inspector-client",  "~>1.0.0",           :require => false
 gem "kubeclient",              "=0.8.0",            :require => false
 gem "hawkular-client",         "~>0.1.2",           :require => false
-gem "linux_admin",             "~>0.14.0",          :require => false
+gem "linux_admin",             "~>0.15.0",          :require => false
 gem "log4r",                   "=1.1.8",            :require => false
 gem "memoist",                 "~>0.14.0",          :require => false
 gem "memory_buffer",           ">=0.1.0",           :require => false


### PR DESCRIPTION
Right now, running `rake gettext:find` fails..

The reason seems to be a conflict between `Object#namespace` introduced by `more_core_extensions` 1.2.0, and `namespace` from the Rake DSL, which gettext uses.

Since `more_core_extensions` 2.0.0 is out and does not have that problem (ManageIQ/more_core_extensions#20), this PR aims to update to the newer version.

Also updating `linux-admin` to 0.15.0, because of a `more_core_extensions` dependency - ManageIQ/linux_admin#155.