### PR TITLE
Update azure-armrest and color gems in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,11 +26,6 @@ gem "sass-rails"
 # Vendored and required
 gem "ruport",                         "=1.7.0",                       :git => "git://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 
-# HACK: Force color to be required before azure-armrest. color is lazy required
-#   by ruport.  However, due to a bug in color, it detects the top level
-#   constant "Azure" and fails.
-#   See https://github.com/halostatue/color/pull/24
-gem "color"
 
 # Vendored but not required
 gem "net-ldap",                       "~>0.7.0",   :require => false
@@ -48,7 +43,8 @@ gem "acts_as_tree",                   "~>2.1.0"  # acts_as_tree needs to be requ
 # See miq_expression_spec Date/Time Support examples.
 # https://github.com/jeremyevans/ruby-american_date
 gem "american_date"
-gem "azure-armrest",                  "=0.0.8"
+gem "azure-armrest",                  "~>0.1.0"
+gem "color",                          "~>1.8"
 gem "default_value_for",              "~>3.0.1"
 gem "draper",                         "~>2.1.0"
 gem "hamlit-rails",                   "~>0.1.0"


### PR DESCRIPTION
This updates the azure-armrest gem to 0.1.0 to avoid issues with invalid "preview" api strings. It also updates the entry for the color gem, and removes an old comment about it that's no longer true.