### PR TITLE
fix contract of EventCatcher::Runner

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -80,15 +80,11 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     raise NotImplementedError, "must be implemented in subclass"
   end
 
-  def event_monitor_handle
-    raise NotImplementedError, "must be implemented in subclass"
-  end
-
   def monitor_events
     raise NotImplementedError, "must be implemented in subclass"
   end
 
-  def process_event
+  def process_event(_event)
     raise NotImplementedError, "must be implemented in subclass"
   end
 


### PR DESCRIPTION
I think this corrects the contract of this runner class
`event_monitor_handle` is private to the higher class e.g.:
https://github.com/ManageIQ/manageiq/blob/d690a65afddd6b37149c803dab013860b593be99/app/models/manageiq/providers/amazon/cloud_manager/event_catcher/runner.rb