### PR TITLE
API / AWS : AZ can be selected when creating a provision_request

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -987,8 +987,15 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     ws_network_fields(values, fields, data)
     ws_customize_fields(values, fields, data)
     ws_schedule_fields(values, fields, data)
+    ws_environment_fields(values, fields, data)
 
     data.each { |k, v| _log.warn "Unprocessed key <#{k}> with value <#{v.inspect}>" }
+  end
+
+  def ws_environment_fields(values, _fields, data)
+    return if (dlg_fields = get_ws_dialog_fields(dialog_name = :environment)).nil?
+
+    data.keys.each { |key| set_ws_field_value(values, key, data, dialog_name, dlg_fields) if dlg_fields.key?(key) }
   end
 
   def ws_service_fields(values, _fields, data)
@@ -1114,7 +1121,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     p.init_from_dialog(values)
     values[:src_vm_id] = [src.id, src.name]
     p.refresh_field_values(values)
-    values[:placement_auto] = [true, 1]
+    # values[:placement_auto] = [true, 1]
 
     p.ws_vm_fields(values, vm_fields)
     p.ws_requester_fields(values, requester)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -993,6 +993,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def ws_environment_fields(values, _fields, data)
+    # do not parse environment data unless :placement_auto is false
+    if data[:placement_auto].nil? || data[:placement_auto]
+      values[:placement_auto] = [true, 1]
+      return
+    end
+
     return if (dlg_fields = get_ws_dialog_fields(dialog_name = :environment)).nil?
 
     data.keys.each { |key| set_ws_field_value(values, key, data, dialog_name, dlg_fields) if dlg_fields.key?(key) }
@@ -1121,7 +1127,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     p.init_from_dialog(values)
     values[:src_vm_id] = [src.id, src.name]
     p.refresh_field_values(values)
-    # values[:placement_auto] = [true, 1]
 
     p.ws_vm_fields(values, vm_fields)
     p.ws_requester_fields(values, requester)

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -987,12 +987,12 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     ws_network_fields(values, fields, data)
     ws_customize_fields(values, fields, data)
     ws_schedule_fields(values, fields, data)
-    ws_environment_fields(values, fields, data)
+    ws_environment_fields(values, data)
 
     data.each { |k, v| _log.warn "Unprocessed key <#{k}> with value <#{v.inspect}>" }
   end
 
-  def ws_environment_fields(values, _fields, data)
+  def ws_environment_fields(values, data)
     # do not parse environment data unless :placement_auto is false
     if data[:placement_auto].to_s != "false"
       values[:placement_auto] = [true, 1]

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -994,7 +994,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
   def ws_environment_fields(values, _fields, data)
     # do not parse environment data unless :placement_auto is false
-    if data[:placement_auto].nil? || data[:placement_auto]
+    if data[:placement_auto].to_s != "false"
       values[:placement_auto] = [true, 1]
       return
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1281,6 +1281,8 @@ class MiqRequestWorkflow
 
     result = nil
     if dlg_field.key?(:values)
+      get_source_and_targets(true)
+      get_field(key, dialog_name)
       field_values = dlg_field[:values]
       _log.info "processing key <#{dialog_name}:#{key}(#{data_type})> with values <#{field_values.inspect}>"
       if field_values.present?

--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -37,4 +37,14 @@ FactoryGirl.define do
     name        "miq_provision_configured_system_foreman_dialogs"
     dialog_type "MiqProvisionConfiguredSystemWorkflow"
   end
+
+  factory :miq_dialog_aws_provision, :parent => :miq_dialog do
+    name        "miq_provision_amazon_dialogs_template"
+    dialog_type "MiqProvisionWorkflow"
+
+    content do
+      YAML.load_file Rails.root.join("product", "dialogs", "miq_dialogs",
+                                     "miq_provision_amazon_dialogs_template.yaml")
+    end
+  end
 end

--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -43,8 +43,8 @@ FactoryGirl.define do
     dialog_type "MiqProvisionWorkflow"
 
     content do
-      YAML.load_file Rails.root.join("product", "dialogs", "miq_dialogs",
-                                     "miq_provision_amazon_dialogs_template.yaml")
+      path = Rails.root.join("product", "dialogs", "miq_dialogs", "miq_provision_amazon_dialogs_template.yaml")
+      YAML.load_file(path)[:content]
     end
   end
 end

--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -37,14 +37,4 @@ FactoryGirl.define do
     name        "miq_provision_configured_system_foreman_dialogs"
     dialog_type "MiqProvisionConfiguredSystemWorkflow"
   end
