### PR TITLE
Sort in database for virtual columns

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -88,6 +88,29 @@ class Hardware < ApplicationRecord
     (cpu_total_cores * cpu_speed)
   end
 
+  def v_pct_free_disk_space
+    return nil if disk_free_space.nil? || disk_capacity.nil? || disk_capacity.zero?
+    (disk_free_space.to_f / disk_capacity * 100).round(2)
+  end
+  # resulting sql: "(cast(disk_free_space as float) / (disk_capacity * 100))"
+  virtual_attribute :v_pct_free_disk_space, :float, :arel => (lambda do |t|
+    Arel::Nodes::Grouping.new(Arel::Nodes::Division.new(
+      Arel::Nodes::NamedFunction.new("CAST", [t[:disk_free_space].as("float")]),
+      t[:disk_capacity]) * 100)
+  end)
+
+  def v_pct_used_disk_space
+    percent_free = v_pct_free_disk_space
+    100 - percent_free if percent_free
+  end
+  # resulting sql: "(cast(disk_free_space as float) / (disk_capacity * -100) + 100)"
+  # to work with arel better, put the 100 at the end
+  virtual_attribute :v_pct_used_disk_space, :float, :arel => (lambda do |t|
+    Arel::Nodes::Grouping.new(Arel::Nodes::Division.new(
+      Arel::Nodes::NamedFunction.new("CAST", [t[:disk_free_space].as("float")]),
+      t[:disk_capacity]) * -100 + 100)
+  end)
+
   def m_controller(_parent, xmlNode, deletes)
     # $log.info("Adding controller XML elements for [#{xmlNode.attributes["type"]}]")
     xmlNode.each_element do |e|

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -13,11 +13,6 @@ module MiqReport::Search
     end
   end
 
-  ORDER_OPS = {"ascending" => "asc", "descending" => "desc"}.freeze
-  def order_op
-    MiqReport::Search::ORDER_OPS[order.downcase] if order
-  end
-
   # @param assoc [String] associations and a column name
   # @raise if an association is not valid
   # @return nil if there is a virtual association in the path
@@ -49,11 +44,11 @@ module MiqReport::Search
     order = Array.wrap(sortby).collect do |c|
       sql_col, sql_type = association_column(c)
       return nil if sql_col.nil?
-      [:string, :text].include?(sql_type) ? sql_col.lower : sql_col
+      [:string, :text].include?(sql_type) ? Arel::Nodes::NamedFunction.new('LOWER', [sql_col]) : sql_col
     end
 
-    if (order_op = self.order_op)
-      order = order.map { |col| col.send(order_op) }
+    if (self.order.downcase == "descending")
+      order = order.map { |col| Arel::Nodes::Descending.new col }
     end
 
     order

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -47,7 +47,7 @@ module MiqReport::Search
       [:string, :text].include?(sql_type) ? Arel::Nodes::NamedFunction.new('LOWER', [sql_col]) : sql_col
     end
 
-    if (self.order.downcase == "descending")
+    if (self.order && self.order.downcase == "descending")
       order = order.map { |col| Arel::Nodes::Descending.new col }
     end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -147,11 +147,9 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_storage_by_state]
   virtual_column :mem_cpu,                              :type => :integer,    :uses => :hardware
   virtual_column :ems_cluster_name,                     :type => :string,     :uses => :ems_cluster
-  virtual_column :host_name,                            :type => :string,     :uses => :host
   virtual_column :ipaddresses,                          :type => :string_set, :uses => {:hardware => :ipaddresses}
   virtual_column :hostnames,                            :type => :string_set, :uses => {:hardware => :hostnames}
   virtual_column :mac_addresses,                        :type => :string_set, :uses => {:hardware => :mac_addresses}
-  virtual_column :storage_name,                         :type => :string,     :uses => :storage
   virtual_column :memory_exceeds_current_host_headroom, :type => :string,     :uses => [:mem_cpu, {:host => [:hardware, :ext_management_system]}]
   virtual_column :num_hard_disks,                       :type => :integer,    :uses => {:hardware => :hard_disks}
   virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
@@ -1404,13 +1402,8 @@ class VmOrTemplate < ApplicationRecord
     ems_cluster.nil? ? nil : ems_cluster.name
   end
 
-  def host_name
-    host.nil? ? nil : host.name
-  end
-
-  def storage_name
-    storage.nil? ? nil : storage.name
-  end
+  virtual_delegate :name, :to => :host, :prefix => true, :allow_nil => true
+  virtual_delegate :name, :to => :storage, :prefix => true, :allow_nil => true
 
   def has_compliance_policies?
     _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "vm_compliance_check")
@@ -1514,9 +1507,7 @@ class VmOrTemplate < ApplicationRecord
     Arel::Nodes::NamedFunction.new('COALESCE', [t[:template], Arel::Nodes.build_quoted("false")])
   end)
 
-  delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true
-  virtual_attribute :v_pct_free_disk_space, :float, :uses => :hardware
-  virtual_attribute :v_pct_used_disk_space, :float, :uses => :hardware
+  virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true
 
   def v_datastore_path
     s = storage

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -1,36 +1,29 @@
 describe Hardware do
