### PR TITLE
Update winrm gem to 1.5 and update appropriate SSA code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "color"
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/ManageIQ/rubyrep.git", :tag => "v1.2.0-7"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "winrm",                          "~>1.4.0",   :require => false
+gem "winrm",                          "~>1.5.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required

--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -19,8 +19,8 @@ class MiqHyperVDisk
     @hostname  = hyperv_host
     @winrm     = MiqWinRM.new
     port ||= 5985
-    options       = {:port => port, :user => user, :pass => pass, :hostname => @hostname}
-    @connection   = @winrm.connect(options)
+    options = {:port => port, :user => user, :pass => pass, :hostname => @hostname}
+    @winrm.connect(options)
     @parser       = MiqScvmmParsePowershell.new
     @block_size   = 4096
     @file_size    = 0
@@ -51,8 +51,9 @@ STAT_EOL
 
   def close
     hit_or_miss if DEBUG_CACHE_STATS
-    @file_offset   = 0
-    @connection    = @winrm = nil
+    @file_offset = 0
+    @winrm.executor.close
+    @winrm = nil
   end
 
   def hit_or_miss

--- a/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
+++ b/gems/pending/Scvmm/miq_scvmm_vm_ssa_info.rb
@@ -4,7 +4,7 @@ require 'util/miq_winrm'
 require 'Scvmm/miq_scvmm_parse_powershell'
 
 class MiqScvmmVmSSAInfo
-  attr_reader :vhds, :hostname, :checkpoints, :connection, :vhd_type
+  attr_reader :vhds, :hostname, :checkpoints, :vhd_type
   def initialize(provider, user, pass, port = nil)
     @checkpoints = []
     @vhds        = []
@@ -14,8 +14,8 @@ class MiqScvmmVmSSAInfo
     winrmport    = port.nil? ? 5985 : port
     options      = {:port => winrmport, :user => user, :pass => pass, :hostname => provider}
 
-    @connection = @winrm.connect(options)
-    @parser     = MiqScvmmParsePowershell.new
+    @winrm.connect(options)
+    @parser = MiqScvmmParsePowershell.new
   end
 
   def vm_host(vm_name)

--- a/gems/pending/util/miq_winrm.rb
+++ b/gems/pending/util/miq_winrm.rb
@@ -1,7 +1,7 @@
 require 'winrm'
 
 class MiqWinRM
-  attr_reader :uri, :username, :password, :hostname, :port, :connection
+  attr_reader :uri, :username, :password, :hostname, :port, :connection, :executor
 
   def initialize
     @port = 5985
@@ -17,11 +17,12 @@ class MiqWinRM
     validate_options(options)
     @uri        = build_uri
     @connection = raw_connect(@username, @password, @uri)
+    @executor   = @connection.create_executor
   end
 
   def run_powershell_script(script)
     $log.debug "Running powershell script on #{hostname} as #{username}:\n#{script}" unless $log.nil?
-    @connection.run_powershell_script(script)
+    @executor.run_powershell_script(script)
   rescue WinRM::WinRMAuthorizationError
     $log.info "Error Logging In to #{hostname} using user \"#{username}\"" unless $log.nil?
     raise


### PR DESCRIPTION
Update winrm gem to 1.5.  Change HyperV SSA code to take
advantage of the new executor functionality so that the cmd
process is not restarted on every call.  Throughput improvements
should be realized.

Note that changes to the inventory collection for the RefreshParser
suggested by @djberg96 in #6301 are not being made here.  He and I
have also discussed coalescing winrm wrapper code that has some duplication
between gems/pending/util and apps/models/manageiq/providers/microsoft/inframanager
but that will be left possibly for the #6301 PR as well.

@djberg96 @roliveri @Fryguy @chessbyte please review and merge when appropriate.