### PR TITLE
removed unused provider_object for providers/availability_zones

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/availability_zone.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::Amazon::CloudManager::AvailabilityZone < ::AvailabilityZone
-  def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.availability_zones[ems_ref]
-  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/availability_zone.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::Azure::CloudManager::AvailabilityZone < ::AvailabilityZone
-  def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.availability_zones[ems_ref]
-  end
 end

--- a/app/models/manageiq/providers/google/cloud_manager/availability_zone.rb
+++ b/app/models/manageiq/providers/google/cloud_manager/availability_zone.rb
@@ -1,6 +1,2 @@
 class ManageIQ::Providers::Google::CloudManager::AvailabilityZone < ::AvailabilityZone
-  def provider_object(connection = nil)
-    connection ||= ext_management_system.connect
-    connection.availability_zones[ems_ref]
-  end
 end


### PR DESCRIPTION
seems to be cruft by copy and paste
I could not find a place where `provider_object` or `with_provider_object` was used