-
-  factory :miq_dialog_aws_provision, :parent => :miq_dialog do
-    name        "miq_provision_amazon_dialogs_template"
-    dialog_type "MiqProvisionWorkflow"
-
-    content do
-      path = Rails.root.join("product", "dialogs", "miq_dialogs", "miq_provision_amazon_dialogs_template.yaml")
-      YAML.load_file(path)[:content]
-    end
-  end
 end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -171,14 +171,14 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to include(
-        "options" => include(
-          "placement_auto"              => include(false),
-          "placement_availability_zone" => include(az.id),
-          "cloud_network"               => include(cloud_network1.id),
-          "cloud_subnet"                => include(cloud_subnet1.id),
-          "security_groups"             => include(security_group1.id),
-          "floating_ip_address"         => include(floating_ip1.id)
+      expect(response_hash["results"].first).to a_hash_including(
+        "options" => a_hash_including(
+          "placement_auto"              => [false, 0],
+          "placement_availability_zone" => [az.id, az.name],
+          "cloud_network"               => [cloud_network1.id, cloud_network1.name],
+          "cloud_subnet"                => [cloud_subnet1.id, anything],
+          "security_groups"             => [security_group1.id, security_group1.name],
+          "floating_ip_address"         => [floating_ip1.id, floating_ip1.name]
         )
       )
 
@@ -203,10 +203,10 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to include(
-        "options" => include(
-          "placement_auto"              => include(true),
-          "placement_availability_zone" => include(nil)
+      expect(response_hash["results"].first).to a_hash_including(
+        "options" => a_hash_including(
+          "placement_auto"              => [true, 1],
+          "placement_availability_zone" => [nil, nil]
         )
       )
 
@@ -232,10 +232,10 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      expect(response_hash["results"].first).to include(
-        "options" => include(
-          "placement_auto"              => include(true),
-          "placement_availability_zone" => include(nil)
+      expect(response_hash["results"].first).to a_hash_including(
+        "options" => a_hash_including(
+          "placement_auto"              => [true, 1],
+          "placement_availability_zone" => [nil, nil]
         )
       )
 

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -96,8 +96,11 @@ describe ApiController do
   end
 
   context "AWS advanced provision requests" do
-    let(:aws_dialog) do
-      dialog = FactoryGirl.create(:miq_dialog_aws_provision)
+    let!(:aws_dialog) do
+      path = Rails.root.join("product", "dialogs", "miq_dialogs", "miq_provision_amazon_dialogs_template.yaml")
+      content = YAML.load_file(path)[:content]
+      dialog = FactoryGirl.create(:miq_dialog, :name => "miq_provision_amazon_dialogs_template",
+                                  :dialog_type => "MiqProvisionWorkflow", :content => content)
       allow_any_instance_of(MiqRequestWorkflow).to receive(:dialog_name_from_automate).and_return(dialog.name)
     end
     let(:ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
@@ -162,7 +165,6 @@ describe ApiController do
         }
       )
 
-      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, body)
 
       expect_request_success
@@ -195,7 +197,6 @@ describe ApiController do
         }
       )
 
-      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, body)
 
       expect_request_success
@@ -225,7 +226,6 @@ describe ApiController do
         }
       )
 
-      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, body)
 
       expect_request_success

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -132,42 +132,6 @@ describe ApiController do
       }
     end
 
-    let(:provreq1_body) do
-      provreq_body.merge(
-        "vm_fields" => {
-          "vm_name"                     => "api_test_aws",
-          "instance_type"               => flavor.id,
-          "placement_auto"              => false,
-          "placement_availability_zone" => az.id,
-          "cloud_network"               => cloud_network1.id,
-          "cloud_subnet"                => cloud_subnet1.id,
-          "security_groups"             => security_group1.id,
-          "floating_ip_address"         => floating_ip1.id
-        }
-      )
-    end
-
-    let(:provreq2_body) do
-      provreq_body.merge(
-        "vm_fields" => {
-          "vm_name"                     => "api_test_aws",
-          "instance_type"               => flavor.id,
-          "placement_availability_zone" => az.id
-        }
-      )
-    end
-
-    let(:provreq3_body) do
-      provreq_body.merge(
-        "vm_fields" => {
-          "vm_name"                     => "api_test_aws",
-          "instance_type"               => flavor.id,
-          "placement_auto"              => true,
-          "placement_availability_zone" => az.id
-        }
-      )
-    end
-
     let(:expected_provreq_attributes) { %w(id options) }
 
     let(:expected_provreq_hash) do
@@ -185,8 +149,21 @@ describe ApiController do
     it "supports manual placement" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