-  before(:each) do
-    @vm_hw = FactoryGirl.create(:hardware)
-    @vm    = FactoryGirl.create(:vm_vmware, :hardware => @vm_hw)
-
-    @template_hw = FactoryGirl.create(:hardware)
-    @template    = FactoryGirl.create(:template_vmware, :hardware => @template_hw)
-
-    @host_hw = FactoryGirl.create(:hardware)
-    @host    = FactoryGirl.create(:host, :hardware => @host_hw)
-  end
+  let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware)) }
+  let(:template) { FactoryGirl.create(:template_vmware, :hardware => FactoryGirl.create(:hardware)) }
+  let(:host) { FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware)) }
 
   it "#vm_or_template" do
-    expect(@vm_hw.vm_or_template).to eq(@vm)
-    expect(@template_hw.vm_or_template).to eq(@template)
-    expect(@host_hw.vm_or_template).to     be_nil
+    expect(vm.hardware.vm_or_template).to eq(vm)
+    expect(template.hardware.vm_or_template).to eq(template)
+    expect(host.hardware.vm_or_template).to     be_nil
   end
 
   it "#vm" do
-    expect(@vm_hw.vm).to eq(@vm)
-    expect(@template_hw.vm).to be_nil
-    expect(@host_hw.vm).to     be_nil
+    expect(vm.hardware.vm).to eq(vm)
+    expect(template.hardware.vm).to be_nil
+    expect(host.hardware.vm).to     be_nil
   end
 
   it "#miq_template" do
-    expect(@vm_hw.miq_template).to       be_nil
-    expect(@template_hw.miq_template).to eq(@template)
-    expect(@host_hw.miq_template).to     be_nil
+    expect(vm.hardware.miq_template).to       be_nil
+    expect(template.hardware.miq_template).to eq(template)
+    expect(host.hardware.miq_template).to     be_nil
   end
 
   it "#host" do
-    expect(@vm_hw.host).to       be_nil
-    expect(@template_hw.host).to be_nil
-    expect(@host_hw.host).to eq(@host)
+    expect(vm.hardware.host).to       be_nil
+    expect(template.hardware.host).to be_nil
+    expect(host.hardware.host).to eq(host)
   end
 end

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -1,4 +1,5 @@
 describe Hardware do
+  include ArelSpecHelper
   let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware)) }
   let(:template) { FactoryGirl.create(:template_vmware, :hardware => FactoryGirl.create(:hardware)) }
   let(:host) { FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware)) }
@@ -25,5 +26,66 @@ describe Hardware do
     expect(vm.hardware.host).to       be_nil
     expect(template.hardware.host).to be_nil
     expect(host.hardware.host).to eq(host)
+  end
+
+  describe ".v_pct_free_disk_space" do
+    context "with empty hardware" do
+      let(:hardware) { FactoryGirl.build(:hardware) }
+      it "bails ruby calculation" do
+        expect(hardware.v_pct_free_disk_space).to be_nil
+        expect(hardware.v_pct_used_disk_space).to be_nil
+      end
+
+      it "bails database calculation" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "v_pct_free_disk_space")).to be_nil
+        expect(virtual_column_sql_value(Hardware, "v_pct_used_disk_space")).to be_nil
+      end
+    end
+
+    context "with values" do
+      let(:hardware) { FactoryGirl.build(:hardware, :disk_free_space => 20, :disk_capacity => 100) }
+
+      it "calculates in ruby" do
+        expect(hardware.v_pct_free_disk_space).to eq(20.0)
+        expect(hardware.v_pct_used_disk_space).to eq(80.0)
+      end
+
+      it "calculates in the database" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "v_pct_free_disk_space")).to eq(20.0)
+        expect(virtual_column_sql_value(Hardware, "v_pct_used_disk_space")).to eq(80.0)
+      end
+    end
+
+    context "with 0 disk free " do
+      let(:hardware) { FactoryGirl.build(:hardware, :disk_free_space => 0, :disk_capacity => 100) }
+
+      it "calculates in ruby" do
+        expect(hardware.v_pct_free_disk_space).to eq(0.0)
+        expect(hardware.v_pct_used_disk_space).to eq(100.0)
+      end
+
+      it "calculates in the database" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "v_pct_free_disk_space")).to eq(0.0)
+        expect(virtual_column_sql_value(Hardware, "v_pct_used_disk_space")).to eq(100.0)
+      end
+    end
+
+    context "with null disk capacity" do
+      let(:hardware) { FactoryGirl.build(:hardware, :disk_free_space => 20, :disk_capacity => nil) }
+
+      it "calculates in ruby" do
+        expect(hardware.v_pct_free_disk_space).to eq(nil)
+        expect(hardware.v_pct_used_disk_space).to eq(nil)
+      end
+
+      it "calculates in the database" do
+        hardware.save
+        expect(virtual_column_sql_value(Hardware, "v_pct_free_disk_space")).to eq(nil)
+        expect(virtual_column_sql_value(Hardware, "v_pct_used_disk_space")).to eq(nil)
+      end
+    end
   end
 end

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -89,6 +89,13 @@ describe MiqReport do
       expect(order).to be_truthy
       expect(stringify_arel(order).join(",")).to match(/"vms"."ems_id"/)
     end
