### PR TITLE
Don't save authentication record for unsaved new providers

### DIFF
--- a/app/controllers/ems_cloud_controller.rb
+++ b/app/controllers/ems_cloud_controller.rb
@@ -75,8 +75,7 @@ class EmsCloudController < ApplicationController
     set_ems_record_vars(verify_ems, :validate)
     @in_a_form = true
 
-    save = params[:id] == "new" ? false : true
-    result, details = verify_ems.authentication_check(params[:cred_type], :save => save)
+    result, details = verify_ems.authentication_check(params[:cred_type], :save => !params[:id].nil?)
 
     if result
       add_flash(_("Credential validation was successful"))

--- a/spec/controllers/ems_cloud_controller_spec.rb
+++ b/spec/controllers/ems_cloud_controller_spec.rb
@@ -262,7 +262,6 @@ describe EmsCloudController do
       allow(controller).to receive(:render)
       controller.instance_variable_set(:@_params,
                                        :button           => "validate",
-                                       :id               => "new",
                                        :default_password => "[FILTERED]",
                                        :cred_type        => "default")
       expect(mocked_ems).to receive(:authentication_check).with("default", :save => false)


### PR DESCRIPTION
The update_ems_button_validate method keys off of :id == "new" to indicate an unsaved new cloud provider, but this is no longer set and the id parameter is nil.

https://github.com/ManageIQ/manageiq/issues/6275