+      body = provreq_body.merge(
+        "vm_fields" => {
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
+          "placement_auto"              => false,
+          "placement_availability_zone" => az.id,
+          "cloud_network"               => cloud_network1.id,
+          "cloud_subnet"                => cloud_subnet1.id,
+          "security_groups"             => security_group1.id,
+          "floating_ip_address"         => floating_ip1.id
+        }
+      )
+
       aws_dialog # Create the AWS Provisioning dialog
-      run_post(provision_requests_url, provreq1_body)
+      run_post(provision_requests_url, body)
 
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
@@ -210,8 +187,16 @@ describe ApiController do
     it "does not process manual placement data if placement_auto is not set" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
+      body = provreq_body.merge(
+        "vm_fields" => {
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
+          "placement_availability_zone" => az.id
+        }
+      )
+
       aws_dialog # Create the AWS Provisioning dialog
-      run_post(provision_requests_url, provreq2_body)
+      run_post(provision_requests_url, body)
 
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
@@ -231,8 +216,17 @@ describe ApiController do
     it "does not process manual placement data if placement_auto is set to true" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
+      body = provreq_body.merge(
+        "vm_fields" => {
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
+          "placement_auto"              => true,
+          "placement_availability_zone" => az.id
+        }
+      )
+
       aws_dialog # Create the AWS Provisioning dialog
-      run_post(provision_requests_url, provreq3_body)
+      run_post(provision_requests_url, body)
 
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -96,9 +96,14 @@ describe ApiController do
   end
 
   context "AWS advanced provision requests" do
+    let(:aws_dialog)     { FactoryGirl.create(:miq_dialog_aws_provision) }
     let(:ems)            { FactoryGirl.create(:ems_amazon_with_authentication) }
-    let(:template)       { FactoryGirl.create(:template_amazon, :name => "template1", :ext_management_system => ems) }
-    let(:flavor)         { FactoryGirl.create(:flavor_amazon, :ems_id => ems.id, :name => 't2.small', :cloud_subnet_required => true) }
+    let(:template) do
+      FactoryGirl.create(:template_amazon, :name => "template1", :ext_management_system => ems)
+    end
+    let(:flavor) do
+      FactoryGirl.create(:flavor_amazon, :ems_id => ems.id, :name => 't2.small', :cloud_subnet_required => true)
+    end
     let(:az)             { FactoryGirl.create(:availability_zone_amazon) }
     let(:cloud_network1) { FactoryGirl.create(:cloud_network, :ems_id => ems.id, :enabled => true) }
     let(:cloud_subnet1)  { FactoryGirl.create(:cloud_subnet, :cloud_network_id => cloud_network1.id) }
@@ -111,39 +116,39 @@ describe ApiController do
     end
 
     let(:provreq1_body) do
-      provreq_body.merge({
+      provreq_body.merge(
         "vm_fields" => {
-          "vm_name" => "api_test_aws",
-          "instance_type" => flavor.id,
-          "placement_auto" => false,
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
+          "placement_auto"              => false,
           "placement_availability_zone" => az.id,
-          "cloud_network" => cloud_network1.id,
-          "cloud_subnet" => cloud_subnet1.id,
-          "security_groups" => 1,
-          "floating_ip_address" => 1
+          "cloud_network"               => cloud_network1.id,
+          "cloud_subnet"                => cloud_subnet1.id,
+          "security_groups"             => 1,
+          "floating_ip_address"         => 1
         }
-      })
+      )
     end
 
     let(:provreq2_body) do
-      provreq_body.merge({
-        "vm_fields"       => {
-          "vm_name" => "api_test_aws",
-          "instance_type" => flavor.id,
+      provreq_body.merge(
+        "vm_fields" => {
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
           "placement_availability_zone" => az.id
         }
-      })
+      )
     end
 
     let(:provreq3_body) do
-      provreq_body.merge({
-        "vm_fields"       => {
-          "vm_name" => "api_test_aws",
-          "instance_type" => flavor.id,
-          "placement_auto" => true,
+      provreq_body.merge(
+        "vm_fields" => {
+          "vm_name"                     => "api_test_aws",
+          "instance_type"               => flavor.id,
+          "placement_auto"              => true,
           "placement_availability_zone" => az.id
         }
-      })
+      )
     end
 
     let(:expected_provreq_attributes) { %w(id options) }
@@ -160,18 +165,20 @@ describe ApiController do
       }
     end
 
-
     it "supports manual placement" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
-      dialog  # Create the Provisioning dialog
+      # dialog  # Create the Provisioning dialog
+      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, provreq1_body)
 
+      # pp @result
       expect_request_success
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
       options = @result["results"].first["options"]