+
+    it "is sortable for a virtual column that is in another table" do
+      @miq_report.sortby = ["hardware.v_pct_used_disk_space"]
+      order = @miq_report.get_order_info
+      expect(order).to be_truthy
+      expect(stringify_arel(order).join(",")).to match(/disk_free_space/)
+    end
   end
 
   context "paged_view_search" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1,4 +1,6 @@
 describe VmOrTemplate do
+  include ArelSpecHelper
+
   context ".event_by_property" do
     context "should add an EMS event" do
       before(:each) do
@@ -561,6 +563,41 @@ describe VmOrTemplate do
     it "calculates in ruby" do
       expect(vm.v_pct_free_disk_space).to eq(20.0)
       expect(vm.v_pct_used_disk_space).to eq(80.0)
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "v_pct_free_disk_space")).to eq(20.0)
+      expect(virtual_column_sql_value(VmOrTemplate, "v_pct_used_disk_space")).to eq(80.0)
+    end
+
+    context "with null disk capacity" do
+      let(:hardware) { FactoryGirl.build(:hardware, :disk_free_space => 20, :disk_capacity => nil) }
+
+      it "calculates in ruby" do
+        expect(vm.v_pct_free_disk_space).to be_nil
+        expect(vm.v_pct_used_disk_space).to be_nil
+      end
+
+      it "calculates in the database" do
+        vm.save
+        expect(virtual_column_sql_value(VmOrTemplate, "v_pct_free_disk_space")).to be_nil
+        expect(virtual_column_sql_value(VmOrTemplate, "v_pct_used_disk_space")).to be_nil
+      end
+    end
+  end
+
+  describe ".host_name" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
+    let(:host) { FactoryGirl.create(:host_vmware, :name => "our host") }
+
+    it "calculates in ruby" do
+      expect(vm.host_name).to eq("our host")
+    end
+
+    it "calculates in the database" do
+      vm.save
+      expect(virtual_column_sql_value(VmOrTemplate, "host_name")).to eq("our host")
     end
   end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -553,4 +553,14 @@ describe VmOrTemplate do
 
     expect(template.miq_provision_vms.collect(&:id)).to eq([vm.id])
   end
+
+  describe ".v_pct_free_disk_space" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryGirl.create(:hardware, :disk_free_space => 20, :disk_capacity => 100) }
+
+    it "calculates in ruby" do
+      expect(vm.v_pct_free_disk_space).to eq(20.0)
+      expect(vm.v_pct_used_disk_space).to eq(80.0)
+    end
+  end
 end

--- a/spec/support/arel_spec_helper.rb
+++ b/spec/support/arel_spec_helper.rb
@@ -7,12 +7,10 @@ module ArelSpecHelper
   end
 
   # run the sql for a virtual column. making sure it works in select and order
-  # due to active record, this test uses inner joins
   def virtual_column_sql_value(klass, v_col_name)
     query = klass.select(klass.arel_attribute("id"),
                          Arel::Nodes::As.new(klass.arel_attribute(v_col_name),
                                              Arel::Nodes::SqlLiteral.new("extra")))
-                 .joins(klass.virtual_includes(v_col_name).presence || [])
                  .order(klass.arel_attribute(v_col_name))
     query.first["extra"]
   end

--- a/spec/support/arel_spec_helper.rb
+++ b/spec/support/arel_spec_helper.rb
@@ -5,4 +5,15 @@ module ArelSpecHelper
     visitor = Arel::Visitors::ToSql.new model.connection
     Array.wrap(nodes).map { |node| visitor.accept(node, Arel::Collectors::SQLString.new).value }
   end
+
+  # run the sql for a virtual column. making sure it works in select and order
+  # due to active record, this test uses inner joins
+  def virtual_column_sql_value(klass, v_col_name)
+    query = klass.select(klass.arel_attribute("id"),
+                         Arel::Nodes::As.new(klass.arel_attribute(v_col_name),
+                                             Arel::Nodes::SqlLiteral.new("extra")))
+                 .joins(klass.virtual_includes(v_col_name).presence || [])
+                 .order(klass.arel_attribute(v_col_name))
+    query.first["extra"]
+  end
 end


### PR DESCRIPTION
**Before:**

When we view a screen and sort by a virtual column, we fetch all data for all the tables and associations and sort in memory. This is slow

https://bugzilla.redhat.com/show_bug.cgi?id=1182777

Today, we can use `virtual_attribute` option `:arel` to teach active record how to sort in the database. e.g.: calculate `Vm#archived` from `vms.ems_id` and `vms.storage_id`.

**After:**

Introduce `virtual_delegate` that teaches active record how to leverage `virtual_attribute :arel` and `belongs_to`/`has_one` to calculate attributes from another table. e.g.: calculate `Vm#host_name` from `hosts.name join hosts on host.id = vms.host_id`.

**Future:**

Better leverage joins to get the query speed down even further.
/cc @dmetzger57 FYI
/cc @matthewd good stuff