### PR TITLE
Load ar_virtual before ar_region

### DIFF
--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -1,3 +1,5 @@
+require_relative './ar_virtual'
+
 module ArRegion
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
The current half-each-way arrangement of ApplicationRecord extensions (following #6300) revealed this undeclared dependency.

cc @kbrock @h-kataria 