### PR TITLE
disconnecting container entities 

### DIFF
--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -204,7 +204,7 @@ class ContainerController < ApplicationController
     @sb[:action] = nil
     if x_node == "root" || TreeBuilder.get_model_for_prefix(@nodetype) == "MiqSearch"
       typ = "Container"
-      process_show_list
+      process_show_list(:where_clause => 'container_groups.deleted_on IS NULL')
       @right_cell_text = _("All %s") % ui_lookup(:models => typ)
     else
       show_record(from_cid(id))

--- a/app/controllers/container_group_controller.rb
+++ b/app/controllers/container_group_controller.rb
@@ -6,6 +6,10 @@ class ContainerGroupController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def show_list
+    process_show_list(:where_clause => 'container_groups.deleted_on IS NULL')
+  end
+
   private ############################
 
   def display_name

--- a/app/controllers/container_project_controller.rb
+++ b/app/controllers/container_project_controller.rb
@@ -6,4 +6,7 @@ class ContainerProjectController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
+  def show_list
+    process_show_list(:where_clause => 'container_projects.deleted_on IS NULL')
+  end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -43,4 +43,11 @@ class Container < ApplicationRecord
   def perf_rollup_parents(_interval_name = nil)
     # No rollups: nodes performance are collected separately
   end
+
+  def disconnect_inv
+    _log.info "Disconnecting Container [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
+    "id [#{ext_management_system.id}] "
+    self.deleted_on = Time.now.utc
+    save
+  end
 end

--- a/app/models/container_definition.rb
+++ b/app/models/container_definition.rb
@@ -5,4 +5,12 @@ class ContainerDefinition < ApplicationRecord
   has_many :container_env_vars,     :dependent => :destroy
   has_one :container,               :dependent => :destroy
   has_one :security_context,        :as => :resource, :dependent => :destroy
+
+  def disconnect_inv
+    _log.info "Disconnecting Container definition [#{name}] id [#{id}]"
+    self.deleted_on = Time.now.utc
+    container.disconnect_inv
+    save
+  end
+
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -75,4 +75,18 @@ class ContainerGroup < ApplicationRecord
       ([container_project, container_replicator] + container_services).compact
     end
   end
+
+  def disconnect_inv
+    _log.info "Disconnecting Container group [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
+    "id [#{ext_management_system.id}] "
+    self.old_ems_id = ems_id
+    self.ext_management_system = nil
+    self.container_node_id = nil
+    self.container_services = []
+    self.container_replicator_id = nil
+    self.container_build_pod_id = nil
+    self.deleted_on = Time.now.utc
+    container_definitions.map(&:disconnect_inv)
+    save
+  end
 end

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -69,4 +69,13 @@ class ContainerProject < ApplicationRecord
   def perf_rollup_parents(interval_name = nil)
     []
   end
+
+  def disconnect_inv
+    _log.info "Disconnecting Container Project [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
+    "id [#{ext_management_system.id}] "
+    self.old_ems_id = ems_id
+    self.ext_management_system = nil
+    self.deleted_on = Time.now.utc
+    save
+  end
 end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -28,7 +28,7 @@ module EmsRefresh::SaveInventoryContainer
               end
 
     save_inventory_multi(ems.container_projects, hashes, deletes, [:ems_ref],
-                         :labels)
+                         :labels, [], true)
     store_ids_for_new_records(ems.container_projects, hashes, :ems_ref)
   end
 
@@ -214,7 +214,8 @@ module EmsRefresh::SaveInventoryContainer
 
     save_inventory_multi(ems.container_groups, hashes, deletes, [:ems_ref],
                          [:container_definitions, :containers, :labels, :node_selector_parts, :container_conditions,
-                          :container_volumes], [:container_node, :container_replicator, :project, :namespace, :build_pod_name])
+                          :container_volumes], [:container_node, :container_replicator, :project, :namespace, :build_pod_name],
+                         true)
     store_ids_for_new_records(ems.container_groups, hashes, :ems_ref)
   end
 

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -29,7 +29,7 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
-  def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [])
+  def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [], disconnect = false)
     deletes = deletes.to_a # make sure to load the association if it's an association
     child_keys = Array.wrap(child_keys)
     remove_keys = Array.wrap(extra_keys) + child_keys
@@ -46,7 +46,7 @@ module EmsRefresh::SaveInventoryHelper
     unless deletes.blank?
       type = association.proxy_association.reflection.name
       _log.info("[#{type}] Deleting #{log_format_deletes(deletes)}")
-      association.delete(deletes)
+      disconnect ? deletes.map(&:disconnect_inv) : association.delete(deletes)
     end
 
     # Add the new items

--- a/db/migrate/20160203162135_add_deletion_time_for_container_archivables.rb
+++ b/db/migrate/20160203162135_add_deletion_time_for_container_archivables.rb
@@ -1,0 +1,10 @@
+class AddDeletionTimeForContainerArchivables < ActiveRecord::Migration
+  def change
+    add_column :container_projects, :deleted_on, :datetime
+    add_column :container_projects, :old_ems_id, :bigint
+    add_column :container_groups, :deleted_on, :datetime
+    add_column :container_groups, :old_ems_id, :bigint
+    add_column :container_definitions, :deleted_on, :datetime
+    add_column :containers, :deleted_on, :datetime
+  end
+end


### PR DESCRIPTION
Avoid deleting projects pods and containers as preparation for chargeback.