+      # pp options
       expect(options["placement_auto"]).to eq([false, 0])
       expect(options["placement_availability_zone"]).to eq(['xxx'])
       expect(options["cloud_network"]).to eq(['xxx'])
@@ -186,7 +193,8 @@ describe ApiController do
     it "does not process manual placement data if placement_auto is not set" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
-      dialog  # Create the Provisioning dialog
+      # dialog  # Create the Provisioning dialog
+      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, provreq2_body)
 
       expect_request_success
@@ -204,7 +212,8 @@ describe ApiController do
     it "does not process manual placement data if placement_auto is set to true" do
       api_basic_authorize collection_action_identifier(:provision_requests, :create)
 
-      dialog  # Create the Provisioning dialog
+      # dialog  # Create the Provisioning dialog
+      aws_dialog # Create the AWS Provisioning dialog
       run_post(provision_requests_url, provreq3_body)
 
       expect_request_success

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -108,7 +108,7 @@ describe ApiController do
       FactoryGirl.create(:flavor_amazon, :ems_id => ems.id, :name => 't2.small', :cloud_subnet_required => true)
     end
     let(:az)             { FactoryGirl.create(:availability_zone_amazon, :ems_id => ems.id) }
-    let(:cloud_network1) { FactoryGirl.create(:cloud_network, :ems_id => ems.id, :enabled => true) }
+    let(:cloud_network1) { FactoryGirl.create(:cloud_network_amazon, :ems_id => ems.network_manager.id, :enabled => true) }
     let(:cloud_subnet1) do
       FactoryGirl.create(:cloud_subnet, :ems_id => ems.id, :cloud_network => cloud_network1, :availability_zone => az)
     end
@@ -116,7 +116,10 @@ describe ApiController do
       FactoryGirl.create(:security_group_amazon, :name => "sgn_1", :ext_management_system => ems,
                          :cloud_network => cloud_network1)
     end
-    let(:floating_ip1) { FactoryGirl.create(:floating_ip, :cloud_network_only => true, :ext_management_system => ems) }
+    let(:floating_ip1) do
+      FactoryGirl.create(:floating_ip_amazon, :cloud_network_only => true, :ems_id => ems.network_manager.id,
+                         :cloud_network => cloud_network1)
+    end
 
     let(:provreq_body) do
       {
@@ -189,13 +192,16 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      options = response_hash["results"].first["options"]
-      expect(options["placement_auto"]).to eq([false, 0])
-      expect(options["placement_availability_zone"].first).to eq(az.id)
-      expect(options["cloud_network"].first).to eq(cloud_network1.id)
-      expect(options["cloud_subnet"].first).to eq(cloud_subnet1.id)
-      expect(options["security_groups"].first).to eq(security_group1.id)
-      expect(options["floating_ip_address"].first).to eq(floating_ip1.id)
+      expect(response_hash["results"].first).to include(
+        "options" => include(
+          "placement_auto"              => include(false),
+          "placement_availability_zone" => include(az.id),
+          "cloud_network"               => include(cloud_network1.id),
+          "cloud_subnet"                => include(cloud_subnet1.id),
+          "security_groups"             => include(security_group1.id),
+          "floating_ip_address"         => include(floating_ip1.id)
+        )
+      )
 
       task_id = response_hash["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
@@ -211,9 +217,12 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      options = response_hash["results"].first["options"]
-      expect(options["placement_auto"]).to eq([true, 1])
-      expect(options["placement_availability_zone"].first).to eq nil
+      expect(response_hash["results"].first).to include(
+        "options" => include(
+          "placement_auto"              => include(true),
+          "placement_availability_zone" => include(nil)
+        )
+      )
 
       task_id = response_hash["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
@@ -229,9 +238,12 @@ describe ApiController do
       expect_result_resources_to_include_keys("results", expected_provreq_attributes)
       expect_results_to_match_hash("results", [expected_provreq_hash])
 
-      options = response_hash["results"].first["options"]
-      expect(options["placement_auto"]).to eq([true, 1])
-      expect(options["placement_availability_zone"].first).to eq nil
+      expect(response_hash["results"].first).to include(
+        "options" => include(
+          "placement_auto"              => include(true),
+          "placement_availability_zone" => include(nil)
+        )
+      )
 
       task_id = response_hash["results"].first["id"]
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy


### PR DESCRIPTION
Hi,

with this diff, I can select an AZ when creating a provision_request from the API.
Did not succeed to let user chose VPC / subnet / security group.

What is the current status of the environment tab of an AWS provision by the API ? Is this a work in progress ? Am I going in the right direction ?

Thanks 