### PR TITLE
[WIP] Take advantage of Rails.application.secrets for Azure specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,8 +123,8 @@ VCR.configure do |c|
     next if [:secret_key_base, :secret_token].include?(provider) # Defaults
     cred_hash = secrets.public_send(provider)
     cred_hash.each do |key, value|
-      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { CGI.escape(value) }
-      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { value }
+      c.filter_sensitive_data("(#{provider.upcase}_#{key.upcase})") { CGI.escape(value) }
+      c.filter_sensitive_data("(#{provider.upcase}_#{key.upcase})") { value }
     end
   end
 

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_all_existing_records.yml
@@ -1,127 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
-    body:
-      encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Length:
-      - '188'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 48224f43-c449-4206-a456-3c5f4fcca631
-      Client-Request-Id:
-      - cbaf25dd-6754-4202-ab67-ab51c40b3c4d
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_49
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - flight-uxoptin=true; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Wed, 28 Oct 2015 16:40:15 GMT
-      Content-Length:
-      - '1218'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446054015","not_before":"1446050115","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ"}'
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
-- request:
     method: get
-    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 76c7b732-27f7-4657-93dd-3b6f9b8c403c
-      X-Ms-Correlation-Request-Id:
-      - 76c7b732-27f7-4657-93dd-3b6f9b8c403c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164015Z:76c7b732-27f7-4657-93dd-3b6f9b8c403c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
-        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/providers?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -131,273 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
-      X-Ms-Correlation-Request-Id:
-      - 1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164015Z:1e22b9ba-463d-48a4-b2cb-5dfd1a36758d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
-        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
-        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
-        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
-        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
-        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
-        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
-        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
-        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
-        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
-        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
-        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
-        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
-        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
-        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
-        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
-        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
-        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
-        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
-        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
-        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
-        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
-        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
-        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
-        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
-        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
-        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
-        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
-        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
-        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
-        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
-        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
-        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
-        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
-        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
-        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
-        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
-        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
-        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
-        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
-        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
-        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
-        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
-        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
-        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
-        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
-        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
-        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
-        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
-        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
-        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
-        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
-        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
-        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
-        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
-        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
-        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
-        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
-        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
-        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
-        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
-        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
-        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
-        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
-        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
-        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
-        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
-        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
-        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
-        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
-        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
-        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
-        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
-        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
-        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
-        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
-        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
-        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
-        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
-        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
-        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
-        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
-        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
-        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
-        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
-        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
-        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
-        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
-        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
-        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
-        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
-        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
-        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
-        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
-        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
-        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
-        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
-        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
-        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
-        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
-        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
-        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
-        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
-        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
-        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
-        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
-        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
-        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
-        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
-        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
-        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
-        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
-        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
-        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
-        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
-        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
-        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
-        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
-        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
-        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
-        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
-        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
-        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
-        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
-        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
-        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
-        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
-        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
-        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
-        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
-        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
-        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
-        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
-        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
-        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
-        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
-        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
-        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
-        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
-        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
-        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
-        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
-        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
-        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
-        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
-        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
-        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
-        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
-        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
-        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
-        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
-        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
-        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
-        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
-        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
-        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
-        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
-        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
-        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
-        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
-        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
-        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
-        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
-        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
-        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
-        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
-        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
-        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
-        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
-        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
-        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
-        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
-        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
-        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
-        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
-        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
-        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
-        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
-        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
-        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
-        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
-        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -416,22 +35,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1c3c7072-7657-4a67-b4f1-c023212d96c0
-      - f05a5df5-2265-4f66-9cf1-7ef2ca79f2a7
+      - a5538acb-bd30-43a7-89f4-de74c068d0c6
+      - a737644d-5f71-43d5-ac95-8c6c3763958b
+      - e1532e43-758c-448b-8cdc-8fe5ffedea65
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14910'
       X-Ms-Request-Id:
-      - c18f3a55-a050-4f63-a912-30383c6d653d
+      - 937bdc21-69c3-4843-a5b6-7785757c3afa
       X-Ms-Correlation-Request-Id:
-      - c18f3a55-a050-4f63-a912-30383c6d653d
+      - 937bdc21-69c3-4843-a5b6-7785757c3afa
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164016Z:c18f3a55-a050-4f63-a912-30383c6d653d
+      - NORTHCENTRALUS:20160203T194340Z:937bdc21-69c3-4843-a5b6-7785757c3afa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:15 GMT
+      - Wed, 03 Feb 2016 19:43:39 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -442,61 +62,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -506,11 +136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -529,22 +159,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 87f777b7-8843-47ae-83dd-8c08f64503ea
-      - 989e5b7b-fc5c-4ce2-b6a0-613875c7df59
+      - 02ef1fca-c101-400c-9f59-492f75da4a64
+      - 43d5b7c4-39c0-4d9f-8760-f3935b92f97d
+      - a0c4b3ee-982d-44f1-919f-b78018f59c27
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14911'
       X-Ms-Request-Id:
-      - c57550c9-705b-44d9-a1ac-d386126b33cf
+      - 03622bef-eac4-4f83-86c2-fe38033f298c
       X-Ms-Correlation-Request-Id:
-      - c57550c9-705b-44d9-a1ac-d386126b33cf
+      - 03622bef-eac4-4f83-86c2-fe38033f298c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164017Z:c57550c9-705b-44d9-a1ac-d386126b33cf
+      - NORTHCENTRALUS:20160203T194340Z:03622bef-eac4-4f83-86c2-fe38033f298c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:16 GMT
+      - Wed, 03 Feb 2016 19:43:40 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -555,61 +186,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -619,11 +260,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -642,22 +283,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3b831f92-a44c-4e72-a737-c8796d9fcdd8
-      - 6c25c0da-9a0c-48a1-981f-0d45ce86343c
+      - 09ad23b1-959a-4052-b840-59d62504c5f9
+      - 21bd341b-cb66-4964-946f-0e83a93b418b
+      - 742a6e9a-0d1d-4f23-b23d-0ecb9ce867dc
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14904'
       X-Ms-Request-Id:
-      - 63abb515-4f8d-40cb-8833-744112c560ac
+      - c2dec963-74cf-4058-82b9-6ad066d7b25d
       X-Ms-Correlation-Request-Id:
-      - 63abb515-4f8d-40cb-8833-744112c560ac
+      - c2dec963-74cf-4058-82b9-6ad066d7b25d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164017Z:63abb515-4f8d-40cb-8833-744112c560ac
+      - NORTHCENTRALUS:20160203T194341Z:c2dec963-74cf-4058-82b9-6ad066d7b25d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:16 GMT
+      - Wed, 03 Feb 2016 19:43:40 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -668,61 +310,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -732,11 +384,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -755,22 +407,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4706c265-2f79-4c17-99a5-d96060b04bc0
-      - 8c682b95-8526-48c0-82c6-aa8388e04ed1
+      - 08f49dcf-a314-4a84-851d-56efded2addb
+      - 58870ecc-c0fd-465f-a2f3-7791cb7a0799
+      - 7f48efd9-6ed8-466d-b625-c4749facf603
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14900'
       X-Ms-Request-Id:
-      - e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      - 456f4a64-bc0a-4990-8061-60965db90d86
       X-Ms-Correlation-Request-Id:
-      - e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      - 456f4a64-bc0a-4990-8061-60965db90d86
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164018Z:e101fd9c-3a1a-4dfb-a349-17fd65b06297
+      - NORTHCENTRALUS:20160203T194341Z:456f4a64-bc0a-4990-8061-60965db90d86
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:18 GMT
+      - Wed, 03 Feb 2016 19:43:41 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -781,61 +434,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -845,11 +508,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -868,22 +531,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 507cb549-ae31-4af0-896e-c9d570ff8af5
-      - 8aa62020-b0e6-49dc-8f54-df25d2346ad7
+      - 68764a1f-59a1-4d00-8dd5-6c0d88e78ab5
+      - 7cfef2eb-59fd-44a6-8d09-31eddd6b6269
+      - 85b010c1-dadf-478c-a819-5645e4e21dae
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14906'
       X-Ms-Request-Id:
-      - df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      - 0c107cc0-eb41-4b9d-bfa0-0d36c101eadb
       X-Ms-Correlation-Request-Id:
-      - df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      - 0c107cc0-eb41-4b9d-bfa0-0d36c101eadb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164018Z:df4a1243-e69a-474d-8ba2-2e08b725c0e5
+      - NORTHCENTRALUS:20160203T194342Z:0c107cc0-eb41-4b9d-bfa0-0d36c101eadb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:18 GMT
+      - Wed, 03 Feb 2016 19:43:42 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,61 +558,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -958,11 +632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -981,22 +655,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 81600ec8-4421-4a3f-b21e-15d6252b7337
-      - e869e5d9-0ea1-4ac1-a0cf-cbed4b9905a2
+      - 655f66e9-397a-415e-8978-c1b0903a1a92
+      - b75f53af-c88c-4cdd-9dc9-97799686bb4e
+      - b8ea5767-c2cb-44ae-94cf-4d659895981f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14907'
       X-Ms-Request-Id:
-      - 2d137dae-5f57-45c5-8590-790d3b5d6daf
+      - 68404eec-663f-4bee-89ee-d13b8fba5aea
       X-Ms-Correlation-Request-Id:
-      - 2d137dae-5f57-45c5-8590-790d3b5d6daf
+      - 68404eec-663f-4bee-89ee-d13b8fba5aea
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164019Z:2d137dae-5f57-45c5-8590-790d3b5d6daf
+      - NORTHCENTRALUS:20160203T194343Z:68404eec-663f-4bee-89ee-d13b8fba5aea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:18 GMT
+      - Wed, 03 Feb 2016 19:43:42 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1007,61 +682,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1071,11 +756,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1094,22 +779,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 15661851-8350-4571-b3bc-546cbb6d8033
-      - c6e303cb-b151-436a-a860-b6463b2c5831
+      - 76c8b0e5-09d1-46e2-9dea-6d1e7935e1e3
+      - a9c01e93-b0c0-4a99-9dec-e4feb0ee08e1
+      - ded88f2f-31a8-481f-9a52-269f0c89572c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14894'
       X-Ms-Request-Id:
-      - ee3882db-e389-4290-ab65-984f6ee2e5ff
+      - 861d2530-ee4d-4eb8-a648-1439056b9a5f
       X-Ms-Correlation-Request-Id:
-      - ee3882db-e389-4290-ab65-984f6ee2e5ff
+      - 861d2530-ee4d-4eb8-a648-1439056b9a5f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164019Z:ee3882db-e389-4290-ab65-984f6ee2e5ff
+      - NORTHCENTRALUS:20160203T194343Z:861d2530-ee4d-4eb8-a648-1439056b9a5f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:18 GMT
+      - Wed, 03 Feb 2016 19:43:43 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1120,61 +806,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1184,11 +880,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1207,22 +903,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1eee67e0-7a9a-4abb-ab1d-83e1884257a0
-      - 57dc249a-bfd0-48a5-ba92-5e8f31042bb4
+      - 1106477c-0c18-4dc5-b679-032b4c7c94c9
+      - 4c90338b-fa87-48f3-96cc-a72d3ba42a79
+      - d54c735b-056d-4e26-a724-853750affba7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14896'
       X-Ms-Request-Id:
-      - 13670aa1-627a-4825-bdba-721c3944ea07
+      - 5c6dbce2-b38c-458c-8806-9af0ddc11176
       X-Ms-Correlation-Request-Id:
-      - 13670aa1-627a-4825-bdba-721c3944ea07
+      - 5c6dbce2-b38c-458c-8806-9af0ddc11176
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164020Z:13670aa1-627a-4825-bdba-721c3944ea07
+      - NORTHCENTRALUS:20160203T194344Z:5c6dbce2-b38c-458c-8806-9af0ddc11176
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:19 GMT
+      - Wed, 03 Feb 2016 19:43:43 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1233,61 +930,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1297,11 +1004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1320,22 +1027,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 031180d6-703f-4664-886c-d9e7499914ec
-      - 4ac2bb9c-4728-4ee2-89a3-6f574ce99189
+      - 0100280a-8f6b-42fa-a1a2-5ed88e816d68
+      - b48b9854-1534-4792-b6df-2d86ff95a21c
+      - e8a75ddc-b7d4-4db8-a906-4a4bf103ed8c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14902'
       X-Ms-Request-Id:
-      - daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      - 06d9f920-9c48-47c0-a73c-9acf5e0cc3e5
       X-Ms-Correlation-Request-Id:
-      - daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      - 06d9f920-9c48-47c0-a73c-9acf5e0cc3e5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164020Z:daec746c-05cf-42ea-afed-0cb7e1e5abd1
+      - NORTHCENTRALUS:20160203T194345Z:06d9f920-9c48-47c0-a73c-9acf5e0cc3e5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:20 GMT
+      - Wed, 03 Feb 2016 19:43:44 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1346,61 +1054,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1410,11 +1128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1433,22 +1151,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2e31d7b4-f7e1-4751-b920-dfa395ef8e90
-      - e2e62b6c-dbd2-463a-97c8-66d149c16fdc
+      - 60d96131-8b8a-4b46-b2f4-b28f19f72dc0
+      - 627a1b36-09bc-480f-864f-ec1d719d4f7a
+      - a17234de-4ad9-4c13-b5b5-48fe44e0ffd8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14904'
       X-Ms-Request-Id:
-      - e376da29-4c17-4a04-8877-379d4b12b8a8
+      - 622e092a-9d8e-430a-bc53-aa3a417571a9
       X-Ms-Correlation-Request-Id:
-      - e376da29-4c17-4a04-8877-379d4b12b8a8
+      - 622e092a-9d8e-430a-bc53-aa3a417571a9
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164021Z:e376da29-4c17-4a04-8877-379d4b12b8a8
+      - NORTHCENTRALUS:20160203T194345Z:622e092a-9d8e-430a-bc53-aa3a417571a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:21 GMT
+      - Wed, 03 Feb 2016 19:43:45 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1459,61 +1178,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1523,11 +1252,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1546,22 +1275,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 85b3cf4b-e2f5-45bf-b3ce-487edaea9615
-      - d2d9f309-4da8-4b20-bbf9-17d1b15cf60d
+      - 33c640ab-f71d-4269-a8fc-c2711260e40f
+      - beb9fe02-08f8-4801-a987-0aa463b16f9f
+      - fb2e391f-6c31-40d4-a1c0-95a22c35e32a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14904'
       X-Ms-Request-Id:
-      - 614fe18a-218c-4a21-922b-078e0fd45ccb
+      - dc4c4375-44f5-4076-aa6c-58c88b22f9ba
       X-Ms-Correlation-Request-Id:
-      - 614fe18a-218c-4a21-922b-078e0fd45ccb
+      - dc4c4375-44f5-4076-aa6c-58c88b22f9ba
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164021Z:614fe18a-218c-4a21-922b-078e0fd45ccb
+      - NORTHCENTRALUS:20160203T194346Z:dc4c4375-44f5-4076-aa6c-58c88b22f9ba
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:21 GMT
+      - Wed, 03 Feb 2016 19:43:46 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1572,61 +1302,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1636,11 +1376,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1659,22 +1399,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b72daced-db43-4695-96b5-07212efa3cd0
-      - d54bd2d2-1a40-4160-9554-98bfdaf28a31
+      - 38336a86-f7ad-452a-bc46-c5145da291a8
+      - 4b58b092-3636-4848-8a04-8e82d1d94285
+      - f0487301-6b7f-47d2-ad4c-c5e6b326d01b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14903'
       X-Ms-Request-Id:
-      - 71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      - 643b0454-e445-45d8-b124-efe98560aa74
       X-Ms-Correlation-Request-Id:
-      - 71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      - 643b0454-e445-45d8-b124-efe98560aa74
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164021Z:71fc1a8d-9086-4672-9edb-cc5b49bc863b
+      - NORTHCENTRALUS:20160203T194347Z:643b0454-e445-45d8-b124-efe98560aa74
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:21 GMT
+      - Wed, 03 Feb 2016 19:43:46 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1685,61 +1426,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1749,11 +1500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1772,22 +1523,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 8ba4888a-5863-4dfc-b6f7-c55d8583b82c
-      - cbc41774-f4fe-4ec6-9d4c-466cf77eec01
+      - 02c9549b-4a22-4766-aaef-efa847758641
+      - 0c09ad60-9112-48da-a9ff-3c6c3fc9e1b0
+      - 5ec86ddf-40ab-47d7-9342-049405d03cc1
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14906'
       X-Ms-Request-Id:
-      - f90fa7f9-aaec-4015-8964-4b69958be7ce
+      - ec44fffb-c86b-49ad-84d9-09c55c2b20e7
       X-Ms-Correlation-Request-Id:
-      - f90fa7f9-aaec-4015-8964-4b69958be7ce
+      - ec44fffb-c86b-49ad-84d9-09c55c2b20e7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164022Z:f90fa7f9-aaec-4015-8964-4b69958be7ce
+      - NORTHCENTRALUS:20160203T194347Z:ec44fffb-c86b-49ad-84d9-09c55c2b20e7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:22 GMT
+      - Wed, 03 Feb 2016 19:43:47 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1798,61 +1550,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1862,11 +1624,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1885,22 +1647,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2d5b5625-ce3d-4811-a60a-bc690ecac1d2
-      - 4dc67b26-7376-4004-a6e0-c646154d0554
+      - 14c885df-856b-41ed-9c50-b2badb6a9426
+      - 3cbe8db8-6d65-4ee5-8183-0d1efe73d587
+      - 8d88f909-96dd-4b5f-bf29-4a181bbfd9cc
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14909'
       X-Ms-Request-Id:
-      - 3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      - e3463340-13bf-41b2-a63e-4efe3e042b2c
       X-Ms-Correlation-Request-Id:
-      - 3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      - e3463340-13bf-41b2-a63e-4efe3e042b2c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164022Z:3bb8b810-fcc7-484f-b29d-645b3a5446cb
+      - NORTHCENTRALUS:20160203T194348Z:e3463340-13bf-41b2-a63e-4efe3e042b2c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:22 GMT
+      - Wed, 03 Feb 2016 19:43:47 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1911,61 +1674,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1975,11 +1748,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1998,22 +1771,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0471516c-b01a-4872-b8e9-ed41001a9ccf
-      - a6d9b41c-f5e4-4cc4-80c9-212a56b2ea65
+      - 6a2cba66-b520-42ad-a992-6ebf122af5ce
+      - cfa08313-8aec-4b0e-ab04-73d5ed5fe7e3
+      - d7558d73-a354-4faf-8c96-7ad280420cc4
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14905'
       X-Ms-Request-Id:
-      - 28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      - 1a823b71-8a5d-4e64-8082-7cc7efd25ca3
       X-Ms-Correlation-Request-Id:
-      - 28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      - 1a823b71-8a5d-4e64-8082-7cc7efd25ca3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164023Z:28254d89-16fc-4b7c-b3ca-20e74efc55bd
+      - NORTHCENTRALUS:20160203T194348Z:1a823b71-8a5d-4e64-8082-7cc7efd25ca3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:22 GMT
+      - Wed, 03 Feb 2016 19:43:48 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2024,61 +1798,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2088,11 +1872,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2111,22 +1895,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - ca6265b2-e00f-4d03-ad6e-543c4337bf12
-      - f4c2a5db-d6e5-4412-99a1-c5d11ce63af1
+      - 3f1cdaf7-d1ab-4b1e-b494-36c78aa63e8d
+      - 49ab0e17-72cf-442e-aeff-7f92b4a6cde5
+      - c3247179-326c-4088-91e7-9040cb1934f9
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14910'
       X-Ms-Request-Id:
-      - 439e64fb-e4c4-4e53-a38d-3be841c00109
+      - 64a9ec9d-9617-478d-b7fd-2aabf5830212
       X-Ms-Correlation-Request-Id:
-      - 439e64fb-e4c4-4e53-a38d-3be841c00109
+      - 64a9ec9d-9617-478d-b7fd-2aabf5830212
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164024Z:439e64fb-e4c4-4e53-a38d-3be841c00109
+      - NORTHCENTRALUS:20160203T194349Z:64a9ec9d-9617-478d-b7fd-2aabf5830212
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:24 GMT
+      - Wed, 03 Feb 2016 19:43:49 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2137,61 +1922,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:22 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2201,11 +1996,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2224,22 +2019,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4e98c91a-4b9b-474c-aeaa-670cc3cb81a2
-      - c894d597-73e2-453e-9d28-3205f59954ea
+      - 5e13aab2-d4b9-4d87-99ec-7f6d2e129315
+      - 698842d9-ddad-4be7-af66-7ad660667dcf
+      - b5a22855-4a70-47c2-93a8-d382e55260e3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14903'
       X-Ms-Request-Id:
-      - 010e1711-7eaf-492f-a55e-edfa4717c11a
+      - 6c8c1409-06f4-4cb6-8ddf-5b972384bbd7
       X-Ms-Correlation-Request-Id:
-      - 010e1711-7eaf-492f-a55e-edfa4717c11a
+      - 6c8c1409-06f4-4cb6-8ddf-5b972384bbd7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164024Z:010e1711-7eaf-492f-a55e-edfa4717c11a
+      - NORTHCENTRALUS:20160203T194350Z:6c8c1409-06f4-4cb6-8ddf-5b972384bbd7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:24 GMT
+      - Wed, 03 Feb 2016 19:43:49 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2250,61 +2046,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:23 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2314,11 +2120,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2337,22 +2143,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4ef4520f-4cf4-441e-85f0-2b3cd5b0c65b
-      - 7f11af8a-0d71-4912-8ec2-41bb4c671cad
+      - 23dc29f3-0d5b-4316-b48c-840b24e40336
+      - 981a70a7-66c2-4de9-8a90-b66475fd8016
+      - ed5a12e4-d1b8-45f9-9fe3-cbb956a0519c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14899'
       X-Ms-Request-Id:
-      - 9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      - 257ed320-e4f3-4080-91b4-f3722ffdb5e8
       X-Ms-Correlation-Request-Id:
-      - 9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      - 257ed320-e4f3-4080-91b4-f3722ffdb5e8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164025Z:9a3eb6f2-b516-4167-a1ff-39bd89b5ac9c
+      - NORTHCENTRALUS:20160203T194350Z:257ed320-e4f3-4080-91b4-f3722ffdb5e8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:25 GMT
+      - Wed, 03 Feb 2016 19:43:50 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2363,61 +2170,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:23 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2427,11 +2244,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2450,22 +2267,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - ba3c227b-2104-46dd-b8dc-0a36fd9644dd
-      - f09247b7-57b9-423c-aa6f-5d87ce9187a1
+      - 21072242-8bda-4b12-b9a1-bcbbb6f3141a
+      - 5ba2fdf8-3ad8-493d-9c02-d0e592f9662c
+      - c78c1008-51c3-426e-ac99-ab1c04cf3387
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14900'
       X-Ms-Request-Id:
-      - 2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      - 75f4b548-9de0-434b-9970-9ae7f8b14f12
       X-Ms-Correlation-Request-Id:
-      - 2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      - 75f4b548-9de0-434b-9970-9ae7f8b14f12
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164025Z:2a929ab6-9269-4ad6-8d3f-7b0a2201ab49
+      - NORTHCENTRALUS:20160203T194351Z:75f4b548-9de0-434b-9970-9ae7f8b14f12
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:25 GMT
+      - Wed, 03 Feb 2016 19:43:50 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2476,61 +2294,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2540,11 +2368,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2563,22 +2391,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0a651fd9-4a03-432e-9f3b-a25e38195d3b
-      - d6c58cc8-e17f-48dc-9913-246494345755
+      - 1ca24309-2f05-4932-817c-7d8db90fe657
+      - 825247f2-9a54-41ef-8fa5-691323ff0687
+      - a1b1f47e-2355-44a4-8793-bdff653ad07e
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14892'
       X-Ms-Request-Id:
-      - 54e73d93-0909-4b22-9d3b-2e279873f24a
+      - a7133116-0a92-4bd0-9ad3-5c39ee75c3ab
       X-Ms-Correlation-Request-Id:
-      - 54e73d93-0909-4b22-9d3b-2e279873f24a
+      - a7133116-0a92-4bd0-9ad3-5c39ee75c3ab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164026Z:54e73d93-0909-4b22-9d3b-2e279873f24a
+      - NORTHCENTRALUS:20160203T194352Z:a7133116-0a92-4bd0-9ad3-5c39ee75c3ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:26 GMT
+      - Wed, 03 Feb 2016 19:43:52 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2589,61 +2418,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2653,11 +2492,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2676,22 +2515,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0e852c03-c7a0-4461-828d-85cba50b6397
-      - 2702641b-773e-4827-b811-d3cb19704874
+      - 6cffcb75-353f-45fa-a578-05d14354a2d0
+      - 70561216-031b-4045-aabf-b87ece471efc
+      - 9cc8571f-056d-43d5-9318-c53e9e8d6804
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14905'
       X-Ms-Request-Id:
-      - 1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      - bb15717d-b500-490b-be02-2f480e7346fd
       X-Ms-Correlation-Request-Id:
-      - 1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      - bb15717d-b500-490b-be02-2f480e7346fd
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164027Z:1c56d863-5fcb-4b24-b93f-4eb8fe8af7cd
+      - NORTHCENTRALUS:20160203T194352Z:bb15717d-b500-490b-be02-2f480e7346fd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:26 GMT
+      - Wed, 03 Feb 2016 19:43:51 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2702,61 +2542,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2766,11 +2616,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2789,22 +2639,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1d5c2746-f46b-4d22-a0a7-ab0b49ebe35a
-      - 641178bf-00cc-4be3-8e2c-c2e82572c091
+      - 06fb68f4-522c-4808-a84e-0d3cbc42d190
+      - a5c03726-e753-4467-84dd-99d93706b142
+      - f873df11-785c-4c6b-8e86-fd6063dabc74
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14906'
       X-Ms-Request-Id:
-      - 5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      - e9dde277-19b3-4f7b-9bb0-4467d5424d31
       X-Ms-Correlation-Request-Id:
-      - 5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      - e9dde277-19b3-4f7b-9bb0-4467d5424d31
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164027Z:5c3675a9-80e2-487b-9ba6-5d6ec61feb96
+      - NORTHCENTRALUS:20160203T194353Z:e9dde277-19b3-4f7b-9bb0-4467d5424d31
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:26 GMT
+      - Wed, 03 Feb 2016 19:43:52 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2815,61 +2666,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2879,11 +2740,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2902,22 +2763,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2cc0c2b0-14c6-4500-b23c-00744f8d3c0d
-      - 2fcac979-eeb0-446d-b624-007fed7809e6
+      - b8120361-d847-4ea3-babf-d4737f003264
+      - dbec003d-9d10-4f2a-9dae-40a566c76e7a
+      - ec9800a1-6a43-4f2e-a883-18b1714fd467
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14893'
       X-Ms-Request-Id:
-      - 244e6bba-640e-4801-812c-712a3b44900f
+      - 5f4c655c-4621-4054-b7ae-0417ea386b1c
       X-Ms-Correlation-Request-Id:
-      - 244e6bba-640e-4801-812c-712a3b44900f
+      - 5f4c655c-4621-4054-b7ae-0417ea386b1c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164027Z:244e6bba-640e-4801-812c-712a3b44900f
+      - NORTHCENTRALUS:20160203T194353Z:5f4c655c-4621-4054-b7ae-0417ea386b1c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:27 GMT
+      - Wed, 03 Feb 2016 19:43:52 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2928,61 +2790,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2992,11 +2864,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3015,22 +2887,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - ba2fdea3-f817-4352-8a4e-558a29dd1728
-      - ce8161ff-6ee5-4777-895b-fb839b9675e7
+      - 604cca7c-8df7-47a9-be13-4d12ef19024e
+      - a8d05a21-f0ee-488c-b4a6-00874079aa0e
+      - f631189e-4f4e-40a4-a56a-5a6fbaf7c4b8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14895'
       X-Ms-Request-Id:
-      - a3f72022-f6e1-4450-b173-20b5c8389a08
+      - c1c8d384-943a-477a-9616-95cc40b18f7f
       X-Ms-Correlation-Request-Id:
-      - a3f72022-f6e1-4450-b173-20b5c8389a08
+      - c1c8d384-943a-477a-9616-95cc40b18f7f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164028Z:a3f72022-f6e1-4450-b173-20b5c8389a08
+      - NORTHCENTRALUS:20160203T194354Z:c1c8d384-943a-477a-9616-95cc40b18f7f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:28 GMT
+      - Wed, 03 Feb 2016 19:43:53 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3041,61 +2914,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3105,11 +2988,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3128,22 +3011,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1374e1fc-ee2c-44b9-b3c3-c86a435c688f
-      - df910620-ed92-4f1f-b8bd-90ddfd33b3bf
+      - 282e212d-a74f-4cec-9952-0bc19f9b7191
+      - 91d588f6-5984-44ab-b67a-c90bcb5439f6
+      - 949c280f-f12c-44f8-9483-aa0343145064
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14901'
       X-Ms-Request-Id:
-      - 73d91cf3-3533-4547-9da5-87e41be9f2c2
+      - 7808a73f-baf6-458b-b624-654fc6105f1a
       X-Ms-Correlation-Request-Id:
-      - 73d91cf3-3533-4547-9da5-87e41be9f2c2
+      - 7808a73f-baf6-458b-b624-654fc6105f1a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164028Z:73d91cf3-3533-4547-9da5-87e41be9f2c2
+      - NORTHCENTRALUS:20160203T194355Z:7808a73f-baf6-458b-b624-654fc6105f1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:28 GMT
+      - Wed, 03 Feb 2016 19:43:54 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3154,61 +3038,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3218,11 +3112,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3241,22 +3135,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1fb010b5-4f3e-47fa-aa73-b72cf652f0a0
-      - d1649780-4af7-4cbe-87ca-8a4b7fcedab5
+      - 2b32a46f-c867-45a1-8915-a39e521b8f43
+      - 3f750699-a871-4f97-95a0-0522fdbb7176
+      - af6d84be-50b5-421c-ad9e-b757e2e22402
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14903'
       X-Ms-Request-Id:
-      - b1f63c45-ab83-4418-a760-7f200a292e5b
+      - 14974827-a347-4513-ba7f-710f7b58db94
       X-Ms-Correlation-Request-Id:
-      - b1f63c45-ab83-4418-a760-7f200a292e5b
+      - 14974827-a347-4513-ba7f-710f7b58db94
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164028Z:b1f63c45-ab83-4418-a760-7f200a292e5b
+      - NORTHCENTRALUS:20160203T194355Z:14974827-a347-4513-ba7f-710f7b58db94
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:40:28 GMT
+      - Wed, 03 Feb 2016 19:43:55 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3267,8850 +3162,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 09d826a7-d798-4471-9f5b-11e1f8502110
-      - 9041d5b0-2270-4ca7-a2fb-f1d4e30dfefd
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 77892022-257c-4d7c-b72d-d854c42aff42
-      X-Ms-Correlation-Request-Id:
-      - 77892022-257c-4d7c-b72d-d854c42aff42
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164030Z:77892022-257c-4d7c-b72d-d854c42aff42
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7f0b7093-1e79-4422-9333-364104e00549
-      - 92a064d4-8e23-4690-b28d-d9f04ca40b27
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 0de7428b-a93d-4498-83a1-16b9ef0caa85
-      X-Ms-Correlation-Request-Id:
-      - 0de7428b-a93d-4498-83a1-16b9ef0caa85
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164030Z:0de7428b-a93d-4498-83a1-16b9ef0caa85
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 13156844-5f89-439d-b494-d119cf4fc156
-      - 7f03d32c-b263-40f2-a783-58030d374c3c
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 05901df7-7ff5-4416-b249-0a0e1658fc2a
-      X-Ms-Correlation-Request-Id:
-      - 05901df7-7ff5-4416-b249-0a0e1658fc2a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164031Z:05901df7-7ff5-4416-b249-0a0e1658fc2a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - a1d2aabe-423c-4fb7-8cb3-10d12420aa32
-      - dce58fa8-a404-4ec5-925e-1882cbcd46c3
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 5267d697-3378-4646-bda2-cf45d88ff474
-      X-Ms-Correlation-Request-Id:
-      - 5267d697-3378-4646-bda2-cf45d88ff474
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164031Z:5267d697-3378-4646-bda2-cf45d88ff474
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5af6c2e6-9826-4ac7-8267-960e165b7698
-      - 7cfd11eb-0e83-40c1-8a77-e34babacf2b4
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 1bc44088-e0a9-4256-a48f-49809cb1a7e1
-      X-Ms-Correlation-Request-Id:
-      - 1bc44088-e0a9-4256-a48f-49809cb1a7e1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164031Z:1bc44088-e0a9-4256-a48f-49809cb1a7e1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - c4c453dd-dd9e-4311-aca0-7ed6eef3dcc5
-      - e283d19e-010a-4a86-92d7-341ac93e31ce
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 75dc80e4-efaf-4c86-9c72-3e3d7f127871
-      X-Ms-Correlation-Request-Id:
-      - 75dc80e4-efaf-4c86-9c72-3e3d7f127871
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164032Z:75dc80e4-efaf-4c86-9c72-3e3d7f127871
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 211e063e-740d-4123-9286-9e95b689cd5a
-      - cec00229-607e-452c-ab1e-7427a79c67bc
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 6cfbc081-e207-49e7-8457-8aea16f7b076
-      X-Ms-Correlation-Request-Id:
-      - 6cfbc081-e207-49e7-8457-8aea16f7b076
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164032Z:6cfbc081-e207-49e7-8457-8aea16f7b076
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 714c2938-8619-46b6-ac35-2113e9125993
-      - b34c64b9-e31d-4168-94be-caa803c153c2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 19a31545-2415-46a4-9033-8582eec97dc4
-      X-Ms-Correlation-Request-Id:
-      - 19a31545-2415-46a4-9033-8582eec97dc4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164032Z:19a31545-2415-46a4-9033-8582eec97dc4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 20493006-3794-4227-a062-59741d2fcf03
-      - 91a17597-5892-4832-8088-92a3759265ff
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 051c5870-3d8f-4d0b-bab4-070bede3a8e5
-      X-Ms-Correlation-Request-Id:
-      - 051c5870-3d8f-4d0b-bab4-070bede3a8e5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164033Z:051c5870-3d8f-4d0b-bab4-070bede3a8e5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1b4c7f49-13aa-4978-8cd0-08679b2f1e68
-      - 4eca1be4-38dd-4f12-b745-d80ba25b903d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Request-Id:
-      - 8d05e6fe-d9ee-4c29-a61b-86b1169fece9
-      X-Ms-Correlation-Request-Id:
-      - 8d05e6fe-d9ee-4c29-a61b-86b1169fece9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164033Z:8d05e6fe-d9ee-4c29-a61b-86b1169fece9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - aaae9c72-63d4-4b63-88fe-1e8021940a8e
-      - d1e8f6e8-ce38-4548-b308-78fc01a0e249
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - b4475355-ced2-4310-9255-a60c33ac77af
-      X-Ms-Correlation-Request-Id:
-      - b4475355-ced2-4310-9255-a60c33ac77af
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164033Z:b4475355-ced2-4310-9255-a60c33ac77af
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 65de5b80-3fff-488d-8964-729c75789999
-      - e02a2d55-4530-4d5e-9687-fbbc798b1f1a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 855cb813-a0d4-4493-b0ae-8f884fe42791
-      X-Ms-Correlation-Request-Id:
-      - 855cb813-a0d4-4493-b0ae-8f884fe42791
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164034Z:855cb813-a0d4-4493-b0ae-8f884fe42791
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7b874385-3c06-4a43-9303-2b3d6b92a1e0
-      - f388c994-f6c6-46f7-96f1-6f5ce33e579f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 0e678c7e-e060-4ffb-a87a-3943dd6864e7
-      X-Ms-Correlation-Request-Id:
-      - 0e678c7e-e060-4ffb-a87a-3943dd6864e7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164034Z:0e678c7e-e060-4ffb-a87a-3943dd6864e7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 246e30ec-5ffa-4791-9840-f00bc7ec80ea
-      - e71d0f2f-88dd-4a0b-a45d-8a714a05f46b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 7239e88f-3e5a-485c-b6cf-8da6aec4dd18
-      X-Ms-Correlation-Request-Id:
-      - 7239e88f-3e5a-485c-b6cf-8da6aec4dd18
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164035Z:7239e88f-3e5a-485c-b6cf-8da6aec4dd18
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7de546ea-6750-4e59-be89-5fcd4af212fe
-      - cfa62301-5cb7-4c7b-aa63-047305c481d9
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - c58036cf-3a20-48aa-940e-87fde103865f
-      X-Ms-Correlation-Request-Id:
-      - c58036cf-3a20-48aa-940e-87fde103865f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164035Z:c58036cf-3a20-48aa-940e-87fde103865f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - ac1b4cd5-d7c1-4c27-b4c0-742ef2b97766
-      - cd9ecd42-27f0-4dbc-ab97-edb755fe97d5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 8d2549b4-2246-4019-95b7-63bb69a22cdc
-      X-Ms-Correlation-Request-Id:
-      - 8d2549b4-2246-4019-95b7-63bb69a22cdc
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164035Z:8d2549b4-2246-4019-95b7-63bb69a22cdc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8d10fb97-7dba-417e-b2d5-4055e0c6850c
-      - a6a12c74-d3fe-4653-ab24-c4334be651e2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - be8bbce6-048d-44b9-995c-2d381c1c5720
-      X-Ms-Correlation-Request-Id:
-      - be8bbce6-048d-44b9-995c-2d381c1c5720
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164036Z:be8bbce6-048d-44b9-995c-2d381c1c5720
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 31d8b4f5-2ce8-477f-9b90-322b5fa397fa
-      - 69bd8006-e58a-45b0-a91e-ce9d7204bf2d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - dd270c39-316e-481b-942c-eb2af077cca2
-      X-Ms-Correlation-Request-Id:
-      - dd270c39-316e-481b-942c-eb2af077cca2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164036Z:dd270c39-316e-481b-942c-eb2af077cca2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - d9b8f599-f7de-46bc-b321-0c65b6156214
-      - dd893989-f430-4fca-b88c-a702c014775f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 33db4c6d-013e-4b2c-80a9-d59555c31d43
-      X-Ms-Correlation-Request-Id:
-      - 33db4c6d-013e-4b2c-80a9-d59555c31d43
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164036Z:33db4c6d-013e-4b2c-80a9-d59555c31d43
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:36 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - b47f0af0-9589-4912-b35c-c24e8417f264
-      - f5545e68-9a8e-402b-bbec-71538fc7b7d9
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - bb37a462-ac29-42f4-93d2-5052dbc4b7d3
-      X-Ms-Correlation-Request-Id:
-      - bb37a462-ac29-42f4-93d2-5052dbc4b7d3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164037Z:bb37a462-ac29-42f4-93d2-5052dbc4b7d3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:36 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1d52bbc1-c469-4e54-b0e1-6acc5ec9f142
-      - 77be3324-40e7-4377-a3b0-6300400cab91
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 3127604c-8745-4d78-9725-960e3616f088
-      X-Ms-Correlation-Request-Id:
-      - 3127604c-8745-4d78-9725-960e3616f088
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164037Z:3127604c-8745-4d78-9725-960e3616f088
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:36 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - dd5877f0-bbcd-45f8-b04b-69a117697094
-      - ec4c3b40-c04b-4729-9102-80dd0cf74194
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 74c1c80a-b731-440b-a8d1-9a43d407d580
-      X-Ms-Correlation-Request-Id:
-      - 74c1c80a-b731-440b-a8d1-9a43d407d580
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164037Z:74c1c80a-b731-440b-a8d1-9a43d407d580
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - da3af471-8711-490e-8db4-fe41378b07b0
-      - f82ccdb4-0d8a-453d-9b22-2d42f2cef554
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - bf64ede3-06c5-41ce-b561-17d10b252f37
-      X-Ms-Correlation-Request-Id:
-      - bf64ede3-06c5-41ce-b561-17d10b252f37
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164038Z:bf64ede3-06c5-41ce-b561-17d10b252f37
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2ee64f29-077e-44c3-a7fc-ca83714f909f
-      - 304a1dce-e551-4944-b0f0-fd07a559a017
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 7c337c52-e21d-49c2-9440-9b5eb7562f35
-      X-Ms-Correlation-Request-Id:
-      - 7c337c52-e21d-49c2-9440-9b5eb7562f35
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164038Z:7c337c52-e21d-49c2-9440-9b5eb7562f35
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 35ee161d-fec4-4946-8582-546768e0e611
-      - cc7a5557-d1b6-47b7-b045-e0dff88f814b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
-      X-Ms-Correlation-Request-Id:
-      - c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164039Z:c85936ab-2b05-4bc3-b3aa-66e4ea60d4be
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 259e416c-9f2a-4544-8ac6-5938ebb3d779
-      - d20ff211-42a7-48ed-aa12-4acfc9ed96f3
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 38f8f274-1666-4bb2-ace1-e423caf66e1a
-      X-Ms-Correlation-Request-Id:
-      - 38f8f274-1666-4bb2-ace1-e423caf66e1a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164039Z:38f8f274-1666-4bb2-ace1-e423caf66e1a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4eb78f05-636b-46e9-a65d-775b89d11122
-      - bc8767f8-fa9d-40f9-93f7-47a656a57b06
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 4d8c7d9b-e664-4ec2-83ed-624b984867c4
-      X-Ms-Correlation-Request-Id:
-      - 4d8c7d9b-e664-4ec2-83ed-624b984867c4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164039Z:4d8c7d9b-e664-4ec2-83ed-624b984867c4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 02e3c921-aba4-46bb-b555-ed8bf09e5e1f
-      - a4ec282f-a33d-47be-a00c-c9e1636329d7
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 4b492f5a-574c-44cc-8cef-91aaae5b3cc3
-      X-Ms-Correlation-Request-Id:
-      - 4b492f5a-574c-44cc-8cef-91aaae5b3cc3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164039Z:4b492f5a-574c-44cc-8cef-91aaae5b3cc3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 766d5181-61fc-43bb-ae1d-a403108fa100
-      - cdc5ac3f-5ebc-417b-81d7-1a677ee9fb65
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 93f8e616-921d-4aff-bd48-3313f47d6773
-      X-Ms-Correlation-Request-Id:
-      - 93f8e616-921d-4aff-bd48-3313f47d6773
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164040Z:93f8e616-921d-4aff-bd48-3313f47d6773
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:40 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 21f7d1d3-9dcf-422a-a6ca-a590a8325ffa
-      - 539bbb7c-953c-4b32-a238-b3257d065034
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 83575265-990e-479f-ac30-6dc30b822ec3
-      X-Ms-Correlation-Request-Id:
-      - 83575265-990e-479f-ac30-6dc30b822ec3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164040Z:83575265-990e-479f-ac30-6dc30b822ec3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:40 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 40ccd4ad-9a36-413e-85dd-265f611626ab
-      X-Ms-Correlation-Request-Id:
-      - 40ccd4ad-9a36-413e-85dd-265f611626ab
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164040Z:40ccd4ad-9a36-413e-85dd-265f611626ab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:39 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 326fd145-c626-45c1-8d3e-d7036fec87e4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 003f115f-44f5-4f7f-a2ff-b279023bbd1c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164041Z:003f115f-44f5-4f7f-a2ff-b279023bbd1c
-      Date:
-      - Wed, 28 Oct 2015 16:40:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - b118c723-8584-496d-9141-f49d9e9ad2e0
-      X-Ms-Correlation-Request-Id:
-      - b118c723-8584-496d-9141-f49d9e9ad2e0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164042Z:b118c723-8584-496d-9141-f49d9e9ad2e0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:41 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - aeecf67f-23e8-42ff-be1c-8155ef5c2e50
-      X-Ms-Correlation-Request-Id:
-      - aeecf67f-23e8-42ff-be1c-8155ef5c2e50
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164043Z:aeecf67f-23e8-42ff-be1c-8155ef5c2e50
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:43 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 154e4001-2761-44ce-a6b2-c5eb212d406d
-      X-Ms-Correlation-Request-Id:
-      - 154e4001-2761-44ce-a6b2-c5eb212d406d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164043Z:154e4001-2761-44ce-a6b2-c5eb212d406d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:42 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 648540d2-20a9-45a4-aa29-70266e1c038a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - fd49b1a6-4556-4cce-88d8-84b99e77ffe6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164044Z:fd49b1a6-4556-4cce-88d8-84b99e77ffe6
-      Date:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 31cad604-1ab4-46c0-8ed5-427255bce807
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 151a6b83-e1c3-4943-8c1b-1206b8fa7983
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164044Z:151a6b83-e1c3-4943-8c1b-1206b8fa7983
-      Date:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 817b2975-0f9d-4d9e-89db-58ba9e586a74
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - fd342667-5421-4917-b039-10d1f010d85a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164044Z:fd342667-5421-4917-b039-10d1f010d85a
-      Date:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/82h//5OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+/onnr/P6Mq+f5peu2yjtvNfx
-        bKBfs55O83yWzxxEPI5+Z8vzqvMdYRqSzwebDkGMEef+o/0Hj+7vjx/e+/T+
-        /XtdIhFpzK9MKP37+wz3o0lVtU+L7GJZNW0xBR46ZhrtsqnK/PW0zvNlM6/a
-        J2U1+aouqMlH87ZdNY/u3r3Km3ZaZU07mzT3H366N55Qm/G0qvPxVbGcVVfN
-        eJm3d9HJzHWy3fyisuE52N659zCfTfcOtu/nBzvb+zs7e9uT2f3p9v79h9n+
-        LLu/u3ewf9efsvFt3hg3FunxZLFiUih/5O9a+oKIjKHqTOuI6VvDJF8U07pq
-        qvN2fEaNL+ZtM/7JLzwyvc7blmapYcgEGz+UoH1GcuDfi4GGmOf9GWcz0zx8
-        uLv7cDdgGqFVFPPqKq/Rc353lmdlWU3pV7+rWyNNusCHIA2FkL9x8kv+H4e4
-        yhZABQAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e7a25889-1011-4d07-baeb-669a4ebe093d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 67ebe139-0a3f-4fff-acc4-70dda96a7af6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164045Z:67ebe139-0a3f-4fff-acc4-70dda96a7af6
-      Date:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
-        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
-        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
-        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
-        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
-        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
-        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
-        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
-        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
-        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
-        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a854afe8-dcf9-4e60-8c41-2a3906957a76
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 479637dd-22ad-4924-ba41-b2f99c43f33a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164046Z:479637dd-22ad-4924-ba41-b2f99c43f33a
-      Date:
-      - Wed, 28 Oct 2015 16:40:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - e7df7f64-f6f4-4825-b100-1e8228d2dbd9
-      X-Ms-Correlation-Request-Id:
-      - e7df7f64-f6f4-4825-b100-1e8228d2dbd9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164047Z:e7df7f64-f6f4-4825-b100-1e8228d2dbd9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:47 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - b139eef8-aedb-43ad-9286-e5a6327f1c7e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - ac4e5899-4de0-40eb-940d-ea756707f09c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164047Z:ac4e5899-4de0-40eb-940d-ea756707f09c
-      Date:
-      - Wed, 28 Oct 2015 16:40:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 5ce67bbc-f461-4fb5-aa90-476e3e390574
-      X-Ms-Correlation-Request-Id:
-      - 5ce67bbc-f461-4fb5-aa90-476e3e390574
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164047Z:5ce67bbc-f461-4fb5-aa90-476e3e390574
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:47 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
-      X-Ms-Correlation-Request-Id:
-      - 5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164048Z:5d5cf1df-0a67-4d0a-9b5b-624ee0a69a64
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:47 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - 6a055201-21bf-469d-acbf-8351d479ed37
-      X-Ms-Correlation-Request-Id:
-      - 6a055201-21bf-469d-acbf-8351d479ed37
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164048Z:6a055201-21bf-469d-acbf-8351d479ed37
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 397608b1-c617-454a-8e0f-9f33042e56cf
-      X-Ms-Correlation-Request-Id:
-      - 397608b1-c617-454a-8e0f-9f33042e56cf
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164048Z:397608b1-c617-454a-8e0f-9f33042e56cf
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Request-Id:
-      - 0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
-      X-Ms-Correlation-Request-Id:
-      - 0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164048Z:0cbc3a9e-ab34-4774-be5a-ef99d8b6458d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:47 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 1e941426-1cdb-4ff1-a684-056c44f65b78
-      X-Ms-Correlation-Request-Id:
-      - 1e941426-1cdb-4ff1-a684-056c44f65b78
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164048Z:1e941426-1cdb-4ff1-a684-056c44f65b78
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 56fc0177-711a-4d8d-9190-506b3b52611c
-      X-Ms-Correlation-Request-Id:
-      - 56fc0177-711a-4d8d-9190-506b3b52611c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164049Z:56fc0177-711a-4d8d-9190-506b3b52611c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - f530cf07-7299-473a-a489-c4612766857e
-      X-Ms-Correlation-Request-Id:
-      - f530cf07-7299-473a-a489-c4612766857e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164049Z:f530cf07-7299-473a-a489-c4612766857e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:48 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 69ca47ed-783f-4bac-9258-d9c030aa813f
-      X-Ms-Correlation-Request-Id:
-      - 69ca47ed-783f-4bac-9258-d9c030aa813f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164049Z:69ca47ed-783f-4bac-9258-d9c030aa813f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:49 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - eb05bb4e-f3c8-4888-935b-0be1c655c425
-      X-Ms-Correlation-Request-Id:
-      - eb05bb4e-f3c8-4888-935b-0be1c655c425
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164049Z:eb05bb4e-f3c8-4888-935b-0be1c655c425
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:48 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 4349b5a7-948d-41b6-8dc9-f074bbd58de7
-      X-Ms-Correlation-Request-Id:
-      - 4349b5a7-948d-41b6-8dc9-f074bbd58de7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164049Z:4349b5a7-948d-41b6-8dc9-f074bbd58de7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:49 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C1C:7988:6055F0A:5630FA92
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:40:50 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1025-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:45:50 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 90c15674-9d8a-40e1-ae56-38c8e6cd2585
-      X-Ms-Correlation-Request-Id:
-      - 90c15674-9d8a-40e1-ae56-38c8e6cd2585
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164050Z:90c15674-9d8a-40e1-ae56-38c8e6cd2585
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:49 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:48 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB2E24:3708:BB52466:5630FA92
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:40:50 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-iad2148-IAD
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:45:50 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
-      X-Ms-Correlation-Request-Id:
-      - c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164051Z:c3e59dd7-0f67-4f10-9a3c-1e3787ab9e63
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:50 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB2E15:370A:7E463F6:5630FA92
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:40:51 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-iad2120-IAD
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:45:51 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 6205a725-39f0-4640-a72a-c4789bd1995f
-      X-Ms-Correlation-Request-Id:
-      - 6205a725-39f0-4640-a72a-c4789bd1995f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164051Z:6205a725-39f0-4640-a72a-c4789bd1995f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:51 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 68c7ab62-0e6d-478f-afb9-c64612837db6
-      X-Ms-Correlation-Request-Id:
-      - 68c7ab62-0e6d-478f-afb9-c64612837db6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164051Z:68c7ab62-0e6d-478f-afb9-c64612837db6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:50 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2abdebd6-457f-4dda-ae10-e26249a43761
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 97b58c48-bf1b-46e0-a794-5a1bc4d87e04
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164052Z:97b58c48-bf1b-46e0-a794-5a1bc4d87e04
-      Date:
-      - Wed, 28 Oct 2015 16:40:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b6b4bb7d-2093-4de9-a698-2e354a4bd709
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 264b9a49-720d-4f05-8486-25fc02838622
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164052Z:264b9a49-720d-4f05-8486-25fc02838622
-      Date:
-      - Wed, 28 Oct 2015 16:40:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 93908a15-2981-4355-a77d-af7df19bf57a
-      X-Ms-Correlation-Request-Id:
-      - 93908a15-2981-4355-a77d-af7df19bf57a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164052Z:93908a15-2981-4355-a77d-af7df19bf57a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Request-Id:
-      - b75a9d7c-e043-424a-91e8-d8cacde269cd
-      X-Ms-Correlation-Request-Id:
-      - b75a9d7c-e043-424a-91e8-d8cacde269cd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:b75a9d7c-e043-424a-91e8-d8cacde269cd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2716546a-e910-4409-827b-e8a187095340
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 42ec9912-5275-4500-bef8-94f2dbe21d0a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:42ec9912-5275-4500-bef8-94f2dbe21d0a
-      Date:
-      - Wed, 28 Oct 2015 16:40:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 9f88d726-a396-4880-8319-f82ec3b425f8
-      X-Ms-Correlation-Request-Id:
-      - 9f88d726-a396-4880-8319-f82ec3b425f8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:9f88d726-a396-4880-8319-f82ec3b425f8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Request-Id:
-      - 8a77641d-fc48-411f-a563-4b956da90915
-      X-Ms-Correlation-Request-Id:
-      - 8a77641d-fc48-411f-a563-4b956da90915
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:8a77641d-fc48-411f-a563-4b956da90915
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 05caa0a1-9ea9-4f51-87a0-148b01d846f4
-      X-Ms-Correlation-Request-Id:
-      - 05caa0a1-9ea9-4f51-87a0-148b01d846f4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:05caa0a1-9ea9-4f51-87a0-148b01d846f4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 8d6a51d8-6f7b-471e-b8c0-c1c7c6bcd590
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 174c9088-e99a-4ad5-b70b-f916252654aa
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164053Z:174c9088-e99a-4ad5-b70b-f916252654aa
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 982b2f69-ec6f-4c5d-be99-05144b39d013
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 18e484f9-50c4-47ac-95cd-1d392d9acdef
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:18e484f9-50c4-47ac-95cd-1d392d9acdef
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - d6770183-1f1c-4c46-b75d-9deffc6062e5
-      X-Ms-Correlation-Request-Id:
-      - d6770183-1f1c-4c46-b75d-9deffc6062e5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:d6770183-1f1c-4c46-b75d-9deffc6062e5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:54 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 1ee5a629-5a49-4b37-bfd0-49381b3d48a5
-      X-Ms-Correlation-Request-Id:
-      - 1ee5a629-5a49-4b37-bfd0-49381b3d48a5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:1ee5a629-5a49-4b37-bfd0-49381b3d48a5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 01a0c380-6c5d-4489-bedd-e314b395283f
-      X-Ms-Correlation-Request-Id:
-      - 01a0c380-6c5d-4489-bedd-e314b395283f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:01a0c380-6c5d-4489-bedd-e314b395283f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:53 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 23ce7140-49ee-4da2-9ae8-f17ff3d42963
-      X-Ms-Correlation-Request-Id:
-      - 23ce7140-49ee-4da2-9ae8-f17ff3d42963
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:23ce7140-49ee-4da2-9ae8-f17ff3d42963
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:54 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 7eee27e1-14d5-4f17-88de-f55f95ee0737
-      X-Ms-Correlation-Request-Id:
-      - 7eee27e1-14d5-4f17-88de-f55f95ee0737
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164054Z:7eee27e1-14d5-4f17-88de-f55f95ee0737
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:40:54 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 8b056664-e1d0-4bdd-b73f-9f0af509830b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 863eaa64-f5a9-40d6-8b03-4f4296bf006a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164055Z:863eaa64-f5a9-40d6-8b03-4f4296bf006a
-      Date:
-      - Wed, 28 Oct 2015 16:40:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 887bae6b-da90-426b-aa42-5475bf25b365
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - bc8a4b6f-1192-413e-8cde-dca57167cdc6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164055Z:bc8a4b6f-1192-413e-8cde-dca57167cdc6
-      Date:
-      - Wed, 28 Oct 2015 16:40:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
-        3ux++mh/59H9+5/s7Dza2fnINP4l8sv38eOXMAhg+hYYKlUsTT5aZgL1ZJ6f
-        bxNZZq7PKDW9d/FsoGiznk7zfJZ7EPE4ip4tz6vOd4RmSFAfbDoEMUaZ+4/2
-        Hzy6/+n4wf69/b0Hux0KEV3Mr0wl/fv7DPej/F2bL9EpUNCR21Fbin1RTOuq
-        qc7b8Rk1vpi3zfgnv3haZBfLqmmLafM6b1vCutFO/Q76hHXg34ugQ8R8f0Ju
-        JuLDnXs79x8ERBTGimJeXeU1es7vzvKsLKsp/ep3dWukSVp8CNJQCPkbJ7/k
-        /wEUKcVCYgQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0d712b27-900a-42c0-9b08-e7516f5ddaf1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 09bf8521-45cf-4f4c-91ee-a50dd8905dca
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164055Z:09bf8521-45cf-4f4c-91ee-a50dd8905dca
-      Date:
-      - Wed, 28 Oct 2015 16:40:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
-        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
-        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
-        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
-        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
-        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
-        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
-        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
-        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
-        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
-        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8119c994-9436-4f8e-abea-81085143d2a6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 54ee710f-b139-46fe-8238-188a95d5672d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164056Z:54ee710f-b139-46fe-8238-188a95d5672d
-      Date:
-      - Wed, 28 Oct 2015 16:40:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 26f7ff73-c1a1-41e0-99c8-eb3c7c52823a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 41056eb5-300b-4937-ac06-aabf3f5e4bc1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164056Z:41056eb5-300b-4937-ac06-aabf3f5e4bc1
-      Date:
-      - Wed, 28 Oct 2015 16:40:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+p5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZdW0F9T19tP80nUbpZ33Op4N
-        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHi3H+0/4CIM36w9+DB/kGH
-        RkQZ8yvTSf/+PoP9aFJV7dMiu1gSVYop0NAh02CXTVXmr6d1ni+bedU+KavJ
-        V3VBTT6at+2qeXT37nSen6/qanZ/d29nPKHvx9OqzsdXxXJWXTXjZd7eRQcz
-        18H2in6C/LPt8+n5vdk0n26fTw5m2/sPz+9vP5wdTLcnu/fz2fT8/MHO/vSu
-        P1vj27wxbizC48lixWRQ1sjftfQF0RfD1EnW0dK3hj++KKZ11VTn7fiMGl/M
-        22b8k194JHqdty1NUMOQCTZ+KDH7POTAvxfvDPHN+/PMZn55uHNv5/6DgGGE
-        VjHMv3yNbvO7JMB5nZXFD4J+bo0x6QAfgjQc7vVldZXXeDu/O8uzsqym9OvX
-        7diHIA1l+n7j5Jf8Pz4oY5ixBQAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8338f2f0-c757-4f34-a4b8-0739cde12bdc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - bc2e30ef-b89a-4cf4-802b-024eb2ce51f7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164056Z:bc2e30ef-b89a-4cf4-802b-024eb2ce51f7
-      Date:
-      - Wed, 28 Oct 2015 16:40:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
-        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
-        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
-        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
-        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
-        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
-        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
-        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
-        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
-        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
-        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a9e74055-5729-4bd3-a1f8-2f0774bfae9b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - a7d00222-ab52-4b00-9067-b6249651776c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164056Z:a7d00222-ab52-4b00-9067-b6249651776c
-      Date:
-      - Wed, 28 Oct 2015 16:40:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - b260a2d9-81d0-4c02-9f90-8192cee1e85b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - 87c608d3-5c47-47f4-b7e5-428e857ff54b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164057Z:87c608d3-5c47-47f4-b7e5-428e857ff54b
-      Date:
-      - Wed, 28 Oct 2015 16:40:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+g092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4E6nefnTV5f5vWu6zVKOu9tPBvI
-        16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQY7S5/2h/79H9g/HBvfu7Dz+9
-        16ERUcb8ynTSv7/PcD/K37U5TQFNA0HVkdtRW5p9UUzrqqnO2/EZNb6Yt834
-        J794WmQXy6ppi2nzOm9bwrrRTv0O+oR14N+LoEPEfH9Cbibiwd7u/v79gIjC
-        WlHMq6u8Rs/53VmelWU1pV/9rm6NNImGD0EaCiF/4+SX/D+6hmeETwQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 964fa48f-51a0-4a47-90ac-d37cafd38912
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - 17fe1d8d-6f62-48ad-9dc7-c96dd58a79db
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164057Z:17fe1d8d-6f62-48ad-9dc7-c96dd58a79db
-      Date:
-      - Wed, 28 Oct 2015 16:40:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
-        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
-        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
-        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
-        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
-        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
-        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
-        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
-        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
-        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - f6c431c2-f62f-4e0e-9006-7920bfcdefda
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - 09131a97-d0ff-4328-8e7d-6f1e6805a2d7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164057Z:09131a97-d0ff-4328-8e7d-6f1e6805a2d7
-      Date:
-      - Wed, 28 Oct 2015 16:40:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+g092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6+uql6y1KMu8tPBvI1qyn0zyf
-        5TMHEY8j29nyvOp8RwiGVPPBpkMQYzS5/2h/79H9++OH+/uf7uwcdGhDFDG/
-        Mn307+8z3I/yd21OpCfyE1QduR21pdUXxbSumuq8HZ9R44t524x/8ounRXax
-        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+3N1/uPtpQERhqRjmX75G
-        t/ldYua8zsriB0E/t8aY5MGHIA2He31ZXeU13s7vzvKsLKsp/fp1O/YhSEOZ
-        vt84+SX/D3Wp62q9BAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 05872d95-33ba-43b6-b181-fe16d47bc93a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 5a98c3f5-bbee-4c78-aa5f-85f501001a8d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164057Z:5a98c3f5-bbee-4c78-aa5f-85f501001a8d
-      Date:
-      - Wed, 28 Oct 2015 16:40:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
-        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
-        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
-        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
-        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
-        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
-        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
-        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
-        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
-        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 698e9579-14b5-4461-82f4-ed38e100fceb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 3af96e29-6944-4dc1-98f5-0cb3fc1b121d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164058Z:3af96e29-6944-4dc1-98f5-0cb3fc1b121d
-      Date:
-      - Wed, 28 Oct 2015 16:40:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 68b01d79-9139-41dd-a850-0a0fb7aaf7f0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - e7376835-9b63-452e-860e-921534e2ea9f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164058Z:e7376835-9b63-452e-860e-921534e2ea9f
-      Date:
-      - Wed, 28 Oct 2015 16:40:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/8+j+wSc7O492
-        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUD94uwn9lx3UZp5r+HZQLdmPZ3m
-        +SyfOYh4HN3OludV5zvCMCSbDzYdghgjyv1H+3uP7t8fP9zf/3Rnp0scIon5
-        lQmkf3+f4X6Uv2tzoj3Rn6DqyO2oHbGKaV011Xk7PqPGF/O2Gf/kF0+L7GJZ
-        NW0xbV7nbUtYN9qp30GfsA78exF0iJjvT8jNRHy4u/9w99OAiMJTUcyrq7xG
-        z/ndWZ6VZTWlX/2ubo00yYQPQRoKIX/j5Jf8P4KQkFtIBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5bd19a31-c60d-40d3-ae58-23c5bfd26dd0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - 9bdd8385-8e51-4650-aee5-c016aa692279
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164058Z:9bdd8385-8e51-4650-aee5-c016aa692279
-      Date:
-      - Wed, 28 Oct 2015 16:40:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
-        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
-        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
-        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
-        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
-        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
-        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
-        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
-        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
-        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
-        Abt1q/kPBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - aca45686-e743-44ce-8b19-54cd7c5bb26c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
-      X-Ms-Correlation-Request-Id:
-      - df72eb27-58b9-4e63-8ccb-c5f9339d0d9e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164058Z:df72eb27-58b9-4e63-8ccb-c5f9339d0d9e
-      Date:
-      - Wed, 28 Oct 2015 16:40:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - f5fa37a1-8f1a-4901-b320-e5c7facdcc8a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 2392e244-2247-493b-999c-467d009a8a5f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164059Z:2392e244-2247-493b-999c-467d009a8a5f
-      Date:
-      - Wed, 28 Oct 2015 16:40:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99tL/z6P7DT3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
-        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
-        GKPN/Uf7e4/ufzre+fThp5/e65CICGN+ZTLR3wrRDs6SZpa1GaH19keEoX/p
-        6RFmz3X6/wvC7O5+uv9g9xaUwY/vM9yP8ndtTkJLgktQdeR21JZiXxTTumqq
-        83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+fkJuJ
-        +Om9ewd7oWrqs5LFvLrKa/Sc353lWVlWU/rV7+rWSJMy9SFIQyHkb5z8kv8H
-        Po1oXkYGAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 14725499-3f1c-4cc5-8a96-bcac14209898
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - 587ca008-7737-4d24-940b-d88c2f09db1e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164059Z:587ca008-7737-4d24-940b-d88c2f09db1e
-      Date:
-      - Wed, 28 Oct 2015 16:40:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
-        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
-        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
-        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
-        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
-        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
-        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
-        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
-        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
-        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
-        4wf980v+H8QOklQ5BwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 15eaeff7-7948-427a-9984-3e233f322b0c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - bc4bef2b-6d3f-47b7-afc9-15be545a82b7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164059Z:bc4bef2b-6d3f-47b7-afc9-15be545a82b7
-      Date:
-      - Wed, 28 Oct 2015 16:40:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 4276b1d8-f868-4bc0-94b9-dc92fd814786
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 4d3620ac-1555-409f-af4b-3ab4f6c3e8f4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164059Z:4d3620ac-1555-409f-af4b-3ab4f6c3e8f4
-      Date:
-      - Wed, 28 Oct 2015 16:40:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/+2hn55OdHfr3
-        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1KpBE9dhlGrei3g2UK5ZT6d5Pstn
-        DiIeR7mz5XnV+Y4QCAnng02HIMbIcv/R/oNH9x+M9+4/3Nnd3++Qh4hifmUS
-        6d/fZ7gfTaqqfVpkF8uqaYsp8NAx02iXTVXmr6d1ni+bedU+KavJV3VBTT6a
-        t+2qeXT3brPKp7tNW9U0tbvjCTUYT6s6H18Vy1l11YyXeXsXPcxcD9t453Kx
-        s51nuw/ybG9/O5tls+39/em97ezg4OH2zs7+vfPJ3u79h+d73MH2T36xM75N
-        63FjcR1PFiumgDJEf3p1mPTde03r0JS+/3RunMp7NKL9nfvBVMpQophXV3mN
-        nvO7szwry2pKv/pd3Rppkk0fgjQUfvmNk1/y/wCefpbR0AQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1e0b1ecb-758d-4e6f-9ddd-b0da3746469e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - a426f511-fe39-476e-95fd-89ceae204dc2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164100Z:a426f511-fe39-476e-95fd-89ceae204dc2
-      Date:
-      - Wed, 28 Oct 2015 16:40:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
-        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
-        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
-        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
-        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
-        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
-        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
-        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
-        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
-        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
-        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
-        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 5df7a01b-befa-406e-bc21-34ed65ddc26e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 96b54b3f-af9e-4d9d-8374-b3610e792b68
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164100Z:96b54b3f-af9e-4d9d-8374-b3610e792b68
-      Date:
-      - Wed, 28 Oct 2015 16:41:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbS/+2hn55OdHfr3
-        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1KpBE9dhlGrei3g2UK5ZT6d5Pstn
-        DiIeR7mz5XnV+Y4QCAnng02HIMbIcv/R/gERZLy7e3Dvwf17HfIQUcyvTCL9
-        +/sM96NJVbVPi+xiWTVtMQUeOmYa7bKpyvz1tM7zZTOv2idlNfmqLqjJR/O2
-        XTWP7t5tVvl0t2mrmqZ2dzyhBuNpVefjq2I5q66a8TJv76KHmethG+9cLna3
-        dyb3s71s/3x7d/bpg+393Vm+ne3uTbfv7c52Hux++nDv0z0iLDXe/skvdse3
-        aT1uLK7jyWLFFFCG6E+vDpO+e69pHZrS95/OzVN5sPPw4cFuMJUylCjm1VVe
-        o+f87izPyrKa0q9+V7dGmmTThyANhV9+4+SX/D9gqnOb0AQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5247b217-9838-435c-ae3c-7daeca345354
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - a0637888-4e4c-419a-8e64-a97ec6ae143a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164100Z:a0637888-4e4c-419a-8e64-a97ec6ae143a
-      Date:
-      - Wed, 28 Oct 2015 16:40:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
-        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
-        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
-        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
-        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
-        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
-        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
-        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
-        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
-        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
-        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
-        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 6c1254c8-906c-4dee-8412-7b240ee92339
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 46f93e7b-2082-4ffa-827e-f5822bd48a41
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164100Z:46f93e7b-2082-4ffa-827e-f5822bd48a41
-      Date:
-      - Wed, 28 Oct 2015 16:40:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99tL/7aGf3k52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
-        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
-        xohz/9H+g0f3Px0fPHz46cGn+x0iEWnMr0wo/fv7DPejSVW1T4vsYlk1bTEF
-        HjpmGu2yqcr89bTO82Uzr9onZTX5qi6oyUfztl01j+7eXV7XFw93D/bHE/pu
-        PK3qfHxVLGfVVTNe5u1dAJ854NuNof32dHa+k50/eLh9b2d/tr0/e3Bv++F0
-        en/74P793cnuw9k033lw15+q8W3eGDcW2fFksWISKF/k71r6goiLIeoM60jp
-        W8McXxTTumqq83Z8Ro0v5m0z/skvPPK8ztuWZqdhyAQbP5SQfQZy4N+LcYaY
-        5v0ZZiOzPPx0b/fBzkHALEKrKObVVV6j5/zuLM/KsprSr35Xt0aadIAPQRoK
-        IX/j5Jf8P3sJr6L9BAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a30e5d0e-4507-4b0f-9fe7-2fd36ed927a7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 352a9ed2-b2ef-4644-947d-be9690628699
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164101Z:352a9ed2-b2ef-4644-947d-be9690628699
-      Date:
-      - Wed, 28 Oct 2015 16:41:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
-        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
-        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
-        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
-        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
-        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
-        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
-        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
-        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
-        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
-        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTAxMTUsIm5iZiI6MTQ0NjA1MDExNSwiZXhwIjoxNDQ2MDU0MDE1LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.YBE7gZcfLrkycpS5FIbK26yxXnd6-8KlnFmz2ZObR0M8mt4Z6XyE9LRdREj3_jFyNzb-ndQZbCXUSKq8SQJ1qhZl7_Xh7Xwi7hlAZN1MZzXMbmDHao64ZPjyBZlRaXb06k_8YQ6e9Q20c0iRBYmELLjbDZLrQ6EY9k7sPZSq7SBjTfroB3qkHhg3CQIpYtENsjhYbXc--0XiEGxtPE-mD5vxjaTPyYzdb1813LzfCMfYddZnJtl4SuZbKXsBQIdkuyv-LqqAQLA4o6xg4TsBViVpu2a1A23a5WIhX3e6UHJkEabCjoxpArLDBAuwsiVeJcueVvSTy6lbV8Me5fROAQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fc55336f-0a86-4cba-a7dc-42dc58cff07d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - b66b6055-bdb9-493d-bf65-01d19ab015ab
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T164101Z:b66b6055-bdb9-493d-bf65-01d19ab015ab
-      Date:
-      - Wed, 28 Oct 2015 16:41:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:40:59 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:43:55 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_no_existing_records.yml
@@ -1,127 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
-    body:
-      encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Length:
-      - '188'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 17d509d8-d803-4654-a4f7-29a41ade7e24
-      Client-Request-Id:
-      - d146f1d7-5dd5-4f1e-95fe-cfb8e168a146
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_109
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - flight-uxoptin=true; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Wed, 28 Oct 2015 16:06:10 GMT
-      Content-Length:
-      - '1218'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446051970","not_before":"1446048070","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng"}'
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:09 GMT
-- request:
     method: get
-    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - a5060b69-e7a7-4af7-be59-88f0ea05a152
-      X-Ms-Correlation-Request-Id:
-      - a5060b69-e7a7-4af7-be59-88f0ea05a152
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160611Z:a5060b69-e7a7-4af7-be59-88f0ea05a152
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
-        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/providers?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -131,273 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 7879b2d7-931c-460e-8228-b75549e22f6c
-      X-Ms-Correlation-Request-Id:
-      - 7879b2d7-931c-460e-8228-b75549e22f6c
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160612Z:7879b2d7-931c-460e-8228-b75549e22f6c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
-        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
-        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
-        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
-        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
-        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
-        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
-        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
-        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
-        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
-        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
-        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
-        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
-        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
-        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
-        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
-        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
-        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
-        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
-        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
-        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
-        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
-        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
-        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
-        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
-        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
-        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
-        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
-        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
-        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
-        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
-        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
-        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
-        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
-        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
-        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
-        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
-        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
-        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
-        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
-        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
-        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
-        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
-        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
-        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
-        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
-        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
-        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
-        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
-        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
-        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
-        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
-        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
-        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
-        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
-        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
-        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
-        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
-        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
-        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
-        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
-        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
-        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
-        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
-        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
-        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
-        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
-        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
-        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
-        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
-        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
-        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
-        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
-        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
-        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
-        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
-        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
-        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
-        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
-        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
-        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
-        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
-        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
-        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
-        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
-        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
-        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
-        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
-        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
-        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
-        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
-        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
-        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
-        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
-        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
-        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
-        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
-        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
-        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
-        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
-        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
-        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
-        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
-        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
-        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
-        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
-        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
-        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
-        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
-        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
-        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
-        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
-        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
-        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
-        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
-        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
-        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
-        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
-        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
-        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
-        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
-        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
-        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
-        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
-        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
-        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
-        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
-        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
-        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
-        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
-        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
-        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
-        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
-        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
-        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
-        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
-        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
-        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
-        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
-        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
-        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
-        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
-        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
-        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
-        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
-        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
-        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
-        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
-        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
-        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
-        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
-        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
-        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
-        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
-        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
-        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
-        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
-        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
-        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
-        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
-        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
-        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
-        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
-        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
-        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
-        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
-        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
-        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
-        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
-        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
-        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
-        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
-        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
-        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
-        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
-        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
-        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
-        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
-        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
-        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
-        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
-        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -416,22 +35,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 36eaab47-96b4-426f-8e33-927ea73acfac
-      - 7e598d69-d6c8-40a0-be8f-1d4609ac9929
+      - 8902b9ee-fb75-4ac3-a7be-4d24a7436e36
+      - a6af9c96-3fb4-4805-b3a4-7fbb5502cd65
+      - dbbae321-96b4-4c90-9b8f-0e142374fc6e
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14906'
       X-Ms-Request-Id:
-      - c193768e-be37-43e3-8e83-0689d88958fd
+      - 8bb6b806-6d30-45a7-92c7-daa930acd7ef
       X-Ms-Correlation-Request-Id:
-      - c193768e-be37-43e3-8e83-0689d88958fd
+      - 8bb6b806-6d30-45a7-92c7-daa930acd7ef
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160613Z:c193768e-be37-43e3-8e83-0689d88958fd
+      - NORTHCENTRALUS:20160203T194322Z:8bb6b806-6d30-45a7-92c7-daa930acd7ef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:12 GMT
+      - Wed, 03 Feb 2016 19:43:22 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -442,61 +62,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:11 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -506,11 +136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -529,22 +159,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 12585c8b-9800-47a7-a345-0032169f8c16
-      - 2d7bd0e2-11ef-4ae5-87f5-8cd1a83e57cd
+      - 20d26e89-d582-451f-b117-d83ff8148130
+      - 57996821-95be-49ef-a176-d4cafc94fca0
+      - cc919a6b-3639-4d67-8b56-5e38e7c80a89
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14902'
       X-Ms-Request-Id:
-      - cea7d711-a7d4-49db-8c26-2ab71417e266
+      - fda5f56a-f3a3-4d61-b673-15a0826febac
       X-Ms-Correlation-Request-Id:
-      - cea7d711-a7d4-49db-8c26-2ab71417e266
+      - fda5f56a-f3a3-4d61-b673-15a0826febac
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160613Z:cea7d711-a7d4-49db-8c26-2ab71417e266
+      - NORTHCENTRALUS:20160203T194322Z:fda5f56a-f3a3-4d61-b673-15a0826febac
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:12 GMT
+      - Wed, 03 Feb 2016 19:43:22 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -555,61 +186,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:12 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -619,11 +260,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -642,22 +283,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 30511ba3-c3ae-4283-8d4e-d57744a10b99
-      - b52e8488-603f-42fc-b245-76a856921a89
+      - 5da001c5-5d84-4d49-bc6d-e2f39efc873f
+      - ac67fa23-25cd-4516-ae7b-682f192e502e
+      - db63aec2-2dc0-4c0d-9926-994e24af7299
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14902'
       X-Ms-Request-Id:
-      - 322eeb24-23d8-4898-9227-3a9523296b21
+      - c4012ed8-df91-4ac5-9080-0d458d588155
       X-Ms-Correlation-Request-Id:
-      - 322eeb24-23d8-4898-9227-3a9523296b21
+      - c4012ed8-df91-4ac5-9080-0d458d588155
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160614Z:322eeb24-23d8-4898-9227-3a9523296b21
+      - NORTHCENTRALUS:20160203T194323Z:c4012ed8-df91-4ac5-9080-0d458d588155
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:14 GMT
+      - Wed, 03 Feb 2016 19:43:22 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -668,61 +310,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:13 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -732,11 +384,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -755,22 +407,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 24be0c62-6204-4b49-895d-ae51b9c3a94f
-      - 6523826d-9b06-4a0f-b275-3c9f1c265e99
+      - 50ebb62f-26b8-4a01-a7ed-61fc16b5e532
+      - 8d1ffc59-60cb-4def-86e2-74d6847cdb5c
+      - af6f9cbb-b5a8-46cd-ba6b-e948bacf12fa
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14894'
       X-Ms-Request-Id:
-      - 8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      - 9ce428ef-4020-453f-9833-498eea1e4569
       X-Ms-Correlation-Request-Id:
-      - 8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      - 9ce428ef-4020-453f-9833-498eea1e4569
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160616Z:8f798662-e7d1-46c5-a6e0-7eeae5e18bdf
+      - NORTHCENTRALUS:20160203T194323Z:9ce428ef-4020-453f-9833-498eea1e4569
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:15 GMT
+      - Wed, 03 Feb 2016 19:43:23 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -781,61 +434,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -845,11 +508,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -868,22 +531,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 547abbe1-12db-49e8-a864-f16d4dd37e8a
-      - 8397146a-6a86-48ff-a2c4-cacc28d0662f
+      - 6b17eab5-d049-4223-9bc3-d120263392f6
+      - cc49e478-f92e-451f-a2b6-0bdf0508db8f
+      - d0d04366-04e6-443f-8a03-3ec57b875575
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14908'
       X-Ms-Request-Id:
-      - fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      - 9bb9726e-5b55-45cf-82ee-cd075cb91118
       X-Ms-Correlation-Request-Id:
-      - fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      - 9bb9726e-5b55-45cf-82ee-cd075cb91118
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160617Z:fd87de94-96d0-4fd3-8ce5-5289b27055eb
+      - NORTHCENTRALUS:20160203T194324Z:9bb9726e-5b55-45cf-82ee-cd075cb91118
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:16 GMT
+      - Wed, 03 Feb 2016 19:43:23 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,61 +558,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -958,11 +632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -981,22 +655,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 5b230f58-4850-4a13-821b-5da9cd71b85e
-      - 6fe065a5-e44b-4665-b2cf-b863df87c81a
+      - 48ed37cd-0d45-4c24-b185-a44a46b83561
+      - 9674737f-db6f-4710-9818-398d70ce9bf5
+      - d03298a6-b4bb-4e3e-a874-67a491a1ee7a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14909'
       X-Ms-Request-Id:
-      - 18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      - 1402b2d3-030d-4986-8c12-7127e0c9a8d3
       X-Ms-Correlation-Request-Id:
-      - 18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      - 1402b2d3-030d-4986-8c12-7127e0c9a8d3
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160617Z:18fadc06-5c3a-4d10-bcbe-c265ca74a522
+      - NORTHCENTRALUS:20160203T194325Z:1402b2d3-030d-4986-8c12-7127e0c9a8d3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:17 GMT
+      - Wed, 03 Feb 2016 19:43:24 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1007,61 +682,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1071,11 +756,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1094,22 +779,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2d451ba9-5ade-4230-9bad-74a35ea2e8d9
-      - 660a9256-d1e4-4a42-97d3-964027ae36af
+      - 23163642-0afd-46ad-817d-968160a029af
+      - 46f16d92-8cbd-469e-9717-fdd3520ba573
+      - c00289ee-621f-44ae-9dd1-fb8cd729e4b2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14896'
       X-Ms-Request-Id:
-      - 5e23b520-2edf-423b-bd5f-75f6c002f57c
+      - c7c8827d-2403-4708-8e49-516121cea409
       X-Ms-Correlation-Request-Id:
-      - 5e23b520-2edf-423b-bd5f-75f6c002f57c
+      - c7c8827d-2403-4708-8e49-516121cea409
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160618Z:5e23b520-2edf-423b-bd5f-75f6c002f57c
+      - NORTHCENTRALUS:20160203T194325Z:c7c8827d-2403-4708-8e49-516121cea409
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:18 GMT
+      - Wed, 03 Feb 2016 19:43:25 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1120,61 +806,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1184,11 +880,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1207,22 +903,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - c5ce66fe-44db-4d1e-9998-d738296dd038
-      - f5f8d342-f804-4352-909e-8f603230c150
+      - 03b1c05d-6df6-4d29-8926-17280e3fde20
+      - 6a0b7a38-be04-4e14-a8b9-876e2512c357
+      - c405771a-b7d8-4fab-895f-f73361159bd2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14898'
       X-Ms-Request-Id:
-      - 1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      - 79d26432-bc5d-4bf1-8613-cb05b236ac83
       X-Ms-Correlation-Request-Id:
-      - 1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      - 79d26432-bc5d-4bf1-8613-cb05b236ac83
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160618Z:1f815d0d-61c2-424f-8ff0-76e2c96beff5
+      - NORTHCENTRALUS:20160203T194326Z:79d26432-bc5d-4bf1-8613-cb05b236ac83
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:18 GMT
+      - Wed, 03 Feb 2016 19:43:25 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1233,61 +930,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1297,11 +1004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1320,22 +1027,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 52d1fec1-6740-4976-9224-a749acf9dd5a
-      - 8044f5bf-7ac2-485c-825f-950b934e0eec
+      - 57e29a91-52ce-4791-bd9f-1e1fdc48c0a0
+      - 747f00bf-1d56-4e64-9a94-03a97f7a4936
+      - e192c39e-ff0c-4a1a-a3a6-26318d9e798a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14904'
       X-Ms-Request-Id:
-      - 9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      - 1bc70331-eee6-4014-a18b-18b49b5e0535
       X-Ms-Correlation-Request-Id:
-      - 9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      - 1bc70331-eee6-4014-a18b-18b49b5e0535
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160619Z:9ab41ba7-6ec8-41e3-b498-a15e9bb80371
+      - NORTHCENTRALUS:20160203T194326Z:1bc70331-eee6-4014-a18b-18b49b5e0535
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:18 GMT
+      - Wed, 03 Feb 2016 19:43:26 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1346,61 +1054,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1410,11 +1128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1433,22 +1151,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4003aeb5-e9be-41ed-8a28-056b9f0f94fd
-      - b7439c3f-15c7-4cbf-94af-545d27729f37
+      - 67843a5f-59d7-4236-ac45-f6b1e1f630a8
+      - d5be1ec4-f0ab-44a6-b690-762f52dbc342
+      - ecfa12ab-29c7-4fb4-9c6d-100841303948
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14906'
       X-Ms-Request-Id:
-      - 85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      - 4600dab1-ea01-49d1-add5-318ff4cd88a0
       X-Ms-Correlation-Request-Id:
-      - 85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      - 4600dab1-ea01-49d1-add5-318ff4cd88a0
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160619Z:85cbaf6f-f6f5-4b73-8cd9-f07a6eb25a6f
+      - NORTHCENTRALUS:20160203T194327Z:4600dab1-ea01-49d1-add5-318ff4cd88a0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:19 GMT
+      - Wed, 03 Feb 2016 19:43:26 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1459,61 +1178,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1523,11 +1252,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1546,22 +1275,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1009f555-0dd6-4fe1-8903-ed73d5b0585a
-      - 2c056b43-967b-492d-a983-0d31fe5cc854
+      - a0f2e239-6f45-4200-98f0-487eaddf7c9a
+      - b1c725c4-32c2-4df5-916c-1bdb17d398d1
+      - b981b441-4686-4efc-a705-83cb5404025f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14906'
       X-Ms-Request-Id:
-      - 0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      - 9ebae5fd-97b8-481b-abfc-4d7fd96570c8
       X-Ms-Correlation-Request-Id:
-      - 0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      - 9ebae5fd-97b8-481b-abfc-4d7fd96570c8
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160620Z:0b3be6e8-9fee-4108-91fb-7116a55bec3b
+      - NORTHCENTRALUS:20160203T194327Z:9ebae5fd-97b8-481b-abfc-4d7fd96570c8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:19 GMT
+      - Wed, 03 Feb 2016 19:43:27 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1572,61 +1302,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1636,11 +1376,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1659,22 +1399,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 314a21c9-fde9-4d21-ba01-1f9c29199046
-      - c283b145-1acf-4fa9-b615-d6b91edda304
+      - 679b5175-21c1-4ff7-9846-fa40982997eb
+      - cd1a01e4-8575-486f-a364-34e3478b4f6b
+      - f7fff166-c8a6-41e2-a859-a657185e9370
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14905'
       X-Ms-Request-Id:
-      - 9041a700-4a73-414f-aa08-459eeced0a32
+      - 5383c5a3-fe0e-4bd2-9296-43077f58becf
       X-Ms-Correlation-Request-Id:
-      - 9041a700-4a73-414f-aa08-459eeced0a32
+      - 5383c5a3-fe0e-4bd2-9296-43077f58becf
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160620Z:9041a700-4a73-414f-aa08-459eeced0a32
+      - NORTHCENTRALUS:20160203T194328Z:5383c5a3-fe0e-4bd2-9296-43077f58becf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:20 GMT
+      - Wed, 03 Feb 2016 19:43:28 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1685,61 +1426,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1749,11 +1500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1772,22 +1523,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b2a6a1ce-eae4-41c9-ba96-60ebb2cdebe5
-      - e0cfe62b-536a-491e-8778-7dad8d3f991e
+      - 8e3ffb2a-4885-4843-8936-d9a90bfa35b7
+      - f6f12b36-f60f-4bde-8a47-c1511af1a456
+      - f8437b1b-de3f-466e-aa3b-5c64b18c64cc
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14911'
       X-Ms-Request-Id:
-      - e0cc3885-c215-41a8-8820-d753b6080f7b
+      - e87d8bcc-4851-4e07-82ce-2995a3664f1a
       X-Ms-Correlation-Request-Id:
-      - e0cc3885-c215-41a8-8820-d753b6080f7b
+      - e87d8bcc-4851-4e07-82ce-2995a3664f1a
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160621Z:e0cc3885-c215-41a8-8820-d753b6080f7b
+      - NORTHCENTRALUS:20160203T194328Z:e87d8bcc-4851-4e07-82ce-2995a3664f1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:21 GMT
+      - Wed, 03 Feb 2016 19:43:28 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1798,61 +1550,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1862,11 +1624,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1885,22 +1647,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 467f6e57-f833-4d55-a19e-f7e3ab7733d2
-      - b5cbb65b-2a02-4fcf-b72c-b97bea668ee4
+      - 10916ebe-4d93-416c-a746-4af5f8278384
+      - 11e938c2-39e3-44b5-8c34-e9e5ac10e20b
+      - d924d114-4ff6-4e76-a0f5-a24a500e5057
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14906'
       X-Ms-Request-Id:
-      - 349fb902-e445-424a-ab73-3bdb3b467469
+      - d5b4f1d9-d0de-455d-9494-1b026800944d
       X-Ms-Correlation-Request-Id:
-      - 349fb902-e445-424a-ab73-3bdb3b467469
+      - d5b4f1d9-d0de-455d-9494-1b026800944d
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160622Z:349fb902-e445-424a-ab73-3bdb3b467469
+      - NORTHCENTRALUS:20160203T194329Z:d5b4f1d9-d0de-455d-9494-1b026800944d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:21 GMT
+      - Wed, 03 Feb 2016 19:43:28 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1911,61 +1674,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1975,11 +1748,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1998,22 +1771,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a700307d-43bd-45fd-9081-844c4615bb20
-      - d7189e1a-b17b-433e-bccf-04b0101be3c5
+      - 76834966-7932-41d1-9bf7-4f179b003af7
+      - c516756a-1429-4749-873a-b4a99ac2831e
+      - f0420535-4cd6-48be-b0ef-9e1e88ea743b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14912'
       X-Ms-Request-Id:
-      - 09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      - 404d82d2-71c5-4119-aeea-6e4a33af74ea
       X-Ms-Correlation-Request-Id:
-      - 09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      - 404d82d2-71c5-4119-aeea-6e4a33af74ea
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160622Z:09143ec0-0a62-49dd-901b-301e2d2c1f7b
+      - NORTHCENTRALUS:20160203T194330Z:404d82d2-71c5-4119-aeea-6e4a33af74ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:22 GMT
+      - Wed, 03 Feb 2016 19:43:30 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2024,61 +1798,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2088,11 +1872,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2111,22 +1895,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 136248a7-f348-4e58-9c18-3e161554cdaa
-      - 5eb9fb42-22d7-44e8-aa98-5d554a69ac83
+      - 291b58ac-8c1a-4ec3-b9ae-433c56eca6df
+      - bea31809-65f5-4714-b7eb-122e74b0a1a8
+      - cdfe752c-84ec-49b9-9beb-6eb07f598db0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14905'
       X-Ms-Request-Id:
-      - 90fe193b-4d26-4482-881d-608b015cea6f
+      - 0257768e-17b9-4745-8b52-4df9387964f6
       X-Ms-Correlation-Request-Id:
-      - 90fe193b-4d26-4482-881d-608b015cea6f
+      - 0257768e-17b9-4745-8b52-4df9387964f6
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160622Z:90fe193b-4d26-4482-881d-608b015cea6f
+      - NORTHCENTRALUS:20160203T194330Z:0257768e-17b9-4745-8b52-4df9387964f6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:22 GMT
+      - Wed, 03 Feb 2016 19:43:30 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2137,61 +1922,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2201,11 +1996,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2224,22 +2019,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 20760a4d-9a5c-4a02-8d60-ac16ee1116fe
-      - cf6cea42-3b2e-4310-9080-3d7db2aeefa8
+      - 51cc700a-8072-487d-ad33-5a9dc70f2cca
+      - a700b1f7-56a2-4716-a9c0-a73cf498d301
+      - e0768263-4648-4bbb-8ddc-3c9d2977d193
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14901'
       X-Ms-Request-Id:
-      - 23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      - 85d49189-8036-4721-8afc-7fb925b0f8fe
       X-Ms-Correlation-Request-Id:
-      - 23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      - 85d49189-8036-4721-8afc-7fb925b0f8fe
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160623Z:23c25429-5145-4ff8-b0e1-e1d5c718ad13
+      - NORTHCENTRALUS:20160203T194331Z:85d49189-8036-4721-8afc-7fb925b0f8fe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:23 GMT
+      - Wed, 03 Feb 2016 19:43:31 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2250,61 +2046,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2314,11 +2120,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2337,22 +2143,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 9fede14c-481f-4071-b4d3-781761db060d
-      - fc4fb2ca-4a93-49be-a504-5a209cc28d0b
+      - ad90c7ef-c713-4245-9db0-5475d7fda4a2
+      - b779bac3-4a6f-4c97-a264-249b6f5176e9
+      - f450f4d7-85aa-42a9-9582-b14ea3d5d7f8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14901'
       X-Ms-Request-Id:
-      - ba2a2406-0642-47b4-b977-361f58c548f0
+      - dab1f9b2-78ff-4936-93dd-e30ae3cf052e
       X-Ms-Correlation-Request-Id:
-      - ba2a2406-0642-47b4-b977-361f58c548f0
+      - dab1f9b2-78ff-4936-93dd-e30ae3cf052e
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160623Z:ba2a2406-0642-47b4-b977-361f58c548f0
+      - NORTHCENTRALUS:20160203T194332Z:dab1f9b2-78ff-4936-93dd-e30ae3cf052e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:23 GMT
+      - Wed, 03 Feb 2016 19:43:31 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2363,61 +2170,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:22 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2427,11 +2244,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2450,22 +2267,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4d8b9c3e-0e0c-4c34-8953-d390fc7eaada
-      - ccdef002-e171-46f5-9ef6-8913d11a5124
+      - 01398bb9-c55a-4c54-bf8d-d92050925b63
+      - 050e953d-7c15-48f0-bfa8-9082b05a5546
+      - 91ac92ae-a8e3-4cee-90ed-6d15f958f0e7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14893'
       X-Ms-Request-Id:
-      - 8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      - d64b201f-9ab4-46e4-bf72-c97937cd09e5
       X-Ms-Correlation-Request-Id:
-      - 8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      - d64b201f-9ab4-46e4-bf72-c97937cd09e5
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160624Z:8622ca99-5b0e-4fa2-87d5-ca70c1d6799b
+      - NORTHCENTRALUS:20160203T194332Z:d64b201f-9ab4-46e4-bf72-c97937cd09e5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:24 GMT
+      - Wed, 03 Feb 2016 19:43:32 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2476,61 +2294,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:23 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2540,11 +2368,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2563,22 +2391,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 20f2074c-8a50-4e16-963b-a9fe85cbc80d
-      - 76ec443f-cf08-4c79-95b1-5f72b2986e64
+      - 02c64278-46c6-46bb-94db-ac442c665351
+      - aa524fe5-0a89-443b-bcf7-204fa0198482
+      - b49f6159-490d-4321-8deb-9bf29f18695f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14907'
       X-Ms-Request-Id:
-      - 40719cd3-9bd0-4ef3-945d-147b075a7303
+      - ed3efcf4-de38-42a1-8f95-33e9e2d56307
       X-Ms-Correlation-Request-Id:
-      - 40719cd3-9bd0-4ef3-945d-147b075a7303
+      - ed3efcf4-de38-42a1-8f95-33e9e2d56307
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160625Z:40719cd3-9bd0-4ef3-945d-147b075a7303
+      - NORTHCENTRALUS:20160203T194333Z:ed3efcf4-de38-42a1-8f95-33e9e2d56307
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:24 GMT
+      - Wed, 03 Feb 2016 19:43:32 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2589,61 +2418,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:23 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2653,11 +2492,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2676,22 +2515,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - bf5e1016-a7e5-4bc9-8352-903b6a7abc00
-      - fe2ba23e-928b-45f1-bd7e-66743c07357e
+      - 9573869f-6cd3-4321-a5bc-5a5ea0c2a826
+      - a29db8e2-cdd7-46a5-8739-51f066cbfc77
+      - b553da6a-38ce-4fe1-90f5-2a219bbbd988
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14908'
       X-Ms-Request-Id:
-      - 918567fe-3e55-4d94-9a08-9f3220022e84
+      - f4e58714-446c-4099-9d87-abaf9be33a98
       X-Ms-Correlation-Request-Id:
-      - 918567fe-3e55-4d94-9a08-9f3220022e84
+      - f4e58714-446c-4099-9d87-abaf9be33a98
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160625Z:918567fe-3e55-4d94-9a08-9f3220022e84
+      - NORTHCENTRALUS:20160203T194334Z:f4e58714-446c-4099-9d87-abaf9be33a98
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:25 GMT
+      - Wed, 03 Feb 2016 19:43:33 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2702,61 +2542,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2766,11 +2616,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2789,22 +2639,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 948aa5b7-cf4f-4757-a533-604ce0e085ec
-      - e75823d5-3a28-4314-a908-3d1d32f2540a
+      - 04926b34-9856-475f-bf5d-b048bee2d7a8
+      - dfda427d-d777-482d-aa4d-e0d467f90617
+      - f1c350e7-f4cb-4fda-b139-b16d99f2b3f7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14895'
       X-Ms-Request-Id:
-      - 5d883e2d-0986-4426-aeed-a16e38eaec5e
+      - dae17873-fb51-48f7-bd47-48ac38260296
       X-Ms-Correlation-Request-Id:
-      - 5d883e2d-0986-4426-aeed-a16e38eaec5e
+      - dae17873-fb51-48f7-bd47-48ac38260296
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160626Z:5d883e2d-0986-4426-aeed-a16e38eaec5e
+      - NORTHCENTRALUS:20160203T194334Z:dae17873-fb51-48f7-bd47-48ac38260296
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:26 GMT
+      - Wed, 03 Feb 2016 19:43:34 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2815,61 +2666,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2879,11 +2740,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2902,22 +2763,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 7eb38320-9542-4901-bbd3-44ecf3534bd6
-      - ddbce0a3-c7ca-42cc-8997-63dbbcf2768b
+      - 30b54a9d-8730-4192-ad6b-948cc3c7c115
+      - 9571f86d-3207-4858-b888-3661afad067f
+      - bbd263e9-2678-454b-9a43-3c0bfb3e1ec8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14897'
       X-Ms-Request-Id:
-      - ada9dccb-8da4-4d94-8604-2b3864ea9378
+      - c0a5bfb3-87d7-4ddc-9591-08705abb4e39
       X-Ms-Correlation-Request-Id:
-      - ada9dccb-8da4-4d94-8604-2b3864ea9378
+      - c0a5bfb3-87d7-4ddc-9591-08705abb4e39
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160626Z:ada9dccb-8da4-4d94-8604-2b3864ea9378
+      - NORTHCENTRALUS:20160203T194335Z:c0a5bfb3-87d7-4ddc-9591-08705abb4e39
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:26 GMT
+      - Wed, 03 Feb 2016 19:43:35 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2928,61 +2790,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2992,11 +2864,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3015,22 +2887,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - d5209bc4-f182-40e0-8696-4981f0a2d0e4
-      - df063519-b884-40ed-8d70-7b709fa60a52
+      - 2e04a03d-99f9-4a79-b842-c2348759bddb
+      - b09662e8-175b-4e3e-8697-75ca1590f74d
+      - bde37093-0821-4109-b8b1-cfaf4edfd029
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14903'
       X-Ms-Request-Id:
-      - 8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      - b6f53209-123c-43b4-9423-20787619999b
       X-Ms-Correlation-Request-Id:
-      - 8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      - b6f53209-123c-43b4-9423-20787619999b
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160627Z:8dd547e0-3a41-40c6-9a10-6b27d0d7c3e5
+      - NORTHCENTRALUS:20160203T194335Z:b6f53209-123c-43b4-9423-20787619999b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:27 GMT
+      - Wed, 03 Feb 2016 19:43:35 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3041,61 +2914,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3105,11 +2988,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3128,22 +3011,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 8edc4da6-7005-4c71-888e-21ee3181278a
-      - d821876d-80c6-40ae-84bf-24eab2b36682
+      - cf19a008-9ebb-4758-802b-1b022e7c0e9a
+      - f66fcdc7-1cbb-4490-a398-8857b1a90619
+      - f7b5f805-7383-4e3b-ad89-c61e1880e0ee
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14905'
       X-Ms-Request-Id:
-      - c1917c21-5e9f-46e1-852c-1318e10b6484
+      - 0e8d6c5e-570b-4d1e-8656-6ce4f509e0c2
       X-Ms-Correlation-Request-Id:
-      - c1917c21-5e9f-46e1-852c-1318e10b6484
+      - 0e8d6c5e-570b-4d1e-8656-6ce4f509e0c2
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160627Z:c1917c21-5e9f-46e1-852c-1318e10b6484
+      - NORTHCENTRALUS:20160203T194337Z:0e8d6c5e-570b-4d1e-8656-6ce4f509e0c2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:27 GMT
+      - Wed, 03 Feb 2016 19:43:36 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3154,61 +3038,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3218,11 +3112,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3241,22 +3135,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 87579a15-c14c-47ba-9f65-029029d9a709
-      - cd2ae45c-cdfd-428b-a078-53673d776883
+      - 116fefd2-47ce-45ef-bf78-bca3091ca4f8
+      - c5beb2d0-0dd0-4b00-9e36-f7e5f49245b3
+      - db7f5fd4-1d56-475b-a81e-bf6feeffa0b2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14905'
       X-Ms-Request-Id:
-      - a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      - 5528793f-f638-41a3-8b17-839a065c7b6a
       X-Ms-Correlation-Request-Id:
-      - a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      - 5528793f-f638-41a3-8b17-839a065c7b6a
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160628Z:a175066b-6e4a-433f-8a1a-0bdebf858c8d
+      - NORTHCENTRALUS:20160203T194338Z:5528793f-f638-41a3-8b17-839a065c7b6a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:28 GMT
+      - Wed, 03 Feb 2016 19:43:37 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3267,61 +3162,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3331,11 +3236,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3354,22 +3259,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6b0fe660-72f9-4cbe-979a-e6583086fff4
-      - b53c1eea-d7e2-48e4-8096-4c2e5da43774
+      - 8d66ea05-3f11-42a9-8fcb-4840aca51ff7
+      - b5885618-5ea4-4220-91bf-4502202d8783
+      - b7bcbad7-8c78-45c8-b019-9dcec2ea8c9f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14904'
       X-Ms-Request-Id:
-      - 40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      - d13cec0a-6052-4fe3-9153-889f5c0df104
       X-Ms-Correlation-Request-Id:
-      - 40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      - d13cec0a-6052-4fe3-9153-889f5c0df104
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160628Z:40c71632-4d93-4d4f-8c53-4e7a8ec60780
+      - NORTHCENTRALUS:20160203T194338Z:d13cec0a-6052-4fe3-9153-889f5c0df104
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:28 GMT
+      - Wed, 03 Feb 2016 19:43:38 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3380,61 +3286,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:27 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3444,11 +3360,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3467,22 +3383,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3e0fb4ca-8a75-477d-ab68-33f439dd14b2
-      - 87c946c8-c8c5-4f44-803c-92a8217f36a4
+      - 565c3846-921a-418e-b3fb-94a785412556
+      - c4ae810a-9fb0-431a-a146-ccd74949f401
+      - ce3f8155-8aae-4422-8319-b7cf154ed2a8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14907'
       X-Ms-Request-Id:
-      - d40f9592-d67a-4a4a-b688-330022546dff
+      - 575c05b1-ab45-4d04-a26c-55b5aa900bb4
       X-Ms-Correlation-Request-Id:
-      - d40f9592-d67a-4a4a-b688-330022546dff
+      - 575c05b1-ab45-4d04-a26c-55b5aa900bb4
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160629Z:d40f9592-d67a-4a4a-b688-330022546dff
+      - NORTHCENTRALUS:20160203T194339Z:575c05b1-ab45-4d04-a26c-55b5aa900bb4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:06:29 GMT
+      - Wed, 03 Feb 2016 19:43:39 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3493,8624 +3410,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 555201ee-93d2-4fa7-9e4e-9f34d954a89c
-      - 997c35b5-c40c-48b2-9e9c-ef3cb3d2fa72
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 34811df1-92fb-4868-b0f6-e095ad6d1892
-      X-Ms-Correlation-Request-Id:
-      - 34811df1-92fb-4868-b0f6-e095ad6d1892
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160629Z:34811df1-92fb-4868-b0f6-e095ad6d1892
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1112143b-a4ca-451f-bccd-7cf866f42ce5
-      - a66633b0-193a-4e5f-8e25-4fa0a304feb3
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - c42f54cc-a632-4b97-802c-5b950aeac821
-      X-Ms-Correlation-Request-Id:
-      - c42f54cc-a632-4b97-802c-5b950aeac821
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160630Z:c42f54cc-a632-4b97-802c-5b950aeac821
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - c22997b4-983b-4582-848c-8ffac2b09d73
-      - eb9f8d71-d065-4200-91c0-e8f980d36774
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 8f2642fd-4200-4780-9a34-b5d2c5503490
-      X-Ms-Correlation-Request-Id:
-      - 8f2642fd-4200-4780-9a34-b5d2c5503490
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160630Z:8f2642fd-4200-4780-9a34-b5d2c5503490
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 54c4fdb6-ca86-4bae-824f-62b8f8a3cb90
-      - d7f20717-0ac3-4c7d-b844-bfd126cc0109
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 5d3a9434-aa7e-4dbb-b0fc-463633c36d09
-      X-Ms-Correlation-Request-Id:
-      - 5d3a9434-aa7e-4dbb-b0fc-463633c36d09
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160631Z:5d3a9434-aa7e-4dbb-b0fc-463633c36d09
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 72f2187f-b0cc-4c36-99e9-1b2cff0f535f
-      - c0a286d2-ce93-4730-8594-0772d92ca023
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 07292aae-25f4-4487-ba85-eeb4bc5c469a
-      X-Ms-Correlation-Request-Id:
-      - 07292aae-25f4-4487-ba85-eeb4bc5c469a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160631Z:07292aae-25f4-4487-ba85-eeb4bc5c469a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - b705733e-b2d6-4e8a-ac73-ee9233e8cec4
-      - ba5149d9-e3ae-4fb1-8c68-e001259dd58e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 5583345b-3aed-493f-af77-b0bf11c5becc
-      X-Ms-Correlation-Request-Id:
-      - 5583345b-3aed-493f-af77-b0bf11c5becc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160632Z:5583345b-3aed-493f-af77-b0bf11c5becc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 31988902-18cb-4cf8-9b3f-fd689e028841
-      - bdf3ae49-6f9a-4135-a1f0-561916ebf8d2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 11993a3b-8d8a-439c-8d04-5863d6678216
-      X-Ms-Correlation-Request-Id:
-      - 11993a3b-8d8a-439c-8d04-5863d6678216
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160632Z:11993a3b-8d8a-439c-8d04-5863d6678216
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 3c582b99-0ac9-42fa-a2a4-62fa9eefa362
-      - bf6a7f8d-44d7-4c30-9f5c-1cd1fff2ef5f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 738c6eff-0812-4046-b139-c9938878d5d0
-      X-Ms-Correlation-Request-Id:
-      - 738c6eff-0812-4046-b139-c9938878d5d0
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160633Z:738c6eff-0812-4046-b139-c9938878d5d0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - b7f65517-9b50-402d-a966-09d8faf574f9
-      - ea2ce756-225c-4a35-a646-b44e031fa35d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 542d3b9c-4883-43c5-b3d4-91bb8ea03dff
-      X-Ms-Correlation-Request-Id:
-      - 542d3b9c-4883-43c5-b3d4-91bb8ea03dff
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160633Z:542d3b9c-4883-43c5-b3d4-91bb8ea03dff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - b49ffe75-3def-4b70-ae2b-2e2224e0d2b9
-      - cef570fb-9f09-461c-aef0-4588d4bc6175
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 10140cfe-7d77-4dba-9b6f-598485fc08fa
-      X-Ms-Correlation-Request-Id:
-      - 10140cfe-7d77-4dba-9b6f-598485fc08fa
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160634Z:10140cfe-7d77-4dba-9b6f-598485fc08fa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2423044f-8704-405a-8872-f26c05979839
-      - f4ebdd36-3e3d-4bfb-bbde-4aba1bb221c0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - ef6a31f0-7496-4514-8a6d-15a93547e586
-      X-Ms-Correlation-Request-Id:
-      - ef6a31f0-7496-4514-8a6d-15a93547e586
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160634Z:ef6a31f0-7496-4514-8a6d-15a93547e586
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2e63acc3-e08b-4c65-aaab-48b67645940a
-      - f11e54a1-d48d-4069-80a9-d995311517c3
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 5752a446-37b9-4283-a689-9b49d1a6e93e
-      X-Ms-Correlation-Request-Id:
-      - 5752a446-37b9-4283-a689-9b49d1a6e93e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160634Z:5752a446-37b9-4283-a689-9b49d1a6e93e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - cd3a1e15-107b-43d7-92bf-5f8cd36a613b
-      - f96dd53f-c46e-4e65-9c11-3d5143173aca
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 4e5460cf-1adb-4d17-a699-37519a2f3e53
-      X-Ms-Correlation-Request-Id:
-      - 4e5460cf-1adb-4d17-a699-37519a2f3e53
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160635Z:4e5460cf-1adb-4d17-a699-37519a2f3e53
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 966ec10d-effb-47e3-92fa-ddf99e7901cc
-      - ad918320-bee5-420f-916b-58fa1fc717fc
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
-      X-Ms-Correlation-Request-Id:
-      - dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160635Z:dde18b6c-54d0-4cfc-b5a3-e0da81b89ac7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 316c5cbe-6cee-47ad-8bd0-c5c984921ed7
-      - 3d572cba-b640-4d13-ab86-6b270f2cf808
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - c45bba8f-94ba-4b97-b98e-aecdf9e464e2
-      X-Ms-Correlation-Request-Id:
-      - c45bba8f-94ba-4b97-b98e-aecdf9e464e2
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160636Z:c45bba8f-94ba-4b97-b98e-aecdf9e464e2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:35 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2e4e5475-08e4-48e4-befa-31cdba71eaa6
-      - c52ad923-d50c-42fe-ac2b-a0d62f338589
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
-      X-Ms-Correlation-Request-Id:
-      - b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160636Z:b77b50ef-6c96-43c7-9a61-1479aaa8cf5d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:36 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - af5bc45d-3f44-4b39-9ff8-518a3e8d8fb1
-      - eca0c68c-6a51-422c-b808-362e703f5d13
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 3fb07f40-b547-4b56-a88f-660d4bdefa3b
-      X-Ms-Correlation-Request-Id:
-      - 3fb07f40-b547-4b56-a88f-660d4bdefa3b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160637Z:3fb07f40-b547-4b56-a88f-660d4bdefa3b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:36 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8ce1cdb1-c471-47ef-98c6-29b6ec0ae02a
-      - f04ea275-6b48-4f6e-8574-d793df6a0580
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - f142d144-fc45-4e6a-8de0-998ef5004ce1
-      X-Ms-Correlation-Request-Id:
-      - f142d144-fc45-4e6a-8de0-998ef5004ce1
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160637Z:f142d144-fc45-4e6a-8de0-998ef5004ce1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7412664a-15a6-4881-b203-30bb1bbee775
-      - fe8a60b1-9ab9-4d56-b577-2db403124ea0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - b739f750-eaf9-489d-a7e5-0654b021372d
-      X-Ms-Correlation-Request-Id:
-      - b739f750-eaf9-489d-a7e5-0654b021372d
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160638Z:b739f750-eaf9-489d-a7e5-0654b021372d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6b130eb9-51b5-45df-a708-fd90826d587c
-      - dd36478b-ecbc-4949-9c1a-5e03c4c604e6
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 1e4ba712-47ec-411c-9a26-a266f4943997
-      X-Ms-Correlation-Request-Id:
-      - 1e4ba712-47ec-411c-9a26-a266f4943997
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160638Z:1e4ba712-47ec-411c-9a26-a266f4943997
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:37 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6afcab65-bed8-4d60-b8ff-dfcfec42313f
-      - b02acd64-ac15-4a87-bf92-54ed0e16bb3d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 291f9210-6bad-4594-956b-17ae442e185b
-      X-Ms-Correlation-Request-Id:
-      - 291f9210-6bad-4594-956b-17ae442e185b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160639Z:291f9210-6bad-4594-956b-17ae442e185b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:38 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 0a9f6778-1f00-4850-a044-2b4eb6204992
-      - ad2d65ac-a9a1-486b-9df2-1d0ef9183587
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 56e75b9a-c9fe-4ee2-bdd9-20139756eebc
-      X-Ms-Correlation-Request-Id:
-      - 56e75b9a-c9fe-4ee2-bdd9-20139756eebc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160639Z:56e75b9a-c9fe-4ee2-bdd9-20139756eebc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:38 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 002428ee-2beb-4515-a1f8-f44c3140ff75
-      - 0286f669-0f06-48f0-89e5-645033bb852f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - f311357e-cc31-4c97-acdd-bb4223636ee6
-      X-Ms-Correlation-Request-Id:
-      - f311357e-cc31-4c97-acdd-bb4223636ee6
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160639Z:f311357e-cc31-4c97-acdd-bb4223636ee6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 341b92f3-4f19-48bc-bbe6-75b9b45edf03
-      - 7216bf33-6fa5-4ca5-91c1-f7a841c291a2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 7f5a32b5-a38e-4e76-83d1-580ab385e1cc
-      X-Ms-Correlation-Request-Id:
-      - 7f5a32b5-a38e-4e76-83d1-580ab385e1cc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160640Z:7f5a32b5-a38e-4e76-83d1-580ab385e1cc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:39 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 976bb79d-6403-460b-b270-f008f6375fb2
-      - c80c8b2c-2800-47f9-9a53-edf1b1e6d11b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - f627bda7-b076-47cf-acd5-2ec3f31bbc84
-      X-Ms-Correlation-Request-Id:
-      - f627bda7-b076-47cf-acd5-2ec3f31bbc84
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160640Z:f627bda7-b076-47cf-acd5-2ec3f31bbc84
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:40 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 11d39ccb-0228-4c1c-b6d3-5573b1050714
-      - a580d96c-64e7-4d3b-987b-16ef38cd1fc0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - edffbab1-dc9c-4b76-b0fb-40108a22d60e
-      X-Ms-Correlation-Request-Id:
-      - edffbab1-dc9c-4b76-b0fb-40108a22d60e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160641Z:edffbab1-dc9c-4b76-b0fb-40108a22d60e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:40 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7544fffd-5848-4ff3-bd73-15c039f36c36
-      - 7d6d7f91-754e-4cbc-babc-80c224c4923b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 23ccfca2-8278-40c4-9c26-707b967fe9d3
-      X-Ms-Correlation-Request-Id:
-      - 23ccfca2-8278-40c4-9c26-707b967fe9d3
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160641Z:23ccfca2-8278-40c4-9c26-707b967fe9d3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:40 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 618081cb-a36e-4418-a054-48d7e993f061
-      - 970c63ec-c32c-4260-8bf2-43316ad61f86
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - c7505d81-5e81-4b04-904a-5d4034e1a4ad
-      X-Ms-Correlation-Request-Id:
-      - c7505d81-5e81-4b04-904a-5d4034e1a4ad
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160642Z:c7505d81-5e81-4b04-904a-5d4034e1a4ad
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:41 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
-      X-Ms-Correlation-Request-Id:
-      - 2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160642Z:2dcdf8eb-8179-40fe-9c06-b932ecf5bffc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:41 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - ca4bd3f8-c48e-4e72-93a3-d378e8255f2e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - dca3f331-224c-4112-8f7b-2fcb000085eb
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160643Z:dca3f331-224c-4112-8f7b-2fcb000085eb
-      Date:
-      - Wed, 28 Oct 2015 16:06:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 1daac3e2-bf34-4fae-bcc0-7f2d893a7526
-      X-Ms-Correlation-Request-Id:
-      - 1daac3e2-bf34-4fae-bcc0-7f2d893a7526
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160644Z:1daac3e2-bf34-4fae-bcc0-7f2d893a7526
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:43 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 75fe929f-1758-40dc-9e00-68e274b55743
-      X-Ms-Correlation-Request-Id:
-      - 75fe929f-1758-40dc-9e00-68e274b55743
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160644Z:75fe929f-1758-40dc-9e00-68e274b55743
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:44 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - ed41f461-51eb-4f9e-8de1-dac1a867f396
-      X-Ms-Correlation-Request-Id:
-      - ed41f461-51eb-4f9e-8de1-dac1a867f396
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160645Z:ed41f461-51eb-4f9e-8de1-dac1a867f396
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:45 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a2a145d4-cc1b-4b58-9838-c7bfaab6d21e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 295dd2b2-599e-439a-99ff-1542292cff9e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160646Z:295dd2b2-599e-439a-99ff-1542292cff9e
-      Date:
-      - Wed, 28 Oct 2015 16:06:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - a04053e9-7a93-4e8b-a64a-1d661e0ebda0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 99566903-55a3-4f30-98c1-7de3f4b19fdf
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160646Z:99566903-55a3-4f30-98c1-7de3f4b19fdf
-      Date:
-      - Wed, 28 Oct 2015 16:06:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 7702a149-7761-434e-9ee9-7c175b38d5ae
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 414b080e-dbe7-429a-b22d-1d41b1c572c7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160646Z:414b080e-dbe7-429a-b22d-1d41b1c572c7
-      Date:
-      - Wed, 28 Oct 2015 16:06:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz6aP9Tz/Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATq6594/jqvL/P6aX7puo3Sznsd
-        zwb6NevpNM9n+cxBxOPod7Y8rzrfEaYh+Xyw6RDEGHHuP9p/8Oj+/vjhvU/v
-        37+33yESkcb8yoTSv7/PcD+aVFX7tMgullXTFlPgoWOm0S6bqsxfT+s8Xzbz
-        qn1SVpOv6oKafDRv21Xz6O7dq7xpp1XWtLNJc//hp3vjCbUZT6s6H18Vy1l1
-        1YyXeXsXncxcJ9vNLyobnoPtnXsP89l072D7fn6ws72/s7O3PZndn27v33+Y
-        7c+y+7t7B/t3/Skb3+aNcWORHk8WKyaF8kf+rqUviMgYqs60jpi+NUzyRTGt
-        q6Y6b8dn1Phi3jbjn/zCI9PrvG1plhqGTLDxQwnaZyQH/r0YaIh53p9xNjPN
-        w4e7uw93A6YRWkUxr67yGj3nd2d5VpbVlH71u7o10qQLfAjSUAj5Gye/5P8B
-        DhRlSkAFAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 251d73f2-bf08-4ee3-b8ae-feb28f3aef99
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - b60d9bce-05c1-457e-bc42-53616407fa61
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160647Z:b60d9bce-05c1-457e-bc42-53616407fa61
-      Date:
-      - Wed, 28 Oct 2015 16:06:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
-        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
-        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
-        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
-        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
-        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
-        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
-        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
-        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
-        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
-        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8ca1edf9-2faa-4758-91c6-cf1ce7c5f21f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - dd932738-6f54-41fc-b8f9-34e2420b9cdc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160648Z:dd932738-6f54-41fc-b8f9-34e2420b9cdc
-      Date:
-      - Wed, 28 Oct 2015 16:06:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
-      X-Ms-Correlation-Request-Id:
-      - b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160649Z:b9e7574b-4e5a-4ca6-bf39-9037cfc2574b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:49 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 1d87e490-9c3f-44eb-89a4-fb95a0b78746
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 4d5ed352-21c7-4c63-a846-5d8c6ed82770
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160650Z:4d5ed352-21c7-4c63-a846-5d8c6ed82770
-      Date:
-      - Wed, 28 Oct 2015 16:06:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - bba3203c-b17c-4da1-93aa-54c66723b5e5
-      X-Ms-Correlation-Request-Id:
-      - bba3203c-b17c-4da1-93aa-54c66723b5e5
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160650Z:bba3203c-b17c-4da1-93aa-54c66723b5e5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:50 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 83d8ee28-1dbe-4880-9cf7-7e1cabec186e
-      X-Ms-Correlation-Request-Id:
-      - 83d8ee28-1dbe-4880-9cf7-7e1cabec186e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160651Z:83d8ee28-1dbe-4880-9cf7-7e1cabec186e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:50 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 16546bdf-6f12-487f-adbd-03248d7cb544
-      X-Ms-Correlation-Request-Id:
-      - 16546bdf-6f12-487f-adbd-03248d7cb544
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160652Z:16546bdf-6f12-487f-adbd-03248d7cb544
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:51 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 26a1172d-902c-47c0-99e6-ebd2705da4a1
-      X-Ms-Correlation-Request-Id:
-      - 26a1172d-902c-47c0-99e6-ebd2705da4a1
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160652Z:26a1172d-902c-47c0-99e6-ebd2705da4a1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
-      X-Ms-Correlation-Request-Id:
-      - f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160653Z:f863eccf-55c0-4e3d-8dea-bc0d1ffda0bd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:52 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 943a5b87-3460-4b14-a85e-8a5ed0c82dfe
-      X-Ms-Correlation-Request-Id:
-      - 943a5b87-3460-4b14-a85e-8a5ed0c82dfe
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160653Z:943a5b87-3460-4b14-a85e-8a5ed0c82dfe
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:52 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - b575e49c-8fd6-4d7c-801c-903446936585
-      X-Ms-Correlation-Request-Id:
-      - b575e49c-8fd6-4d7c-801c-903446936585
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160653Z:b575e49c-8fd6-4d7c-801c-903446936585
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:53 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - de8d65eb-5133-426b-ad51-0a79d239bc8f
-      X-Ms-Correlation-Request-Id:
-      - de8d65eb-5133-426b-ad51-0a79d239bc8f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160654Z:de8d65eb-5133-426b-ad51-0a79d239bc8f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:53 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - f07ca7ef-f603-48bc-bf64-d0c58a2bce73
-      X-Ms-Correlation-Request-Id:
-      - f07ca7ef-f603-48bc-bf64-d0c58a2bce73
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160654Z:f07ca7ef-f603-48bc-bf64-d0c58a2bce73
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:54 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 2f59938c-48a8-4f81-93d5-4fa09907d149
-      X-Ms-Correlation-Request-Id:
-      - 2f59938c-48a8-4f81-93d5-4fa09907d149
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160655Z:2f59938c-48a8-4f81-93d5-4fa09907d149
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:55 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - fdadf65d-1c1d-45f8-bd45-72d360013ec8
-      X-Ms-Correlation-Request-Id:
-      - fdadf65d-1c1d-45f8-bd45-72d360013ec8
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160656Z:fdadf65d-1c1d-45f8-bd45-72d360013ec8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:55 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:54 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB271C:798A:A033321:5630F211
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:06:56 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6224-ATL
-      X-Cache:
-      - HIT
-      X-Cache-Hits:
-      - '1'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:11:56 GMT
-      Source-Age:
-      - '143'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 59b91a1f-a12a-4191-8828-450d8baa5e16
-      X-Ms-Correlation-Request-Id:
-      - 59b91a1f-a12a-4191-8828-450d8baa5e16
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160657Z:59b91a1f-a12a-4191-8828-450d8baa5e16
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:56 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:55 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB271C:7987:40297FE:5630F211
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:06:57 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6225-ATL
-      X-Cache:
-      - HIT
-      X-Cache-Hits:
-      - '1'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:11:57 GMT
-      Source-Age:
-      - '144'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - aa25861b-864b-4e8e-a763-724ffeda7cef
-      X-Ms-Correlation-Request-Id:
-      - aa25861b-864b-4e8e-a763-724ffeda7cef
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160658Z:aa25861b-864b-4e8e-a763-724ffeda7cef
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:57 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB2714:7989:80C0DE5:5630F211
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:06:58 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6235-ATL
-      X-Cache:
-      - HIT
-      X-Cache-Hits:
-      - '1'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:11:58 GMT
-      Source-Age:
-      - '144'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 2bce695b-68a1-4645-833f-26dd5535490a
-      X-Ms-Correlation-Request-Id:
-      - 2bce695b-68a1-4645-833f-26dd5535490a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160659Z:2bce695b-68a1-4645-833f-26dd5535490a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:58 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - d5b0ff65-80cb-4f81-adfd-df3217f73a12
-      X-Ms-Correlation-Request-Id:
-      - d5b0ff65-80cb-4f81-adfd-df3217f73a12
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160659Z:d5b0ff65-80cb-4f81-adfd-df3217f73a12
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:06:59 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - dcdc1567-68db-4c38-8399-d08685c9ed4c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 4e5d4ba2-398d-418c-8b4b-73120b3e88d7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160700Z:4e5d4ba2-398d-418c-8b4b-73120b3e88d7
-      Date:
-      - Wed, 28 Oct 2015 16:07:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eb84d0a8-1f77-4615-9c63-5c1d378b6378
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 32626507-bd6b-47ac-a822-4bbdebb6dc14
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160701Z:32626507-bd6b-47ac-a822-4bbdebb6dc14
-      Date:
-      - Wed, 28 Oct 2015 16:07:00 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:06:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - cabc4e2b-ce32-45fb-b482-0794203b5f56
-      X-Ms-Correlation-Request-Id:
-      - cabc4e2b-ce32-45fb-b482-0794203b5f56
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160701Z:cabc4e2b-ce32-45fb-b482-0794203b5f56
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:01 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 52920d62-833b-4b5b-b9f1-a59798d6398d
-      X-Ms-Correlation-Request-Id:
-      - 52920d62-833b-4b5b-b9f1-a59798d6398d
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160702Z:52920d62-833b-4b5b-b9f1-a59798d6398d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:01 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5cc90cde-ad20-4316-bbe1-c72e8fd32989
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 790d8656-b833-42db-96fa-c9c8891ad2b8
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160702Z:790d8656-b833-42db-96fa-c9c8891ad2b8
-      Date:
-      - Wed, 28 Oct 2015 16:07:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 4ce7706c-61b4-4def-82e7-e72c0372ec3c
-      X-Ms-Correlation-Request-Id:
-      - 4ce7706c-61b4-4def-82e7-e72c0372ec3c
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160703Z:4ce7706c-61b4-4def-82e7-e72c0372ec3c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:02 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - abcd71e8-ee76-4b68-a27e-348be7458b1a
-      X-Ms-Correlation-Request-Id:
-      - abcd71e8-ee76-4b68-a27e-348be7458b1a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160703Z:abcd71e8-ee76-4b68-a27e-348be7458b1a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:02 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - a19654b3-b1cd-497d-a07d-b497f4962a3f
-      X-Ms-Correlation-Request-Id:
-      - a19654b3-b1cd-497d-a07d-b497f4962a3f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160703Z:a19654b3-b1cd-497d-a07d-b497f4962a3f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:03 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 8829c353-1c1b-42e4-857c-f291a88e57a1
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 3e35a61d-a4ea-4ee4-8d34-4dbe8b2a91b1
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160704Z:3e35a61d-a4ea-4ee4-8d34-4dbe8b2a91b1
-      Date:
-      - Wed, 28 Oct 2015 16:07:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 00f03466-0269-478c-9910-70160ef2aea1
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - da34d54e-bbef-496b-b1f1-2e83fdb55863
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160704Z:da34d54e-bbef-496b-b1f1-2e83fdb55863
-      Date:
-      - Wed, 28 Oct 2015 16:07:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - e06d0d37-cb27-4c50-a337-0b69addcea53
-      X-Ms-Correlation-Request-Id:
-      - e06d0d37-cb27-4c50-a337-0b69addcea53
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160705Z:e06d0d37-cb27-4c50-a337-0b69addcea53
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:04 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
-      X-Ms-Correlation-Request-Id:
-      - 5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160705Z:5e0f6aa4-9a1c-48e0-b063-6c2bd4e309d5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 88816b85-4620-48a9-ae2c-ff0cbb518388
-      X-Ms-Correlation-Request-Id:
-      - 88816b85-4620-48a9-ae2c-ff0cbb518388
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160705Z:88816b85-4620-48a9-ae2c-ff0cbb518388
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 49319d5d-9297-4437-a383-b98d8027d2b1
-      X-Ms-Correlation-Request-Id:
-      - 49319d5d-9297-4437-a383-b98d8027d2b1
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160706Z:49319d5d-9297-4437-a383-b98d8027d2b1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 455ef356-f19e-4c08-89d3-95370decf8c7
-      X-Ms-Correlation-Request-Id:
-      - 455ef356-f19e-4c08-89d3-95370decf8c7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160706Z:455ef356-f19e-4c08-89d3-95370decf8c7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:07:06 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - b9be75f5-7820-4b9b-a458-2eb8a7a9071d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 1eb763da-4edd-413f-a1e0-d38223b6aaeb
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160706Z:1eb763da-4edd-413f-a1e0-d38223b6aaeb
-      Date:
-      - Wed, 28 Oct 2015 16:07:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 7c4a00f7-b092-4e7f-bf95-8a124d3e55e4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 7eefa523-29f9-4595-9218-c1dbb2ca677d
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160707Z:7eefa523-29f9-4595-9218-c1dbb2ca677d
-      Date:
-      - Wed, 28 Oct 2015 16:07:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
-        3ux++mjnAf3vk52dRzs7H5nGv0R++T5+/BIGAUzfAkOliqXJR8tMoJ7M8/Nt
-        IsvM9Rmlpvcung0UbdbTaZ7Pcg8iHkfRs+V51fmO0AwJ6oNNhyDGKHP/0f6D
-        R/c/HT/Yv7e/92C3QyGii/mVqaR/f5/hfpS/a/MlOgUKOnI7akuxL4ppXTXV
-        eTs+o8YX87YZ/+QXT4vsYlk1bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyM1E
-        fLhzb+d+yGbCWFHMq6u8Rs/53VmelWU1pV/9rm6NNEmLD0EaCiF/4+SX/D9Z
-        37Y6YgQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 81ffed43-3acc-4c03-bee7-ab6f2427e290
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 608d7837-cb19-450f-837b-f51383f2fa68
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160707Z:608d7837-cb19-450f-837b-f51383f2fa68
-      Date:
-      - Wed, 28 Oct 2015 16:07:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
-        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
-        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
-        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
-        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
-        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
-        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
-        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
-        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
-        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
-        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c5463d1f-03f6-428e-a6c3-17ae97ccfb68
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - db735259-fddb-4f8f-aea2-9af9ecfa0c8d
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160708Z:db735259-fddb-4f8f-aea2-9af9ecfa0c8d
-      Date:
-      - Wed, 28 Oct 2015 16:07:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - b13bd001-5e77-4243-8b77-b07a2f55d537
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 3cc8c732-29d0-4a36-ab64-f04bdde189e8
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160708Z:3cc8c732-29d0-4a36-ab64-f04bdde189e8
-      Date:
-      - Wed, 28 Oct 2015 16:07:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHOw092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6smraC+p6+2l+6bqN0s57Hc8G
-        +jXr6TTPZ/nMQcTj6He2PK863xGmIfl8sOkQxBhx7j/af/Do/qfjB3sPHuwf
-        dGhElDG/Mp307+8z2I8mVdU+LbKLJVGlmAINHTINdtlUZf56Wuf5splX7ZOy
-        mnxVF9Tko3nbrppHd+9O5/n5qq5m93f3dsYT+n48rep8fFUsZ9VVM17m7V10
-        MHMdbK/oJ8g/2z6fnt+bTfPp9vnkYLa9//D8/vbD2cF0e7J7P59Nz88f7OxP
-        7/qzNb7NG+PGIjyeLFZMBmWN/F1LXxB9MUydZB0tfWv444tiWldNdd6Oz6jx
-        xbxtxj/5hUei13nb0gQ1DJlg44cSs89DDvx78c4Q37w/z2zml4c793buPwgY
-        RmgVw/zL1+g2v0sCnNdZWfwg6OfWGJMO8CFIw+FeX1ZXeY2387uzPCvLakq/
-        ft2OfQjSUKbvN05+yf8DJTk02LEFAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - faccb6cd-d14b-4ffc-8668-b741780bdded
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 74e84b8b-cee2-4629-b878-9ba71d56c6e4
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160709Z:74e84b8b-cee2-4629-b878-9ba71d56c6e4
-      Date:
-      - Wed, 28 Oct 2015 16:07:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
-        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
-        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
-        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
-        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
-        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
-        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
-        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
-        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
-        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
-        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4aba7665-16a1-4f71-b211-cbc92df7dc29
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 151a2396-ff6e-43e4-a09a-793e0690891f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160709Z:151a2396-ff6e-43e4-a09a-793e0690891f
-      Date:
-      - Wed, 28 Oct 2015 16:07:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 8f619ab5-bfdc-4c76-8cb6-de0bfcf0f49e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - 7fddf34d-6588-4165-af26-381555d7b9fb
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160710Z:7fddf34d-6588-4165-af26-381555d7b9fb
-      Date:
-      - Wed, 28 Oct 2015 16:07:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHuzic7O492
-        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUCdzvPzJq8v83rX9Rolnfc2ng3k
-        a9bTaZ7P8pmDiMeR72x5XnW+I0RD6vlg0yGIMdrcf7S/9+j+wfjg3v3dh5/e
-        69CIKGN+ZTrp399nuB/l79qcpoCmgaDqyO2oLc2+KKZ11VTn7fiMGl/M22b8
-        k188LbKLZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPxYG93f/9+QERh
-        rSjm1VVeo+f87izPyrKa0q9+V7dGmkTDhyANhZC/cfJL/h/2arQOTwQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2039879e-38c9-4861-91b6-67366bd61953
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 11b6d935-500d-4bb7-945f-62e027ab2cf6
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160710Z:11b6d935-500d-4bb7-945f-62e027ab2cf6
-      Date:
-      - Wed, 28 Oct 2015 16:07:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
-        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
-        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
-        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
-        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
-        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
-        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
-        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
-        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
-        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - ca9b8cd5-1fd7-43d1-b0a7-edf2bab467c3
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - aab48c77-540e-4cdc-9b2f-3daf46240c3e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160711Z:aab48c77-540e-4cdc-9b2f-3daf46240c3e
-      Date:
-      - Wed, 28 Oct 2015 16:07:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu7ic7O492
-        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUA9ffXS9RYlmfcWng1ka9bTaZ7P
-        8pmDiMeR7Wx5XnW+IwRDqvlg0yGIMZrcf7S/9+j+/fHD/f1Pd3YOOrQhiphf
-        mT769/cZ7kf5uzYn0hP5CaqO3I7a0uqLYlpXTXXejs+o8cW8bcY/+cXTIrtY
-        Vk1bTJvXedsS1o126nfQJ6wD/14EHSLm+xNyMxEf7u4/3P00IKKwVAzzL1+j
-        2/wuMXNeZ2Xxg6CfW2NM8uBDkIbDvb6srvIab+d3Z3lWltWUfv26HfsQpKFM
-        32+c/JL/B4KzAfC9BAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 298a213f-cb25-4fea-85e7-6a6848c33cfe
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 8ca50672-c605-49b0-8551-a752d24fbe6b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160711Z:8ca50672-c605-49b0-8551-a752d24fbe6b
-      Date:
-      - Wed, 28 Oct 2015 16:07:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
-        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
-        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
-        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
-        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
-        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
-        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
-        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
-        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
-        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 22dbe051-b4fc-4a8a-9e36-4122d494bbfd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 5f24404d-c01a-48e7-b861-f00bbaeec91c
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160712Z:5f24404d-c01a-48e7-b861-f00bbaeec91c
-      Date:
-      - Wed, 28 Oct 2015 16:07:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - a04cc63b-73bc-4bbd-84ba-d7e9f9b19146
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - f1124027-a7f7-4d4f-871d-3f3d4f540669
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160712Z:f1124027-a7f7-4d4f-871d-3f3d4f540669
-      Date:
-      - Wed, 28 Oct 2015 16:07:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu3ic7O492
-        dj4yjX+J/PJ9/PglDAJIvQUySgA7/I+WmUD94uwn9lx3UZp5r+HZQLdmPZ3m
-        +SyfOYh4HN3OludV5zvCMCSbDzYdghgjyv1H+3uP7t8fP9zf/3Rn56BDHCKJ
-        +ZUJpH9/n+F+lL9rc6I90Z+g6sjtqB2ximldNdV5Oz6jxhfzthn/5BdPi+xi
-        WTVtMW1e521LWDfaqd9Bn7AO/HsRdIiY70/IzUR8uLv/cPfTgIjCU1HMq6u8
-        Rs/53VmelWU1pV/9rm6NNMmED0EaCiF/4+SX/D+5kTjSSAQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9bf08aa0-1e6e-4ffa-9acf-629c2076ceca
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - c2368b4c-e5c2-421f-a5c1-6bba0de66a6a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160713Z:c2368b4c-e5c2-421f-a5c1-6bba0de66a6a
-      Date:
-      - Wed, 28 Oct 2015 16:07:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
-        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
-        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
-        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
-        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
-        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
-        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
-        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
-        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
-        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
-        Abt1q/kPBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 09b4be0d-a77f-4463-858e-b13d9c4142b2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 70246e81-7a26-4b35-8bb9-b9414da6ba71
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160713Z:70246e81-7a26-4b35-8bb9-b9414da6ba71
-      Date:
-      - Wed, 28 Oct 2015 16:07:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 28892e7c-e902-4121-9484-a68ebdff94d2
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - fdfb69b9-c55e-488d-afbf-a0bd788cdc24
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160714Z:fdfb69b9-c55e-488d-afbf-a0bd788cdc24
-      Date:
-      - Wed, 28 Oct 2015 16:07:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99tPPg0e7+Jzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQP3i
-        7CdOqsVq3ea7rtco6by38WwgX7OeTvN8ls8cRDyOfGfL86rzHSEaUs8Hmw5B
-        jNHm/qP9vUf3Px3vfPrw00/vdUhEhDG/Mpnob4VoB2dJM8vajNB6+yPC0L/0
-        9Aiz5zr9/wVhdnc/3X+wewvK4Mf3Ge5H+bs2J6ElwSWoOnI7akuxL4ppXTXV
-        eTs+o8YX87YZ/+QXT4vsYlk1bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyM1E
-        /PTevYO9hwER+6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTH0I0lAI+Rsnv+T/
-        Ac3NFXtGBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 307e9823-8dfc-419f-9b81-9418bfc36b93
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 7eec5408-6186-4dda-88aa-b8824d391daa
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160714Z:7eec5408-6186-4dda-88aa-b8824d391daa
-      Date:
-      - Wed, 28 Oct 2015 16:07:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
-        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
-        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
-        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
-        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
-        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
-        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
-        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
-        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
-        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
-        4wf980v+H8QOklQ5BwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 85aa2d8e-3f2f-4360-938f-30fc9ddce941
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - bf7241db-1fca-4110-bc91-27c52c807749
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160715Z:bf7241db-1fca-4110-bc91-27c52c807749
-      Date:
-      - Wed, 28 Oct 2015 16:07:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - cfefca26-7c81-4ca9-b686-e964fe51417c
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - bdd1f685-4872-44d4-b693-b2defd7e0c0f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160715Z:bdd1f685-4872-44d4-b693-b2defd7e0c0f
-      Date:
-      - Wed, 28 Oct 2015 16:07:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHu/U92dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
-        +cxBxOMod7Y8rzrfEQIh4Xyw6RDEGFnuP9p/8Oj+g/He/Yc7u/v7HfIQUcyv
-        TCL9+/sM96NJVbVPi+xiWTVtMQUeOmYa7bKpyvz1tM7zZTOv2idlNfmqLqjJ
-        R/O2XTWP7t5tVvl0t2mrmqZ2dzyhBuNpVefjq2I5q66a8TJv76KHmethG+9c
-        Lna282z3QZ7t7W9ns2y2vb8/vbedHRw83N7Z2b93Ptnbvf/wfI872P7JL3bG
-        t2k9biyu48lixRRQhuhPrw6TvnuvaR2a0vefzo1TeY9GtL8TcroMJYp5dZXX
-        6Dm/O8uzsqym9Kvf1a2RJtn0IUhD4ZffOPkl/w9AVy5b0AQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2448004f-6cee-4750-9083-6cb65092da09
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - c0e8d542-6f6e-4a53-bdeb-20ea060ed868
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160716Z:c0e8d542-6f6e-4a53-bdeb-20ea060ed868
-      Date:
-      - Wed, 28 Oct 2015 16:07:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
-        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
-        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
-        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
-        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
-        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
-        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
-        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
-        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
-        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
-        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
-        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - f927e28b-c8d9-4090-9801-1e40ae4f344d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - e76bf218-714c-4de2-b1e2-54f87a7f2f5c
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160716Z:e76bf218-714c-4de2-b1e2-54f87a7f2f5c
-      Date:
-      - Wed, 28 Oct 2015 16:07:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fbTz4NHup5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
-        8pmDiMdR7mx5XnW+IwRCwvlg0yGIMbLcf7R/QAQZ7+4e3Htw/16HPEQU8yuT
-        SP/+PsP9aFJV7dMiu1hWTVtMgYeOmUa7bKoyfz2t83zZzKv2SVlNvqoLavLR
-        vG1XzaO7d5tVPt1t2qqmqd0dT6jBeFrV+fiqWM6qq2a8zNu76GHmetjGO5eL
-        3e2dyf1sL9s/396dffpge393lm9nu3vT7Xu7s50Hu58+3Pt0jwhLjbd/8ovd
-        8W1ajxuL63iyWDEFlCH606vDpO/ea1qHpvT9p3PzVB7sPHx4sBtMpQwlinl1
-        ldfoOb87y7OyrKb0q9/VrZEm2fQhSEPhl984+SX/D8rMeNnQBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8058a85f-fd3e-42f9-899e-87e5d853ea7a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 134a201f-f94c-4aa6-b78b-963683f40279
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160717Z:134a201f-f94c-4aa6-b78b-963683f40279
-      Date:
-      - Wed, 28 Oct 2015 16:07:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
-        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
-        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
-        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
-        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
-        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
-        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
-        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
-        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
-        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
-        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
-        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 9b58e8d3-4491-4f24-96db-cb1e9363b452
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 7421a78c-7be8-46ba-8d0a-85259f0deea7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160717Z:7421a78c-7be8-46ba-8d0a-85259f0deea7
-      Date:
-      - Wed, 28 Oct 2015 16:07:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99tPPg0e6DT3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfo6
-        K/PmvKqn+VevXbdR2nmv49lAv2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2C
-        GCPO/Uf7Dx7d/3R88PDhpwef7neIRKQxvzKh9O/vM9yPJlXVPi2yi2XVtMUU
-        eOiYabTLpirz19M6z5fNvGqflNXkq7qgJh/N23bVPLp7d3ldXzzcPdgfT+i7
-        8bSq8/FVsZxVV814mbd3AXzmgG83hvbb09n5Tnb+4OH2vZ392fb+7MG97YfT
-        6f3tg/v3dye7D2fTfOfBXX+qxrd5Y9xYZMeTxYpJoHyRv2vpCyIuhqgzrCOl
-        bw1zfFFM66qpztvxGTW+mLfN+Ce/8MjzOm9bmp2GIRNs/FBC9hnIgX8vxhli
-        mvdnmI3M8vDTvd0HOwcBswitophXV3mNnvO7szwry2pKv/pd3Rpp0gE+BGko
-        hPyNk1/y/wBEnenI/QQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 65dd3494-560e-4da5-b6f0-75d73f57ba62
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - f8e95b50-9cd6-4ce1-a8b8-3964f4afa2cc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160718Z:f8e95b50-9cd6-4ce1-a8b8-3964f4afa2cc
-      Date:
-      - Wed, 28 Oct 2015 16:07:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
-        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
-        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
-        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
-        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
-        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
-        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
-        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
-        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
-        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
-        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDgwNzAsIm5iZiI6MTQ0NjA0ODA3MCwiZXhwIjoxNDQ2MDUxOTcwLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.e6_WO_9iYUp_tEopcHxaS5zoNSY48jWBYOayCGXwKNYEamAiKev9NW7hhpAOVhi9vgHK7uu4nz-EMRBJi9Nz6v3qaEjGdWqW2QcOon1e7QzcH7kkeYtXQKo-QWkjSubXR5-83F5BGSOXuOn3g5FK9OE0nttLvY1SRBgDs16dshRbvvMJPPdFeb41xRrpxHGfoYpLy6HpQj0ab5L_PuuWc5Ap2Q2hw2TTuCWiSQpL4OvyaaZ8y60eU_4BX9iuzz1Ks84Vp1zTkELD1rVThi7_a05T3twlhu0Hw_MCRrYXZep6aqAT6_YJ6pODponcNw3eQSq55C_VFI3vMgiKcWg5ng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8d6022e8-ac94-4693-bd11-cf2c023e3085
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - c768133a-2a4d-469c-9cea-5968566e714a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T160718Z:c768133a-2a4d-469c-9cea-5968566e714a
-      Date:
-      - Wed, 28 Oct 2015 16:07:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:07:17 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:43:39 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_some_existing_records.yml
@@ -2,17 +2,17 @@
 http_interactions:
 - request:
     method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
+    uri: https://login.windows.net/(AZURE_TENANT_ID)/oauth2/token
     body:
       encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+      string: grant_type=client_credentials&client_id=(AZURE_CLIENT_ID)&client_secret=(AZURE_CLIENT_SECRET)&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Length:
       - '188'
       Content-Type:
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - b39e8f21-2830-49b5-aa83-8948651c550c
+      - 9214805a-b8c7-4df9-9bb7-3d0129834fe7
       Client-Request-Id:
-      - 0938ec38-8ad3-43a8-a84b-093ead356152
+      - 469d8860-24b8-4033-b6cb-c95f85b0c9be
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_89
+      - ESTSFE_IN_251
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -51,14 +51,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 28 Oct 2015 16:35:12 GMT
+      - Wed, 03 Feb 2016 19:42:56 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446053711","not_before":"1446049811","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1454532176","not_before":"1454528276","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg"}'
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:10 GMT
+  recorded_at: Wed, 03 Feb 2016 19:42:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -71,11 +71,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -96,17 +96,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - fdc1f84a-258e-4901-9651-2a78038f667a
+      - bce8f78f-eb2f-49aa-8364-f225bdd542be
       X-Ms-Correlation-Request-Id:
-      - fdc1f84a-258e-4901-9651-2a78038f667a
+      - bce8f78f-eb2f-49aa-8364-f225bdd542be
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163512Z:fdc1f84a-258e-4901-9651-2a78038f667a
+      - NORTHCENTRALUS:20160203T194257Z:bce8f78f-eb2f-49aa-8364-f225bdd542be
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:11 GMT
+      - Wed, 03 Feb 2016 19:42:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -115,10 +115,10 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
         qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
         /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
+        fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
+        UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:10 GMT
+  recorded_at: Wed, 03 Feb 2016 19:42:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -131,11 +131,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -156,17 +156,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - 70ab68dd-8e5a-461d-9900-bf13c2383aae
+      - d57c331d-36df-4506-9254-87d1435793d6
       X-Ms-Correlation-Request-Id:
-      - 70ab68dd-8e5a-461d-9900-bf13c2383aae
+      - d57c331d-36df-4506-9254-87d1435793d6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163512Z:70ab68dd-8e5a-461d-9900-bf13c2383aae
+      - NORTHCENTRALUS:20160203T194258Z:d57c331d-36df-4506-9254-87d1435793d6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:12 GMT
+      - Wed, 03 Feb 2016 19:42:57 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -175,215 +175,272 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
         66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
         bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
-        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
-        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
-        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
-        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
-        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
-        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
-        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
-        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
-        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
-        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
-        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
-        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
-        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
-        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
-        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
-        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
-        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
-        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
-        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
-        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
-        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
-        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
-        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
-        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
-        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
-        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
-        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
-        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
-        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
-        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
-        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
-        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
-        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
-        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
-        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
-        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
-        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
-        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
-        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
-        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
-        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
-        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
-        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
-        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
-        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
-        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
-        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
-        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
-        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
-        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
-        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
-        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
-        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
-        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
-        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
-        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
-        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
-        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
-        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
-        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
-        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
-        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
-        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
-        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
-        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
-        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
-        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
-        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
-        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
-        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
-        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
-        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
-        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
-        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
-        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
-        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
-        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
-        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
-        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
-        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
-        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
-        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
-        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
-        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
-        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
-        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
-        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
-        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
-        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
-        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
-        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
-        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
-        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
-        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
-        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
-        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
-        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
-        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
-        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
-        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
-        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
-        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
-        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
-        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
-        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
-        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
-        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
-        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
-        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
-        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
-        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
-        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
-        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
-        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
-        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
-        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
-        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
-        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
-        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
-        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
-        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
-        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
-        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
-        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
-        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
-        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
-        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
-        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
-        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
-        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
-        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
-        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
-        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
-        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
-        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
-        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
-        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
-        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
-        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
-        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
-        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
-        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
-        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
-        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
-        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
-        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
-        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
-        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
-        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
-        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
-        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
-        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
-        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
-        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
-        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
-        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
-        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
-        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
-        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
-        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
-        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
-        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
-        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
-        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
-        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
-        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
-        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
-        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
-        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
-        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
-        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
-        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
-        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
-        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
-        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
-        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
-        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
-        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
-        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
+        9QBms1nzjQOdVsvz4mJdM6hvDGq1ygXiN4dodpEv228QXDZr1qtVVbfTrPkG
+        6VnngPnNwdMJnzP3LfK2LqbfHPCyuvjmgGXLanm9qNYNvbYmtL8uZIY9IIur
+        4otsSZywIF4g8D4GANTDidAA9ahpgMnxumnrrCyy9DRrAMh98Lpat0Rs/vSE
+        eqFPgfPoI7QMfkv36PcXNNnzNGjIEMKPzMhN+9N1TRJCf/IX9i8GfNwUGf3O
+        UICH+eA72SpbGnzlD7xNfzypsx8UpWBOf5qez5YzfpE/t3/hHf0jOg/3t3ce
+        bu/ep5b0B03K3vbuPk0KTUmHtKQ3i1nW5qoRX9CE0Us+mT8M/nSeT996wI8v
+        s6LMJkVZtNf09jfc0c9qD6ITnuX5bJJN31L7bw40I28gv8p/0bqo8xm99s31
+        QKwZV+XvA5YBD8n0SmeZXvL7BsgeNtRjtlp1URHJYQFj/ubfhO+NNPBHHenj
+        t2LixUBsMwbUF0U0oj8EZtBN8EdHOtEDfcHKI6513KdoSx+gIxVZRcb+ZXqS
+        v4dm5B4p1u1VnV8W+RW95H04yVuA8T7JytWcIGG+eqRfnc2ov6ItaG5+NAH8
+        l+lJ/v7ZnYAL0rZX2fWPaK9/mZ7k759d2s/yVVldw+1o88WqpJnoTsP79z/c
+        G5H+/XQuw9vYCXczoIGJqFVd/IB7obd9ZNBHD726KvPjpikuliDIbXF8QOhQ
+        U/njU/8P+l8H+/3t3Z3Ihwyj9yH9z33I44zg+zQ/L5akuoDS/9vxnZYZUXd6
+        PFsQypCHtup500NY/1ARJTZdFIQqMLgdeuiHmsofP1RcCbu3t8VSI5E+kPcW
+        TOBKTeUPBst/DA2NKRLreFWVxfT6vZk47GUY8HtL8y0A19VlMcvrL78OySxk
+        Jox+SN1wR4NarFowcHrJxwWge9hltvXxdFqt++NWO6dWCD+M4WKLNGwf+YPQ
+        JG6wkhttFxH5njIMkQDcY+nChLhxTHfr9XJSVT2+///H4ILU1f8PhkgIDYyl
+        h9PX6ZC7jMvOk6ydwj/zEQLUHooTNDQTQC8EWIaEVZK73xzx+dMIUTveorSw
+        AIOmDFNnLJhp50AyGMwsfSpN0Dn9Yb8wAPiDEBUHRuFKG5luh4v5G5D1j6Gp
+        2aPZoJb8B8XI3h+s2/gPsgD0NyatuCQX080dzVxnJogmA8zCuFiqAX0Zkv72
+        o2lQYhOleRpi1HUEDYk7APUWgO7+onXVZl14grGlLQYpA9fffjRZvcliKg+o
+        sWJ58UXG2SF/GgCwNzGLbEXZZDTtzwfRfetlVrfLvL5DDfSzISwhv3uEGKHV
+        6YPmIC6j7w2ppDDgpFos1stCoLys8/O8zpdEgQ8EvV4hi/uNAGfwQ1PzgzdZ
+        afK5oIePBkD1ENNXqKmPgnAxzYablx7X8xf2L+ZCn3UZgv4ubxrWZGAB38sf
+        eIP+YEh+4yg9SInT/6DEc9XeG+hyklEGl0D7YwegHjVe5bM+t0aw7+HoBI//
+        wLgcbQSA/ZO/5GYYcfAba6KAGvIHXqE/OmqIfw7RvKcn3Af2PfrUoC0qQpEz
+        f3BD/Ss6C8SVBzQL1FT+QDJE/qDJof+5+Qk+lHSJ/xHNH81eZzZo0r72msHP
+        Ilo0i++ncH4WcWGGPWEX3YWt9NrXQ2uwh7uyJuq66A5dedxwE/O0cA8+sh+B
+        FYPfmOGZ5/jTfmPlZoYFljUfSH+hTNm/RGjwvv0DDeiPjgTFZcJ9qiAMWiIJ
+        2pv5g9/Uv6Kkpsmj/22iLr16sayatpi+ztuW7GuPvEDEo4oSTohgsOOv5SNL
+        CcbU/tUZPX/JbwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSG
+        ipf5gxvqXzeQlwk8YAFmkAqf+Hi9Nx2UTjkvSvquQ36DIRMDYwl+G5oLQT34
+        iIfGv0l7OzX8hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIY
+        TpIpje7my9mqKiIhajBidB389vOdWndpFeCioJd/RLX3odqU4FaLGaWnfkS7
+        jbQjDMU9oc/X5Ubp/GDYd3Wi9M8fYleWM/Tvn8OuVaD1r59LRHwZ0c++SXRu
+        449/UAd2vN8o2vnsIl9Ws41W/QagDHbAs8jrtjhHTJ+/yi8ogyAjoL58NACy
+        h9jUvfplTYs4PQQvymqSlYPIsQPPqN0E+K73yTfWCzHjZYHGnzOA49VKEw8v
+        62I5LVZZebb8qsnrN/kyW0K9fSO9XpJ+5FyKG5FP97PleVXLEsbX65H7HJhq
+        WTGmLM5q3cIM+KgBUg9ZEUWITI/qUPnGYlhtbz7gL4kt7W9swmBF6Hf6TYyT
+        x78KI/wo+ENesRaMYdm/xEqhL/sHGtAfX8dkGWTEaXd4mL8B2v4BOIRhupdu
+        vW6zixy5QMHVvEZfmq8G5i5IYdLyjPtDBJj/oCAh+AMLNzTfNNudSWM199TO
+        3AZl90NBx+Ohu01Z9VU6U1AZhwmPSTAf8JfMAPrbjziJv/q5mbq7dUVeLb34
+        owmUvwHa/gE4hOH/+yfwxnRYFDnqiP73dTr6YPCXRd2us/ILyoMXyx8xIOFh
+        /gZo+wfgEIY/fAak/7k/BrlxSsRgO1T0pvCbQCbWZXQ99ZvozPwxONgOy/58
+        z5Hy75ZRTcfmb3Rk/wAcQukDuJjmhf53u3kRDTWsCg069LH+9qNpUdqbIZvX
+        6Evz1Tc0Lb3J6HZI38sQgo8UVfcbTxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kN
+        vG//QAP6ozPbjvba2H3ATdAjfcq/W3obJM3fAG3/ABxC/2dpMmh4Eo126R+F
+        RMry62hO+p/7Y1CN+n/+bGAT63NRXeav15NmWhcr9PVKv/76/cd6MYkAv6cv
+        qOdvJF6LdWhnldiiXTcfNByGvzHL8CJvr6r6Lb3oowGwPcRU9vWNLlrC6yqP
+        LCIQF/MBf+nkmLg+FPWuUNBHDCP8KPhDXrFSzrDsXyLm6Mv+gQb0x/8HZJ7m
+        z59MkQD+w4iD+WOTPFKSLJ+drf5/NE9EO5oW0JcIEJkn+vT/a/P0tR3fEH7w
+        x2BnF6TGrrLr1+vVisaZz57mSKP+sHonwRS99g13SP9zfwz2vhSt9TqfrmvS
+        2J/X1fpHokF4mL8B2v4BOIThNy0asXn5WQ82udONJvB1W9U0EnrRxw0d9rCl
+        dS80PZ5OqzWtFtMrPsJCN2UXJjdIbz7gL3na9bcf8Q9/dZtplsnkP8zMmj/o
+        f7vbk7xFv+4T+8egQvihal7O9SufKfN8oP8Ydhz8MYhFh3vvwkWIGACZS2Yw
+        N130hzBA8JGwFabb/oGX6Q98ZjifXwQXmQ8cg6FZ8IFtS5/y75apTMfmb3Rk
+        /wAcQul2HGebu99YFrsv2I+sTHGf9q9AjqKTRrNB/3u/2bhFCorRYPwCZBmR
+        EH+ZEwzS/oGX6Q98ZuaDXwTRzQduPtAs+MC2pU/5dzsHpmPzNzqyfwAOofT/
+        iwmSpMdwLuqb7ukbhy9gfxYHIB18MNgPdA5Ctch/xHqZFU0vmv0GwRcLoszP
+        IvyqOfvZ7uGH6Llz/xvdtbPleU06oV5P23Wdf1FcEG4Qdh9p4NIbxjT2/lDS
+        SPSOqkNWINB55gP+kvWP/sbqiZUPfypaKVBUDCP8KPhDXrGqi2HZv0Rzoy/7
+        BxrQH4GK8/W0NnYfcBMMIq4JeaZ2798wBdVitb4dtTPPvyE7Fqcvj1x/65Aw
+        QpzgIx5O+JG0skRjWPYv7kWnj98FKcwHQlI0sX/gbfrD0U+/dR9YKPRpMA1R
+        +hLn72/f29le1RR151f0Dn1oiG7+oP/t2hY8Dx2qag7O5N/pxR8R9Zsm6t38
+        XZsvpZsf0fdngb7kEd7g4AJtIY/+9v9zOpP9o//B/t1MPfGthp03GQyPWX/7
+        EfGUeK+nWZkTz/28J9nPhlxb4v5If8pgiYo/u3QOP/8RsX9Wia0LCGfLNq/P
+        yS/+Ebl/Vskdfv4j8v8skd+RMCRntEuC9jWh3yWaUZiOX+lt+zHgggxCbv3t
+        R/P2XpS9XLwufvAjcQBZv0myrptITk1GycTQ335E1fei6mo9KYtmTp3Q2/Zj
+        dAZEhSD6248oewvK0lh+pFaZnkSq9yNdLOsvY6LBRrvoTlkMarPMVs286keY
+        HwzZQqP0SfOWiD4w8e/ZEXcVT/Y+zdrspFou8ymmwEcH4HoITqUp9fZFtiTl
+        2ZfxjajRhB3cNGcO2s8aZOep0MrAunzPibxNV9N5Pn37gih+7GXIP7AX7md4
+        Fp9lU1qgQyc+LgDXw25mm/fX3CxWPV0A4ZUv9DfWNtIo0CEMwb4WiHVHJ/GH
+        4cuiOdCD/QPw6A98ZpQNvwi9IR8MUHB3hyhIrfmPnYf+H6Ct/eMB/WEJbT6k
+        //U/xAJW+OG+rIT1PkTX3Q9JLqlXnsdNM0LC//Vyp5G5kI/sZICU7q/O1PCX
+        /FYAgr8Oocq8oGv7B16mP/CZzIm+eMMkEUXof7chytdMiQoBAuzlI0sFYO7+
+        +n85TVixeOJ+g46Jwic+pv91uJM/of+ZDwc7P/4Brah+MAYsH9SU//jmRTOG
+        vWOn69c0kgWm4/+dmBIninnq8vjPFYqM5LDpeZ69zY+XWXlNGgso+8MBlr0B
+        ZtNptV727S5LCgvuppF6iBFaA6DvYrqB2Gua8PxYP/3Z7LChjsgl+jno6i65
+        ZW1GKbS+O/bD6fUuBXzt66x5U72lRYGfBRwcvBD2hwN0viC1iPiCX7sHC/dr
+        QmSYm2WOWZug+z0DYA8XM4XU1sfkm5gZA/rueVHnV1lZvlqXhMQ335GDF8L+
+        cID/n2QBaiMJcr9PgOphQbbu5lhEJ4g+7nhH/AX7Kr4zxL/ZNrdxaigqJT/5
+        HrWmP8jCHFAg7w2VBtpBm0DHiScoMRr/b8H1rGq/vZ78vw5RRnWQf95Qd8+z
+        Cb3sjwage+MjrukNroOfDsoNxP1mh8QtwtakEYy3jE/sH3gxPmYa5v3tPV9M
+        aJAdfPMlLS1VywX55/+fwpu6i/P8rSAaLqD/xYMHB/FrQN8I0KnQLmxDMPpY
+        f2PSgU70u/ktSureTAmJ0cT+gbdvS28ewYA4VNM1uOXpE4LsDxLQesOGaznJ
+        GusJ0TvBkIGUDK4j9/yF/QsDkWb8mw6yN2qXLUWz4APblj41wejZktIH9Dd/
+        1/nLtOFOgz+EmtqB/AFkB0lLAeoBtaQ/6Df6X5zhOoSCEfoRsYaIReMcECEA
+        l55/XpGIiTQkrwuKPF7lFxR3CNHoZZ+eAN2j8Izf6pH3oqwmWbkJNRdCk7kF
+        aoRYB3ZbrZ7nl3kpmP3s9MGenHSwyZf7RvpCRCddvcqn1YKUIwkzA/rZ6O2S
+        2I/g56ZHN69ny/OqXvCvBOab7/kipwCWen7dVK/yX7QGj/5sdEMSSr3wmx8O
+        njsYEIxr+pyyMM9vl4gpp82qrn6alnTQPMCrkwiFKBsNwr9vFHOjqQKdwB85
+        dcWQwxZ41zXgv/hzbgq9lB4LBsFb6J5+Y7/ii9fP3jAK9IH5U78P/tSR8Acd
+        vJw6RMvgA4vH4HTR/3a3s3I1B3T5CDPY+ehe/yNMLfkqxSXxonFZOt9FPpzk
+        bQeEQGUOGZ5rpG6wjlf1E0Y/mnZuGXxg8fj//LSX1Xo2y1dldU0K/Ucyb7t1
+        c42WwQcWj/8vTj6NbsDs/GiquWXwgcVjcKqZ3GZWNhri00saAyWFqAN/TgCr
+        N0sWQm+WHG4bkI3Ty/3GlHNEE3oErzCs8CN+V8nIX6Mr80GHeYQz8Ib9A93R
+        H9KXpT0+dX+Z/sKYwvzFbeWP6GyQiPFKF89Bh6DsKHO0Capu8JWjkGme3bLZ
+        pm5oGHHpeh+wDNhyAEF1PPQsz1pabAV0+tf2DIA9XM5d21tgsgtGpqb0B2EC
+        tDyuJnwIkA+cDMhlMSMg9MqHQmf4/njJXdXxUtxUXMzZLPkIAHAPJYpJVtWS
+        OAitfZwsWxEbD+DHGpteoz8UP/sH/Q+TQih2+rvKJy1x5A+pNwpE6oIG/k10
+        FoOflXnd1rGVGhY7gq8agH/bKMXcTPUCS7CvKEQZoIn9A2/THwLTG5C+HX6E
+        N+k31mDBF04PoknwAYMBEvRpoKiGSEaEciSj/w2QbN1WzZQI1+RtWywvfkQ5
+        JdaNlKO0yLJt6fcuyW4DdnfX+0O+ifXhwIZdGDp84BAsSJfofvU+a4UC+cZu
+        LPCvBZZWg9wf9L94H+Bjyqfks9N3K+Kk1z/i5igx6X9x+pFDcrGsmraY/jwk
+        nelB/DIH0PwNzPSPISo/GCLsIm/rYvo0Py+WhdDyR3Q1fwMz/eO96VpWFz8i
+        KpAzAM3fwEz/uIGoTFbfZ3U++u+VX/9kRoaA4Pl0B4zeTFyiYW8GIpTBGOU3
+        +dISn1G2f3EzpTwPFVQwH/CXMVJyy7A/Bsu/yZzhXfsHvqQ/HMH1W/cBQ0Tf
+        9GkwA0Nk9S0VBQu7D734gCgdJdvdJp/W+Y/I997ko8G+n1OxCTx3EJeE59VF
+        MaX3/O4BtYfQVVW/PS+rqy4+OlsBaYM/mCrh9/KKnVIQ2/0FSpv55HdBZPMB
+        N2UY3Mz/jSc9mD35A1/TH8Ec+ROp37sPuAk6HZxKRGiWvExz+hDhs/2QKd6h
+        IA0vPqVKj4BEwR+MUfi9vGKJhhG7vzAkQzF+F6MxH3BThsHN/N/+X09CAvXl
+        IBUD9G7Vb6yLRbbMLvLZ8ar4We/gRNZz+P1voCvuLC7lX2T127xdlfT5lzWl
+        hMgBph59xAC2h2p2Ued5dM2BEQs5EhyD34awZQXFOHZ6IZ6Nz+gNkBhWfLwv
+        8hb6iuD5fQFEr/fLom7XWalvdFGwo7IyQr99fdmTNwOycZvwo+APhheIJj6x
+        f6Bz+iPgF18StbH7gJsApw0TtXufXpE/6H+Ox/hDNi/ehzwNHaKu1pOymJ69
+        PJ7N6JuGKP8jsn4DZF0Kk54t27w+J57//wxZ/99N1rLKZk+yMltOCTq99iNO
+        /WCSKqe+zqfrmhZwPq+r9epHpP1GSEukbPM32YRy2vTSjwj6wQQNPYDPKct6
+        lV3/iLbfCG1Bwh9R9meDstPh4AEI03joY6AmvwlZLAm5if2Lmyn9LPLmA3kz
+        IBi3CT8K/mB4/18jaLZakc/KVPwRp9JgiWxEyG+AsI6EITl/GF26lb+f297f
+        b93xG8XhZJ5P3z5dNi8oUj6+zIoymxQl+WQEyzairn8ouKwbSn38EKlg6f9D
+        7DN/R982zSsSrfykqKfrojfvoiV8iabfRB1Y1cFN7F/cTPWGFVrzgbwZKApu
+        E34U/MHw/r+mSHzKvs7ry2Kav6yry4ISWl0K/yxiMVs2P6iWPS7+6KKsJlk5
+        NP7d3e17O/SK+YP+NZ3oh0Bn3364qee7x/TOz1nf9NBrP1fdn7w4/uKU3vu5
+        6v/lm1f01s9V71/83vTSz1Xnb37vN/TWz1Xvr1/9JL31Q+6dtNv5eTGVlH29
+        qqvzIhJ234gHpatNl/vbewcbu5zCXL+Rfr+Qfm+w3B/SP2MwkEOv2oJw4G6+
+        vZ5g1D6q6KCHvIWE1gGOzlRssB1xI+V+Y3MF20S/02+3s3v8rlpK/hpdmQ86
+        Fk6sH96wf6A7+kP6svYYn5q/onTf3955CLozgQepdHfZJ/KPyDZANpYMyALT
+        bpNAOCIpTu4DRhlDoU/74/V/+/8J1YhCJS33vSnymkD9iEwDZKKX4pGCRxTF
+        wX3AKAJ1+rQ/Pv+3/09SielklRURyRkHuwqflWfLpriYc4zj0xTgelRGGpCB
+        oXVAZWAuo74RQTVp1ooZ03Zve0/tPbnxZO/dHzv0PxoPjaaDT9NWNVlYHQKt
+        x58XF13UojhsAkri9vZNVl/kTBMflB1lFGZ3CIMdEGWE+F34UbAEiYmxcT4p
+        jvppyiZ++e68qmcE1e8RgHo4ZNNptV72R8izNzRCWrjvhFcbUHqVL6o2P16t
+        qAu/cwDroTOtypLw5746GDlxBfXpW/cBCw+Eij7tyNOgIPLv7lMVbZE4fGL/
+        ACXoDxG/AJx8pCweEW3+IHwFwNwb/Bd9HiWyk18i7TCZ7nr5zh/R7JY0a3Q9
+        c1UXy2mxysr/n1DuZ4dyTkeE3PW1Abb5YlVSbv5sQUq7R/pbgmXAQypHugNo
+        v2sAiSCzzPoKMNo5aXZYLGpKfxAm9D9fCRI+HdgUab5XWuv9oLMjbT4DJejV
+        b74X8+fPzhgaCpamdbESqD/rPdw1X/4w+vrZnf2wLxJx8SWo1XusULxfl+bP
+        z+tqvep2MWw2WKf7Sp6/dM3Ujhi5N0YigMcwwo+kVaje7F9ihwDe/oEG9EfH
+        2MUtovtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJNV/+iO7U0v5lkJK/fzbpfsF0
+        t392Z+Bno2sH/2e/rza7gPX4IXXFmR/88pNZuf5Z6nSWr8rqekEMckv4FFoZ
+        +B/SmVPDP4R+EZ/eshuC9D6Q33cUBI7Ab3TJXpOzMluXnLzyewOQXv8/XU08
+        b53e8HFQ/WOkn1WSKIbgI2ll9RLrEfsXlItRivwu1I/5gJsyDG7GvwWaTP7A
+        l/RHR60FOKAJ/cZatqfZ3Af8LjCgT/l3VWkOmvkbCOgf0amgwJynwsz0Af3x
+        9WZa6WcQ4OEIbsFH0srSlfGzf2Gghqj8LsZoPuCmDIOb8W9CWHxj/8CX9Mf/
+        t6l8XlZXtyFw8IfgGHwkr1j6Mp72LwzYEJffxVjNB9yUYXAz/zemmxAbrewf
+        +Jr+6FDe0VO/dx9wE3QapxqpiYBQTD368PaZpNd5Vk+BhE9egO8RvOGWr/P6
+        suib6ygxNpLWjsyQk9/T3+XNYJ64ffiR0BRg6Q9HMwCiDzpENm9u4EEi3MH2
+        7kNqLH/s0Xqg/EEM+WD73u72S0tSImiHPqSMp2+VPLDHGxZhhnr/Gh1+zZ54
+        nDGgNDlx5bUREuNMf/AAbuA3yRLRK37PANjDxWSUXrdZu+7iYyeUWQFzjt+i
+        WLJuIfSycjUHd5mPKKXc+2iv/9Gu/xG5FyxcwUc0V72P+F0ngkSQjaMjCvz/
+        enx3L4u6XWflF9l0Xiz/fz/afDlbVQV5rwTh/8/jbNaTZWQt5//ro2yzphcG
+        /H9+UBlFCv//m6pFtSxopZKW8emd/5+O7O4qa9lJ+//r+CZZk1PoDb/w/69D
+        pPWQYpGVV1n9/7tRzrI2O7G5heMLGk5PzfCw1Ltnl7zn+tOY7W8cP8Gxp9/p
+        t9uFA8Ef8oqNNhiW/UsCB/Rl/0AD+qMTNPSCCvcBN8Eg6FP+XSMLh4f5G6D1
+        j//PTiqt/kVWQGS6dBKZCCCI+YC/5MnQ3340q/TRz+2srqqymBb//3O/s9WK
+        pm8ZSUz8v35kN4zsKp8cY3AypGdFnV9lZfn/8WHyQIcSBJxBecIBv08L4N+j
+        joWB1gFBnEyDGvSt+4AFW4U8Sjf729fSWPyu6kD+Gl2ZDzqqSNQU3rB/oDv6
+        Q/qyyg2fur9Mf6J/tBv7F7eVP6IcQMmlhzQfNA80Cx2C2qQSU/VrZZYIMk/7
+        pm5oGO+bZiJIHbAM2HIAQe1x0bNsUhdTes/vHlB7CE1LYg/qldr66Agt3bTy
+        b/yZnQuhvZkRajA0BE94NuP+i0oC6+MHID2Mqfc4CbuY8m89LO2AmMeDL4T1
+        go+4rbIwg/J5OuBb+QPt6Q985iglcO2fHVFw8qkvuw+4CXqkTw1awt/ahfmD
+        G+pf0Wkg5qH/OVVkOIr+B46iOelQ2RH2R0TWP7ih/vUNE/nulAbG6ibiowBj
+        IRSjw78JLgZd/kib/Yji9An9L05xq+Y3aHihDtOJseHfBBWDLX+kzX5EcPqE
+        /hcneEMGiUBQwx+RmP/ghvrXN0riu4hckVD6EbHtH9xQ/4oSm9wT+l+c2NEP
+        N84AfpL39eXkp5E9uPzRTLzHTBBx6X9fg+jTarFYLzVOfF4s+wsYwFqIxSjx
+        b4KPQZk/0mY/ojp9Qv/bTPVstiiWBRCiPO+PKG7/4Ib6188ixb80QdCmBCXT
+        jbHj3wQ1gz1/pM1+NAH0Cf1v8wTQx0T5bFLmTwn9VT57+iODS39zF+YPbqh/
+        fdPUn1b0C5P/R3Snv7kL8wc31L++WboXixVhT+1/RGn+gxvqXz8blD59h39/
+        pN8JLSGydmH+4Ib61zdLf0L5RzQXwmoX5g9uqH99szQ/13Wdel3+SJ3/MAhu
+        kgSv8+m6ptzXy4GFUeAuJGPE+DfByiDOH2mzH9GePqH/baZ9tp5Rgnd58SOa
+        09/chfmDG+pf3yzN4TYuFvlyls9OS8KkmL6sqv4yMlAXijFe/JsgZfDmj7TZ
+        /y9Iz8Q2o/zZIL1RNQOM/yPq0x/cUP/62aL+tFoukY+slj9SPPQ3d2H+4Ib6
+        188W/fHbF1nz9keaH1TWLswf3FD/+iFOwN0fOZzchfmDG+pfP1vT0KjLeVzm
+        dWsmggAFU8BY2ZHyX0xHQdCMgT/CaOm320+D+03pz0BBHvOBzAF6tX+gPf0h
+        MC1i/5+agtsTnikkiBhc+SOMin77OSE1mri/fi4ITyuE9D9H+E20duxuvP3X
+        eYsfPyK4/YMb6l8fTPAfkZkQFFoqTPMHN9S/PpjM5uPVj6IndGH+4Ib6V5TG
+        pJzpf47Gt1bauUSrP6I3d2H+4Ib61zdL73WTXfStIjAVAjEa/JvgYNDkj7TZ
+        jyhNn9D/NlPamchF3tbF9Gl+TgvbQvIfkV//4Ib6188u+X9EdPsHN9S/vlmi
+        +9r8R3Snv7kL8wc31L9+1uk++5G64c65C/MHN9S/vtkZcOqmrVY/sc7rSOwJ
+        vIVcjBT/JhgZpPkjbfYjutMn9L/3p/vdX0Q/r9/k74DXj2aA/+CG+tc3OwPZ
+        7LJoqvpH3G7/4Ib61zdLa9XzWNs7pV8WWfsjLfMedKc0AP3P0f37v4SJvcwW
+        ebPKpqD0F8W0rprqvB2/bquaYiWC608GQPWnR5oeT6fVetlumBH9jYluf0+3
+        Xrf09h36jIfDLfk3Syxuq/TmUYIc5oOA5vIH3qY/hOSGZgyX3w4/Cv6QV2zH
+        X2eWhkj/6fbufXpF/qD/+fNAs9ChKfVfKwlDcn4z4KNx8DcDejrPp29fEE8d
+        X2ZFmU2KkpLS9Po331OH7ygDXl8W096whH14esEY8pt+1mc/O/cdVuAXlOXs
+        ZJsPhO3QxP4BYPSHQAl4jN8OP8Kb9BsLRvCFYzA0CT5gMECCPg34NEpc0q30
+        vwH1OkBHdaXfM3LXz5SyP58oy7Qd0qZ1ni2Ol1l5TQYMdPTnAKAis4JXKNn9
+        09UELwSED4YCgnTIqSMWGtmvhH5oQH/wW/w+Dw7jNUTnDyJ01K8FDN6nP6SL
+        flv+zdEUnwUfcB/olD4NiOzmaaMp290B0Y2ueOj/8an/B/3P/cETZf64R39Y
+        /cIf0tf0P0wlTWRnOhz5O1MBOjgSG9x5+Bg0/fajqZA/6H/uDya0+SOYio3U
+        p+CmarPuJPzcIUY0dFJ6l4h0sazINZ0OLVSB+DIh+pvHHIbY/LV8ZPkFU+z+
+        2jhL2pihmG/4D24e9iL8A1TsH3iZ/sBnhsv4RTCI+cDxDpoFH9i2cW4h6tL/
+        4iJGIDxavofx0d9+REpLShpb3H2UAdnR81+MfjAWoEK/eQS1b8jI0ID+sBia
+        0fAHIV3Q1HwtL6NT+kMA99vyb44K+Cz4gPtAp/TpxtmLUm2jVjigP6y4mw9v
+        oyroN/of5oJnw3cCFtYJaNarFY2Z3vBnC4i9x/xFqMajDz8K/gC93QQKAPsn
+        f8nNQOjgN55+mTJ8Yv/AK/RHh/b8E9NiJhvvmN/d7OHT4AP73tB87Twgym6/
+        7MwKNDORm4jdIZ1SmXTw27wfjMroA/IwAuFHwR8YrqOXALB/8pfcDAMLfvv/
+        AvmYgHFupbTWOiubdj0rKnrNpzKA9+ieSfhATb8GwTEs+Q3Ukd+CBgImJLv9
+        i99WUjFw0MN8IERHE/sH3qY/OjPgaMqNo+QkIaf/dXQEfbK3vfcpkZOIGafK
+        3VVd/XQ+Ra8/f6nD9PGZzcVH380n1NqnHWD2qNkUlPG7S5ntfCn9dsgJ1MzI
+        NtKER+XTgb9mWjIM/i0gh/yBL+kPfj06Ryz00nXwdfDHZtL6H3AT4EmfAhG1
+        bA6e+Zsb2r++eP3sDSMu/fGfgN39UwfPHwjSlkL8PcbjJUj4M7zjfWYQoabu
+        Q4EV+SrKNqSOYHjpPfkDCsv+cRvrS3/s2T/2t3d3vT88APQH/a/PnvQ/6EJi
+        zii7NWVFSZEfMZ2DZ/7mhvYv5iJuz/3xn4Dd/VMHzx8I0pZC/D3GYxlGP8M7
+        3mcGEWrqPhRYka/+v8h0xbJpsyUl4eiFH3Eb/80N7V/MPtye++M/Abv7pw6e
+        PxCkLYX4e4zHcop+hne8zwwi1NR9KLAiX/1/kdtExf2I5yw88zc3tH8xE3F7
+        7o//BOzunzp4/kCQthTi7zEeyy/6Gd7xPjOIUFP3ocCKfPX/RZ6z3PYj00p/
+        GHjmb25o/2JO4vbcH/8J2N0/dfD8gSBtKcTfYzyWafQzvON9ZhChpu5DgRX5
+        6v+LjNdRdj9iP/rDwDN/c0P7F/MTt+f++E/A7v6pg+cPBGlLIf4e47Gso5/h
+        He8zgwg1dR8KrMhX/99iv9V6UhbNnBLcX9ES64+4zf7NDe1fzD7cnvvjPwG7
+        +6cOnj8QpC2F+HuMx3KKfoZ3vM8MItTUfSiwIl/9v5HbhrmNOI1WopBuyS6z
+        oswmJSjzw+Y4nnyZX0dR+ohng2j7I46jDwVW5Kv/r3HcmvTajziO8TXwzN/c
+        0P7FLMTtuT/+E7C7f+rg+QNB2lKIv8d4LLfoZ3jH+8wgQk3dhwIr8tX/tzhO
+        /jipaBhV+SODav/mhvYv5h5uz/3xn4Dd/VMHzx8I0pZC/D3GYxlFP8M73mcG
+        EWrqPhRYka/+v8VsVqkR9tO3P+I2+zc3tH8x+3B77o//BOzunzp4/kCQthTi
+        7zEeyyn6Gd7xPjOIUFP3ocCKfPX/LW6jSKF9jXj1uGmKi2U+e1N9m/y5F2Rd
+        6eUfcR7/zQ3tX8xK3J774z8Bu/unDp4/EKQthfh7jMdyjX6Gd7zPDCLU1H0o
+        sCJf/exyXox7JNOBAAAM86QgCi0vfqSy7N/c0P7FnMDtuT/+E7C7f+rg+QNB
+        2lKIv8d47KTrZ3jH+8wgQk3dhwIr8tXPFePMqkVWLL+8WlLP82J1NiPUivOC
+        /iIIP2Ih/psb2r+YJ7g998d/Anb3Tx08fyBIWwrx9xiPnX79DO94nxlEqKn7
+        UGBFvvq5YiHJsv5IAxkGMfDM39zQ/sX8wO25P/4TsLt/6uD5A0HaUoi/x3js
+        1OtneMf7zCBCTd2HAivy1Q+ffWg0tTLIj5hF/+aG9i+efW7P/fGfgN39UwfP
+        HwjSlkL8PcZjJ1o/wzveZwYRauo+FFiRr352mYX/+AY97Glew6gRg/1oxfv/
+        V6wWsoB+aP/4fw3/Ua70Mq+fZfXiR+xn/+aG9i/mJ27P/fGfgN39UwfPHwjS
+        lkL8PcZjWUc/wzveZwYRauo+FFiRrzaxH70nf/y/h9PgkVGzH/EY/80N7V/M
+        NNye++M/Abv7pw6ePxCkLYX4e4zH8od+hne8zwwi1NR9KLAiX23isXDu9UP7
+        x/+7GE9CAWr8I/bjv7mh/Yv5idtzf/wnYHf/1MHzB4K0pRB/j/FY1tHP8I73
+        mUGEmroPBVbkq03sR+/JH/+v4bR6TRmKRU/L/b9hEFF8RTIWeVsX0/9PIv00
+        Py+WhaC8Af3/96HP2kgH8f9h1P+/SH/n8Oog/j+M+v8X6c9MVOfTarHIlzNF
+        +P99yL+H1v//0Vgu8qrOLxjT/y8PQ5iMmi9ouSCbzYByOB7nm9AX4n5YV4Yd
+        IfsXe0pwqUxr/podI4bBv4m3h2/sH/iS/uDXPdeGPsI39NuPXD98KLAiX33j
+        HBdjFCwN0JLA6fKyqKslCfGPYoQfMYr54z1U022Z6+5iXbbFq6rMX1ZV+SNe
+        s39zQ/sXMw+35/74T8Du/qmD5w8EaUsh/h7jsXyin+Ed7zODCDV1HwqsyFf/
+        n+K1q6p+m9c/YjQ0sX9zQ/sXcw635/74T8Du/qmD5w8EaUsh/h7jsUyin+Ed
+        7zODCDV1HwqsyFf/n2I0CUa6TPb/wSH8fzCeig4mMDI6tv//jej/J7PlqWkd
+        2P/PhvP/k3nq8GCxbNpsOf1/Zbb39pHy+wxUp/Pn3YD/382/HzZ0X1rtuAnU
+        z4NR6uz+/Brt/194eZEtyU+efbs/fHrXH5bzxekLcbet686Ov/2LIwOEEKY1
+        f82BAMPg3yS6wTf2D3xJf/DrnitPH+Eb+u1HoQ4+FFiRr/7fwHhRHpvlq7K6
+        BlM9twwVMtf/G1C/vcys6uqyAKafl9UkK49Xq9e0olRM85d1sZwWq6w8W35F
+        i0xv8mW2BHf9f3eoRaOKMXeaYZkt8uwyK8psUoKb/787ummZNU0x/aKaFGWu
+        c/izyZqMCGP1szUiIv4XGTQ6Jup4Oq3W36QmFzXJeo7VFf8myhvf2D/wJf0h
+        etNpKvoI39BvP9Lk+FBgRb4akCLmku16Sq96fxveuDU73F1VV3lNWqt5RUuU
+        oKFIbyjJbhj0hWBqR800s38xUUF905q/ZhoyDP5NGAPf2D/wJf3Br3tUoI/w
+        Df32Iy7BhwIr8tUAl7CutVyhrCIfTvIWKHqfZOVqnr0H60yr5TKfCo/8iF/0
+        b25o/2IG4PbcH/8J2N0/dfD8gSBtKcTfYzx2rvUzvON9ZhChpu5DgRX5aoBf
+        RIt8uFZxrHE8/dFCyY+4I+QO+tRnEf/3H7ELNbF/c0P7F88/t+f++E/A7v6p
+        g+cPBGlLIf4e47FTrZ/hHe8zgwg1dR8KrMhXP1x2+RGLUBP7Nze0f/Gcc3vu
+        j/8E7O6fOnj+QJC2FOLvMR47vfoZ3vE+M4hQU/ehwIp89bPPIj9iC2pi/+aG
+        9i+eZ27P/fGfgN39UwfPHwjSlkL8PcZjp1Q/wzveZwYRauo+FFiRr3722YL/
+        +RFvUBP7Nze0f/Fkc3vuj/8E7O6fOnj+QJC2FOLvMR47r/oZ3vE+M4hQU/eh
+        wIp89UPgDYLxI57gv7mh/Ysnmdtzf/wnYHf/1MHzB4K0pRB/j/HY+dTP8I73
+        mUGEmroPBVbkqx8CT3iexo/4w/7NDe1fPOHcnvvjPwG7+6cOnj8QpC2F+HuM
+        x86tfoZ3vM8MItTUfSiwIl99Tf5gDkEqu1llU7DHi/zqVV4W0/Hxyy/oJZ95
+        ALXPTspB1DZgmC6i9L1QMvjIUZIpwL/Jm5Zc3MT+xTAwbUwt+oDf49+jFKCk
+        8g6NmBryHyZl3Bv263w5u6iL2fh0QSl9au4PE8BuPXCH0BC2PEr9jbmah8if
+        ytgDEjGM8KPgD3nFEohh2b8C2ZI/0ID++DqSEqUw5dDAU1Girqe0ktA8oYXi
+        t834pMyz+ukTgu1TEmB6tJ1lbTbJGvqyQ9wO1gEhgPhmOgsB8In9Q6khRAzA
+        yUeWktwlqGC6wJvua/6L34sRzv9Uu+cv/R6jxCV2pf+BuETaDpGmJcGk5gTs
+        RzRiGjGVfAZ8U5NYf1FM62r8NM9pfXK6rov2mkD7tASgHnWHxFsHkW69zOp2
+        mddQyjdhSCLy6fbufcKQ8Ov0Q6SJrzy8N6SSFjFOqsVivSwEyss6P8+JAkSK
+        DwS9XpFE5t8IcPz3/wCWiSCZQZsBAA==
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:11 GMT
+  recorded_at: Wed, 03 Feb 2016 19:42:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -393,11 +450,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -416,22 +473,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4055ec61-464e-41cf-a4e0-b66575e5db65
-      - b6789cfc-fa6d-4d8c-a904-0453962aaf41
+      - 500a4d96-97d8-4e49-ab3d-d346cdebea29
+      - 56bed88f-e809-4a96-b3e9-310fa42048b9
+      - edecf9db-a7de-4639-a715-ee2a462551a7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14907'
       X-Ms-Request-Id:
-      - d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      - d02244fb-029e-440b-a647-3dca7d5bbbad
       X-Ms-Correlation-Request-Id:
-      - d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      - d02244fb-029e-440b-a647-3dca7d5bbbad
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163513Z:d6d37a3c-6b83-467a-b70d-b7e403758cfc
+      - NORTHCENTRALUS:20160203T194259Z:d02244fb-029e-440b-a647-3dca7d5bbbad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:13 GMT
+      - Wed, 03 Feb 2016 19:42:58 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -442,61 +500,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+  recorded_at: Wed, 03 Feb 2016 19:42:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -506,11 +574,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -529,22 +597,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 5ad33207-30c7-4558-9104-882c265b968e
-      - d01f2eac-84a6-4e9f-a59a-774e42ead3df
+      - 40efa0e4-1abd-48b0-9368-a477b670e77e
+      - 9a61c25c-048d-4134-8819-47c8efa6580b
+      - afa36dde-c6d6-4ebd-89a5-1211eb98f2c7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14904'
       X-Ms-Request-Id:
-      - 32e8ea9e-03df-4e16-af97-690cb43c7bee
+      - 0556f008-07cd-480b-8994-414cfc4d2676
       X-Ms-Correlation-Request-Id:
-      - 32e8ea9e-03df-4e16-af97-690cb43c7bee
+      - 0556f008-07cd-480b-8994-414cfc4d2676
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163514Z:32e8ea9e-03df-4e16-af97-690cb43c7bee
+      - NORTHCENTRALUS:20160203T194300Z:0556f008-07cd-480b-8994-414cfc4d2676
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:13 GMT
+      - Wed, 03 Feb 2016 19:42:59 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -555,61 +624,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -619,11 +698,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -642,22 +721,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 052b8258-5dcf-4b5c-8778-82c1e7b8c388
-      - cc84a063-74c3-402a-9817-9571610c4557
+      - 6be790b7-bcd0-4119-9561-8a374c7ffed2
+      - b4b49334-edeb-47d5-9861-3d083b2511f7
+      - cc70a61a-9d09-418d-af6f-4a8ab8e901a7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14905'
       X-Ms-Request-Id:
-      - 948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      - adbb4fdc-ba2e-4941-80d0-cbb079cc4845
       X-Ms-Correlation-Request-Id:
-      - 948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      - adbb4fdc-ba2e-4941-80d0-cbb079cc4845
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163514Z:948e0eda-ecec-4dbd-8df8-2865d3e11e4d
+      - NORTHCENTRALUS:20160203T194300Z:adbb4fdc-ba2e-4941-80d0-cbb079cc4845
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:14 GMT
+      - Wed, 03 Feb 2016 19:42:59 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -668,61 +748,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:12 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -732,11 +822,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -755,22 +845,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 411da219-aae5-47fb-8b3a-f120d0bc1018
-      - d3e776db-e155-442b-a01c-e227f94cd9fa
+      - 4ce855c7-64af-432d-9ef4-5484639a35d4
+      - d82d82e8-6a54-4593-8c3f-9099fde1bed2
+      - e286f71e-1fa3-4b8d-9eb6-8efa366645df
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14896'
       X-Ms-Request-Id:
-      - 726acedc-e819-4b8f-8958-393dd69b25e2
+      - 23889c4c-83f7-4c4c-8c59-7d81b6d1355b
       X-Ms-Correlation-Request-Id:
-      - 726acedc-e819-4b8f-8958-393dd69b25e2
+      - 23889c4c-83f7-4c4c-8c59-7d81b6d1355b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163515Z:726acedc-e819-4b8f-8958-393dd69b25e2
+      - NORTHCENTRALUS:20160203T194301Z:23889c4c-83f7-4c4c-8c59-7d81b6d1355b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:14 GMT
+      - Wed, 03 Feb 2016 19:43:00 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -781,61 +872,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:13 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -845,11 +946,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -868,22 +969,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2de3c3be-d9f2-4e59-be19-aff309740715
-      - a0042f2e-02a0-4f9e-b16a-98257f135b8e
+      - 1fc7c5fc-8e88-4146-8f01-7feba10ac558
+      - b6ce3904-9dfd-41f3-bed5-8c7c36d62492
+      - f090d528-0815-42ad-8662-406e7f2f1474
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14910'
       X-Ms-Request-Id:
-      - 626f5b30-6806-43ab-93ce-6aa23e0a1557
+      - 7acad5ec-f073-4d29-beb4-93625ba081a8
       X-Ms-Correlation-Request-Id:
-      - 626f5b30-6806-43ab-93ce-6aa23e0a1557
+      - 7acad5ec-f073-4d29-beb4-93625ba081a8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163515Z:626f5b30-6806-43ab-93ce-6aa23e0a1557
+      - NORTHCENTRALUS:20160203T194305Z:7acad5ec-f073-4d29-beb4-93625ba081a8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:15 GMT
+      - Wed, 03 Feb 2016 19:43:04 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,61 +996,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:13 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -958,11 +1070,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -981,22 +1093,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 26d86c69-ae1c-4f6e-a469-ffca0b6e793b
-      - 9e3fb8fc-b01b-4bd1-8d78-95accd66ba38
+      - 516e1197-a05f-46c9-b4d7-fb9c2894e605
+      - 7a6ddc4c-b69e-487d-944c-ef5b6c661481
+      - d2270585-acb9-476c-a596-756544591796
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14913'
       X-Ms-Request-Id:
-      - ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      - 202e80c7-d88d-4144-b635-1adfe526f0b7
       X-Ms-Correlation-Request-Id:
-      - ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      - 202e80c7-d88d-4144-b635-1adfe526f0b7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163515Z:ab2a825f-2e9e-4954-9e0c-715e742e53bc
+      - NORTHCENTRALUS:20160203T194305Z:202e80c7-d88d-4144-b635-1adfe526f0b7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:15 GMT
+      - Wed, 03 Feb 2016 19:43:04 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1007,61 +1120,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1071,11 +1194,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1094,22 +1217,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 81030e21-165c-4312-a6e6-61ddcb952c16
-      - 9342e3c4-b3b7-42a4-b817-93256a304834
+      - 058c3f02-5352-4649-84ce-89cb8104a816
+      - 911c7480-e187-4fc8-a758-6f47e6fbb930
+      - d80f46a6-ed7a-44b5-aa13-bac7310d534f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14904'
       X-Ms-Request-Id:
-      - adfa98ab-a603-4cb3-96e4-bf407341295d
+      - 2d0fb1b8-b8c8-47e6-b27b-5961494f6e35
       X-Ms-Correlation-Request-Id:
-      - adfa98ab-a603-4cb3-96e4-bf407341295d
+      - 2d0fb1b8-b8c8-47e6-b27b-5961494f6e35
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163516Z:adfa98ab-a603-4cb3-96e4-bf407341295d
+      - NORTHCENTRALUS:20160203T194306Z:2d0fb1b8-b8c8-47e6-b27b-5961494f6e35
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:15 GMT
+      - Wed, 03 Feb 2016 19:43:06 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1120,61 +1244,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1184,11 +1318,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1207,22 +1341,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1889017a-7ebe-4ed8-bc39-294884d47133
-      - a04922aa-d079-4c02-b990-8888e85bb883
+      - 315801c8-4ad1-40fa-a8bb-a8575269d9b9
+      - 713ffd42-a149-43f7-a8f6-61f4ae0be5f5
+      - bde6ed74-2dea-4818-a11c-e7f16d19c6ae
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14898'
       X-Ms-Request-Id:
-      - 49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      - 9fca1d24-4fb3-40de-b002-23d6066b1bc2
       X-Ms-Correlation-Request-Id:
-      - 49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      - 9fca1d24-4fb3-40de-b002-23d6066b1bc2
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163516Z:49cf9bdc-0593-42fe-a0f2-d71899355ecc
+      - NORTHCENTRALUS:20160203T194307Z:9fca1d24-4fb3-40de-b002-23d6066b1bc2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:16 GMT
+      - Wed, 03 Feb 2016 19:43:06 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1233,61 +1368,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1297,11 +1442,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1320,22 +1465,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4a5d1820-c8e0-425d-8a96-347c09855276
-      - ffefb4bd-4af8-4b20-8bd5-8c7866f6801b
+      - 5edbaeb1-227b-4693-b455-d7118aba6544
+      - 623afa9b-3d0f-45ac-9fcf-b4d11b7bb41e
+      - c5bf382a-2af6-41c8-946c-d12dcdbdfbe3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14908'
       X-Ms-Request-Id:
-      - b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      - 1f20eab1-c3a1-45d7-a340-b6dea8d85d66
       X-Ms-Correlation-Request-Id:
-      - b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      - 1f20eab1-c3a1-45d7-a340-b6dea8d85d66
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163517Z:b551d40f-d7a5-47fb-878e-4ec7b3aa42be
+      - NORTHCENTRALUS:20160203T194307Z:1f20eab1-c3a1-45d7-a340-b6dea8d85d66
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:16 GMT
+      - Wed, 03 Feb 2016 19:43:06 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1346,61 +1492,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1410,11 +1566,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1433,22 +1589,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 178db479-30dd-4c5f-9aa1-81ae45110963
-      - c84a0da7-e88b-45ea-8f7c-b05ed0cc40fa
+      - b5e07bed-80ba-43ca-8aee-7b6ff2e190b0
+      - d97c58c3-474c-499e-918c-ef687570841c
+      - e22f8e27-f839-4127-9d1c-b389c11f20c7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14908'
       X-Ms-Request-Id:
-      - d9fd9fed-838c-4f45-95f0-b03238b651fb
+      - 3f268552-d16b-4491-aac3-d1b64c9f72ac
       X-Ms-Correlation-Request-Id:
-      - d9fd9fed-838c-4f45-95f0-b03238b651fb
+      - 3f268552-d16b-4491-aac3-d1b64c9f72ac
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163517Z:d9fd9fed-838c-4f45-95f0-b03238b651fb
+      - NORTHCENTRALUS:20160203T194308Z:3f268552-d16b-4491-aac3-d1b64c9f72ac
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:17 GMT
+      - Wed, 03 Feb 2016 19:43:08 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1459,61 +1616,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1523,11 +1690,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1546,22 +1713,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3484f69b-91ac-4ca4-8abc-543d8dcb7348
-      - 507bf603-b939-4d45-8bb8-b5880a12f20c
+      - 4bb6bac7-d231-42d3-b507-d930a737805c
+      - 86edcc89-7866-4e73-9e30-cf18fa443f4d
+      - c09484fa-16b9-4449-b9bd-3b60ef86755b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14900'
       X-Ms-Request-Id:
-      - 3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      - efd9228f-8724-44ff-be3e-80d0ea1a304b
       X-Ms-Correlation-Request-Id:
-      - 3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      - efd9228f-8724-44ff-be3e-80d0ea1a304b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163518Z:3c3eebd0-28b1-4645-9eac-9ce44033f7e4
+      - NORTHCENTRALUS:20160203T194309Z:efd9228f-8724-44ff-be3e-80d0ea1a304b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:17 GMT
+      - Wed, 03 Feb 2016 19:43:08 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1572,61 +1740,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1636,11 +1814,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1659,22 +1837,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0298137a-c9cb-431d-bea8-ea912ce5be29
-      - 6da9b6aa-7941-4bd0-8006-4971b238addb
+      - 228eabd1-315e-44c7-8c58-59bf0bbf7c6a
+      - 5eb9ae50-9916-47c6-9c3d-ba83f425d2f7
+      - 9fc253d3-8f04-435e-9aba-99f765f203a3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14907'
       X-Ms-Request-Id:
-      - fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      - 8635cedf-e799-4d2f-a4b9-4b0a9e9290ea
       X-Ms-Correlation-Request-Id:
-      - fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      - 8635cedf-e799-4d2f-a4b9-4b0a9e9290ea
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163518Z:fdc4b4f0-1943-4052-9c82-f10147dfcd66
+      - NORTHCENTRALUS:20160203T194309Z:8635cedf-e799-4d2f-a4b9-4b0a9e9290ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:17 GMT
+      - Wed, 03 Feb 2016 19:43:09 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1685,61 +1864,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1749,11 +1938,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1772,22 +1961,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - af08601d-7c19-4ceb-ad93-734e74a0c8bb
-      - f432093b-4591-4a2c-9c42-40410a6819ba
+      - 00783197-8b18-455e-bbcf-250ae18e3ec9
+      - 5a041125-c3df-4ca9-a4e7-a7fa4522262d
+      - 68b3c4ce-0c05-4315-b699-586dc6d858cd
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14903'
       X-Ms-Request-Id:
-      - f56124bd-185a-45a4-ace9-f976d423504d
+      - 44151c0f-2e74-4e8b-a09d-967baa5823bf
       X-Ms-Correlation-Request-Id:
-      - f56124bd-185a-45a4-ace9-f976d423504d
+      - 44151c0f-2e74-4e8b-a09d-967baa5823bf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163518Z:f56124bd-185a-45a4-ace9-f976d423504d
+      - NORTHCENTRALUS:20160203T194310Z:44151c0f-2e74-4e8b-a09d-967baa5823bf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:18 GMT
+      - Wed, 03 Feb 2016 19:43:09 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1798,61 +1988,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1862,11 +2062,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1885,22 +2085,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 664c9290-8822-402a-ac70-f381e2dcc5db
-      - ec1f1ed7-7d8d-47cf-9f4f-7d74d901ea06
+      - 43caacb5-4d8d-4806-b0d4-6f65bb12f44a
+      - 70c5e8a6-5661-48b9-bc79-d822350b62f6
+      - 9d4b8004-d671-49c2-93b4-bd19b22effc3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14903'
       X-Ms-Request-Id:
-      - 37f90733-3fa7-459f-8f28-377de512f4b0
+      - ee093c03-b2a3-4a69-ab73-d14a66dbe942
       X-Ms-Correlation-Request-Id:
-      - 37f90733-3fa7-459f-8f28-377de512f4b0
+      - ee093c03-b2a3-4a69-ab73-d14a66dbe942
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163519Z:37f90733-3fa7-459f-8f28-377de512f4b0
+      - NORTHCENTRALUS:20160203T194311Z:ee093c03-b2a3-4a69-ab73-d14a66dbe942
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:19 GMT
+      - Wed, 03 Feb 2016 19:43:10 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1911,61 +2112,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1975,11 +2186,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1998,22 +2209,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b38d86d1-ada7-4beb-ba97-284cc0d2a7f8
-      - e373c89a-90b0-4793-ae53-0a7fada4bf56
+      - 2c614ee7-f1e1-4b86-82f8-b0ee2bbb392c
+      - 9ebebb41-5b70-4594-a79c-bf80b39b7e3e
+      - fc6e5d2a-d5ab-45dd-ab3e-55b682bd3b43
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14895'
       X-Ms-Request-Id:
-      - 5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      - e3d5bc98-64e1-4080-87d6-2372571f288a
       X-Ms-Correlation-Request-Id:
-      - 5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      - e3d5bc98-64e1-4080-87d6-2372571f288a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163519Z:5eb3a819-4c33-4eb2-9c86-f99c0f5017cc
+      - NORTHCENTRALUS:20160203T194311Z:e3d5bc98-64e1-4080-87d6-2372571f288a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:19 GMT
+      - Wed, 03 Feb 2016 19:43:11 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2024,61 +2236,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2088,11 +2310,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2111,22 +2333,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 459b7940-f6b3-4d8d-bae2-dc873312c6f6
-      - c7dfc2c1-16f5-46a5-9681-fe471252f5b0
+      - 87573d02-8ad5-4289-8398-933339459f3c
+      - 95d28ac6-dcb8-4b0f-ab73-597ce8228792
+      - d204a42a-d781-4dd7-81f1-042bea225d50
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14909'
       X-Ms-Request-Id:
-      - 902d217e-12f9-408f-9ee5-b4f381177923
+      - b8672619-f1ca-4fb7-ace8-6edac334e7b8
       X-Ms-Correlation-Request-Id:
-      - 902d217e-12f9-408f-9ee5-b4f381177923
+      - b8672619-f1ca-4fb7-ace8-6edac334e7b8
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163520Z:902d217e-12f9-408f-9ee5-b4f381177923
+      - NORTHCENTRALUS:20160203T194313Z:b8672619-f1ca-4fb7-ace8-6edac334e7b8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:20 GMT
+      - Wed, 03 Feb 2016 19:43:12 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2137,61 +2360,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2201,11 +2434,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2224,22 +2457,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 690ef100-c3ce-4a13-8d13-4a1e7572dbe9
-      - acc9b5ee-6ddc-4c91-8d67-a09e0b88e3b1
+      - 390ffaae-70b9-4d18-9bf2-bc579f703e7f
+      - 40bd1e4c-9960-4332-a64a-a6ff00b959ca
+      - 67acb195-b4d7-471d-9106-45a5ee5367d0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14910'
       X-Ms-Request-Id:
-      - 62825ca9-f5ae-434d-b91e-299e6d672659
+      - 284f0fd8-3ab7-468f-9c5a-30d6a325db4c
       X-Ms-Correlation-Request-Id:
-      - 62825ca9-f5ae-434d-b91e-299e6d672659
+      - 284f0fd8-3ab7-468f-9c5a-30d6a325db4c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163520Z:62825ca9-f5ae-434d-b91e-299e6d672659
+      - NORTHCENTRALUS:20160203T194314Z:284f0fd8-3ab7-468f-9c5a-30d6a325db4c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:20 GMT
+      - Wed, 03 Feb 2016 19:43:13 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2250,61 +2484,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2314,11 +2558,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2337,22 +2581,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - c4187aec-3877-4f8d-be1b-acab3d0aaa5a
-      - d3a088dc-ac2e-4ef1-9fdb-bce80d272a63
+      - 855fe684-e7c8-483b-8578-5fa776a1eb6f
+      - 9e57b669-e792-4294-83b4-2e436fde1435
+      - a0a9c1b2-38c1-4358-b921-b9a26275b16f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14897'
       X-Ms-Request-Id:
-      - caeb980b-5d87-4923-9ba4-a7cf9e608958
+      - d9ed3f49-770e-466f-9907-0c1e0bd1282d
       X-Ms-Correlation-Request-Id:
-      - caeb980b-5d87-4923-9ba4-a7cf9e608958
+      - d9ed3f49-770e-466f-9907-0c1e0bd1282d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163521Z:caeb980b-5d87-4923-9ba4-a7cf9e608958
+      - NORTHCENTRALUS:20160203T194314Z:d9ed3f49-770e-466f-9907-0c1e0bd1282d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:20 GMT
+      - Wed, 03 Feb 2016 19:43:14 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2363,61 +2608,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2427,11 +2682,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2450,22 +2705,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 148cfa8a-9557-40fa-a63b-474f1f4539fc
-      - 381ac3ce-bda2-4a4b-8c6c-b327f45d75dd
+      - 0dabcdd3-989c-4bbc-ad16-b4f4fe0af521
+      - 977bb281-4059-4ede-81fd-5d91549a5618
+      - da8ca5ca-efef-41f6-8d5c-e529c2d4d8b4
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14899'
       X-Ms-Request-Id:
-      - 685be522-4a05-4065-ac32-147365cf3bbb
+      - a330b801-7284-404e-be6c-98e43d30c357
       X-Ms-Correlation-Request-Id:
-      - 685be522-4a05-4065-ac32-147365cf3bbb
+      - a330b801-7284-404e-be6c-98e43d30c357
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163521Z:685be522-4a05-4065-ac32-147365cf3bbb
+      - NORTHCENTRALUS:20160203T194315Z:a330b801-7284-404e-be6c-98e43d30c357
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:20 GMT
+      - Wed, 03 Feb 2016 19:43:15 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2476,61 +2732,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2540,11 +2806,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2563,22 +2829,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 9df83c59-0174-431e-9832-8e510494d6f0
-      - a1c1892e-7654-4c12-bfa5-a5720eef5f9b
+      - 97ce7b0b-7599-4e83-a6bc-c1ffddfa7e11
+      - c3d7d657-3b31-4931-ba54-55edb3c9bdc6
+      - c8deccdd-bfc1-4cfc-8092-a2b61b8b9c83
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14905'
       X-Ms-Request-Id:
-      - e9fbef01-5e9c-46a2-a619-f0816dec6834
+      - fd55b141-ff57-4d06-9233-36c0f3c02b01
       X-Ms-Correlation-Request-Id:
-      - e9fbef01-5e9c-46a2-a619-f0816dec6834
+      - fd55b141-ff57-4d06-9233-36c0f3c02b01
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163521Z:e9fbef01-5e9c-46a2-a619-f0816dec6834
+      - NORTHCENTRALUS:20160203T194315Z:fd55b141-ff57-4d06-9233-36c0f3c02b01
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:21 GMT
+      - Wed, 03 Feb 2016 19:43:15 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2589,61 +2856,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2653,11 +2930,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2676,22 +2953,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1dc04ce0-4c5a-4f55-b2ec-f1c2b74837e8
-      - d51c902c-5ea9-4d22-968a-ecb7a32d9cd8
+      - 1c62d1ed-efa8-470a-866c-6040db19dae8
+      - 7a69d6cf-453f-475e-b746-e02162669b4f
+      - 85515dc4-a17e-43f9-b876-738323b71037
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14907'
       X-Ms-Request-Id:
-      - 28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      - ebe22975-e9dc-4a05-a239-4fe3b6aad975
       X-Ms-Correlation-Request-Id:
-      - 28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      - ebe22975-e9dc-4a05-a239-4fe3b6aad975
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163521Z:28c1248e-9e7f-40f6-a9c0-950086b5dd68
+      - NORTHCENTRALUS:20160203T194316Z:ebe22975-e9dc-4a05-a239-4fe3b6aad975
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:21 GMT
+      - Wed, 03 Feb 2016 19:43:16 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2702,61 +2980,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2766,11 +3054,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2789,22 +3077,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a1b82cc7-bc18-4d47-92cc-ac25c9200519
-      - cd031bad-d667-4882-9cef-57ed6ed304be
+      - 52833ad0-6025-4734-b01c-7c25e3b53072
+      - 5eb2beeb-f14d-45e5-bd16-b13b15e5c152
+      - edf55587-5b6b-4df9-b8ef-15d618ded20a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14907'
       X-Ms-Request-Id:
-      - db63827e-d942-4821-801d-67e7cabaa018
+      - dbdb93d1-848b-43d0-b895-c1e167b8f513
       X-Ms-Correlation-Request-Id:
-      - db63827e-d942-4821-801d-67e7cabaa018
+      - dbdb93d1-848b-43d0-b895-c1e167b8f513
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163522Z:db63827e-d942-4821-801d-67e7cabaa018
+      - NORTHCENTRALUS:20160203T194316Z:dbdb93d1-848b-43d0-b895-c1e167b8f513
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:21 GMT
+      - Wed, 03 Feb 2016 19:43:16 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2815,61 +3104,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2879,11 +3178,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2902,22 +3201,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2214f903-00cc-4796-b1bb-ce387bcc5f88
-      - 846f5f81-081f-4c9c-a04c-00c1f32c2702
+      - 264f7c26-86c4-4759-8184-029cea92e6d9
+      - e4ca5c1d-8f6d-4ebd-96e1-8a6cdcf7be35
+      - fe4eb4d4-e554-4a9b-9b46-311720a01078
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14906'
       X-Ms-Request-Id:
-      - 83cefac5-3e04-4517-a417-01a5d043d636
+      - 63363727-c0d6-4948-9e9b-80b74657f082
       X-Ms-Correlation-Request-Id:
-      - 83cefac5-3e04-4517-a417-01a5d043d636
+      - 63363727-c0d6-4948-9e9b-80b74657f082
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163522Z:83cefac5-3e04-4517-a417-01a5d043d636
+      - NORTHCENTRALUS:20160203T194317Z:63363727-c0d6-4948-9e9b-80b74657f082
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:22 GMT
+      - Wed, 03 Feb 2016 19:43:16 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2928,61 +3228,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2992,11 +3302,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3015,22 +3325,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1da230e6-6c4f-4b8e-94c8-d2577fe29a1c
-      - 21fdecd5-1467-45e0-88fb-3bb79ddd8b63
+      - 299b57d1-8eed-4227-a75b-d3d4259689a0
+      - c812d69b-71af-4f09-9090-c4dc7cfc0581
+      - ca2ba50b-da6d-469c-82b5-8bb46fb62598
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14908'
       X-Ms-Request-Id:
-      - 40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      - 36fb689e-0794-4c08-a957-66bae90e80c7
       X-Ms-Correlation-Request-Id:
-      - 40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      - 36fb689e-0794-4c08-a957-66bae90e80c7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163522Z:40ae3a7a-57ef-495b-ba34-eb873572b4d0
+      - NORTHCENTRALUS:20160203T194318Z:36fb689e-0794-4c08-a957-66bae90e80c7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:22 GMT
+      - Wed, 03 Feb 2016 19:43:18 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3041,61 +3352,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3105,11 +3426,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3128,22 +3449,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 718aa02e-4f88-4923-b263-81312ee87bc6
-      - ffcbdde9-3d49-4b4b-b7d6-2a94c7293013
+      - 3c5b3e99-bf2c-432f-b8c3-393da8ea368e
+      - 5e0afca7-1e63-4b14-a901-35b06ba12b65
+      - 82d5426d-b387-432c-bf42-25a5593fdcbc
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14912'
       X-Ms-Request-Id:
-      - 72355828-b324-47e6-ba10-b62286f72691
+      - e72d341c-2d7b-422d-b2ec-b7ffdcab70d7
       X-Ms-Correlation-Request-Id:
-      - 72355828-b324-47e6-ba10-b62286f72691
+      - e72d341c-2d7b-422d-b2ec-b7ffdcab70d7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163523Z:72355828-b324-47e6-ba10-b62286f72691
+      - NORTHCENTRALUS:20160203T194320Z:e72d341c-2d7b-422d-b2ec-b7ffdcab70d7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:22 GMT
+      - Wed, 03 Feb 2016 19:43:19 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3154,61 +3476,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3218,11 +3550,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3241,22 +3573,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 495503a1-ded9-44df-beee-a9b28bbdf39d
-      - 7797e931-ade0-43a5-b97b-c19a8e1622c6
+      - 566dae06-060d-4308-97b7-24af47ceac62
+      - ae048037-0a3f-4307-a0b1-4308e4253878
+      - cf4bb411-4314-406c-b004-d736797891c5
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14907'
       X-Ms-Request-Id:
-      - 6d479355-4d12-44f5-b283-e1b562de6c8c
+      - f5d196d2-4ece-4feb-81a5-f6636b3d4549
       X-Ms-Correlation-Request-Id:
-      - 6d479355-4d12-44f5-b283-e1b562de6c8c
+      - f5d196d2-4ece-4feb-81a5-f6636b3d4549
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163523Z:6d479355-4d12-44f5-b283-e1b562de6c8c
+      - NORTHCENTRALUS:20160203T194320Z:f5d196d2-4ece-4feb-81a5-f6636b3d4549
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:22 GMT
+      - Wed, 03 Feb 2016 19:43:20 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3267,61 +3600,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3331,11 +3674,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3354,22 +3697,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 05030f81-6084-4c7e-89ef-4d1441edfbf1
-      - 07280be1-60ff-4dbd-8239-676336718b95
+      - 7dd20f20-5af9-4c2c-b610-56a4b2861ed5
+      - ca4c3240-4ef5-4ca0-b8a1-bcdf491596fe
+      - d8e2c386-77b8-4a7d-9657-0ef9ec6fbed2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14913'
       X-Ms-Request-Id:
-      - f69996aa-8bae-4e64-9ca7-34e81e49805a
+      - 564020b1-0c9d-444d-9fa1-a48f353e2d77
       X-Ms-Correlation-Request-Id:
-      - f69996aa-8bae-4e64-9ca7-34e81e49805a
+      - 564020b1-0c9d-444d-9fa1-a48f353e2d77
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163524Z:f69996aa-8bae-4e64-9ca7-34e81e49805a
+      - NORTHCENTRALUS:20160203T194321Z:564020b1-0c9d-444d-9fa1-a48f353e2d77
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 16:35:23 GMT
+      - Wed, 03 Feb 2016 19:43:20 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3380,8737 +3724,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 669552b1-97ab-4933-871d-dc59833a3c04
-      - eca59a27-35ec-4f0e-9a71-3ac9066d872e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - f87e28d6-06f5-46d2-9984-7b121d66ea21
-      X-Ms-Correlation-Request-Id:
-      - f87e28d6-06f5-46d2-9984-7b121d66ea21
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163524Z:f87e28d6-06f5-46d2-9984-7b121d66ea21
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:23 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2f72bf7b-47f9-4ba6-b8fb-aafcdae04763
-      - f7a557e0-94d7-4661-a577-18d716cddba4
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 5b25c3ba-4b78-410a-bd33-e4b8438d6373
-      X-Ms-Correlation-Request-Id:
-      - 5b25c3ba-4b78-410a-bd33-e4b8438d6373
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163524Z:5b25c3ba-4b78-410a-bd33-e4b8438d6373
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:23 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - e418c967-748e-4db8-badd-ef5890509926
-      - e8d84987-2a06-4497-94b9-fc159e8fad2e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
-      X-Ms-Correlation-Request-Id:
-      - e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163525Z:e8b67fc1-ddd5-487d-b99e-47ffd5b62fed
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:24 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 025ec6d2-27cf-4743-af9d-9ac343a59e70
-      - 909de84d-91d3-4647-bb48-2db2f36b050b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - fc468091-c04b-4115-8ae9-f44dfc6779a2
-      X-Ms-Correlation-Request-Id:
-      - fc468091-c04b-4115-8ae9-f44dfc6779a2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163525Z:fc468091-c04b-4115-8ae9-f44dfc6779a2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:24 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8e1b4905-26a8-4d3c-9ab7-0f594de3026a
-      - cfe55d83-aadd-4271-80c4-d6bcdbad1727
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - ca7900c8-be9e-438a-98e4-7090f5d49e73
-      X-Ms-Correlation-Request-Id:
-      - ca7900c8-be9e-438a-98e4-7090f5d49e73
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163525Z:ca7900c8-be9e-438a-98e4-7090f5d49e73
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:24 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7e06919f-af25-4210-9f48-3bef8955dd49
-      - c5321f65-7577-4319-bca2-bedb983273fd
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 2531a42f-8a62-4a68-b21b-9e3fb1c29828
-      X-Ms-Correlation-Request-Id:
-      - 2531a42f-8a62-4a68-b21b-9e3fb1c29828
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163526Z:2531a42f-8a62-4a68-b21b-9e3fb1c29828
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:25 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 764d4ed2-3313-42c5-9b30-155b9a14ca1c
-      - b5d8980c-7b0f-4906-b7b2-4f794954ef8c
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - b13d017e-73ef-48c6-a342-cd9ac584511b
-      X-Ms-Correlation-Request-Id:
-      - b13d017e-73ef-48c6-a342-cd9ac584511b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163526Z:b13d017e-73ef-48c6-a342-cd9ac584511b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:26 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - c80fca4a-f35e-45ac-9ae2-cb68266d1ba0
-      - cae0dc70-2768-4efb-9069-afcb7e2b1384
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 13bee540-4b2e-4979-8667-1de3768494cd
-      X-Ms-Correlation-Request-Id:
-      - 13bee540-4b2e-4979-8667-1de3768494cd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163527Z:13bee540-4b2e-4979-8667-1de3768494cd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8438fbee-8dbf-49e4-8a49-4408b854e858
-      - de213cc7-1b22-42c7-add4-180bb406fc87
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - f1253a95-0260-4994-b719-ea6171b08116
-      X-Ms-Correlation-Request-Id:
-      - f1253a95-0260-4994-b719-ea6171b08116
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163527Z:f1253a95-0260-4994-b719-ea6171b08116
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 247dcbc1-3f09-4cd7-a8bd-fdc2c63d1bd8
-      - 36769973-b620-47b1-b4c2-253d109334f2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 0f84083b-a4ff-4fa9-b17f-28db20a3beb5
-      X-Ms-Correlation-Request-Id:
-      - 0f84083b-a4ff-4fa9-b17f-28db20a3beb5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163527Z:0f84083b-a4ff-4fa9-b17f-28db20a3beb5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 21faa11f-b26e-4f61-a3a8-d70b994ad7fc
-      - 348a800f-3470-4276-96c0-6bc5aa0dda99
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
-      X-Ms-Correlation-Request-Id:
-      - 37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163528Z:37819c61-e2b6-4d9e-9bfd-49e1e1a07e04
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 326885f6-a81b-44f9-8eea-8bdbfd4817c5
-      - 7ff36c85-7bf3-433a-abfa-0a6ea1b81248
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - e68c66c1-a183-4601-89a8-6af0f1e42097
-      X-Ms-Correlation-Request-Id:
-      - e68c66c1-a183-4601-89a8-6af0f1e42097
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163528Z:e68c66c1-a183-4601-89a8-6af0f1e42097
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6fc0d724-7dd5-4ab7-a014-9ec639f244b1
-      - 8f9b11f6-9c33-4a01-90db-1be9c84e8d39
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 1d0a2192-0fb6-484f-80c6-d6ef1549900b
-      X-Ms-Correlation-Request-Id:
-      - 1d0a2192-0fb6-484f-80c6-d6ef1549900b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163528Z:1d0a2192-0fb6-484f-80c6-d6ef1549900b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - a1181ec5-8b7f-49a8-9456-33faae3193b5
-      - a681ad7b-5261-47e0-9779-086bc9ee0590
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 663bccf7-4aa5-45d3-954a-78d5f44a5be1
-      X-Ms-Correlation-Request-Id:
-      - 663bccf7-4aa5-45d3-954a-78d5f44a5be1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163528Z:663bccf7-4aa5-45d3-954a-78d5f44a5be1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 9739e587-4fd4-4501-a768-6faef4ca4ab4
-      - e1a6abbb-e6ce-4fcc-9b47-50a22e7c9e26
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
-      X-Ms-Correlation-Request-Id:
-      - 7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163529Z:7bcbaf8b-1304-4f0b-ad4b-23508e978ef6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5e7f236c-639f-4238-bcd4-1877fd2d91f3
-      - 709f00ab-44ae-4797-9d5a-b2c96baa09e3
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 45f994eb-c61f-4ea6-86cb-d29524dbe7a2
-      X-Ms-Correlation-Request-Id:
-      - 45f994eb-c61f-4ea6-86cb-d29524dbe7a2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163529Z:45f994eb-c61f-4ea6-86cb-d29524dbe7a2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5082126d-c149-4561-8cb4-35250ca24b90
-      - 6438087f-faa0-4386-8db5-375b28adf7e2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 70009eac-3d02-440c-a14c-c9060f9a5fe7
-      X-Ms-Correlation-Request-Id:
-      - 70009eac-3d02-440c-a14c-c9060f9a5fe7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163529Z:70009eac-3d02-440c-a14c-c9060f9a5fe7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 009f48f2-82f3-4ea2-a8e9-38e7bd8ab450
-      - 16b4c993-a424-4248-bc43-b8a5bbf0c2a6
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 58cd2784-0404-44b5-a019-484e88c3d157
-      X-Ms-Correlation-Request-Id:
-      - 58cd2784-0404-44b5-a019-484e88c3d157
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163530Z:58cd2784-0404-44b5-a019-484e88c3d157
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6d3bbb41-89a7-4657-9ee2-9a2b725b4b03
-      - ab68b57d-dbad-4aa6-8ccb-bde0f16899c5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 840ea5ea-4561-444b-9424-097d08d44f79
-      X-Ms-Correlation-Request-Id:
-      - 840ea5ea-4561-444b-9424-097d08d44f79
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163531Z:840ea5ea-4561-444b-9424-097d08d44f79
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1a34292f-9fc3-459a-88c1-61351378c8ea
-      - cb389b18-077b-407a-9f2a-a4a6c19cc559
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 69bfa40a-6df5-48b1-af99-7c89a939aad2
-      X-Ms-Correlation-Request-Id:
-      - 69bfa40a-6df5-48b1-af99-7c89a939aad2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163531Z:69bfa40a-6df5-48b1-af99-7c89a939aad2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 29ff17dd-14b9-4594-944b-c743ef5cfba5
-      - effc15c2-6673-4562-90e0-9c380ecd94f6
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 88be2c30-1bfd-4456-9e71-6379da82e428
-      X-Ms-Correlation-Request-Id:
-      - 88be2c30-1bfd-4456-9e71-6379da82e428
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163531Z:88be2c30-1bfd-4456-9e71-6379da82e428
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4679a377-2faa-4861-9ccd-a82451a34886
-      - c8a4bb1d-207e-4cca-94e4-38e31bd1ae4e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - bb472d9a-3c6d-41de-b346-13b965e20bf9
-      X-Ms-Correlation-Request-Id:
-      - bb472d9a-3c6d-41de-b346-13b965e20bf9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163532Z:bb472d9a-3c6d-41de-b346-13b965e20bf9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 092a0d5a-38be-40cd-8b7d-cacbf0bdaa42
-      - 58599eab-ddc2-401c-944b-974e4fa62d74
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - fe203b1f-42b1-413e-95e9-66d6089f5698
-      X-Ms-Correlation-Request-Id:
-      - fe203b1f-42b1-413e-95e9-66d6089f5698
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163532Z:fe203b1f-42b1-413e-95e9-66d6089f5698
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2fbd4d26-9755-44c3-91ab-9ec99ae47c64
-      - 55195397-7a31-4da8-8182-d4793f15ad14
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 7e6cef3e-b380-4313-a646-8f1e2f028c03
-      X-Ms-Correlation-Request-Id:
-      - 7e6cef3e-b380-4313-a646-8f1e2f028c03
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163532Z:7e6cef3e-b380-4313-a646-8f1e2f028c03
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5753d44c-e9a2-448e-bd0b-4f48617c3658
-      - b1d8a212-2f65-4ebc-8b2a-e2d60af7709c
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - eff311e4-1f58-440b-88e6-63a6ffe866c9
-      X-Ms-Correlation-Request-Id:
-      - eff311e4-1f58-440b-88e6-63a6ffe866c9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163532Z:eff311e4-1f58-440b-88e6-63a6ffe866c9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 3d8dfc2f-926a-49b9-81b6-a467f3a28325
-      - 53b26ff1-434c-4008-a0a6-86c717c30c75
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - bc14ecba-0e41-4251-a1d7-709fd835f10b
-      X-Ms-Correlation-Request-Id:
-      - bc14ecba-0e41-4251-a1d7-709fd835f10b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163533Z:bc14ecba-0e41-4251-a1d7-709fd835f10b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8227915a-6a4b-489d-b6a8-da449e769d5e
-      - ed36c2b4-1af8-46ed-af3a-22ed9c46809f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - c750862b-7fd1-44ae-a81a-eb531bb718dd
-      X-Ms-Correlation-Request-Id:
-      - c750862b-7fd1-44ae-a81a-eb531bb718dd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163533Z:c750862b-7fd1-44ae-a81a-eb531bb718dd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 0e5ec959-4bc2-42ce-8178-21ea5d72c27a
-      - 62337c8f-150d-4038-bae1-696d3773088e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 982272c5-9fda-4a5e-a564-d8b2277ca0e7
-      X-Ms-Correlation-Request-Id:
-      - 982272c5-9fda-4a5e-a564-d8b2277ca0e7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163534Z:982272c5-9fda-4a5e-a564-d8b2277ca0e7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 640edb2e-5c6f-4317-9512-6c3a5c45e8fa
-      - 952f6ed6-9834-4592-ac87-275532909f23
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 3b5378f0-65a8-403d-86d2-87181206a495
-      X-Ms-Correlation-Request-Id:
-      - 3b5378f0-65a8-403d-86d2-87181206a495
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163534Z:3b5378f0-65a8-403d-86d2-87181206a495
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 09f95b24-449b-47f2-8935-db264754b8b0
-      X-Ms-Correlation-Request-Id:
-      - 09f95b24-449b-47f2-8935-db264754b8b0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163534Z:09f95b24-449b-47f2-8935-db264754b8b0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:33 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 04a64a8e-7c81-4725-a6f9-fa4f4e69e411
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - b83d38e3-22e9-49a0-b063-d765f5927c49
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163535Z:b83d38e3-22e9-49a0-b063-d765f5927c49
-      Date:
-      - Wed, 28 Oct 2015 16:35:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 7ff7ce68-baaa-4be5-ad7c-cf91989b6393
-      X-Ms-Correlation-Request-Id:
-      - 7ff7ce68-baaa-4be5-ad7c-cf91989b6393
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163535Z:7ff7ce68-baaa-4be5-ad7c-cf91989b6393
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:35 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - bd11ea49-f967-4f1b-ac0e-90302d37b392
-      X-Ms-Correlation-Request-Id:
-      - bd11ea49-f967-4f1b-ac0e-90302d37b392
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163536Z:bd11ea49-f967-4f1b-ac0e-90302d37b392
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:36 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 3b6626d1-b82c-4be6-b631-e24411982be3
-      X-Ms-Correlation-Request-Id:
-      - 3b6626d1-b82c-4be6-b631-e24411982be3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163537Z:3b6626d1-b82c-4be6-b631-e24411982be3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:37 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f5a65b0e-4c64-4326-967a-c154738263d6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - caf71346-a236-4cb0-a264-53d12b709a6e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163538Z:caf71346-a236-4cb0-a264-53d12b709a6e
-      Date:
-      - Wed, 28 Oct 2015 16:35:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 13b71b5e-8a0f-46e6-914f-8f35126ada1d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - e20162a1-82d8-4d65-872d-1b28b8f3898c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163538Z:e20162a1-82d8-4d65-872d-1b28b8f3898c
-      Date:
-      - Wed, 28 Oct 2015 16:35:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 3a3bf562-6aab-44cd-b337-f5dddb10e376
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - eebdd6c5-388d-463a-b56b-d3e473bf5a01
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163539Z:eebdd6c5-388d-463a-b56b-d3e473bf5a01
-      Date:
-      - Wed, 28 Oct 2015 16:35:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qN7B5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19U88f53Xl3n9NL903UZp572O
-        ZwP9mvV0muezfOYg4nH0O1ueV53vCNOQfD7YdAhijDj3H+0/eHR/f/zw3qf3
-        79/b7xCJSGN+ZULp399nuB9Nqqp9WmQXy6ppiynw0DHTaJdNVeavp3WeL5t5
-        1T4pq8lXdUFNPpq37ap5dPfuVd600ypr2tmkuf/w073xhNqMp1Wdj6+K5ay6
-        asbLvL2LTmauk+3mF5UNz8H2zr2H+Wy6d7B9Pz/Y2d7f2dnbnszuT7f37z/M
-        9mfZ/d29g/27/pSNb/PGuLFIjyeLFZNC+SN/19IXRGQMVWdaR0zfGib5opjW
-        VVOdt+Mzanwxb5vxT37hkel13rY0Sw1DJtj4oQTtM5ID/14MNMQ87884m5nm
-        4cPd3Ye7AdMIraKYV1d5jZ7zu7M8K8tqSr/6Xd0aadIFPgRpKIT8jZNf8v8A
-        0+Qg/UAFAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2fecef40-0d1e-45f9-a810-b8e61b1a38a1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1305ec3a-96b5-4e9f-9a1d-07bfc7c8abb2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 56938193-f9ba-4159-aaaf-792f69dffe9f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163539Z:56938193-f9ba-4159-aaaf-792f69dffe9f
-      Date:
-      - Wed, 28 Oct 2015 16:35:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR3nk+
-        zc/3d7Z3ZruE0P3zh9vZwe7O9uQg/3R3spvdO8h2f9+P9MX2esUDvkXX+kZZ
-        TTOMHG9d5U27Nl/QOFZ53RbU8lHK5JQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
-        Sc0sfdZC451Jdj/b2Z9tTx8+vLe9f/Bgup1N7+1v39vfzc8fzA5muw/37cvF
-        6qRanhcX65oRQ/ffk69SgwceO7nFasrtdw0EPP9vnNy73ZHRBzHUv+7sy4M5
-        6k2cPPjqFtMnDzUuLqnJ2cvj2YxoAmgf7e6M7413xnay5PGaloafvsjbecVz
-        8PSaZqqYdl9ZT8piSm9Y4AGq1OKHP4MdnGgGX//E89c8g0/zy498/H5JOBpC
-        kqaf8P25H8RlUbfrrNQ/Oy8SHoRnc3eWn2frsg2H5P6wv+ov39fRfjRbNq/z
-        tiX2CWZMPged8PH3THP6IlutyiKfPQ2/l68NDT/Kl9mkJO55VtVXWT0j6NTq
-        PCPhMS0IaYzmdT5d10V7zTShNg6BHz6dYyhFGcYOU2fmi2w6L5YQvZ8N9E9f
-        vzn58vj1m6dPXkfRP6kWq3WbGzZRZOKI4wf980v+H/CSLWlNBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1bd32c05-3887-4377-bca0-885aa39cb0ab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - aa318178-192d-4efc-ae8a-ebe5c0857d20
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163539Z:aa318178-192d-4efc-ae8a-ebe5c0857d20
-      Date:
-      - Wed, 28 Oct 2015 16:35:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - a0228457-aaab-4bbd-ac5c-f4bd9485a737
-      X-Ms-Correlation-Request-Id:
-      - a0228457-aaab-4bbd-ac5c-f4bd9485a737
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163541Z:a0228457-aaab-4bbd-ac5c-f4bd9485a737
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:40 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - fd2bdb71-e08b-43f3-a6a4-079392d8ae5f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 6c16ede5-d04d-4a4e-83d3-f1bba231e171
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163541Z:6c16ede5-d04d-4a4e-83d3-f1bba231e171
-      Date:
-      - Wed, 28 Oct 2015 16:35:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - e283ed4f-6375-409f-b812-bc4b8e8a43e7
-      X-Ms-Correlation-Request-Id:
-      - e283ed4f-6375-409f-b812-bc4b8e8a43e7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163541Z:e283ed4f-6375-409f-b812-bc4b8e8a43e7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:41 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
-      X-Ms-Correlation-Request-Id:
-      - 2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:2f8f6fb6-ddd1-4de3-aec6-8dd755c0093b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:41 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 47800d9b-5e8c-4ce2-a334-a57f8a501b7b
-      X-Ms-Correlation-Request-Id:
-      - 47800d9b-5e8c-4ce2-a334-a57f8a501b7b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:47800d9b-5e8c-4ce2-a334-a57f8a501b7b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:42 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
-      X-Ms-Correlation-Request-Id:
-      - ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:ee0a15f5-2a4d-45b4-a432-9c0a90996bf2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:42 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 9d0b5d92-1db1-4d8b-86aa-d77198191c82
-      X-Ms-Correlation-Request-Id:
-      - 9d0b5d92-1db1-4d8b-86aa-d77198191c82
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:9d0b5d92-1db1-4d8b-86aa-d77198191c82
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:42 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 66f926f4-f1a7-4d24-9390-138110c30948
-      X-Ms-Correlation-Request-Id:
-      - 66f926f4-f1a7-4d24-9390-138110c30948
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:66f926f4-f1a7-4d24-9390-138110c30948
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:41 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - f6a8c87b-d575-4ec7-a906-efa6b75aae0d
-      X-Ms-Correlation-Request-Id:
-      - f6a8c87b-d575-4ec7-a906-efa6b75aae0d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163542Z:f6a8c87b-d575-4ec7-a906-efa6b75aae0d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:42 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
-      X-Ms-Correlation-Request-Id:
-      - 8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163543Z:8255eda6-5a6a-4d2b-a53c-c3aa69da5e2c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:42 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 23f699f5-ff98-4f06-94ce-2ed344863e2d
-      X-Ms-Correlation-Request-Id:
-      - 23f699f5-ff98-4f06-94ce-2ed344863e2d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163543Z:23f699f5-ff98-4f06-94ce-2ed344863e2d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:43 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - d9bcf0a0-e299-4170-b255-daccc22c18c8
-      X-Ms-Correlation-Request-Id:
-      - d9bcf0a0-e299-4170-b255-daccc22c18c8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163543Z:d9bcf0a0-e299-4170-b255-daccc22c18c8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:43 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 0a73ee52-36df-4ac9-bff5-69e6573f4bb1
-      X-Ms-Correlation-Request-Id:
-      - 0a73ee52-36df-4ac9-bff5-69e6573f4bb1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163543Z:0a73ee52-36df-4ac9-bff5-69e6573f4bb1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:43 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C1C:798A:A0FADFD:5630F960
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1026-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - a1c918cc-8d01-4827-a81e-271aa1502353
-      X-Ms-Correlation-Request-Id:
-      - a1c918cc-8d01-4827-a81e-271aa1502353
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163544Z:a1c918cc-8d01-4827-a81e-271aa1502353
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:42 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C1C:798A:A0FAE4F:5630F960
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1022-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:40:44 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 4ffa3527-ecd4-4409-a4e6-1efd22dad066
-      X-Ms-Correlation-Request-Id:
-      - 4ffa3527-ecd4-4409-a4e6-1efd22dad066
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163544Z:4ffa3527-ecd4-4409-a4e6-1efd22dad066
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C14:798C:C1F0B2F:5630F961
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 16:35:45 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1034-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Expires:
-      - Wed, 28 Oct 2015 16:40:45 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 5bae7a51-a5e8-4783-b81c-492f00999206
-      X-Ms-Correlation-Request-Id:
-      - 5bae7a51-a5e8-4783-b81c-492f00999206
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163545Z:5bae7a51-a5e8-4783-b81c-492f00999206
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 46fea4fd-0b8a-483d-969c-13977010a540
-      X-Ms-Correlation-Request-Id:
-      - 46fea4fd-0b8a-483d-969c-13977010a540
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163545Z:46fea4fd-0b8a-483d-969c-13977010a540
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:44 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 101a9c84-8ebd-4853-b7c3-aa083f7066d0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 2518967b-b860-4345-95b8-e6fca829f4c9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163545Z:2518967b-b860-4345-95b8-e6fca829f4c9
-      Date:
-      - Wed, 28 Oct 2015 16:35:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - dc410e58-a6c2-48f9-b6c2-1d9cb13efe2f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 8b56cf27-d50b-41ad-9a94-2cb16294f6d5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163546Z:8b56cf27-d50b-41ad-9a94-2cb16294f6d5
-      Date:
-      - Wed, 28 Oct 2015 16:35:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 3512e777-491f-42bc-a105-aa944c12e419
-      X-Ms-Correlation-Request-Id:
-      - 3512e777-491f-42bc-a105-aa944c12e419
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163546Z:3512e777-491f-42bc-a105-aa944c12e419
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:46 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 494f7047-5430-4802-9a96-c07c45aea8d7
-      X-Ms-Correlation-Request-Id:
-      - 494f7047-5430-4802-9a96-c07c45aea8d7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163546Z:494f7047-5430-4802-9a96-c07c45aea8d7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:45 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b4dadbef-3594-4414-b7d1-a575393a1888
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - 3995dfab-7667-4777-937e-6e3425df12fd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:3995dfab-7667-4777-937e-6e3425df12fd
-      Date:
-      - Wed, 28 Oct 2015 16:35:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 02d81947-1c4f-46a5-8e54-4b16c72aa1d2
-      X-Ms-Correlation-Request-Id:
-      - 02d81947-1c4f-46a5-8e54-4b16c72aa1d2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:02d81947-1c4f-46a5-8e54-4b16c72aa1d2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:46 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 176cec38-9e89-482e-aa11-010fa2859d36
-      X-Ms-Correlation-Request-Id:
-      - 176cec38-9e89-482e-aa11-010fa2859d36
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:176cec38-9e89-482e-aa11-010fa2859d36
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:46 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 20a46daa-4a2f-42c4-8888-533a8bbf9c6d
-      X-Ms-Correlation-Request-Id:
-      - 20a46daa-4a2f-42c4-8888-533a8bbf9c6d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:20a46daa-4a2f-42c4-8888-533a8bbf9c6d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 3b309668-d0e8-42d1-8404-9b1b8eb5cf9f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 48d142fe-f7e9-475b-8615-d05dd56ae176
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:48d142fe-f7e9-475b-8615-d05dd56ae176
-      Date:
-      - Wed, 28 Oct 2015 16:35:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - e4ad777c-58b2-43c7-801b-56a91339a6e4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - f114ae20-1eb3-415c-9f10-a7bd5df153c0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163547Z:f114ae20-1eb3-415c-9f10-a7bd5df153c0
-      Date:
-      - Wed, 28 Oct 2015 16:35:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - adc9b1a9-5408-4453-9cff-f48491fc38c5
-      X-Ms-Correlation-Request-Id:
-      - adc9b1a9-5408-4453-9cff-f48491fc38c5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163548Z:adc9b1a9-5408-4453-9cff-f48491fc38c5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
-      X-Ms-Correlation-Request-Id:
-      - 7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163548Z:7e8d1da4-0f5a-4ec5-baaa-b8415e03f3b8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - c7a36473-f8b5-4c47-a545-4f761a9ddcff
-      X-Ms-Correlation-Request-Id:
-      - c7a36473-f8b5-4c47-a545-4f761a9ddcff
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163548Z:c7a36473-f8b5-4c47-a545-4f761a9ddcff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 0bbc39e4-7210-45a7-9158-51050b165706
-      X-Ms-Correlation-Request-Id:
-      - 0bbc39e4-7210-45a7-9158-51050b165706
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163548Z:0bbc39e4-7210-45a7-9158-51050b165706
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 38d52d9f-f615-46f8-aae5-bf2c2c6f44af
-      X-Ms-Correlation-Request-Id:
-      - 38d52d9f-f615-46f8-aae5-bf2c2c6f44af
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163549Z:38d52d9f-f615-46f8-aae5-bf2c2c6f44af
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 16:35:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - c6d569a1-dbc9-422e-9e1d-fb7ce164b920
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - ff414aba-3a8c-4efa-997c-439c5cba3de6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163549Z:ff414aba-3a8c-4efa-997c-439c5cba3de6
-      Date:
-      - Wed, 28 Oct 2015 16:35:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 5ad34d38-9321-4caf-bdad-56a58cf6d427
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 3bafaf9d-0f1e-400c-ac33-4b6305b44350
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163549Z:3bafaf9d-0f1e-400c-ac33-4b6305b44350
-      Date:
-      - Wed, 28 Oct 2015 16:35:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
-        3ux++uje/Uf7Dz/Z2Xm0s/ORafxL5Jfv48cvYRDA9C0wVKpYmny0zATqyTw/
-        3yayzFyfUWp67+LZQNFmPZ3m+Sz3IOJxFD1bnled7wjNkKA+2HQIYowyRJYH
-        j+5/On6wf29/78Fuh0JEF/MrU0n//j7D/Sh/1+ZLdAoUdOR21JZiXxTTumqq
-        83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+fkJuJ
-        +HDn3s79BwERhbGimFdXeY2e87uzPCvLakq/+l3dGmmSFh+CNBRC/sbJL/l/
-        AFVnufNiBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"495e2c07-d03e-4134-8793-19b4f2f6f188"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b48acc42-b5c4-49f6-a4e5-99febefa4b72
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 2f8a8312-9db5-4bb9-a640-4b459fab41d8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163549Z:2f8a8312-9db5-4bb9-a640-4b459fab41d8
-      Date:
-      - Wed, 28 Oct 2015 16:35:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+P9h/ez/emOw+2Zzv3
-        CJXde/vbBw8e3tvefTjZP987//R89+Dg9/1IX2yvVzzOW/Srb5TVNMOY8Vae
-        Ne3afEEYrfK6Lajlo5SpKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlnKrIW6
-        ewefTs7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nZ27cvF6qRanhcX
-        65oRQ/ffk69SgwceO6fFasrtLQQ8/++a1rvdMdEHMaS/7rzLg9npTZk8+OoW
-        EycPNS4uqcnZy+PZjKgBaB/t7oz3xjvj/cGmpeGkL/J2XjH1n17THBXT7ivr
-        SVlM6Q0LPECVWvyQ566DEM2dfe8jH7NfEo6D0KNZJ0x/jtG/LOp2nZX6p/8W
-        YUAYNndn+Xm2LttwMO4P+6v+8n0d50ezZfM6b1timWCW5PP6ktChj79nmtMX
-        2WpVFvnsafi9fG2o91G+zCYlccyzqr7K6hlBp1bnWdnkpgUhjaG8zqfrumiv
-        mRrUxiHwQ6ZwDB/vXaWrHaBOyBfZdF4sIWg/G4h/+/TZ9stXXz6NIn5SLVbr
-        NjesoZjQW12U8YP++SX/D/MWHiYmBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 383a01b0-b9f9-42f3-ba07-0707415b1010
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - cef6388d-4892-4e5f-b8ee-e4231bbeeaba
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163550Z:cef6388d-4892-4e5f-b8ee-e4231bbeeaba
-      Date:
-      - Wed, 28 Oct 2015 16:35:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 7a78382d-f73e-4d29-ab60-71ee3b3d60c0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 2de87afb-e51d-4643-98c4-bd0f0e3b1d6f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163550Z:2de87afb-e51d-4643-98c4-bd0f0e3b1d6f
-      Date:
-      - Wed, 28 Oct 2015 16:35:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7O5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZdW0F9T19tP80nUbpZ33Op4N
-        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHi3H+0/+DR/U/HD/YePNg/
-        6NCIKGN+ZTrp399nsB9Nqqp9WmQXS6JKMQUaOmQa7LKpyvz1tM7zZTOv2idl
-        NfmqLqjJR/O2XTWP7t6dzvPzVV3N7u/u7Ywn9P14WtX5+KpYzqqrZrzM27vo
-        YOY62F7RT5B/tn0+Pb83m+bT7fPJwWx7/+H5/e2Hs4Pp9mT3fj6bnp8/2Nmf
-        3vVna3ybN8aNRXg8WayYDMoa+buWviD6Ypg6yTpa+tbwxxfFtK6a6rwdn1Hj
-        i3nbjH/yC49Er/O2pQlqGDLBxg8lZp+HHPj34p0hvnl/ntnMLw937u3cfxAw
-        jNAqhvmXr9FtfpcEOK+zsvhB0M+tMSYd4EOQhsO9vqyu8hpv53dneVaW1ZR+
-        /bod+xCkoUzfb5z8kv8HFSfU3LEFAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"c8b068d1-1bb7-43a0-ac91-ab2f530f8527"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 818f9bee-4bfc-4c3e-b661-8b289659e01f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - b78ff9b3-09e5-4f3d-8c11-de6de0e6ce50
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163550Z:b78ff9b3-09e5-4f3d-8c11-de6de0e6ce50
-      Date:
-      - Wed, 28 Oct 2015 16:35:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+aHkx2Pj2Y
-        7W7vTiYPtvfvZTvb2fTh7nY22Tu/f2/n/OD+3oPf9yN9sb1e8Whv0bW+UVbT
-        DMPGW3nWtGvzBY1jlddtQS0fpUxL+fCyaKh5sbx43WYtd/Z6PZ3m+SyfyZvU
-        jAYkxFkLgXezfPfeZHeyfXCwT2N4+GB/e/Jg//72/XwyPZ/s3JtMHh7Yl4vV
-        SbU8Ly7WNSOG7r8nX6UGDzx2ZovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
-        mzV58NUt5k4ealxcUpOzl8ezGQ0C0D7a3RnvjXfGyqTm8ZqWhpm+yNt5xRPw
-        9JqmqZh2X1lPymJKb1jgAarU4oc8fR2EaPpemul7ml9+5CP3S8KhEIY094Ts
-        z/EILou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuWuCaY
-        KPm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSUzzrKqvsnpG0KnVeVY2
-        uWlBSGMor/Ppui7aa6YGtXEI/JApHMMnyid2jDonX2TTebGEuP1s4P7t02fb
-        L199+TSK+0m1WK3b3HCHYhLHGj/on1/y/wA0h3cdOAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e5341f67-2dc7-4655-9d70-bdb1fd510db3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - cf5bd45b-52fb-4713-b022-9e18c946f64a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163550Z:cf5bd45b-52fb-4713-b022-9e18c946f64a
-      Date:
-      - Wed, 28 Oct 2015 16:35:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - dc52f23d-fd1e-4064-8c9b-d4d01f2da3e5
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 6015b3ae-3c37-41fe-b950-692b01f3d818
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163550Z:6015b3ae-3c37-41fe-b950-692b01f3d818
-      Date:
-      - Wed, 28 Oct 2015 16:35:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7u5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
-        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcgxmhz/9H+3qP7B+ODe/d3H356
-        r0Mjooz5lemkf3+f4X6Uv2tzmgKaBoKqI7ejtjT7opjWVVOdt+Mzanwxb5vx
-        T37xtMgullXTFtPmdd62hHWjnfod9AnrwL8XQYeI+f6E3EzEg73d/f37ARGF
-        taKYV1d5jZ7zu7M8K8tqSr/6Xd0aaRINH4I0FEL+xskv+X8AbbuwKk8EAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"683c907f-1cc6-4f59-8ff1-7f73279f6f7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 66f1bfbe-8fdb-4ec3-b873-c1ed6178101c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 0d2d0997-48ad-42ef-b75b-03ab02e7b505
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163551Z:0d2d0997-48ad-42ef-b75b-03ab02e7b505
-      Date:
-      - Wed, 28 Oct 2015 16:35:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f96NODe9OH
-        Ow/Ot3enhMj++f2H2wfn57vbD84f3Nt78PD80/MH09/3I32xvV7xYG/Rs75R
-        VtMMw8Zbeda0a/MFDWOV121BLR+lTEr58LJoqHmxvHjdZi139no9neb5LJ/J
-        m9TMEmctBJ7ku7O92f5kO7u3N93enx7sbk/Od2bbu/cefHrv4YNsbzbJ7cvF
-        6qRanhcX65oRQ/ffk69SgwceO7HFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
-        6s2aPPjqFnMnDzUuLqnJ2cvj2YwIAmgf7e6M8d/9waalYaYv8nZe8QQ8vaZp
-        KqadV2hWiF70fYAhffHDnrXLom7XWal/Bq8RDoRjc3eWn2frsv3Ix/SXuD/s
-        r/rL93WkH82Wzeu8bYnYIJ4dqHwOrsDH3zPN6YtstSqLfPY0/F6+/iXa7KN8
-        mU1KovWzqr7K6hlBp1bnWdnkpgUhjbG8zqfrumivmR7UxiHww6ZxDCFqd/YT
-        +v6uktaOUSfli2w6L5bg0h8+7vq14Q9FJZBpgzV+0D+/5P8BuJieBm4GAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - d8ea530a-ec5a-4e84-b381-c1886dcfe5b5
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 18b37675-16a6-41f6-b797-0bf87bb366a6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163551Z:18b37675-16a6-41f6-b797-0bf87bb366a6
-      Date:
-      - Wed, 28 Oct 2015 16:35:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7u5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19NVL11uUZN5beDaQrVlPp3k+
-        y2cOIh5HtrPledX5jhAMqeaDTYcgxmhy/9H+3qP798cP9/c/3dk56NCGKGJ+
-        Zfro399nuB/l79qcSE/kJ6g6cjtqS6svimldNdV5Oz6jxhfzthn/5BdPi+xi
-        WTVtMW1e521LWDfaqd9Bn7AO/HsRdIiY70/IzUR8uLv/cPfTgIjCUjHMv3yN
-        bvO7xMx5nZXFD4J+bo0xyYMPQRoO9/qyusprvJ3fneVZWVZT+vXrduxDkIYy
-        fb9x8kv+HwQKKZK9BAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"5c10fc17-3cc0-4c4d-8531-e5d5aef1919b"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8b4ac921-d852-4e98-90aa-303733cb6505
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - a3a253c9-98e8-4a79-b9d2-11932024fd98
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163551Z:a3a253c9-98e8-4a79-b9d2-11932024fd98
-      Date:
-      - Wed, 28 Oct 2015 16:35:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350f7q7cz7dfbB9bzrd
-        2d6f7s+2D+7f293O78/uZ/n57sPdh5Pf9yN9sb1e8eBu0aO+UVbTDMPFW3nW
-        tGvzBaG/yuu2oJaPUiadfHhZNNS8WF68brOWO3u9nk7zfJbP5E1qZomyFsJ+
-        mu1+OnswO9i+/zA/J0qez7YfTjP6c2fy6f3Zp9NJnu3Yl4vVSbU8Ly7WNSOG
-        7r8nX6UGDzx2IovVlNvvGgh4/l8zo3e7w6EPYvh+3SmXBxPTmy158NUt5kwe
-        alxcUpOzl8ezGREC0D7a3Rnjv4PBpqVhoi/ydl4x4Z9e0/QU0+4r60lZTOkN
-        CzxAlVr8sKetgxFN2+mrlx/5SP2ScAiEGU01IflzjfllUbfrrNQ/g9cIB8Kx
-        uTvLz7N12YbDcX/YX/WX7+tIP5otm9d52xK/BFMkn9eXhA99/D3TnL7IVquy
-        yGdPw+/la0O/j/JlNimJXZ5V9VVWzwg6tTrPyiY3LQhpjOV1Pl3XRXvN9KA2
-        DoEfNo1jCPkcYsemk/FFNp0XSwjYDx9n/drwhaISYIsf9M8v+X8AxTRwEQkH
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e024db5b-7142-4795-b75b-8a733b20ee33
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 14fa4e40-a182-4ea8-94a7-dbe2a719937a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163552Z:14fa4e40-a182-4ea8-94a7-dbe2a719937a
-      Date:
-      - Wed, 28 Oct 2015 16:35:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - fb65ef3b-bb2b-427b-ae87-64f1165bec9e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - e1d479b6-5910-4aa1-ae25-49b3da9d1193
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163552Z:e1d479b6-5910-4aa1-ae25-49b3da9d1193
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7e5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1i7Of2HPdRWnmvYZnA92a9XSa
-        57N85iDicXQ7W55Xne8Iw5BsPth0CGKMKPcf7e89un9//HB//9OdnYMOcYgk
-        5lcmkP79fYb7Uf6uzYn2RH+CqiO3o3bEKqZ11VTn7fiMGl/M22b8k188LbKL
-        ZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPx4e7+w91PAyIKT0Uxr67y
-        Gj3nd2d5VpbVlH71u7o10iQTPgRpKIT8jZNf8v8Az+rfIkgEAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf2fb462-027d-4365-9bde-113f775e6906"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f394664f-e438-4d0c-83d4-f08eae338047
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 2fd79f35-a3be-46df-8100-c63959a0921d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163552Z:2fd79f35-a3be-46df-8100-c63959a0921d
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P5qe751PCBfq98Fs
-        e//ep/e3H05m+fbu7r3zBw/u558+3Pn09/1IX2yvVzy8W3Spb5TVNMN48Vae
-        Ne3afEH4r/K6Lajlo5SJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmqrIWy
-        +9P8wb39/fvb053p/e39PD/fzj49ON9+mM0+zfNs+mB/7759uVidVMvz4mJd
-        M2Lo/nvyVWrwwGOnslhNuf2ugYDn/z1Terc7HvoghvDXnXN5MDO96ZIHX91i
-        0uShxsUlNTl7eTybESUA7aPdnTH+ezjYtDRc9EXezium/NNrmp9i2n1lPSmL
-        Kb1hgQeoUosf9rx1MKJ5++LsJ/Y+8rH6JeEYCDWabMLy5xr1y6Ju11mpfwav
-        EQ6EY3N3lp9n67INh+P+sL/qL9/XkX40Wzav87YlhgnmSD6vLwkf+vh7pjl9
-        ka1WZZHPnobfy9eGfh/ly2xSEr88q+qrrJ4RdGp1npVNbloQ0hjL63y6rov2
-        mulBbRwCP2waxxCido5F7OB0Nr7IpvNiCRH74SOtXxvGUFSohYcuftA/v+T/
-        Abt1q/kPBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fadf0e4-d3e1-44f1-95af-7e1387012b1c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 366bc2ec-83b2-4a23-8c63-d6e147ca9932
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163552Z:366bc2ec-83b2-4a23-8c63-d6e147ca9932
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - c95e5fa6-c9e6-4ff9-8ff3-79daef94d2f4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 93602e43-392c-400a-baf0-639229364e07
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163553Z:93602e43-392c-400a-baf0-639229364e07
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99dO/+o/v3PtnZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOoX
-        Zz9xUi1W6zbfdb1GSee9jWcD+Zr1dJrns3zmIOJx5Dtbnled7wjRkHo+2HQI
-        Yow29x/t7z26/+l459OHn37aJRERxvzKZKK/FaIdnCXNLGszQuvtjwhD/9LT
-        I8ye6/T/F4TZ3f10/8HuLSiDH99nuB/l79qchJYEl6DqyO2oLcW+KKZ11VTn
-        7fiMGl/M22b8k188LbKLZdW0xbR5nbctYd1op34HfcI68O9F0CFivj8hNxPx
-        03v3DvYeBkTss5LFvLrKa/Sc353lWVlWU/rV7+rWSJMy9SFIQyHkb5z8kv8H
-        gIQAUkYGAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"6c1b09a5-fb7f-4163-9f9b-a932d73ead70"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3437bb92-cbae-411b-b60a-7d814f254d2e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 4d853835-5d59-4d5b-9001-e81c3f5df695
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163553Z:4d853835-5d59-4d5b-9001-e81c3f5df695
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR59Odyc7D7P7
-        2+eTB+fb+7uf3iNsHk62s4f39mYP7uXZ7MHO7/uRvther3iwt+hZ3yiraYZh
-        4608a9q1+YKGscrrtqCWj1ImpXx4WTTUvFhevG6zljt7vZ5O83yWz+RNamaJ
-        sxYC7z2c7M3u7U23HzzI97f3z6f59mTv00+3H0yyg+zB+cGne7s79uVidVIt
-        z4uLdc2IofvvyVepwQOPndhiNeX2uwYCnv/Xzezd7rDogxjeX3fq5cEE9WZN
-        Hnx1i7mThxoXl9Tk7OXxbEYEAbSPdnfG+G9/sGlpmOmLvJ1XPAFPr2maimn3
-        lfWkLKb0hgUeoEotftjT18GIpu+Ls5/Qd3c/8pH7JeFQCEOaekL253oEl0Xd
-        rrNS/wxeIxwIx+buLD/P1mUbDsf9YX/VX76vI/1otmxe521LfBNMlXxeXxI+
-        9PH3THP6IlutyiKfPQ2/l68N/T7Kl9mkJLZ5VtVXWT0j6NTqPCub3LQgpDGW
-        1/l0XRftNdOD2jgEftg0jiFE7XqcYseok/JFNp0XSwjcDx93/drwh6JCLfpY
-        4wf980v+H8QOklQ5BwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 242c2427-2a2b-4068-8724-5b3a796de0d4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 7fee3a7f-2aca-4331-9c92-1bfcb837be50
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163553Z:7fee3a7f-2aca-4331-9c92-1bfcb837be50
-      Date:
-      - Wed, 28 Oct 2015 16:35:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - cd43f277-1ef9-4fc8-a3c2-70aec1f6b309
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 064b0ba4-8650-48e7-9836-f2653cb7f410
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163554Z:064b0ba4-8650-48e7-9836-f2653cb7f410
-      Date:
-      - Wed, 28 Oct 2015 16:35:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP7+5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
-        8pmDiMdR7mx5XnW+IwRCwvlg0yGIMbLcf7T/4NH9B+O9+w93dve75CGimF+Z
-        RPr39xnuR5Oqap8W2cWyatpiCjx0zDTaZVOV+etpnefLZl61T8pq8lVdUJOP
-        5m27ah7dvdus8ulu01Y1Te3ueEINxtOqzsdXxXJWXTXjZd7eRQ8z18M23rlc
-        7Gzn2e6DPNvb385m2Wx7f396bzs7OHi4vbOzf+98srd7/+H5Hnew/ZNf7Ixv
-        03rcWFzHk8WKKaAM0Z9eHSZ9917TOjSl7z+dG6fyHo1of+d+MJUylCjm1VVe
-        o+f87izPyrKa0q9+V7dGmmTThyANhV9+4+SX/D/UjH3+0AQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"d5fb978d-f340-4b6c-8c0c-9fa0daa6c7a4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 000b2115-ed40-4792-b194-2d5c8795d785
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - c927dc59-9d5f-4c1a-a61a-d5b471499c76
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163554Z:c927dc59-9d5f-4c1a-a61a-d5b471499c76
-      Date:
-      - Wed, 28 Oct 2015 16:35:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hs/vnk4YOD2fb5
-        vf2d7f3Jp9Ptg+nOlLDJdmZZ9un0Qbb/+36kL7bXKx7iLTrVN8pqmmHEeCvP
-        mnZtvqARrPK6Lajlo5QJKB9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlm6rIW2
-        9w8eTnd3HuwTHWe72/v3J5Pth3sHD7Yn2YPzTz+d7j8ketqXi9VJtTwvLtY1
-        I4buvydfpQYPPHY6i9WU2+8aCHj+3zSpd7sjog9iKH/dWZcHc9ObMHnw1S2m
-        TR5qXFxSk7OXx7MZ0QLQPtrdGeO/+4NNS8NHX+TtvGLaP72mGSqmnVdoQohU
-        9H2AIX3xw56wy6Ju11mpf+p0/eSL0zd3CQVCsbn7mn9u737kY/pLwuGUVTZ7
-        kpXZcprXT7Lp23w5U7K9rKoStLO8K09n2ATihz1wH2Ud9vMndyd95O/qgPBH
-        SAQig//n94dpcracVOvl7EXWvlqXzJn/H6FHESJ+99XTl9s/+cXORjK4P+zn
-        +ouh0EezZfM6b1uSQ9DCDl4+ry8JA/r4e6Y5fZGtVmWRz56G38vXhhc/ypfZ
-        pCQxfFbVV1k9I+jU6jwrm9y0UG7/IpvOiyXE33X9zdH7yy9efvXm9Ce/eB2l
-        t06HETxFRSnuSMsUo39+yf8DZ0RrsrUHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 3a8da927-36ca-4cb7-9260-29357f2a4290
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 8f930bc1-50c5-49cf-ab37-d051d4a0c310
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163554Z:8f930bc1-50c5-49cf-ab37-d051d4a0c310
-      Date:
-      - Wed, 28 Oct 2015 16:35:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3Y/fXTv/qP79z/Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
-        5TMHEY+j3NnyvOp8RwiEhPPBpkMQY2S5/2j/gAgy3t09uPfg/r0OeYgo5lcm
-        kf79fYb70aSq2qdFdrGsmraYAg8dM4122VRl/npa5/mymVftk7KafFUX1OSj
-        eduumkd37zarfLrbtFVNU7s7nlCD8bSq8/FVsZxVV814mbd30cPM9bCNdy4X
-        u9s7k/vZXrZ/vr07+/TB9v7uLN/Odvem2/d2ZzsPdj99uPfpHhGWGm//5Be7
-        49u0HjcW1/FksWIKKEP0p1eHSd+917QOTen7T+fmqTzYefjwYDeYShlKFPPq
-        Kq/Rc353lmdlWU3pV7+rWyNNsulDkIbCL79x8kv+Hzmf2UXQBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1c7505d8-05d4-4421-b2d7-06a8b6cc0bc3"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f90bbfa3-f657-4637-893d-4c8bef8f8bfd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - ea022cee-a771-4b99-b524-d728c23fa788
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163555Z:ea022cee-a771-4b99-b524-d728c23fa788
-      Date:
-      - Wed, 28 Oct 2015 16:35:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Hu9MH9nfuzg236
-        Z397f39vd3uyN3uwvfNpdjD5dDrdmUzv/b4f6Yvt9YqHeItO9Y2ymmYYMd7K
-        s6Zdmy9oBKu8bgtq+ShlAsqHl0VDzYvlxes2a7mz1+vpNM9n+UzepGaWLmuh
-        7YOdGY3h/t723t757vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8Ly7W
-        NSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTBV7eY
-        NnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/QhBCp
-        6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMpq2z2
-        JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/VAeGP
-        kAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/2M/1
-        F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36UL7NJ
-        SWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37xOkpv
-        nQ4jeIqKUtyRlilG//yS/wdFCtT2tQcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 0ba580ca-792e-4766-9c53-ea38523453f4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 4fcfd892-c30e-404a-816f-09c268668d93
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163555Z:4fcfd892-c30e-404a-816f-09c268668d93
-      Date:
-      - Wed, 28 Oct 2015 16:35:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdj99dO/+o/v3P9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOrr
-        rMyb86qe5l+9dt1Gaee9jmcD/Zr1dJrns3zmIOJx9Dtbnled7wjTkHw+2HQI
-        Yow49x/tP3h0/9PxwcOHnx58ut8hEpHG/MqE0r+/z3A/mlRV+7TILpZV0xZT
-        4KFjptEum6rMX0/rPF8286p9UlaTr+qCmnw0b9tV8+ju3eV1ffFw92B/PKHv
-        xtOqzsdXxXJWXTXjZd7eBfCZA77dGNpvT2fnO9n5g4fb93b2Z9v7swf3th9O
-        p/e3D+7f353sPpxN850Hd/2pGt/mjXFjkR1PFismgfJF/q6lL4i4GKLOsI6U
-        vjXM8UUxraumOm/HZ9T4Yt4245/8wiPP67xtaXYahkyw8UMJ2WcgB/69GGeI
-        ad6fYTYyy8NP93Yf7BwEzCK0imJeXeU1es7vzvKsLKsp/ep3dWukSQf4EKSh
-        EPI3Tn7J/wO1T9eJ/QQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"dfeac063-9e23-4f80-a682-432fa291a7f4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a5d5625d-65ab-4441-aa58-199c806fa09a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 1f249566-21e7-4e7b-867f-6edb102eab7c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163555Z:1f249566-21e7-4e7b-867f-6edb102eab7c
-      Date:
-      - Wed, 28 Oct 2015 16:35:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHaeZ9OdT+9tP8z3
-        7m3vnx/sbGefHuxt79/bO8/2Hu5mD873f9+P9MX2esXDvEXP+kZZTTMMGG/l
-        WdOuzRc0jFVetwW1fJQyEeXDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlrWQ
-        dpLt5dP7D7Pt2b37B9v7s/3Zdra7u7s93c3vPbi38+nk4WTPvlysTqrleXGx
-        rhkxdP89+So1eOCxU1qsptx+10DA8/+iOb3bHRB9EMP46066PJia3nzJg69u
-        MWvyUOPikpqcvTyezYgUgPbR7s54b7wz/nSwaWnY6Iu8nVdM+qfXNEHFtPvK
-        elIWU3rDAg9QpRY/vInr4EIT99pO3Fevz15+5GP2S8JxEHo074Tpzxr6J/P8
-        fPtlXc02juGyqNt1Vuqf/luEAWHY3J3l59m6bMPBuD/sr/rL93WcH82Wzeu8
-        bYllglmSz+tLQoc+/p5pTl9kq1VZ5LOn4ffytaHeR/kym5TEMc+q+iqrZwSd
-        Wp1nZZObFoQ0hvI6n67ror1malAbh8A3R+FqsVq3+U9+0WwkcQwhanf2E/r+
-        rpLWjlHn5ItsOi+WkLWfBdwHmVuRMoyhSISsbRDGD/rnl/w/X5LmJiMHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNDk4MTEsIm5iZiI6MTQ0NjA0OTgxMSwiZXhwIjoxNDQ2MDUzNzExLCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.krqEm8YMSeYFVaBrPMB9smCz8RZn6_nokNHrgvN4IVMKVmmHyVxiEbw6B4UuO5sJbhQOnOTYNN2k2QCOpITqESwBNVE8ym4IrUgI4UqapNoanYb0MT11lyDABCaAyK35sBa5Gqaofnqzf3-CbtXG0389QHoOTSeQpjkjP7-QD5s4Mo4O4omGOVeyiQe-Mo2Gw1jyKoUrvfpfMl_18z4XuhlIDdQE2NXK1nSrYJMf9cukqJv9g2VVaL4W3yRfSSaGhDKyaYyvF1l6b0Rpuwdogi7zckJhd6DSFx0LEyjpiuMuLFiHVwxqkzhHSKJU2bgLrrXiDziCokZucuZyZtyJuA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bf50c0ba-aa07-42d7-b3dd-85fb44261f5b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 4aa8785b-9227-4f8c-b4a8-ec6c146d059d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T163555Z:4aa8785b-9227-4f8c-b4a8-ec6c146d059d
-      Date:
-      - Wed, 28 Oct 2015 16:35:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 16:35:53 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:43:21 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name.yml
@@ -1,127 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
-    body:
-      encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Length:
-      - '188'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 669df257-2019-486f-a423-3441d0e67f71
-      Client-Request-Id:
-      - b21c05ea-847e-4a48-b306-7a96d4c3743a
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_169
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - flight-uxoptin=true; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productionb; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Wed, 28 Oct 2015 19:19:37 GMT
-      Content-Length:
-      - '1218'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446063578","not_before":"1446059678","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw"}'
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:35 GMT
-- request:
     method: get
-    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - de60da71-c68b-4a3b-b225-4dbd043df410
-      X-Ms-Correlation-Request-Id:
-      - de60da71-c68b-4a3b-b225-4dbd043df410
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191939Z:de60da71-c68b-4a3b-b225-4dbd043df410
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
-        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/providers?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -131,273 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - f0dcbf0a-84ee-4c7b-9782-171298bdad86
-      X-Ms-Correlation-Request-Id:
-      - f0dcbf0a-84ee-4c7b-9782-171298bdad86
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191939Z:f0dcbf0a-84ee-4c7b-9782-171298bdad86
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
-        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
-        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdafjZ7Z8m4z0Ur4EX
-        7dZ0wt0M6GQic1UXP+Be6G0fGfTRQ6+uyvy4aYqLJUh0WxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyUpM6D0/3Z8p2VG1J0ezxaEMiSk
-        rXqe7RDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUqKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjV8qldwg9jythGDVtM/iA0khvs5mZr
-        BoaxpOCx3ziMu/V6OamqHqv/f3Y8QT7n/5ujIhwG0O+hccs+uJe4HDzJ2im8
-        Lx8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8QWlhQUYNGWYOi/BfDr3kMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pJ8RjddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lEfLnmdv8yFJfs+ON/bVkCNKmdCfg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4wz
-        hD4GANzDaZGtKJePpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnJgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRrp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b11oAIk59FtGgW30/hfC1c
-        bocLM+wJh2suUUGvfT20Bnu4u8jbupi6LrpDVx433MQ8LdwTfARWDH5jhmee
-        40/7jZWbGRZY1nwg/YUyZf8SocH79g80oD86EhSXCfepgjBoiSRob+YPflP/
-        ipKaJo/+t4m69OrFsmrI332dty3Z1x55gYhHFSWcEMFgx1/LR5YSjKn9qzN6
-        /pLfCkDw1yFUoSG6tn/gZfoDn5k54RdBQ/NBj5DuA9uWPjVdCQ0VL/MHN9S/
-        biAvE3jAAswgFT7x8XpvOiiBdl6U9F2H/AZDJgbGEvw2NBeCevARD41/k/Z2
-        avgL+xcDViIyFFDKfCD0RxP7B96mPzrz66itjd0H3ARA4zQlhTCcFlUa3c2X
-        s1VVkMtOkH9ErVtT6y6t+1wU9PKPqPY+VJsS3Goxo1Tlj2i3kXaEobgn9Hkk
-        2PRp9cGw7+pE6Z8/xK4sZ+jfP4ddq0DrXz+XiPgyop99k+jcxh//oA7seL9R
-        tPPZRb6sZhut+g1AGeyAZyELxxTar9YtdIPfOyD18JH5AR17GEEPGDViVYD5
-        gL8kXO1vrNegWuh3+k00ljcohRF+FPwhr1i1xrDsX6K60Jf9Aw3oj6+jxwwy
-        4sk5PMzfAG3/ABzCMN1Lt163lBxEgkhwNa/Rl+argbmTVJaJb3gi+Q9yFoM/
-        sMxDU0wT3JknZvendrI2MP3PFgYep9xtyqovzUwnZQ8mL0htPuAveZr1tx/x
-        C3/1Q5utu3VFPgy9+KM5k78B2v4BOITh/yvn7MZ8RxQf6oj+93U6+mDwl0Xd
-        rrPyC0p00tJJF5zQWlmMpwjTZT7gL5lV9Lcf8Rx/FZ2E2/Mc/c/9MciAUxo/
-        25SiN2tfs/9YL9F16q8J3/wxOKQOL/58z27x75YDTcfmb3Rk/wAcQukD2JPm
-        hf53u3kR1TOs4ww69LH+9qNpUdqbIZvX6Evz1Tc0Lb3J6HZI38sQgo8UVfcb
-        TxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kNvG//QAP6ozPbjvba2H3ATdAjfcq/
-        W3obJM3fAG3/ABxC/2dpMmh48Qg0Cun2ypL+5/4Y1Jz+n98QAreJXV/k7VVV
-        Yw04RCASuyqz6htdHGVylIF4TjG/5gP+0jEeTVPIm91ZpI8YRvhR8Ie8YtmS
-        Ydm/hC/Rl/0DDeiP/w8waXQyzR+bGIjW/vPZ2epHU/P/sql5HxcsBBn8MQj/
-        Imvzq+z69Xq1otHks6e0wD0lIf5Z65Bm8r1UZQg2+IP+5/7QDrnLjWrrdVvV
-        NEv0oo8ZOuzhSmlRND2eTqs1LSbQKz7CwhMqCsxKYCvzAX/JLK2/fTOycZNs
-        UF/U5f+vZIP+t7s9yVt05T6xf+jE07R3Zu9nW3Q40afcpCzy/sm+sK/gj8GO
-        O2x5F8o7IrQyScyCbh7oD5nZ4CPhF8yj/QMv0x/4zLA0vwj2MB84zkGz4APb
-        lj7l3y23mI7N3+jI/gE4gpL+xlLTZSb7kbUMDMT+FXB8lPBEXvrf+5FXXezh
-        yOeb7ukbhy9gfxYHIB18MNj3z26EksN/xADPiqbnfX4YxGJB4/9mQVbN2c8C
-        0J87s3v7Ja7MU5+U9OmianQCfay/sXZg2edPIxoi+IgVQviRtLKag2HZv7gX
-        1XX8LhSa+UDUJJrYP/A2/eG0oH7rPrBQ6NObtRRPw+59ait/0P92t1c1uWj5
-        FRGdSN4hoMZZJilAL/6Ifh9Av7v5uzZfCsQfkfLDSEn2/WulczEQ+p1+ixAr
-        +IixDz+SVpaIDMv+xb0oBfldEMN8IFREE/sH3qY/HAX1W/eBhUKf3kxS0p70
-        P2jPm6knhnXYcstgeMz624+Ip8R7Pc3KnHju5z3JSGQ/RIQtHX+kFWWwQsVv
-        hqTh5z+i6zdF16VknM+WbV6fk2f6I8p+U5QNP/8RpT+c0o5aIeW+Yeh3iTzx
-        UFBIxpTV3340RUNEvFy8Ln7wIyYnin1dCq6bSJJDBsTj1t9+RMAhAq7Wk7Jo
-        5gSP3rYfAy5wkrHrbz8iYkhEQjuuAr8OeO4gnvt6mrXZSbVc5lMMxEcCsHto
-        TaUpdf1FtiTp6M8sKIcJGcLzIESNEOt04aD9rEF2BuZV3qzLfuD1wV3xyssL
-        oviG9Zb37YX7GZ7FZ9mUct3oxMcF4HrYzWzzfvraYtWTKIiAfKG/scxKo0AS
-        GYJ9LRCOjmTzh+HLIn/owf4BePQHPjMiyy9C+uSDAQru7hAFqTX/sfPQ/wO0
-        tX88oD8soc2H9L/+h0gmhx/ub+/uxT5E190PhxMCwYx87UxUZC7kIzsZIKX7
-        qzM1/CW/FYDgr0OoMi/o2v6Bl+kPfCZzoi/eMElEEfrfbYjyNRNMQoAAe/nI
-        UgGYu7/+X04TViyeuN+gY6LwiY/pfx3u5E/of+bDwc6Pf7Cu8w/AQDpj+bA9
-        f+OiGcPesdP1axrJAtNxC1r9HGBKnCjmqcvjP1coMpLDpud59hai448CyPXG
-        hRlAW7MaS+/4oxNBYbmNDlS1KuFD2HRAOzghzK8PyDkJ1CLiJNwAmWFvJtnx
-        MiuvSckDMvVhsQCwHl7Z16OZMoc3l4TWAOi7Zn5ek4x83Ul6rw47q/M/xK7u
-        kifbZpQX6nuwP5xe71Jk1L7OmjfVW0pV/yzg4OCFsD8c4NeSjNv0YOF+TYgM
-        c7PMMWsTdL9nAOzhYqaQ2vqYfBMzY0DfPS/q/Cory1frkpD45jty8ELYHw7w
-        /5MsQG0k6+v3CVA9LMg9uDl80wmijzsOJX8x7N6ReT2gYN1DmlDuIHBWtd9e
-        T4Drz1KX3Okgnd6Q4/o8mxBgHy9A62FK1Omh2XFyFT3GGy6x91tkAPo7c75x
-        pPGJ/QMvDg7z/vaezw40yA6++ZLWBarlglz3/0/hTd29l2CEEI1fR/+Dc9IH
-        7yB+DegbATpV0YVtCEYf629MOtCJfje/RUndmykhMZrYP/D2benNIxgQh2q6
-        Brc8fUKQ/UECWm/YcKEmWWMtPr0TDBlIyeA6Esxf2L8wEGnGv+kge6N26Ug0
-        Cz6wbelTE6eeLSmzQH/zd/rXEIEoAj2gpvQH/Ub/i7NNZ7hQmf9/HzJhO8DO
-        PB4ewf8HB8pDHZKABfmsr/IL8lhl6PSyTxWA7tFpxm/1iHRRVpOs3ISai1eR
-        WCPUCLEO7LZaPc8v81Iw+9npg30A6WCTF/CN9IVYQLp6lU+rBakbEiwG9LPR
-        2yUxEcHPTY9uXs+W51W94F8JzDff80VOoQ/1/LqpXuW/aE1iQe98892QnFEv
-        /OaHg+cOBgTjmj6n+P357UL4ctqs6uqnaf0EzQO8OllHSLzRA/w7qwsxa/jb
-        /gHNQn+IvjGqgBvLR1bpMOSwBd51Dfgv/pybQrsYDIK30D39xpb6i9fP3jAK
-        9IH5U78P/lQ4/EEHL6fU0DL4wOIxOF30v93trFzNAV0+wgx2PrrX/whTa61/
-        8OEkbzvN5E3mguH5RGCPhbGqn0740dRyy+ADi8f/J6a2rNazWb4qq2tSzD+S
-        Xdutm0+0DD6wePy/dYJpBAMm4kfTyS2DDyweg9PJ5DazstFonl7SGCi5QR34
-        cwJYvVmyEHqz5HDbgGycXu43ppwjmtAjeIVhhR/xu0pG/hpdmQ86zCOcgTfs
-        H+iO/pC+LO3xqfkrSmKSDV7XYcJ2qMSeKodeINUGZzUKmSbPLRJt6oZwi4vM
-        +4BlwHZaCapjjGd51tLSIqDTv7ZnAOzhcu7a3ogJdQ5MPO4kFOhdHx4p+8ti
-        Ru99PYAM0h8VeYU6KgpPios5Ww2/T8DqYUGu/6paErOhtY+Gz8dRlIja9D9H
-        beBn/6D/gfSEYqe/q3zSEuP9kHojfx8L+dTwwzuLwc/KvG7rWCqdpYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP43QLJ1WzVTIlyTt22xvLgN5XSUllYYu/sLmBtCMYZA2nzA
-        xDKDkz/wNv0hMANq8NvhR3iTfvt/A+Uo+7BsW/q9S7LbgN3F8rr5Q76J9eHA
-        hl0YOnzgECxIl6F99T6LOQL5xm4s8K8F9lP/D/pfvA/wMaUt8tnpuxVx0usf
-        cXOUmPS/OP0oWXixrJq2mP48JJ3pQXKmDqD5G5jpH0NUfjBE2EXe1sX0aX5e
-        LAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+yYwM
-        AcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZhfwyW
-        f5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6TT+v8
-        R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XQLsYeVSPIkf47AA5xqID
-        1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdrZeyA
-        C4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGws8/z
-        +r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jqt3m7
-        KunzL2vKkpCDSFB8pNBXD83sos7zaMqcCRPOJCiN34aGwALMOHZ6eW9iKCSG
-        FR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8wfAC
-        lsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fHsxl9
-        0xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJlVNf
-        59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/RNtv
-        hLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhHwpCc
-        P4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsfCi7r
-        JrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT+xc3
-        U71hhdZ8IG8GioLbhB8FfzC8r6lISG/gdYLyQ1YkPmVf5/VlMc1f1tVlQQmt
-        LoV/FrGYLZsfVMseF390UVaTrBwcP/1v/1Zw7x7/7EGm52cN+MmL4y9Of9ag
-        v3zz6mcN9he/988a6De/95ufNdivX/3kNw2bpPn8vJgusiXp6XpVV+dFJMy8
-        oZf97b2Djb1MYZHeSFdfSFc3GKf37JI7HcgMV21B3TLkb68nGJuPHWD28LWQ
-        0DpAyynADRoxrnrdb+zNsbrnT2+nzfld1f/8NboyH3QcQHEO8Yb9A93RH9KX
-        tTL41PwVJfX+9s5D0o9EYiLwIJXuLvtE/hHZBsjGwgD2Z9ptkgFHJMXJfcAo
-        Yyj0aX+8/m//P6EavRR37DyiKA7uA0YRqNOn/fH5v/1/kkpMJyuFRCSn9b40
-        5MrKs2VTXMzZJfVpCnA9KiNrw8DQOqAyMJdR34ggqed723s71JT+IAdrl9ai
-        7R879D9CnRDvdN20VU2GQbE9qZbnxUUXi2h3m4CWxfLtm6y+yHn4Pig7oCjM
-        7hAGOyAiCJ278KNgCRITY+PUUeTIPQCi3xuA9PpvSNlO62Il3d4CBRrZLv2P
-        mtIfxEr0v83eb9DDXfIQ3sv9/pC+LG2p1XvE0u/XpfkzvmBxe3HnL12zr6lR
-        pJUKl75u/xKtAfD2DzSgPzq6Jq4A3acKAi+nZ8sZ488t7V8GKfn7m6F0E0yu
-        I3NI8p+NvtrsgkWN3v/mu4KK+dmBTLMu/P9e4DfqltfkfMzWZV4TRL83AOn1
-        /9PVZFqV5UDOWVjVMApzr/BQ8JG0sizMLGf/Ah8a+eF3wanmA27KMLgZ/xYw
-        vfyBL+mPjgQEOKAJ/cYC2RMC9wG/CwzoU/5dud9BM38DAf0jOhU0swc0FV9v
-        cpVkpk8egaATfCStLCkZJfsXxmboyO9iWOYDbsowuBn/JrTEN/YPfEl//L+c
-        sEzaAV7Ps3oKnH3KA1JvLhpuqQmm3nwwUv546beN1OcxYryG4vye/i5vmoEz
-        MG4ffiRTALD0h6MkANEHA3OygXCkHA62dx9SY/ljj8Jn+YNI+mD73u72S0tS
-        ImiHPqQ0prSyz+RB4LIhZhnq/Wt0+DV74nHGgNLkxCVuIyTGmf7gAdzAb0yg
-        J2vA9/sGyB42FgZa+9j0p9t9wDMOzqJPzawzv6Bl8BvLJPiHfqffbsd1/K7y
-        KX+NrswHHaYTDsUb9g90R39IX1Ya8Kn5K0ppYgiNZ4i0HSpZRmBSfS1uIMg8
-        h5u6IdzelzUIUgcsA7bTSlA91vhFJbX2OwWs26MhROQ5YvpHpk2nPPhCZiL4
-        SNua33RuGag/2cGEyh9oT38ITJ3PcHZ7POIYV192H3AT9EifGgRFfylM8wc3
-        1L+is0ETQP9zNsHMCv0Ps0Jz0qGyI+yPiKx/cEP96xsm8t0pDYxFtiCm/xHF
-        9Q9uqH99MxS3qnKDlhQcmE6CgMGRP8Jo6LcfEfx2BG/I3hMIavgjEvMf3FD/
-        +kZJfHeWtdkka36kQOLE/maJjZ/kx345+WlE/pd589GPiK5/cEP965slejZb
-        FMsCCFEa/Edsbv/ghvrXzyLF7XIJJd8jqWbBiekmCBmc+SOMjn770QS83wTQ
-        x0T5bFLmTwn9VT57+iMtT38zTPMHN9S/vmnqTyv6hcn/I7rT3wzT/MEN9a9v
-        lu7FYkVjofY/ojT/wQ31r58NSp++w78/0u+EoBBZYZo/uKH+9c3Sn1D+Ec2F
-        sArT/MEN9a9vlubnRZ1fZWVZ0xrfjwhu/+CG+tc3S3ATmb7Op+uaEi4vq7KY
-        /ijTRTDNH9xQ//rZpf0XeVsX0x+R3v7BDfWvb5b02XpGCd3lxY/Ynf5mmOYP
-        bqh/fbM0h8e+WOTLWT47LQmTYvqyqsofkd7+wQ31r2+W9EbT/Ijx8amSWGGa
-        P7ih/vWzRf1ptVwiKVktf0R/+pthmj+4of71s0X/5keWVimsMM0f3FD/+tki
-        Pn77Imve/kj7gMoK0/zBDfWvH+IE3P1RoMUwzR/cUP/6ZqfBfLz6kc8DmOYP
-        bqh/fbMEz8XH/BG9Gab5gxvqX98svddNdvEjVfLDoDT0uGj0BfsxT/NzWgkU
-        kv+I/PoHN9S/fnbJ/yOi2z+4of71zRLd1+Y/ojv9zTDNH9xQ//pZp/vsR+qG
-        O2eY5g9uqH99szPg1E1brX5indfkttPbP6I7/8EN9a+ffbrf/UX08/pN/g54
-        /WgG+A9uqH99nRngOVhmi7xZZVNMwBfFtK6a6rwdv26rmpxKesOfI8Dtz5o0
-        PZ5Oq/Wyv1aL4XlU1bmwv6dbr1t6+w59xmPjlvybpRy3VeLzkEEb80EwAfIH
-        3qY/ZDYMARkuvx1+FPwhr9iOv86URefh/vbOp9u79+kV+YP+5yaFZ6FDU+pf
-        FsC75PxmwEcDhm8G9HSeT9++IJ46vsyKMpsUJSX96PVvvqcO392F9iimvWEJ
-        +/D0gjHkN/2sz3527juswC8oy9nJNh8I26GJ/QPA6A+BEvAYvx1+hDfpNxaM
-        4AvHYGgSfMBggAR9GvBplLgk8PQ/yPzt6ag+x4YQB0gJohiu/Kaf/TykLNN2
-        SJvWebY4XmblNXl0oKM/BwAVmRW8QvnCn64meCEgfDAUEKRDTh2x0Mh+JfRD
-        A/qD3+L3eXAYryE6fxCho34tYPA+/SFd9Nvyb46m+Cz4gPtAp/RpQGQ3Txvs
-        2v3t3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/whfU3/w1TSRHamw5G/MxWg
-        gyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh98gKrNutOws8dYkRDJ6V3iUgX
-        ywpB2+u8xVJvF1FvQvQ3jzkMsflr+cjyC6bY/bVxlrQxQzHf8B/cPOxF+Aeo
-        2D/wMv2BzwyX8YtgEPOB4x00Cz6wbePcQtSl/8VFjEB4tHwP46O//YiUlpQ0
-        trj7KAOyo+e/GP1gLECFfvMIat+QkaEB/WExNKPhD0K6oKn5Wl5Gp/SHAO63
-        5d8cFfBZ8AH3gU7p042zF6XaRq1wQH9YcTcf3kZV0G/0P8wFz4bvBCysE9Cs
-        VysaM73hzxYQe4/5i1CNRx9+FPwBersJFAD2T/6Sm4HQwW88/TJl+MT+gVfo
-        jw7t+SemxUw23jG/u9nDp8EH9r2h+dp5QJTdftmZFWhmIjcRu0M6pTLp4Ld5
-        PxiV0QfkYQTCj4I/MFxHLwFg/+QvuRkGFvz2/wXyMQHj3HpZNOusbNr1rKjo
-        NZ/KAN6jeybhAzX9GgTHsOQ3UEd+CxoImJDs9i9+W0nFwEEP84EQHU3sH3ib
-        /ujMgKMpN46Sk4Sc/tfREfTJ3vbep0ROImacKndXdfXT+RS9/vylDtPHZzYX
-        H303n1Brn3aA2aNmU7QUllIKMF9Kvx1ydnAGpmag/DsTS0aJv+0fOmQh4ybK
-        MuSwBd51Dfgv/pyb+qQO3kL39BvriC9eP3vDKNAH5k/9PvhT4fAHHbw6s+N/
-        YPGgT/ElQQ1ic/4MoL3PHKreh4yhWFbXwvzNvehfUd4gnQPrSk3lD2gl+8dt
-        TCz9sWf/2N/e3fX+8ADQH/S/Pg/S/6DwiAOjPNWUFWU+fsRZP+Ksb5qzimXT
-        ZktKp9ELPwcs9XPNUj9iKeKRb5ilRFn9iLF+xFjfMGNZlvqRJaQPOng5ZkLL
-        4AOLB32KLwnqj7irx10dtfUjHqMPOng5lkLL4AOLB32KLwnqj3jM47HVelIW
-        zZzSx1/RAuaPWMp06zgILYMPLB70Kb4kqD9iKY+liJ1oMQcZi+wyK8psUoKg
-        P2IrdOu4CC2DDywe9Cm+JKg/YiuPreSPk4rGU5U/UlSmW8dAaBl8YPGgT/El
-        Qf0RR4GJlKOseqKBTt/+iKVMt46D0DL4wOJBn+JLgvojlvJYinyp9jXc9uOm
-        KS6W+exN9W0yhi/IGNLLP2IvdOu4CS2DDywe9Cm+JKj/n2avGItIVAcXCVzx
-        pCA0lhc/Uj6mW8cMaBl8YPGgT/ElQf3/KXdIzP8jHjEfdPByLIGWwQcWD/oU
-        XxLU/9/xCBGhVi74EUdIt44B0DL4wOJBn+JLgvr/aY7gP75Bl2Wa121xXhAX
-        /WhNxHbr2Actgw8sHvQpviSoP+Inj58ojXiZ18+yevEjdjLdOu5By+ADiwd9
-        ii8J6o/YyWcnOETU7OcXI2HOfsRI4IxvlpHEs6bGP2IndOu4By2DDywe9Cm+
-        JKg/YiePner1si0WPdX0/4ZBRPEV9l/kbV1M/z+J9NP8vFgWgvL/p9BnlaOD
-        +P8w6v9fpL9zRXUQ/x9G/f+L9GcmqvNptVjky5ki/P8+5N9D6///aCwXeVXn
-        F4zp/5eHIUxGzRcFpcVmM6AcjudH/t3/P/27GDcgZ0658tPlZVFXS5LU/794
-        +27m8GnwgQVCn+JLfsWbIf4M8L3PXD/eh4yXTJZrYf7mXvSvb3wqzR/voSFu
-        O/13F+uyLV5VZf6yqsofcQN/BvjeZ64f70PGS+bbtTB/cy/61/+nuOGqqt/m
-        9Y9YATPMnwG+95nrx/uQ8ZLJdi3M39yL/vX/KVYQv7rLBv8fHML/B0OD6GAC
-        Ra1j+//fiP5/MlueItWB/f9sOP8/macODxbLps2W0/9XJi5vH/S9z0B1On/e
-        Dfj/3fz7YUP3pdWOm0D9PBilzu7Pr9H+/4WXF9mSXOrZt/vDp3f9Yf0oGMFn
-        rh/vQ8ZLwg3XwvzNvehfG1hD54+m+WeZNaJcMMtXZXWNaX9upzyc/v83oH57
-        ri4alefcMfQyW+TZZVaU2aQEN/nM/f+t0U3LrGmK6RfVpCjz17QuU5Beotf+
-        vzsiQvULVkSYqOPptKK17O6I/j+qgDgL7l7kP/X74E+Fwx908HIqCy2DDywe
-        9Cm+JKg/NzqMWWG7nlJr72/DALee87vTarnMpzLnP5p/6dZNN1oGH1g86FN8
-        SVD//zL/x9P/vyREeU7di/ynfh/8qXD4gw5ebsbRMvjA4kGf4kuC+v9tFqBP
-        fT7wf/8RT3h4ORZAy+ADiwd9ii8J6v/neeJHc+/h5aYaLYMPLB70Kb4kqP+f
-        n3v+50cM4OHl5hstgw8sHvQpviSo/99nAILxo4lHt26e0TL4wOJBn+JLgvr/
-        /Yn3rP+PmMB06+YcLYMPLB70Kb4kqP/vZAJmAyRlmlU2BQ+8yK9e5WUxHR+/
-        /IJe8jkEUPs8o2xCbQOuEFoZjJmogm7wEQ+Pf2OK8G/ypqUyN7F/MQwQlqlH
-        H/B7/HuUApQe2aERU0P+wyQ/esN+nS9nF3UxG58uKDlFzf1hAtitB+4QGsKW
-        R6m/MS/yEPlTGXtAIoYRfhT8Ia9YAjEs+5dIGvqyf6AB/dGRWse62th9wE0w
-        iDiFKRsFnooSdT2lnFjzhDL1b5vxSZln9dMnBNunJMD0aDvL2mySNfRlh7gd
-        rANCAPHNdBYC4BP7h1JDiBiAk48sJblLUMF0gTfd1/wXvxcjnP+pds9f+j1G
-        iUvsSv8DcYm0HSJNS4JJzQnYj2jENMJ//w+h5OdLI1cBAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -416,22 +35,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6933ed3f-bfb4-4d51-b1a0-18b66c555d13
-      - b966e9d1-7fee-4b19-9f2f-699df508dbc5
+      - 691fea60-c705-4fc4-acdb-086b444d9a2b
+      - 6f578179-1c6f-4221-9399-745199c5ae87
+      - 7f30f5fb-d84f-4294-af5f-7de224ccffcb
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14898'
       X-Ms-Request-Id:
-      - 4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      - 827c5630-faea-420e-b66d-aa87ae14be8e
       X-Ms-Correlation-Request-Id:
-      - 4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      - 827c5630-faea-420e-b66d-aa87ae14be8e
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191940Z:4833a598-e9fa-4ac1-bd26-46c64bea6ac3
+      - NORTHCENTRALUS:20160203T194442Z:827c5630-faea-420e-b66d-aa87ae14be8e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:39 GMT
+      - Wed, 03 Feb 2016 19:44:41 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -442,61 +62,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:37 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:42 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -506,11 +136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -529,22 +159,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 9e740c5d-1f88-4f6f-91d0-c56aad946f5a
-      - ed99c12f-b638-447b-b264-2829643152ff
+      - 562eccd4-78fb-4f22-a750-ddcd858f8bca
+      - 89f7e53c-9447-4394-970f-33ce9ca6e35d
+      - ed103387-05c7-4819-b527-cdd19183b794
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - 8899c01e-3dd2-4161-be99-41cc468daec9
+      - 4c4ed3ac-52a8-4957-b988-1dab7ba31ad3
       X-Ms-Correlation-Request-Id:
-      - 8899c01e-3dd2-4161-be99-41cc468daec9
+      - 4c4ed3ac-52a8-4957-b988-1dab7ba31ad3
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191940Z:8899c01e-3dd2-4161-be99-41cc468daec9
+      - NORTHCENTRALUS:20160203T194443Z:4c4ed3ac-52a8-4957-b988-1dab7ba31ad3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:40 GMT
+      - Wed, 03 Feb 2016 19:44:43 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -555,61 +186,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:37 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -619,11 +260,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -642,22 +283,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 341fea8b-3676-4439-910b-54875609799f
-      - 9971fac6-34bb-4272-8265-5910c142c257
+      - 18563f2a-9040-4e43-bb26-b8accb844e74
+      - 6dea498e-8af4-41ef-9a4f-2e16d3fc3dae
+      - f937caa6-b30b-4edd-9437-c263318c390c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - 759caae1-ffd8-44a3-9b03-b695155fb720
+      - d9187dc8-8fd7-465b-bca1-4f9918ab0f6f
       X-Ms-Correlation-Request-Id:
-      - 759caae1-ffd8-44a3-9b03-b695155fb720
+      - d9187dc8-8fd7-465b-bca1-4f9918ab0f6f
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191941Z:759caae1-ffd8-44a3-9b03-b695155fb720
+      - NORTHCENTRALUS:20160203T194444Z:d9187dc8-8fd7-465b-bca1-4f9918ab0f6f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:41 GMT
+      - Wed, 03 Feb 2016 19:44:43 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -668,61 +310,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:38 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -732,11 +384,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -755,22 +407,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a2b20e03-45de-4c3c-84c3-33d7242eb5aa
-      - beffef60-1e11-4b45-9099-e30beeb71dc6
+      - 15183d14-ce39-46a7-8cb0-6b5ecf96d125
+      - aba89a4b-2ca5-49f0-ad6e-b73e0b708d9a
+      - eac84d49-e157-460a-ac00-86b301bf0153
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14898'
       X-Ms-Request-Id:
-      - 12ef3095-99cf-44aa-85c3-587857269507
+      - 63e47eb5-9945-4be5-b17f-69a5f574a83e
       X-Ms-Correlation-Request-Id:
-      - 12ef3095-99cf-44aa-85c3-587857269507
+      - 63e47eb5-9945-4be5-b17f-69a5f574a83e
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191941Z:12ef3095-99cf-44aa-85c3-587857269507
+      - NORTHCENTRALUS:20160203T194444Z:63e47eb5-9945-4be5-b17f-69a5f574a83e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:41 GMT
+      - Wed, 03 Feb 2016 19:44:43 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -781,61 +434,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:38 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -845,11 +508,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -868,22 +531,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0f7f9138-4f89-4dd0-99c4-af9b685485db
-      - 73a1fe34-16c4-4abd-90bc-d5ce2786a46d
+      - 1f2614d6-f749-4799-85c0-abf0af309156
+      - 2d1dc089-11f3-48f0-b6f6-22f8b55a0c66
+      - c39c03c3-db00-401b-b951-5d657b461254
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14901'
       X-Ms-Request-Id:
-      - e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      - 4d656796-7927-42cc-b52e-37f6656319c1
       X-Ms-Correlation-Request-Id:
-      - e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      - 4d656796-7927-42cc-b52e-37f6656319c1
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191942Z:e2feb408-1f36-4d4a-97e6-2c629e8c4ab0
+      - NORTHCENTRALUS:20160203T194445Z:4d656796-7927-42cc-b52e-37f6656319c1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:41 GMT
+      - Wed, 03 Feb 2016 19:44:45 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -894,61 +558,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:39 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -958,11 +632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -981,22 +655,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 85c448c7-8270-43bd-8b7c-a7e4781b9c86
-      - c9945f4d-0ce1-4f40-9434-a25d00b013c4
+      - 1392dcd7-f672-4b17-8911-017e87ca82cd
+      - b5555428-37d5-441e-bedc-da47b4aedac8
+      - fb82c4a6-a260-45cf-934c-57d251aa6449
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14904'
       X-Ms-Request-Id:
-      - 50103b33-2a67-41b6-8738-8b2bd33f02f8
+      - 69be38ee-8f35-4926-a80f-47ea9a60a1f9
       X-Ms-Correlation-Request-Id:
-      - 50103b33-2a67-41b6-8738-8b2bd33f02f8
+      - 69be38ee-8f35-4926-a80f-47ea9a60a1f9
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191942Z:50103b33-2a67-41b6-8738-8b2bd33f02f8
+      - NORTHCENTRALUS:20160203T194446Z:69be38ee-8f35-4926-a80f-47ea9a60a1f9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:42 GMT
+      - Wed, 03 Feb 2016 19:44:46 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1007,61 +682,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:39 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:46 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1071,11 +756,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1094,22 +779,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 565d50bb-7d96-4b2d-8894-da26984d9e20
-      - c69053be-7a1d-48a6-9c8c-5e40f4a5d73c
+      - 220bbfee-ab64-4eec-b302-340b7cc1dc65
+      - 2f75f841-2eed-4306-bc85-961df6699327
+      - d675fdd0-89b9-4d6a-b82b-fff822929d03
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - 3c035387-2614-4b19-b89d-09b1c89c32d6
+      - e317d96a-13df-4b85-85cd-1a1bbbfbcf56
       X-Ms-Correlation-Request-Id:
-      - 3c035387-2614-4b19-b89d-09b1c89c32d6
+      - e317d96a-13df-4b85-85cd-1a1bbbfbcf56
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191943Z:3c035387-2614-4b19-b89d-09b1c89c32d6
+      - NORTHCENTRALUS:20160203T194447Z:e317d96a-13df-4b85-85cd-1a1bbbfbcf56
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:43 GMT
+      - Wed, 03 Feb 2016 19:44:46 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1120,61 +806,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:40 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1184,11 +880,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1207,22 +903,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 57d6ae26-c402-4217-ab1d-e0924b3aa975
-      - 6d4dbcd7-d68b-4e10-bc88-e40a93acd4b3
+      - 3db1125e-72b7-44fc-81b4-e9037d63d5a1
+      - 50944831-1c3b-41d2-8786-64c349252be2
+      - 67b95355-01bd-4e06-a779-28a6658df179
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14905'
       X-Ms-Request-Id:
-      - b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      - 7a92d934-9a0c-4e77-aeb7-7672f422f72e
       X-Ms-Correlation-Request-Id:
-      - b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      - 7a92d934-9a0c-4e77-aeb7-7672f422f72e
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191943Z:b20f1551-a4e4-47b5-a2c6-b68b2031cc9d
+      - NORTHCENTRALUS:20160203T194447Z:7a92d934-9a0c-4e77-aeb7-7672f422f72e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:43 GMT
+      - Wed, 03 Feb 2016 19:44:46 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1233,61 +930,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:40 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1297,11 +1004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1320,22 +1027,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4a7addd3-f388-4359-afd8-ca164b5ed523
-      - fcfa7692-9dfd-4bc1-9c4e-cf4241c15742
+      - 0a299562-9f4e-4a65-ab9b-885a216281da
+      - 428b4a93-beaa-4c71-900e-c24345ebcc5c
+      - f4ee25c7-2c53-4b6e-b5c9-c209237a3028
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14898'
       X-Ms-Request-Id:
-      - a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      - 12f497ea-ef7c-4f54-8c93-b70ae13a1b10
       X-Ms-Correlation-Request-Id:
-      - a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      - 12f497ea-ef7c-4f54-8c93-b70ae13a1b10
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191944Z:a5ceaa0b-b3e3-4bbb-b7ce-fbd4363f1b97
+      - NORTHCENTRALUS:20160203T194448Z:12f497ea-ef7c-4f54-8c93-b70ae13a1b10
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:44 GMT
+      - Wed, 03 Feb 2016 19:44:47 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1346,61 +1054,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:41 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1410,11 +1128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1433,22 +1151,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0ce5ce3b-112b-4764-a28d-7b0309ef893a
-      - f5236d2d-2892-487d-94e5-6e9c4702c0be
+      - 9cbd3aa5-4937-48f9-8b2b-208a42e2a22e
+      - bc1e46d5-ee50-43dd-9e50-88d97cd57160
+      - fef8415d-30a5-4535-ac71-8ef3ec198bd7
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14894'
       X-Ms-Request-Id:
-      - 9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      - 9c261e6b-3e1c-4955-859b-c284f2312c85
       X-Ms-Correlation-Request-Id:
-      - 9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      - 9c261e6b-3e1c-4955-859b-c284f2312c85
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191944Z:9410bd52-7ef3-4451-89f7-2a70f4a8e6b2
+      - NORTHCENTRALUS:20160203T194449Z:9c261e6b-3e1c-4955-859b-c284f2312c85
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:44 GMT
+      - Wed, 03 Feb 2016 19:44:48 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1459,61 +1178,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:41 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1523,11 +1252,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1546,22 +1275,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 5debab3b-f053-4b7d-be91-555dc236d109
-      - 6062636b-95cc-4871-852f-2d599d48526a
+      - 73a98668-3f48-4591-9cc9-360b9b1f8422
+      - 80aef589-a77b-41a3-b104-fdf7255e86c1
+      - e46474ad-f08e-4bfe-a491-248bcb3e6f5d
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14895'
       X-Ms-Request-Id:
-      - 69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      - 34c1a601-8dd3-468a-9169-86dbb594d54a
       X-Ms-Correlation-Request-Id:
-      - 69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      - 34c1a601-8dd3-468a-9169-86dbb594d54a
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191945Z:69853bb0-d167-4c8c-b3ce-507a92f4a1f7
+      - NORTHCENTRALUS:20160203T194449Z:34c1a601-8dd3-468a-9169-86dbb594d54a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:44 GMT
+      - Wed, 03 Feb 2016 19:44:49 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1572,61 +1302,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:42 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1636,11 +1376,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1659,22 +1399,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 9d945e6d-1051-45b2-96c6-e25f6e7543c8
-      - a7e4edf6-993c-4330-bdf2-c09a403ac500
+      - 71099568-0822-4172-92c1-6ca2c580404c
+      - 98c61ecd-483a-41b6-a5c2-4c55cb8e605e
+      - d3ca1a0a-fc4a-4c46-8044-b02cbc2cd253
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14888'
       X-Ms-Request-Id:
-      - 862d8063-2253-4c1d-8de1-ab7bd27a317d
+      - 8a8e836d-05f2-48bb-9654-bd64c7fb5eca
       X-Ms-Correlation-Request-Id:
-      - 862d8063-2253-4c1d-8de1-ab7bd27a317d
+      - 8a8e836d-05f2-48bb-9654-bd64c7fb5eca
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191945Z:862d8063-2253-4c1d-8de1-ab7bd27a317d
+      - NORTHCENTRALUS:20160203T194450Z:8a8e836d-05f2-48bb-9654-bd64c7fb5eca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:45 GMT
+      - Wed, 03 Feb 2016 19:44:49 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1685,61 +1426,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:42 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1749,11 +1500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1772,22 +1523,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a7a8ebb0-f2ed-4c72-b4ce-b0e36732cc98
-      - bfb9183d-f28e-4d0c-aa87-60fd28bb60bf
+      - 69ce20a0-4007-4873-9512-a3486ed1f884
+      - b85e152d-74cd-4f89-939d-ca227c8fc23e
+      - ca94bcc4-813b-450e-886e-5fcc550dcc17
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - 31627ad1-01c5-4711-aa7f-c441b2799036
+      - c2dff1ac-4ac3-4cc6-9797-55d2df074138
       X-Ms-Correlation-Request-Id:
-      - 31627ad1-01c5-4711-aa7f-c441b2799036
+      - c2dff1ac-4ac3-4cc6-9797-55d2df074138
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191946Z:31627ad1-01c5-4711-aa7f-c441b2799036
+      - NORTHCENTRALUS:20160203T194451Z:c2dff1ac-4ac3-4cc6-9797-55d2df074138
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:45 GMT
+      - Wed, 03 Feb 2016 19:44:50 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1798,61 +1550,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:43 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1862,11 +1624,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1885,22 +1647,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 72e9a2fc-a479-47f4-9b6c-93c3f1f5ce32
-      - 94e9df99-7926-48e5-9ef3-3baccd6ee09d
+      - 04525d24-c424-4d54-8deb-5a79f59b7d5b
+      - f2fd06b2-8994-4ff7-bf0b-4d6579a91649
+      - f56eb97f-804c-4a90-8053-fbf893cc7be1
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14902'
       X-Ms-Request-Id:
-      - 156c5a4e-67e2-4d0f-8382-2d462752fedc
+      - 3ffa5a15-da34-4ec3-bab4-9d79a4a97f93
       X-Ms-Correlation-Request-Id:
-      - 156c5a4e-67e2-4d0f-8382-2d462752fedc
+      - 3ffa5a15-da34-4ec3-bab4-9d79a4a97f93
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191946Z:156c5a4e-67e2-4d0f-8382-2d462752fedc
+      - NORTHCENTRALUS:20160203T194451Z:3ffa5a15-da34-4ec3-bab4-9d79a4a97f93
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:45 GMT
+      - Wed, 03 Feb 2016 19:44:50 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1911,61 +1674,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:43 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1975,11 +1748,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1998,22 +1771,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 695e7b69-943b-42ad-85f1-21b8bdf8da8b
-      - 940104d5-2eac-4744-bdda-b7d9fe3ec327
+      - 55a4aa6c-c686-48ab-bf93-1a70b4709146
+      - c80673a7-b076-422e-8397-3fff2289a770
+      - e2482ba1-eb16-4894-8c3b-e45ff7e5f7ac
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14889'
       X-Ms-Request-Id:
-      - a63405f0-3425-4e93-9e96-dd07fa213327
+      - 914ca6a3-1aa0-4610-9b63-583149940ef3
       X-Ms-Correlation-Request-Id:
-      - a63405f0-3425-4e93-9e96-dd07fa213327
+      - 914ca6a3-1aa0-4610-9b63-583149940ef3
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191947Z:a63405f0-3425-4e93-9e96-dd07fa213327
+      - NORTHCENTRALUS:20160203T194452Z:914ca6a3-1aa0-4610-9b63-583149940ef3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:46 GMT
+      - Wed, 03 Feb 2016 19:44:51 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2024,61 +1798,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:52 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2088,11 +1872,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2111,22 +1895,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3b6cfb33-5011-4fb3-83ba-3d0f7bb6ac85
-      - bb7cce66-6fb0-4684-b694-4d2ea8ea3a28
+      - 28d32f9d-3768-4078-9a2a-bb4551557e0c
+      - 84225234-8939-4405-b31b-3f367a193511
+      - b4e8a6fa-be19-44ff-885c-8fb8f0658350
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14890'
       X-Ms-Request-Id:
-      - c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      - 252da7f0-9762-42e5-b3e3-d7ebf7d55351
       X-Ms-Correlation-Request-Id:
-      - c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      - 252da7f0-9762-42e5-b3e3-d7ebf7d55351
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191947Z:c80f03e8-416b-4e8f-82bd-d24dd2ee985b
+      - NORTHCENTRALUS:20160203T194453Z:252da7f0-9762-42e5-b3e3-d7ebf7d55351
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:46 GMT
+      - Wed, 03 Feb 2016 19:44:52 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2137,61 +1922,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2201,11 +1996,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2224,22 +2019,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b064a2a9-008b-4980-8378-78bd1559b539
-      - eb514984-df49-482c-a92f-317f12e1076c
+      - 2b991fb7-7a2f-4da7-877c-7198ffdb4ac4
+      - b88c12d2-f468-42dc-abdf-f7490f0dfdbc
+      - fdaee3f3-8cd4-433f-9827-3f293159a171
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14897'
       X-Ms-Request-Id:
-      - 7963625b-190c-4f8c-89a8-a68735abf28a
+      - 8e04a574-2fac-4405-9718-dc7ff30fa944
       X-Ms-Correlation-Request-Id:
-      - 7963625b-190c-4f8c-89a8-a68735abf28a
+      - 8e04a574-2fac-4405-9718-dc7ff30fa944
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191947Z:7963625b-190c-4f8c-89a8-a68735abf28a
+      - NORTHCENTRALUS:20160203T194454Z:8e04a574-2fac-4405-9718-dc7ff30fa944
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:47 GMT
+      - Wed, 03 Feb 2016 19:44:53 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2250,61 +2046,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2314,11 +2120,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2337,22 +2143,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 94ceef14-f880-42e1-93e6-30505510e58f
-      - c945bb07-4dce-4645-bcdc-43acf22508ae
+      - 7245aae1-2d05-4b8b-95f9-d95bdd69c13c
+      - 80f448ba-2157-4923-81f1-7464f4f5b6dc
+      - eeb49de7-6ed6-48ea-8531-49b5edabd0f6
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14899'
       X-Ms-Request-Id:
-      - 58e70409-647e-4fca-ab94-68e407c983cb
+      - 67968e04-d2fb-4263-8609-24b9ca4a6c61
       X-Ms-Correlation-Request-Id:
-      - 58e70409-647e-4fca-ab94-68e407c983cb
+      - 67968e04-d2fb-4263-8609-24b9ca4a6c61
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191948Z:58e70409-647e-4fca-ab94-68e407c983cb
+      - NORTHCENTRALUS:20160203T194454Z:67968e04-d2fb-4263-8609-24b9ca4a6c61
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:48 GMT
+      - Wed, 03 Feb 2016 19:44:53 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2363,61 +2170,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:45 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2427,11 +2244,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2450,22 +2267,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6602dcbe-6f91-46b9-b72c-2ea31dbec408
-      - bcb4d331-45e0-4035-8c3e-dfa52d386a4e
+      - 34cf40ff-b076-4bbe-90c7-5016e42d29e0
+      - 90fa54fd-5970-4c8b-89e1-5d05757b52a9
+      - cd0d7ea2-1505-403c-895b-325b406ed99a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14899'
       X-Ms-Request-Id:
-      - be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      - cfbc82b8-8880-4e59-a008-25e66407c656
       X-Ms-Correlation-Request-Id:
-      - be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      - cfbc82b8-8880-4e59-a008-25e66407c656
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191948Z:be0cd5cf-0ba8-4334-a95b-a46135a234ea
+      - NORTHCENTRALUS:20160203T194455Z:cfbc82b8-8880-4e59-a008-25e66407c656
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:48 GMT
+      - Wed, 03 Feb 2016 19:44:55 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2476,61 +2294,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:45 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2540,11 +2368,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2563,22 +2391,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2f1e6a92-6397-40b8-ac63-e47c9934e44a
-      - 53e9ffff-680b-48c0-b2b9-b6a6b655242b
+      - 3fe21687-37cb-442a-98eb-ff2cc4b8ddae
+      - 66eb0dbe-fa43-4d3c-ad7f-8642f234906a
+      - 81499448-013c-4751-9da8-111fcb20f416
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14897'
       X-Ms-Request-Id:
-      - 40acab8e-b389-47c4-8422-b8e5d6d4e915
+      - c0097baf-840a-4efd-921e-8b7395f8caef
       X-Ms-Correlation-Request-Id:
-      - 40acab8e-b389-47c4-8422-b8e5d6d4e915
+      - c0097baf-840a-4efd-921e-8b7395f8caef
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191949Z:40acab8e-b389-47c4-8422-b8e5d6d4e915
+      - NORTHCENTRALUS:20160203T194456Z:c0097baf-840a-4efd-921e-8b7395f8caef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:49 GMT
+      - Wed, 03 Feb 2016 19:44:55 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2589,61 +2418,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:46 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2653,11 +2492,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2676,22 +2515,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 150f8efa-c5d1-4767-aaeb-63cc43159962
-      - 526754cd-6a9d-48e8-8f10-93cb5b689b7f
+      - 27da6e0c-f24c-4cfd-a691-2a1f77384046
+      - 8a48120b-fd85-4051-b477-377bc8f94f4b
+      - d4862c2c-7dd1-4deb-836a-2f9cec0e4f67
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - 420db90a-e9d3-4762-b07d-deba63ef25af
+      - 209fc3f0-4439-4e2a-9cd6-3e7dc5590091
       X-Ms-Correlation-Request-Id:
-      - 420db90a-e9d3-4762-b07d-deba63ef25af
+      - 209fc3f0-4439-4e2a-9cd6-3e7dc5590091
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191949Z:420db90a-e9d3-4762-b07d-deba63ef25af
+      - NORTHCENTRALUS:20160203T194456Z:209fc3f0-4439-4e2a-9cd6-3e7dc5590091
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:48 GMT
+      - Wed, 03 Feb 2016 19:44:56 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2702,61 +2542,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:46 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2766,11 +2616,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2789,22 +2639,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 621c6887-a5df-4627-b792-5581c79b84ff
-      - af733721-5503-44fd-879e-550d3d39f60f
+      - 92e63dc5-985c-4699-b210-ed5d5b23d292
+      - f5c10cb2-a1dd-40f1-a446-0e2612791f78
+      - f88098ee-8a58-43c0-ba53-9ebd3f34b7a1
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14899'
       X-Ms-Request-Id:
-      - aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      - 7c5af9f6-9ca1-4147-93e7-9aed4e9ab83c
       X-Ms-Correlation-Request-Id:
-      - aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      - 7c5af9f6-9ca1-4147-93e7-9aed4e9ab83c
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191950Z:aab60b1d-40d5-478d-94a2-50d2dbb8aeb3
+      - NORTHCENTRALUS:20160203T194501Z:7c5af9f6-9ca1-4147-93e7-9aed4e9ab83c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:49 GMT
+      - Wed, 03 Feb 2016 19:45:00 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2815,61 +2666,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:47 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2879,11 +2740,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2902,22 +2763,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 7fb583fa-cbce-40e9-87a3-56e7daa892eb
-      - add3ddeb-9068-4311-9e73-caf17740ab11
+      - 3c978a3e-2959-4a95-aa3e-c58ae26cc4bb
+      - a58c458f-30e2-46f1-ac32-baa75e8637e6
+      - ac4212a0-613e-4bcd-bbbb-d99e7bd09c5a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14904'
       X-Ms-Request-Id:
-      - 75b0003e-437f-41d3-91da-41d20d537754
+      - 5d1a45ca-266d-4663-8ede-9ed98bdeb7fe
       X-Ms-Correlation-Request-Id:
-      - 75b0003e-437f-41d3-91da-41d20d537754
+      - 5d1a45ca-266d-4663-8ede-9ed98bdeb7fe
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191950Z:75b0003e-437f-41d3-91da-41d20d537754
+      - NORTHCENTRALUS:20160203T194501Z:5d1a45ca-266d-4663-8ede-9ed98bdeb7fe
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:49 GMT
+      - Wed, 03 Feb 2016 19:45:01 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2928,61 +2790,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:47 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2992,11 +2864,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3015,22 +2887,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 841bcbc1-3c6b-4e59-aac5-7568f1e97cc3
-      - dc9b1e7e-7a78-4c9b-9ecd-1a9fdee7db4f
+      - 23d82f1b-739b-4eea-a519-5ede057f5870
+      - 66b8f86f-5789-4c74-b5ff-b32979af34a5
+      - 85ff2c35-3c72-4a9b-a932-e3ffa75b6754
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14897'
       X-Ms-Request-Id:
-      - 98e4e652-e133-4f4c-895c-0eee20e77257
+      - d18187d3-3c72-46af-b3dd-88c220eff5ec
       X-Ms-Correlation-Request-Id:
-      - 98e4e652-e133-4f4c-895c-0eee20e77257
+      - d18187d3-3c72-46af-b3dd-88c220eff5ec
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191951Z:98e4e652-e133-4f4c-895c-0eee20e77257
+      - NORTHCENTRALUS:20160203T194502Z:d18187d3-3c72-46af-b3dd-88c220eff5ec
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:50 GMT
+      - Wed, 03 Feb 2016 19:45:01 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3041,61 +2914,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3105,11 +2988,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3128,22 +3011,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - c684822c-0623-4cd9-99a9-404260673598
-      - e1fd97f0-d332-4726-9b38-5fb5ffb1582f
+      - 2477cd7e-7f16-4c25-85c7-5c2f56dc0974
+      - 5a71f3f5-05ed-4a07-81d8-0649171603b6
+      - a68b0fc0-2c34-41fc-b602-28f29fedb4ad
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14893'
       X-Ms-Request-Id:
-      - a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      - 3d4e20d4-61d4-4426-a8c5-96a6b3b60f33
       X-Ms-Correlation-Request-Id:
-      - a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      - 3d4e20d4-61d4-4426-a8c5-96a6b3b60f33
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191951Z:a0dd1f28-2cd3-40b3-b8fa-9888d28d2cf6
+      - NORTHCENTRALUS:20160203T194503Z:3d4e20d4-61d4-4426-a8c5-96a6b3b60f33
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:50 GMT
+      - Wed, 03 Feb 2016 19:45:02 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3154,61 +3038,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3218,11 +3112,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3241,22 +3135,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 19108cbf-604c-419a-b468-ef3243367a76
-      - 5ac6068c-3921-4933-978b-3a190afdc23e
+      - 3f03d409-c155-40ab-8977-445c2dd2c2c0
+      - 7dd70639-ace3-46b3-ab08-f8e551e3ba9f
+      - efaad05a-35a1-4a5b-b911-124b6ebaa0ac
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14887'
       X-Ms-Request-Id:
-      - 59269398-cc5a-456b-a0d0-23d0215b06d6
+      - f354836e-13e3-418b-be6d-64ae1241bfbd
       X-Ms-Correlation-Request-Id:
-      - 59269398-cc5a-456b-a0d0-23d0215b06d6
+      - f354836e-13e3-418b-be6d-64ae1241bfbd
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191951Z:59269398-cc5a-456b-a0d0-23d0215b06d6
+      - NORTHCENTRALUS:20160203T194504Z:f354836e-13e3-418b-be6d-64ae1241bfbd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:51 GMT
+      - Wed, 03 Feb 2016 19:45:03 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3267,61 +3162,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:48 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3331,11 +3236,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3354,22 +3259,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 34222713-f9f9-42b9-b0bb-cd0f1720dd32
-      - 91fb1d60-071d-439a-9525-a7192de0d4b7
+      - 5c3625e6-c383-4c78-b6e6-d8d1e9b72615
+      - beb7298d-a360-47f2-a09e-388b4c8fd2be
+      - c0b2a2a3-b194-437b-bca5-aea800a98f8e
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14899'
       X-Ms-Request-Id:
-      - 6fd69513-a47e-4e68-8849-91f6454c9d36
+      - 2a32afff-04ce-4450-a26b-ad1e7eb41684
       X-Ms-Correlation-Request-Id:
-      - 6fd69513-a47e-4e68-8849-91f6454c9d36
+      - 2a32afff-04ce-4450-a26b-ad1e7eb41684
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191952Z:6fd69513-a47e-4e68-8849-91f6454c9d36
+      - NORTHCENTRALUS:20160203T194505Z:2a32afff-04ce-4450-a26b-ad1e7eb41684
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:51 GMT
+      - Wed, 03 Feb 2016 19:45:04 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3380,61 +3286,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:49 GMT
+  recorded_at: Wed, 03 Feb 2016 19:45:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3444,11 +3360,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3467,22 +3383,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 35430d78-6f6f-4978-a9cb-dba50cb640b6
-      - 46a4077b-e823-41aa-b674-64c453ac8324
+      - 0a36d7cc-30a4-4431-b9f0-e51927f17f45
+      - 12b7cdd6-45f8-4e43-a414-db9901a82d00
+      - dc0ff6c3-d16c-4746-9323-b808740af58c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14901'
       X-Ms-Request-Id:
-      - f8c04792-d503-497b-8705-63f05e795176
+      - 2e7c2d9b-236b-4a6c-8372-9d3c96b6fd37
       X-Ms-Correlation-Request-Id:
-      - f8c04792-d503-497b-8705-63f05e795176
+      - 2e7c2d9b-236b-4a6c-8372-9d3c96b6fd37
       X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191952Z:f8c04792-d503-497b-8705-63f05e795176
+      - NORTHCENTRALUS:20160203T194506Z:2e7c2d9b-236b-4a6c-8372-9d3c96b6fd37
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Wed, 28 Oct 2015 19:19:52 GMT
+      - Wed, 03 Feb 2016 19:45:05 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3493,8629 +3410,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4c70f70e-4722-4832-a74b-41e17b6b8109
-      - df61b42a-81d0-476c-a2ae-3bf7c84ae223
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - bc0b837f-91f0-4a74-b089-7b4bcdee8a16
-      X-Ms-Correlation-Request-Id:
-      - bc0b837f-91f0-4a74-b089-7b4bcdee8a16
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191953Z:bc0b837f-91f0-4a74-b089-7b4bcdee8a16
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:53 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 9bb8d6f8-4765-4e61-8a8c-ca817656924b
-      - d43ce9a2-a487-4075-ba83-cee7d4aefd13
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - fb139d56-8ded-44de-976d-74f1e63e78c3
-      X-Ms-Correlation-Request-Id:
-      - fb139d56-8ded-44de-976d-74f1e63e78c3
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191953Z:fb139d56-8ded-44de-976d-74f1e63e78c3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:53 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 329cbb91-1b7a-49fd-be3e-8b8446b036c6
-      - 6adee14d-cd3f-4820-ba76-a34b553bab73
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 637be055-3456-4f8a-8008-9f9bbd84087f
-      X-Ms-Correlation-Request-Id:
-      - 637be055-3456-4f8a-8008-9f9bbd84087f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191954Z:637be055-3456-4f8a-8008-9f9bbd84087f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:54 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4484bd8d-87dd-421a-a66e-15ac283d990a
-      - 55a7ceae-1de7-4a18-bc7a-7397bd46799d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 008e3e12-72a1-4f09-82bb-879be6541a9b
-      X-Ms-Correlation-Request-Id:
-      - 008e3e12-72a1-4f09-82bb-879be6541a9b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191954Z:008e3e12-72a1-4f09-82bb-879be6541a9b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:54 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - b13bbb51-3a06-43b7-84d2-6132d21910c9
-      - f1151bd0-0ec0-421a-8f4b-d88c39a41d38
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - ec492f1a-8680-41b2-9dbf-7a6f95819220
-      X-Ms-Correlation-Request-Id:
-      - ec492f1a-8680-41b2-9dbf-7a6f95819220
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191955Z:ec492f1a-8680-41b2-9dbf-7a6f95819220
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:54 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5b11a1d3-56a9-4720-9c10-b4ee7e970e04
-      - b8e7d553-dc1b-4d48-be92-2fc7ad0286d4
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - d7c69587-1b64-4f2d-b0d5-f9633c74f089
-      X-Ms-Correlation-Request-Id:
-      - d7c69587-1b64-4f2d-b0d5-f9633c74f089
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191955Z:d7c69587-1b64-4f2d-b0d5-f9633c74f089
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:55 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 09ce85ce-658d-404c-b7b0-c7b4ec1259e1
-      - c3a8fa72-d221-4ec3-a621-6b2022ac9d31
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
-      X-Ms-Correlation-Request-Id:
-      - dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191955Z:dc2f8a29-f7de-46a4-bddf-e59b33eaeaa2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:54 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8fdcd4c7-496a-4eac-a99a-43ba6c86af3b
-      - f606289d-f812-432f-8b67-27f5285eba89
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 5e0ad678-1022-489f-a754-dfdbbbd38cc9
-      X-Ms-Correlation-Request-Id:
-      - 5e0ad678-1022-489f-a754-dfdbbbd38cc9
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191956Z:5e0ad678-1022-489f-a754-dfdbbbd38cc9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:56 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - c8d7abf3-e899-4692-beb6-6238b0147982
-      - d1897261-eab3-4840-b386-44df89caabce
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - f34edfb0-4b57-44d0-9073-999af01749a7
-      X-Ms-Correlation-Request-Id:
-      - f34edfb0-4b57-44d0-9073-999af01749a7
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191956Z:f34edfb0-4b57-44d0-9073-999af01749a7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:56 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 32e9269e-5825-44f7-8945-cb4717496fdc
-      - 7dedc152-863b-49d9-9f08-bd71deb06e7a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 5128e35a-129d-48ed-ab67-6ac6b6b49a63
-      X-Ms-Correlation-Request-Id:
-      - 5128e35a-129d-48ed-ab67-6ac6b6b49a63
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191957Z:5128e35a-129d-48ed-ab67-6ac6b6b49a63
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:57 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 097b1f80-8667-40fc-bfc1-c3af72099684
-      - a9304fed-5761-4b3f-9c14-71d312339d69
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - a081a150-1356-497b-a4f4-a989de24fd46
-      X-Ms-Correlation-Request-Id:
-      - a081a150-1356-497b-a4f4-a989de24fd46
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191957Z:a081a150-1356-497b-a4f4-a989de24fd46
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:56 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 0b2746f0-804b-4739-a714-8f18279e478c
-      - ea9acc9c-3798-4eec-926d-7c87e4577ac5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 9ddca1ea-3766-49cc-a558-ec44ea0a19fd
-      X-Ms-Correlation-Request-Id:
-      - 9ddca1ea-3766-49cc-a558-ec44ea0a19fd
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191958Z:9ddca1ea-3766-49cc-a558-ec44ea0a19fd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:57 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 25cb347b-337d-4e5a-9267-b2ab29ac686a
-      - 435ded7a-b068-4d82-9379-a784b544506d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
-      X-Ms-Correlation-Request-Id:
-      - 3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191958Z:3bcf9f34-7815-4ad0-a92b-123eeb91bf7e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:58 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4f3025b1-f413-4092-9811-923580bb6de4
-      - 826832f7-c150-4aa8-a3e5-a08e5a195763
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - dcbc238f-36a7-4a4c-9453-c1cb5750ae91
-      X-Ms-Correlation-Request-Id:
-      - dcbc238f-36a7-4a4c-9453-c1cb5750ae91
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191959Z:dcbc238f-36a7-4a4c-9453-c1cb5750ae91
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:58 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 35d7c0b2-b2e1-450b-a10a-8bc043263a61
-      - 786a81f8-ce8c-4fe5-a336-489194bae608
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - bd19b5dc-4ebe-4007-8453-2241c59dbc62
-      X-Ms-Correlation-Request-Id:
-      - bd19b5dc-4ebe-4007-8453-2241c59dbc62
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191959Z:bd19b5dc-4ebe-4007-8453-2241c59dbc62
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:58 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 27666057-d157-4248-9a8c-69994f066884
-      - 39ea6e39-ec29-4010-b827-3ba0b62cd567
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
-      X-Ms-Correlation-Request-Id:
-      - ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T191959Z:ae5e230f-0a73-45ba-b8f7-721aeb4afa9e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:59 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1752f800-7094-40e6-8f6b-b29295662d76
-      - 467bc159-ba1d-4ea4-b4b4-1668a3811abc
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 4eca2f73-60b1-4e55-aba5-2e0abf687140
-      X-Ms-Correlation-Request-Id:
-      - 4eca2f73-60b1-4e55-aba5-2e0abf687140
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192000Z:4eca2f73-60b1-4e55-aba5-2e0abf687140
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:00 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 9a4b4288-20b1-456e-a1f8-8781a3942102
-      - bed3e4af-7953-4d2e-ba7f-d77b286b45de
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - b3eb8714-ae67-4142-ba02-a05dee37ed20
-      X-Ms-Correlation-Request-Id:
-      - b3eb8714-ae67-4142-ba02-a05dee37ed20
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192000Z:b3eb8714-ae67-4142-ba02-a05dee37ed20
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:19:59 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7ac701c3-e6f7-4ca2-9fda-43b177dd6cf6
-      - bce8d30e-ec87-4e4b-9d4b-57d416ce639a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 12394798-e2e5-4f98-8907-bff77e598389
-      X-Ms-Correlation-Request-Id:
-      - 12394798-e2e5-4f98-8907-bff77e598389
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192001Z:12394798-e2e5-4f98-8907-bff77e598389
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:01 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 71127250-5d17-44ff-abfa-f2d30a84a556
-      - d3057bc5-2073-4be1-aab5-ce7cf24df108
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - c08c3204-4d05-4590-8261-ec85438f1443
-      X-Ms-Correlation-Request-Id:
-      - c08c3204-4d05-4590-8261-ec85438f1443
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192001Z:c08c3204-4d05-4590-8261-ec85438f1443
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:01 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 11bd2613-81e8-4ea3-965d-95d6eaafb71b
-      - 2ac27cd1-2c98-4325-af91-008ef31118a7
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 8ddbd878-7cae-4673-92d2-ff54ed1ede93
-      X-Ms-Correlation-Request-Id:
-      - 8ddbd878-7cae-4673-92d2-ff54ed1ede93
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192002Z:8ddbd878-7cae-4673-92d2-ff54ed1ede93
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:01 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 136da760-f17a-484b-9093-85d838712c0f
-      - e8864003-39ae-43f6-9130-474ca8e96a5a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 623e4773-36b7-450a-b417-2ce035b902e4
-      X-Ms-Correlation-Request-Id:
-      - 623e4773-36b7-450a-b417-2ce035b902e4
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192002Z:623e4773-36b7-450a-b417-2ce035b902e4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:02 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4ec3b7e3-e1ce-47b3-afdb-40f3a1bd772e
-      - 6f4c8afc-e174-47e4-9548-abad456e592a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 1cac122c-49cd-4925-91a1-72ac3450801f
-      X-Ms-Correlation-Request-Id:
-      - 1cac122c-49cd-4925-91a1-72ac3450801f
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192002Z:1cac122c-49cd-4925-91a1-72ac3450801f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:02 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:19:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 7c98d0fe-b4d1-4797-9f50-90ff9ff38d83
-      - c225b406-f9c2-456d-9776-6c4761ad42b6
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 8e8adab4-f341-47fa-b84e-6bcaa6cf2637
-      X-Ms-Correlation-Request-Id:
-      - 8e8adab4-f341-47fa-b84e-6bcaa6cf2637
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192003Z:8e8adab4-f341-47fa-b84e-6bcaa6cf2637
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:02 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4a713172-1796-4f70-b5dd-33b423869e6e
-      - d94f1494-ce56-4210-b71f-5574a09d5b12
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 3396015e-26d0-4164-b7e8-5e642df2ed06
-      X-Ms-Correlation-Request-Id:
-      - 3396015e-26d0-4164-b7e8-5e642df2ed06
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192003Z:3396015e-26d0-4164-b7e8-5e642df2ed06
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:03 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1fadb110-86fe-4805-b157-2f20625269c4
-      - d9f692fa-219e-4dd8-b0b6-236e816b23b1
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - b5623b0d-b5f5-45a9-ba29-44b9427978e6
-      X-Ms-Correlation-Request-Id:
-      - b5623b0d-b5f5-45a9-ba29-44b9427978e6
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192004Z:b5623b0d-b5f5-45a9-ba29-44b9427978e6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:04 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4143ab2f-16ef-4340-aa36-57a592ce859e
-      - 5f0fbd94-4ce3-4531-9f33-d5ea82824f9a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 62d3c501-4e5e-4484-a0ef-ea34191d347a
-      X-Ms-Correlation-Request-Id:
-      - 62d3c501-4e5e-4484-a0ef-ea34191d347a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192004Z:62d3c501-4e5e-4484-a0ef-ea34191d347a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:04 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 57c58193-fa77-43c3-817a-5fba2c745684
-      - d5c054c5-e31b-43e6-aff9-4f7e5157521b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 2021988c-46aa-41ef-9e8a-bb761a553b24
-      X-Ms-Correlation-Request-Id:
-      - 2021988c-46aa-41ef-9e8a-bb761a553b24
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192005Z:2021988c-46aa-41ef-9e8a-bb761a553b24
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:05 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 5613cd65-5099-460c-8071-26e1c35559ea
-      X-Ms-Correlation-Request-Id:
-      - 5613cd65-5099-460c-8071-26e1c35559ea
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192005Z:5613cd65-5099-460c-8071-26e1c35559ea
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:05 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - c8a230eb-3f46-4ce7-8d22-f4db24135029
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - a521d825-bd3d-4f99-9d79-e365893cb30a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192006Z:a521d825-bd3d-4f99-9d79-e365893cb30a
-      Date:
-      - Wed, 28 Oct 2015 19:20:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - e1c36571-d4db-48a2-ac34-ec44a5fbddc2
-      X-Ms-Correlation-Request-Id:
-      - e1c36571-d4db-48a2-ac34-ec44a5fbddc2
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192006Z:e1c36571-d4db-48a2-ac34-ec44a5fbddc2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:06 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - c48a3f4f-b58c-4450-bec5-cd1eea43cc12
-      X-Ms-Correlation-Request-Id:
-      - c48a3f4f-b58c-4450-bec5-cd1eea43cc12
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192007Z:c48a3f4f-b58c-4450-bec5-cd1eea43cc12
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:07 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - f3278b22-255e-4813-bcce-0cc44b33360a
-      X-Ms-Correlation-Request-Id:
-      - f3278b22-255e-4813-bcce-0cc44b33360a
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192008Z:f3278b22-255e-4813-bcce-0cc44b33360a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:07 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a5511ff9-2a89-4695-837a-304b58b3c274
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - 37407780-d771-4433-bb0f-fa698c0b02cd
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192008Z:37407780-d771-4433-bb0f-fa698c0b02cd
-      Date:
-      - Wed, 28 Oct 2015 19:20:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 93c4084e-5d45-4461-8bbd-9a7b038643cc
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 2e1aa28f-5050-4ff0-b2a9-ef5a2f6ede38
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192009Z:2e1aa28f-5050-4ff0-b2a9-ef5a2f6ede38
-      Date:
-      - Wed, 28 Oct 2015 19:20:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 502fd373-c9dc-4000-a82e-523febd8c769
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 4b0af1b8-0542-48ff-a426-1f7d19517c84
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192009Z:4b0af1b8-0542-48ff-a426-1f7d19517c84
-      Date:
-      - Wed, 28 Oct 2015 19:20:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebTz8JMd+nfn
-        I9P4l8gv38ePX8IggNRbIKMEsMP/aJkJ1Nc/8fx1Xl/m9dP80nUbpZ33Op4N
-        9GvW02mez/KZg4jH0e9seV51viNMQ/L5YNMhiDHiHDzaf/Do/qfjnb2dg4cP
-        7nWIRKQxvzKh9O/vM9yPJlXVPi2yi2XVtMUUeOiYabTLpirz19M6z5fNvGqf
-        lNXkq7qgJh/N23bVPLp79ypv2mmVNe1s0tx/+OneeEJtxtOqzsdXxXJWXTXj
-        Zd7eRScz18l284vKhudge+few3w23TvYvp8f7Gzv7+zsbU9m96fb+/cfZvuz
-        7P7u3sH+XX/Kxrd5Y9xYpMeTxYpJofyRv2vpCyIyhqozrSOmbw2TfFFM66qp
-        ztvxGTW+mLfN+Ce/8Mj0Om9bmqWGIRNs/FCC9hnJgX8vBhpinvdnnM1Mc3Bv
-        /8GnBwHTCK2imFdXeY2e87uzPCvLakq/+l3dGmnSBT4EaSiE/I2TX/L/AKOB
-        L+VABQAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1b7149bd-ba96-4d7d-859b-7064afb3abcc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d2d15845-a4c6-4040-80b7-fbb9079b9f7d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - 775cbaae-2b0b-42f8-a7e4-f91bcd9361fc
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192010Z:775cbaae-2b0b-42f8-a7e4-f91bcd9361fc
-      Date:
-      - Wed, 28 Oct 2015 19:20:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7uTB
-        7v7DyWx7kj38dHt/9mC2fXD/4WT7wc6n+9n55F42mU5/34/0xfZ6xQO+Rdf6
-        RllNM4wcb13lTbs2X9A4VnndFtTyUcrklA8vi4aaF8uL123Wcmev19Npns/y
-        mbxJzSx91kLjnUl2P9vZn21PHz68t71/8GC6nU3v7W/f29/Nzx/MDma7D/ft
-        y8XqpFqeFxfrmhFD99+Tr1KDBx47ucVqyu13DQQ8/2+c3LvdkdEHMdS/7uzL
-        gznqTZw8+OoW0ycPNS4uqcnZy+PZjGgCaB/t7ozvjXfGdrLk8ZqWhp++yNt5
-        xXPw9Jpmqph2X1lPymJKb1jgAarU4oc/gx2caAZf/8Tz1zyDT/PLj3z8fkk4
-        GkKSpp/w/bkfxGVRt+us1D87LxIehGdzd5afZ+uyDYfk/rC/6i/f19F+NFs2
-        r/O2JfYJZkw+B53w8fdMc/oiW63KIp89Db+Xrw0NP8qX2aQk7nlW1VdZPSPo
-        1Oo8I+ExLQhpjOZ1Pl3XRXvNNKE2DoEfPp1jKEUZxg5TZ+aLbDovlhC9nw30
-        T1+/Ofny+PWbp09eR9E/qRardZsbNlFk4ojjB/3zS/4fmp61wU0HAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - aaa1e50a-94fc-42aa-9214-1ce7cf2fefdd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - d3dd77df-66ac-443c-9d00-c2102ef4889b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192010Z:d3dd77df-66ac-443c-9d00-c2102ef4889b
-      Date:
-      - Wed, 28 Oct 2015 19:20:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 18fc937d-846f-4357-8f3c-d02d9cd7b2d0
-      X-Ms-Correlation-Request-Id:
-      - 18fc937d-846f-4357-8f3c-d02d9cd7b2d0
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192012Z:18fc937d-846f-4357-8f3c-d02d9cd7b2d0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:11 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 4eddf450-f31f-4e3c-b4ad-00538825c958
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - 6d72f074-1f14-4868-b492-c1b611196a03
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192012Z:6d72f074-1f14-4868-b492-c1b611196a03
-      Date:
-      - Wed, 28 Oct 2015 19:20:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
-      X-Ms-Correlation-Request-Id:
-      - 9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192013Z:9a7e32fe-9b3c-4a7d-af9a-1cb5ac4fcd01
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:12 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 5e659ca3-957f-42f6-9930-f45c7cc54506
-      X-Ms-Correlation-Request-Id:
-      - 5e659ca3-957f-42f6-9930-f45c7cc54506
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192013Z:5e659ca3-957f-42f6-9930-f45c7cc54506
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:13 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - d0e1f5fe-54df-4f3b-9174-ba732db842b5
-      X-Ms-Correlation-Request-Id:
-      - d0e1f5fe-54df-4f3b-9174-ba732db842b5
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192014Z:d0e1f5fe-54df-4f3b-9174-ba732db842b5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:14 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - d81efe0d-cb24-47b8-b4de-2768074b780b
-      X-Ms-Correlation-Request-Id:
-      - d81efe0d-cb24-47b8-b4de-2768074b780b
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192014Z:d81efe0d-cb24-47b8-b4de-2768074b780b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:14 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
-      X-Ms-Correlation-Request-Id:
-      - 4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192015Z:4c8bbfed-b7ae-4317-93d4-ad981d5c9ac4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:14 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 10a3e901-bd28-401f-883a-c03ec54edf7e
-      X-Ms-Correlation-Request-Id:
-      - 10a3e901-bd28-401f-883a-c03ec54edf7e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192015Z:10a3e901-bd28-401f-883a-c03ec54edf7e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:14 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
-      X-Ms-Correlation-Request-Id:
-      - 6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192015Z:6ffcbef3-0dea-45f6-b250-3422ff2ee5e8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:14 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
-      X-Ms-Correlation-Request-Id:
-      - 4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192016Z:4bf4d18b-38bb-449b-8dfc-2a81a456ee8e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:16 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 3d7b58af-f385-4b61-9800-52e40e2a2e07
-      X-Ms-Correlation-Request-Id:
-      - 3d7b58af-f385-4b61-9800-52e40e2a2e07
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192017Z:3d7b58af-f385-4b61-9800-52e40e2a2e07
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:16 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 279eb160-6369-4fbb-8db9-298fff91a944
-      X-Ms-Correlation-Request-Id:
-      - 279eb160-6369-4fbb-8db9-298fff91a944
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192017Z:279eb160-6369-4fbb-8db9-298fff91a944
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:17 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 8db03a4a-c23e-4955-8c05-b787153b1328
-      X-Ms-Correlation-Request-Id:
-      - 8db03a4a-c23e-4955-8c05-b787153b1328
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192018Z:8db03a4a-c23e-4955-8c05-b787153b1328
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:17 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:15 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB2E25:094B:A5CF74F:56311FF2
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 19:20:18 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-iad2148-IAD
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 3dbc8e038a697beb934fb38f368ff32d57face5f
-      Expires:
-      - Wed, 28 Oct 2015 19:25:18 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - a539782d-ba5f-4cbd-af3b-6f074c543739
-      X-Ms-Correlation-Request-Id:
-      - a539782d-ba5f-4cbd-af3b-6f074c543739
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192019Z:a539782d-ba5f-4cbd-af3b-6f074c543739
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:19 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:16 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C1C:0949:62C03EC:56311FF3
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 19:20:19 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1020-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 07ad8b362cf29292e885efe0b1040c05359b139f
-      Expires:
-      - Wed, 28 Oct 2015 19:25:19 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
-      X-Ms-Correlation-Request-Id:
-      - d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192020Z:d43a3e2d-8ca8-4d3b-9dd5-e1c95ca6c50c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:19 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:17 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C14:094B:A5CFB46:56311FF4
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 28 Oct 2015 19:20:20 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1032-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 8710dff6e0cb9293e9a1106f836d11134ed55c54
-      Expires:
-      - Wed, 28 Oct 2015 19:25:20 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 86c05366-2ab1-478e-a686-8e4c9082f5eb
-      X-Ms-Correlation-Request-Id:
-      - 86c05366-2ab1-478e-a686-8e4c9082f5eb
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192021Z:86c05366-2ab1-478e-a686-8e4c9082f5eb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:20 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 404c3a4e-d867-4c90-8b74-df04ebf31481
-      X-Ms-Correlation-Request-Id:
-      - 404c3a4e-d867-4c90-8b74-df04ebf31481
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192021Z:404c3a4e-d867-4c90-8b74-df04ebf31481
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:20 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 72ffc310-6d16-4d16-93a8-ff0e072688ff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - 28c16864-cca0-4f9d-9671-96a26e3dd8aa
-      X-Ms-Routing-Request-Id:
-      - SOUTHCENTRALUS:20151028T192022Z:28c16864-cca0-4f9d-9671-96a26e3dd8aa
-      Date:
-      - Wed, 28 Oct 2015 19:20:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3ddd8696-427a-4c1e-b983-1c4c35b38429
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - b9b8dea5-6267-4785-a6a8-4a1887d2492f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192024Z:b9b8dea5-6267-4785-a6a8-4a1887d2492f
-      Date:
-      - Wed, 28 Oct 2015 19:20:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - d6a3171e-4469-45ff-83a3-46b1470afc74
-      X-Ms-Correlation-Request-Id:
-      - d6a3171e-4469-45ff-83a3-46b1470afc74
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192024Z:d6a3171e-4469-45ff-83a3-46b1470afc74
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:24 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 627de29f-edbb-4ab0-aec5-3d9961ef6a97
-      X-Ms-Correlation-Request-Id:
-      - 627de29f-edbb-4ab0-aec5-3d9961ef6a97
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192024Z:627de29f-edbb-4ab0-aec5-3d9961ef6a97
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:24 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b62b252d-3b0e-4cb7-a0a3-d5f3c41d231c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 5b410708-6933-41f6-969c-838a391831cd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192024Z:5b410708-6933-41f6-969c-838a391831cd
-      Date:
-      - Wed, 28 Oct 2015 19:20:24 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 6819a21e-3101-492c-a58c-ddb6913a4d55
-      X-Ms-Correlation-Request-Id:
-      - 6819a21e-3101-492c-a58c-ddb6913a4d55
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192024Z:6819a21e-3101-492c-a58c-ddb6913a4d55
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:24 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 1c511bab-51ce-479d-a55d-e79e6171e74d
-      X-Ms-Correlation-Request-Id:
-      - 1c511bab-51ce-479d-a55d-e79e6171e74d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192025Z:1c511bab-51ce-479d-a55d-e79e6171e74d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:24 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 259ff1a4-b131-45a8-a320-fd4892dd2703
-      X-Ms-Correlation-Request-Id:
-      - 259ff1a4-b131-45a8-a320-fd4892dd2703
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192025Z:259ff1a4-b131-45a8-a320-fd4892dd2703
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:25 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - a478147a-8802-4dc0-a5a2-379804c8b63f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 9eaaaf16-f0b3-48a0-9990-c757d952cca6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192025Z:9eaaaf16-f0b3-48a0-9990-c757d952cca6
-      Date:
-      - Wed, 28 Oct 2015 19:20:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 74762d52-01f8-420a-9b43-eb84317ae228
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - 48dd719f-bc70-4dbc-91fe-65938e5b0083
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192025Z:48dd719f-bc70-4dbc-91fe-65938e5b0083
-      Date:
-      - Wed, 28 Oct 2015 19:20:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
-      X-Ms-Correlation-Request-Id:
-      - 0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:0d01a9c5-cb4a-410d-9049-1ea2bf12cb91
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:25 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
-      X-Ms-Correlation-Request-Id:
-      - 9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:9f568a80-3c63-41c4-a1fd-7a6d30a4f6c0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:25 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 82cc8d92-a6a4-4582-9a0d-13cfc9df160e
-      X-Ms-Correlation-Request-Id:
-      - 82cc8d92-a6a4-4582-9a0d-13cfc9df160e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:82cc8d92-a6a4-4582-9a0d-13cfc9df160e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
-      X-Ms-Correlation-Request-Id:
-      - a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:a3f4a17b-bb8f-46c1-8f5c-083275ecfa40
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 2e722996-ec0b-43ca-81ad-21b13e2ceffa
-      X-Ms-Correlation-Request-Id:
-      - 2e722996-ec0b-43ca-81ad-21b13e2ceffa
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:2e722996-ec0b-43ca-81ad-21b13e2ceffa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 05fd7f93-3980-4f2e-b83a-9137ef36ac79
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - 0fda8738-bd13-46fb-8006-74186ec9564e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192026Z:0fda8738-bd13-46fb-8006-74186ec9564e
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - d0881d88-5f09-4787-a306-3fe1e0ddf639
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - df8eb603-0d46-4404-abb0-71be1c0e5e27
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192027Z:df8eb603-0d46-4404-abb0-71be1c0e5e27
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tvcO
-        3uw+fLS382jvwSc7O492dj4yjX+J/PJ9/PglDAKYvgWGShVLk4+WmUA9mefn
-        20SWmeszSk3vXTwbKNqsp9M8n+UeRDyOomfL86rzHaEZEtQHmw5BjFHm4NH+
-        g0f3H4wfPNzbv/fpbodCRBfzK1NJ//4+w/0of9fmS3QKFHTkdtSWYl8U07pq
-        qvN2fEaNL+ZtM/7JL54W2cWyatpi2rzO25awbrRTv4M+YR349yLoEDHfn5Ab
-        iXhw//7Ozs7DgIjCWFHMq6u8Rs/53VmelWU1pV/9rm6NNEmLD0EaCiF/4+SX
-        /D8Q7/cZYgQAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ca71de79-bd0e-4e90-a9a7-98ee7f9ae837"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2c2c8881-e7ee-4f9f-93f3-5069dc0256ee
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - 19f26e5e-f249-4f9a-8486-d7bd76fabab2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192027Z:19f26e5e-f249-4f9a-8486-d7bd76fabab2
-      Date:
-      - Wed, 28 Oct 2015 19:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PptmD3Vn+4OH2ZLZD
-        qOQPd7azh9mD7YcHef7g/GGWH9x78Pt+pC+21yse5y361TfKapphzHgrz5p2
-        bb4gjFZ53RbU8lHKVJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8Sc0sZdZC3b2D
-        Tyfn93fubWe7u9Pt/b37NJqd89n2+d6n93anB/m9vZ1d+3KxOqmW58XFumbE
-        0P335KvU4IHHzmmxmnJ7CwHP/7um9W53TPRBDOmvO+/yYHZ6UyYPvrrFxMlD
-        jYtLanL28ng2I2oA2ke7O+O98c54f7BpaTjpi7ydV0z9p9c0R8W0+8p6UhZT
-        esMCD1ClFj/kuesgRHNn3/vIx+yXhOMg9GjWCdOfY/Qvi7pdZ6X+6b9FGBCG
-        zd1Zfp6tyzYcjPvD/qq/fF/H+dFs2bzO25ZYJpgl+by+JHTo4++Z5vRFtlqV
-        RT57Gn4vXxvqfZQvs0lJHPOsqq+yekbQqdV5Vja5aUFIYyiv8+m6Ltprpga1
-        cQj8kCkcw8d7V+lqB6gT8kU2nRdLCNrPBuLfPn22/fLVl0+jiJ9Ui9W6zQ1r
-        KCb0Vhdl/KB/fsn/AyEK1kAmBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7de2ac93-6a64-4d84-9699-3224a9a72317
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 47b1759c-dfca-4a2f-b39c-f2ed936dd17f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192027Z:47b1759c-dfca-4a2f-b39c-f2ed936dd17f
-      Date:
-      - Wed, 28 Oct 2015 19:20:26 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - a5a6ae47-2b8d-4687-97cc-98882413f0c2
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - ef0ce38a-160f-4e05-b472-60b110119e12
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192027Z:ef0ce38a-160f-4e05-b472-60b110119e12
-      Date:
-      - Wed, 28 Oct 2015 19:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebR38MnOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBfVk17QV1vP80vXbdR2nmv49lA
-        v2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2CGCPOwaP9B4/uPxg/vHdvd2/v
-        XodIRBrzKxNK//4+w/1oUlXt0yK7WBJZiinw0DHTaJdNVeavp3WeL5t51T4p
-        q8lXdUFNPpq37ap5dPfudJ6fr+pqdn93b2c8oe/H06rOx1fFclZdNeNl3t5F
-        BzPXwfaKfoL+s+3z6fm92TSfbp9PDmbb+w/P728/nB1Mtye79/PZ9Pz8wc7+
-        9K4/XePbvDFuLMLjyWLFZFDeyN+19AURGMPUWdbR0reGQb4opnXVVOft+Iwa
-        X8zbZvyTX3gkep23Lc1Qw5AJNn4oMftM5MC/F/MMMc77M81mhnl4/9O9+w8C
-        hhFaxTD/8jW6ze+SBOd1VhY/CPq5NcakBHwI0nC415fVVV7j7fzuLM/KsprS
-        r1+3Yx+CNJTp+42TX/L/AFTL6L6yBQAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"38d208d0-9d86-4237-bb35-ef4462679cd1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d949fba7-860c-47ef-91a5-723e68614bf4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - ffe96d1c-51e9-42bf-8bc2-26087cb6aab4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192028Z:ffe96d1c-51e9-42bf-8bc2-26087cb6aab4
-      Date:
-      - Wed, 28 Oct 2015 19:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT+6dzDb2zmY
-        7Ww/nB18ur2/d+/B9mRy7/52fr5PiH764OF0tvv7fqQvttcrHu0tutY3ymqa
-        Ydh4K8+adm2+oHGs8rotqOWjlGkpH14WDTUvlhev26zlzl6vp9M8n+UzeZOa
-        0YCEOGsh8G6W796b7E62Dw72H2zvP3ywvz15sH9/+34+mZ5Pdu5NJg8P7MvF
-        6qRanhcX65oRQ/ffk69SgwceO7PFasrtdw0EPP+vm9m73WHRBzG8v+7Uy4MJ
-        6s2aPPjqFnMnDzUuLqnJ2cvj2YwGAWgf7e6M98Y7Y2VS83hNS8NMX+TtvOIJ
-        eHpN01RMu6+sJ2UxpTcs8ABVavFDnr4OQjR9L830Pc0vP/KR+yXhUAhDmntC
-        9ud4BJdF3a6zUv/03yIMCMPm7iw/z9ZlGw7G/WF/1V++r+P8aLZsXudtS1wT
-        TJR8Xl8SOvTx90xz+iJbrcoinz0Nv5evDfU+ypfZpCSmeVbVV1k9I+jU6jwr
-        m9y0IKQxlNf5dF0X7TVTg9o4BH7IFI7hE+UTO0adky+y6bxYQtx+NnD/9umz
-        7Zevvnwaxf2kWqzWbW64QzGJY40f9M8v+X8A4UjTXDgHAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b2462f03-929c-4c8a-9af2-43f79d17a1ff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 41521af2-cdee-4856-859c-b889cf9ab08d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192028Z:41521af2-cdee-4856-859c-b889cf9ab08d
-      Date:
-      - Wed, 28 Oct 2015 19:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 2a92e365-6a61-43b0-95af-b1a345e9390e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 20befc6c-5661-4522-914d-19cf787f0a5c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192028Z:20befc6c-5661-4522-914d-19cf787f0a5c
-      Date:
-      - Wed, 28 Oct 2015 19:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebT38JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBO5/l5k9eXeb3reo2Sznsbzwby
-        NevpNM9n+cxBxOPId7Y8rzrfEaIh9Xyw6RDEGG0OHu3vPbr/YLx77/7Bg4N7
-        HRoRZcyvTCf9+/sM96P8XZvTFNA0EFQduR21pdkXxbSumuq8HZ9R44t524x/
-        8ounRXaxrJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+PNi//2lIRGGt
-        KObVVV6j5/zuLM/KsprSr35Xt0aaRMOHIA2FkL9x8kv+H73RZbdPBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"247ea269-4b41-4c6b-83aa-993ff7d66184"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8a88ea55-878d-4b24-898d-a6d9ff68a4e0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 6e70719b-a8b9-4f3a-ab15-f79701032ecf
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192028Z:6e70719b-a8b9-4f3a-ab15-f79701032ecf
-      Date:
-      - Wed, 28 Oct 2015 19:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9aG//QZ7t
-        ffpwe3+yv7u9P/10sn1wL8u2Hz68d37+YPbpp7sH+7/vR/pie73iwd6iZ32j
-        rKYZho238qxp1+YLGsYqr9uCWj5KmZTy4WXRUPNiefG6zVru7PV6Os3zWT6T
-        N6mZJc5aCDzJd2d7s/3JdnZvb0pjONjdnpzvzLZ37z349N7DB9nebJLbl4vV
-        SbU8Ly7WNSOG7r8nX6UGDzx2YovVlNvvGgh4/l83s3e7w6IPYnh/3amXBxPU
-        mzV58NUt5k4ealxcUpOzl8ezGREE0D7a3Rnjv/uDTUvDTF/k7bziCXh6TdNU
-        TDuv0KwQvej7AEP64oc9a5dF3a6zUv8MXiMcCMfm7iw/z9Zl+5GP6S9xf9hf
-        9Zfv60g/mi2b13nbErFBPDtQ+RxcgY+/Z5rTF9lqVRb57Gn4vXz9S7TZR/ky
-        m5RE62dVfZXVM4JOrc6zsslNC0IaY3mdT9d10V4zPaiNQ+CHTeMYQtTu7Cf0
-        /V0lrR2jTsoX2XReLMGlP3zc9WvDH4pKINMGa/ygf37J/wNnM0HUbgYAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - bc0f3de1-7b91-4faa-a7b6-3cf44fcc23e3
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 43ee9939-7f7c-4f7e-b9fa-c54003caca11
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192029Z:43ee9939-7f7c-4f7e-b9fa-c54003caca11
-      Date:
-      - Wed, 28 Oct 2015 19:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbebT38JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKCevnrpeouSzHsLzwayNevpNM9n
-        +cxBxOPIdrY8rzrfEYIh1Xyw6RDEGE0OHu3vPbr/YLx77/7Bg4N7HdoQRcyv
-        TB/9+/sM96P8XZsT6Yn8BFVHbkdtafVFMa2rpjpvx2fU+GLeNuOf/OJpkV0s
-        q6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5mYgPD/bvfxoSUVgqhvmXr9Ft
-        fpeYOa+zsvhB0M+tMSZ58CFIw+FeX1ZXeY2387uzPCvLakq/ft2OfQjSUKbv
-        N05+yf8DyUVI6r0EAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f7ccf557-25a8-4f64-be21-7ac0d5327419"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9ebd16f3-99b9-4b72-be42-253401cbcb2e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - fb100e86-e628-4e71-943e-bf939b9dbb4e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192029Z:fb100e86-e628-4e71-943e-bf939b9dbb4e
-      Date:
-      - Wed, 28 Oct 2015 19:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+350/mA6Pb9//8H23v3s
-        YHv//NP97Um+t7v9IJvuzO7f23uwv/vw9/1IX2yvVzy4W/Sob5TVNMNw8Vae
-        Ne3afEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWw
-        n2a7n84ezA627z/Mz4mS57Pth1Mazf2dyaf3Z59OJ3m2Y18uVifV8ry4WNeM
-        GLr/nnyVGjzw2IksVlNuv2sg4Pl/zYze7Q6HPojh+3WnXB5MTG+25MFXt5gz
-        eahxcUlNzl4ez2ZECED7aHdnjP8OBpuWhom+yNt5xYR/ek3TU0y7r6wnZTGl
-        NyzwAFVq8cOetg5GNG2nr15+5CP1S8IhEGY01YTkzzXml0XdrrNS/wxeIxwI
-        x+buLD/P1mUbDsf9YX/VX76vI/1otmxe521L/BJMkXxeXxI+9PH3THP6Ilut
-        yiKfPQ2/l68N/T7Kl9mkJHZ5VtVXWT0j6NTqPCub3LQgpDGW1/l0XRftNdOD
-        2jgEftg0jiHkc4gdm07GF9l0XiwhYD98nPVrwxeKSoAtftA/v+T/ASRleqgJ
-        BwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e5679fcd-fc76-41fe-aff7-9f89e7ee791e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 3c86052a-1058-4b46-99e1-f840fa6e4c52
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192029Z:3c86052a-1058-4b46-99e1-f840fa6e4c52
-      Date:
-      - Wed, 28 Oct 2015 19:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 5731b4db-fb89-4ea0-95e8-e075481a4bd4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - a10ad762-ae99-4470-aa41-6296136a7963
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192029Z:a10ad762-ae99-4470-aa41-6296136a7963
-      Date:
-      - Wed, 28 Oct 2015 19:20:29 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv55OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
-        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQYwR5eDR/t6j+w/Gu/fuHzw4uNchDpHE
-        /MoE0r+/z3A/yt+1OdGe6E9QdeR21I5YxbSumuq8HZ9R44t524x/8ounRXax
-        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkZiI+PNi//2lIROGpKObVVV6j
-        5/zuLM/KsprSr35Xt0aaZMKHIA2FkL9x8kv+H5OriBFIBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"6ef9c26a-a4df-4c03-a614-750d7bc8a473"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ce79fbd7-f427-4364-87ba-a5df86dcab07
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - 0a7ba324-bb1b-4399-bc3a-dd297e0f6832
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192029Z:0a7ba324-bb1b-4399-bc3a-dd297e0f6832
-      Date:
-      - Wed, 28 Oct 2015 19:20:29 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19P/o0P3843fs02872
-        Z+fb+9Ode9vZp7v72w/u78weTKYH2f6De7/vR/pie73i4d2iS32jrKYZxou3
-        8qxp1+YLwn+V121BLR+lTDz58LJoqHmxvHjdZi139no9neb5LJ/Jm9TMUmUt
-        lN2f5g/u7e/f357uTO9v7+f5OY3h4Hz7YTb7NM+z6YP9vfv25WJ1Ui3Pi4t1
-        zYih++/JV6nBA4+dymI15fa7BgKe//dM6d3ueOiDGMJfd87lwcz0pksefHWL
-        SZOHGheX1OTs5fFsRpQAtI92d8b47+Fg09Jw0Rd5O6+Y8k+vaX6KafeV9aQs
-        pvSGBR6gSi1+2PPWwYjm7Yuzn9j7yMfql4RjINRosgnLn2vUL4u6XWel/hm8
-        RjgQjs3dWX6ercs2HI77w/6qv3xfR/rRbNm8ztuWGCaYI/m8viR86OPvmeb0
-        RbZalUU+exp+L18b+n2UL7NJSfzyrKqvsnpG0KnVeVY2uWlBSGMsr/Ppui7a
-        a6YHtXEI/LBpHEOI2jkWsYPT2fgim86LJUTsh4+0fm0YQ1GhFh66+EH//JL/
-        B8+evnUPBwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ce1e24b9-5d49-41ed-818f-2138db28cceb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - 621b3982-e25c-402c-97b7-fe10304e4be1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192030Z:621b3982-e25c-402c-97b7-fe10304e4be1
-      Date:
-      - Wed, 28 Oct 2015 19:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - d16eb53c-76c0-4938-9461-ad545cac6e53
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 6aa61197-5725-4bef-a5d8-1e2792bfaec1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192030Z:6aa61197-5725-4bef-a5d8-1e2792bfaec1
-      Date:
-      - Wed, 28 Oct 2015 19:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdh8+2tt5dG/nk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoH5x
-        9hMn1WK1bvNd12uUdN7beDaQr1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcg
-        xmhz8Gh/79H9T8cHe/fuPbj/aYdGRBnzK9OJ/laQdnSWNrOszQivtz+iDP8g
-        qF3K7Llef35RBj++z3A/yt+1OYktiS5B1ZHbUVuKfVFM66qpztvxGTW+mLfN
-        +Ce/eFpkF8uqaYtp8zpvW8K60U79DvqEdeDfi6BDxHx/Qm4m4sH9h7v7+wER
-        +6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTn0I0lAI+Rsnv+T/ASYOzmpIBgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"c51ddd06-f101-4157-b885-7dd2bcf04fe1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 741141e9-1b22-44bc-86c1-378d9c0c9dae
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 18cee187-73d3-4453-95ef-6b18259c89d7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192030Z:18cee187-73d3-4453-95ef-6b18259c89d7
-      Date:
-      - Wed, 28 Oct 2015 19:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR9P71ONs59Pt
-        892d3e393fsPticHB/e3H8xme5Pp+c7+eb77+36kL7bXKx7sLXrWN8pqmmHY
-        eCvPmnZtvqBhrPK6Lajlo5RJKR9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlni
-        rIXAew8ne7N7e9PtBw/y/e3982m+Pdn79NPtB5PsIHtwfvDp3u6OfblYnVTL
-        8+JiXTNi6P578lVq8MBjJ7ZYTbn9roGA5/91M3u3Oyz6IIb31516eTBBvVmT
-        B1/dYu7kocbFJTU5e3k8mxFBAO2j3Z0x/tsfbFoaZvoib+cVT8DTa5qmYtp9
-        ZT0piym9YYEHqFKLH/b0dTCi6fvi7Cf03d2PfOR+STgUwpCmnpD9uR7BZVG3
-        66zUP4PXCAfCsbk7y8+zddmGw3F/2F/1l+/rSD+aLZvXedsS3wRTJZ/Xl4QP
-        ffw905y+yFarsshnT8Pv5WtDv4/yZTYpiW2eVfVVVs8IOrU6z8omNy0IaYzl
-        dT5d10V7zfSgNg6BHzaNYwhRux6n2DHqpHyRTefFEgL3w8ddvzb8oahQiz7W
-        +EH//JL/B69px505BwAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 35e91023-0702-43fb-aec4-749da8a7ba21
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - e6089dad-7d11-480d-9dc0-e3740eaf7186
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192031Z:e6089dad-7d11-480d-9dc0-e3740eaf7186
-      Date:
-      - Wed, 28 Oct 2015 19:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - c065ffe4-3d2f-4a70-be73-9c215f697c19
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - 4b56ce3e-55be-4418-9e4b-54c13b3f832d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192031Z:4b56ce3e-55be-4418-9e4b-54c13b3f832d
-      Date:
-      - Wed, 28 Oct 2015 19:20:30 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv95OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
-        PnMQ8TjKnS3Pq853hEBIOB9sOgQxRpaDR/sPHt0/GO8+PPj04NP9DnmIKOZX
-        JpH+/X2G+9GkqtqnRXaxrJq2mAIPHTONdtlUZf56Wuf5splX7ZOymnxVF9Tk
-        o3nbrppHd+82q3y627RVTVO7O55Qg/G0qvPxVbGcVVfNeJm3d9HDzPWwjXcu
-        Fzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94vscdbP/kFzvj
-        27QeNxbX8WSxYgooQ/SnV4dJ373XtA5N6ftP58ap3Pt0d/fg/kEwlTKUKObV
-        VV6j5/zuLM/KsprSr35Xt0aaZNOHIA2FX37j5Jf8P4V9/T3QBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fa097d6d-7d5b-4b92-bc68-57b082cb2ddb"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cae137d3-9fb5-4b67-8010-fb61ef519b54
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - ca4b705e-28c0-4286-8b66-aec04876d906
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192031Z:ca4b705e-28c0-4286-8b66-aec04876d906
-      Date:
-      - Wed, 28 Oct 2015 19:20:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9F5tvPwwezT2faD
-        2f3J9v7k4d72ZPrpwfb9B5Odg73pZG82m/y+H+mL7fWKh3iLTvWNsppmGDHe
-        yrOmXZsvaASrvG4LavkoZQLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmli5r
-        oe39g4fT3Z0H+0TH2e72/v3JZPvh3sGD7Un24PzTT6f7D4me9uVidVItz4uL
-        dc2IofvvyVepwQOPnc5iNeX2uwYCnv83Terd7ojogxjKX3fW5cHc9CZMHnx1
-        i2mThxoXl9Tk7OXxbEa0ALSPdnfG+O/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
-        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
-        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
-        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sbORDO4P
-        +7n+Yij00WzZvM7bluQQtLCDl8/rS8KAPv6eaU5fZKtVWeSzp+H38rXhxY/y
-        ZTYpSQyfVfVVVs8IOrU6z8omNy2U27/IpvNiCfF3XX9z9P7yi5dfvTn9yS9e
-        R+mt02EET1FRijvSMsXon1/y/wC5wvXTtQcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 97078b7d-a440-4c4a-805f-a125a1ccec4b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - edece6f3-9e79-4bf7-95db-3866e0de79b0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192032Z:edece6f3-9e79-4bf7-95db-3866e0de79b0
-      Date:
-      - Wed, 28 Oct 2015 19:20:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s723sHb3YfPtrbeXRv75OdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKBWDZq4DqNU817Es4FyzXo6zfNZ
-        PnMQ8TjKnS3Pq853hEBIOB9sOgQxRpaDR/sPHt0/GO9/un/v0wefdshDRDG/
-        Mon07+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAm
-        H83bdtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6Hbbxz
-        udjd3pncz/ay/fPt3dmnD7b3d2f5dra7N92+tzvbebD76cO9T/eIsNR4+ye/
-        2B3fpvW4sbiOJ4sVU0AZoj+9Okz67r2mdWhK3386N07l/b1PD/Y/fRBMpQwl
-        inl1ldfoOb87y7OyrKb0q9/VrZEm2fQhSEPhl984+SX/D9+VFjTQBAAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"be771397-222d-49f3-9642-356d4cf379c4"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 99757a3b-e901-4412-89c0-80b16b0c697f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - e84b0d0c-7b5f-4b5e-8164-8458355d22ce
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192032Z:e84b0d0c-7b5f-4b5e-8164-8458355d22ce
-      Date:
-      - Wed, 28 Oct 2015 19:20:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9Ekf/Bg997DB9t7
-        e3uz7f2H5/e2H366v7d97/6ns/3p+b0HD6f7v+9H+mJ7veIh3qJTfaOsphlG
-        jLfyrGnX5gsawSqv24JaPkqZgPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qZml
-        y1po+2Bndn/n/v09GsP57vb+/U/z7cls73z74WT3fDe/t39+nu/Yl4vVSbU8
-        Ly7WNSOG7r8nX6UGDzx2OovVlNsr8eT5f9Ok3u2OiD6Iofx1Z10ezE1vwuTB
-        V7eYNnmocXFJTc5eHs9mRAtA+2h3Z4z/9gebloaPvsjbecW0f3pNM1RMO6/Q
-        hBCp6PsAQ/rihz1hl0XdrrNS/9Tp+skXp2/uEgqEYnP3Nf/c3v3Ix/SXhMMp
-        q2z2JCuz5TSvn2TTt/lypmR7WVUlaGd5V57OsAnED3vgPso67OdP7k76yN/V
-        AeGPkAhEBv/P7w/T5Gw5qdbL2YusfbUumTP/P0KPIkT87qunL7d/8ovNZHB/
-        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
-        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
-        OkpvnQ4jeIqKUtyRlilG//yS/wcM2vgRtQcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130899656452568160
-      X-Ms-Request-Id:
-      - 555719d7-caa5-4622-be86-668e468b1f78
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 018677d2-c277-40eb-b3b2-f1a12bf1ec6e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192032Z:018677d2-c277-40eb-b3b2-f1a12bf1ec6e
-      Date:
-      - Wed, 28 Oct 2015 19:20:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        ewdvdh8+2tt5dO/eJzs7j3Z2PjKNf4n88n38+CUMAki9BTJKADv8j5aZQH2d
-        lXlzXtXT/KvXrtso7bzX8WygX7OeTvN8ls8cRDyOfmfL86rzHWEaks8Hmw5B
-        jBHn4NH+g0f3D8a79z7d293f6xCJSGN+ZULp399nuB9Nqqp9WmQXy6ppiynw
-        0DHTaJdNVeavp3WeL5t51T4pq8lXdUFNPpq37ap5dPfu8rq+eLh7sD+e0Hfj
-        aVXn46tiOauumvEyb+8C+MwB324M7bens/Od7PzBw+17O/uz7f3Zg3vbD6fT
-        +9sH9+/vTnYfzqb5zoO7/lSNb/PGuLHIjieLFZNA+SJ/19IXRFwMUWdYR0rf
-        Gub4opjWVVOdt+Mzanwxb5vxT37hked13rY0Ow1DJtj4oYTsM5AD/16MM8Q0
-        788wm5nl4cGnB5/uB8witIpiXl3lNXrO787yrCyrKf3qd3VrpEkH+BCkoRDy
-        N05+yf8D0SkFR/0EAAA=
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"c180393e-bd19-4c48-9fe2-00f5478c7ceb"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4361650a-e4f9-45ec-bcbe-1120102dfc57
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - e0d7f496-2c04-443b-951f-af9bc76bf397
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192033Z:e0d7f496-2c04-443b-951f-af9bc76bf397
-      Date:
-      - Wed, 28 Oct 2015 19:20:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aLp7sHPv4b18ezLb
-        fbi9P90/IDzyve2dnfP7+w8Opg+m+eT3/UhfbK9XPMxb9KxvlNU0w4DxVp41
-        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
-        2V4+vf8w257du3+wvT/bn21nu7u729Pd/N6DezufTh5O9uzLxeqkWp4XF+ua
-        EUP335OvUoMHHjulxWrK7XcNBDz/L5rTu90B0QcxjL/upMuDqenNlzz46haz
-        Jg81Li6pydnL49mMSAFoH+3ujPfGO+NPB5uWho2+yNt5xaR/ek0TVEy7r6wn
-        ZTGlNyzwAFVq8cObuA4uNHGv7cR99frs5Uc+Zr8kHAehR/NOmP6soX8yz8+3
-        X9bVbOMYLou6XWel/um/RRgQhs3dWX6ercs2HIz7w/6qv3xfx/nRbNm8ztuW
-        WCaYJfm8viR06OPvmeb0RbZalUU+exp+L18b6n2UL7NJSRzzrKqvsnpG0KnV
-        eVY2uWlBSGMor/Ppui7aa6YGtXEIfHMUrhardZv/5BfNRhLHEKJ2Zz+h7+8q
-        ae0YdU6+yKbzYglZ+1nAfZC5FSnDGIpEyNoGYfygf37J/wNfMGMiIwcAAA==
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYwNTk2NzgsIm5iZiI6MTQ0NjA1OTY3OCwiZXhwIjoxNDQ2MDYzNTc4LCJ2ZXIiOiIxLjAiLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIvIiwiYXBwaWQiOiJmODk1YjVlZi0zYmI1LTQzNjYtOGNlNS1lZTkyMDAxNjk4M2IiLCJhcHBpZGFjciI6IjEifQ.JD1BOBWfRIFdyFagYejbKQLlQf2QX_67fnqBRmKFPS1dWG0GaiffKgemicDSdmaWhn49gfkg5_OZpZ1VdhcwLed1rCj0vhDZa7YqVwthhwG6nOxZWGo6PK4a8PfdFqTwIXDIrQtRghH3x4WbXvUgpBPwfKMXdetkTu5CDLEKwWTRVLUB8k51GK9wZwgpBTfxjjino0aLgeBc5rf19sw6UG_27xQK1wNrpYIU8ypp-kOiII5b_GYT6LeorLcP4TXa2fMtbEW_dGbYUx0iltVWdOs-DKLmIU7Hj9WkYpCAIV02Ow_4OcjG1WObKdKY-fcNOR2zmsdoNgUr5XKjhbQUqw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ff5ef9fb-9254-4c81-90d1-404a715ffe1f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 55278b13-b6e2-4250-9cb0-e246747509e4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151028T192033Z:55278b13-b6e2-4250-9cb0-e246747509e4
-      Date:
-      - Wed, 28 Oct 2015 19:20:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Wed, 28 Oct 2015 19:20:30 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:45:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_and_backup_name.yml
@@ -1,127 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
-    body:
-      encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Length:
-      - '188'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 7df5e2d0-4c0c-4d5d-aad1-9ee09794b6d0
-      Client-Request-Id:
-      - 4a6db227-a83d-4889-8ab4-b68f76e3a251
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_174
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - flight-uxoptin=true; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Fri, 30 Oct 2015 13:50:11 GMT
-      Content-Length:
-      - '1218'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1446216610","not_before":"1446212710","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg"}'
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:12 GMT
-- request:
     method: get
-    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 766f4380-117b-4eac-a215-f2a2b7013029
-      X-Ms-Correlation-Request-Id:
-      - 766f4380-117b-4eac-a215-f2a2b7013029
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135011Z:766f4380-117b-4eac-a215-f2a2b7013029
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
-        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/providers?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -131,274 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
-      X-Ms-Correlation-Request-Id:
-      - a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135011Z:a79d8347-68dd-4fa7-9bae-c7d9f28dcadc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
-        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
-        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdaXj//od7I9K/h5o1
-        8DZ2wt0MaGAialUXP+Be6G0fGfTRQ6+uyvy4aYqLJQhyWxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyWpLqD0/3Z8p2VG1J0ezxaEMuSh
-        rXp+7BDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUGKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjVzqkVwg9juNgiDdtH/iA0iRus5Gbb
-        BYaxpOCx3ziMu/V6OamqHqv/f3Y8Qfbm/5ujIhwG0O+hccs+uJe4HDzJ2il8
-        LR8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8fykhQUYNGWYOi/BfDpnkMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pI8RDddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lDXLnmdv8yFJfs+ON/bVkCNKec+fg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4zz
-        gT4GANzDaZGtKHOPpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnAgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRZp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b1VnwIk59FtGgW30/hfEO4
-        xHBhhj3hcM0lKr42WoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
-        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
-        TYxE/9tEXXr1Ylk15O++ztuW7GuPvEDEo4oSTohgsOOv5SNLCcbU/tUZPX/J
-        bwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSGipf5gxvqXzeQ
-        lwk8YAFmkAqf+Hi9Nx2UQDsvSvquQ36DIRMDYwl+G5oLQT34iIfGv0l7OzX8
-        hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIYTosqje7my9mq
-        KshlJ8g/otatqXWX1n0uCnr5R1R7H6pNCW61mFGq8ke020g7wlDcE/o8Emz6
-        tPpg2Hd1ovTPH2JXljP075/DrlWg9a+fS0R8GdHPvkl0buOPf1AHdrzfKNr5
-        7CJfVrONVv0GoAx2wLOQhWMK7VfrFrrB7x2QevjI/ICOPYygB4wasSrAfMBf
-        Eq72N9ZrUC30O/0mGssblMIIPwr+kFesWmNY9i9RXejL/oEG9MfX0WMGGfHk
-        HB7mb4C2fwAOYZjupVuvW0oOIkEkuJrX6Evz1cDcSSrLxDc8kfwHOYvBH1jm
-        oSmmCe7ME7P7UztZG5j+ZwsDj1PuNmXVl2amk7IHkxekNh/wlzzN+tuP+IW/
-        +qHN1t26Ih+GXvzRnMnfAG3/ABzC8P+Vc3ZjviOKD3VE//s6HX0w+MuibtdZ
-        +QUlOmnppAtOaK0sxlOE6TIf8JfMKvrbj3iOv4pOwu15jv7n/hhkwCmNn21K
-        0Zu1r9l/rJfoOvXXhG/+GBxShxd/vme3+HfLgaZj8zc6sn8ADqH0AexJ80L/
-        u928iOoZ1nEGHfpYf/vRtCjtzZDNa/Sl+eobmpbeZHQ7pO9lCMFHiqr7jaeM
-        R8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB/dGZbUd7bew+4CbokT7l3y29
-        DZLmb4C2fwAOof+zNBk0vHgEGoV0e2VJ/3N/DGpO/89vCIHbxK4v8vaqqrEG
-        HCIQiV2VWfWNLo4yOcpAPKeYX/MBf+kYj6Yp5M3uLNJHDCP8KPhDXrFsybDs
-        X8KX6Mv+gQb0x/8HmDQ6meaPTQxEa//57Gz1o6n5f9nUvI8LFoIM/hiEf5G1
-        +VV2/Xq9WtFo8tlTWuCekhD/rHVIM/leqjIEG/xB/3N/aIfc5Ua19bqtapol
-        etHHDB32cKW0KJoeT6fVmhYT6BUfYeEJFQVmJbCV+YC/ZJbW3362ZOMm2fj/
-        vGzQ/3a3J3mLrtwn9g+deJr2zuz9bIsOJ/qUm5RF3j/ZF/YV/DHYcYct70J5
-        R4RWJolZ0M0D/SEzG3wkuhTzaP/Ay/QHPjMszS+CPcwHjnPQLPjAtqVP+XfL
-        LaZj8zc6sn8AjqCkv7HUdJnJfmQtAwOxfwUcHyU8kZf+937kVRd7OPL5pnv6
-        xuEL2J/FAUgHHwz2/bMboeTwHzHAs6LpeZ8fBrFY0Pi/WZBVc/azAPTnzuze
-        fokr89QnJX26qBqdQB/rb6wdWPb504iGCD5ihRB+JK2s5mBY9i/uRXUdvwuF
-        Zj4QNYkm9g+8TX84Lajfug8sFPr0Zi3F07B7n9rKH/S/3e1VTS5afkVEJ5J3
-        CKhxlkkK0Is/ot8H0O9u/q7NlwLxR6T8MFKSff9a6VwMhH6n3yLECj5i7MOP
-        pJUlIsOyf3EvSkF+F8QwHwgV0cT+gbfpD0dB/dZ9YKHQpzeTlLQn/Q/a82bq
-        iWEdttwyGB6z/vYj4inxXk+zMiee+3lPMhLZDxFhS8cfaUUZrFDxmyFp+PmP
-        6PpN0XUpGeezZZvX5+SZ/oiy3xRlw89/ROkPp7SjVki5bxj6XSJPPBQUkjFl
-        9bcfTdEQES8Xr4sf/IjJiWJfl4LrJpLkkAHxuPW3HxFwiICr9aQsmjnBo7ft
-        x4ALnGTs+tuPiBgSkdCOq8CvA547iOe+nmZtdlItl/kUA/GRAOweWlNpSl1/
-        kS1JOvozC8phQobwPAhRI8Q6XThoP2uQnYF5lTfrsh94fXBXvPLygii+Yb3l
-        fXvhfoZn8Vk2pVw3OvFxAbgedjPbvJ++tlj1JAoiIF/obyyz0iiQRIZgXwuE
-        oyPZ/GH4ssgferB/AB79gc+MyPKLkD75YICCuztEQWrNf+w89P8Abe0fD+gP
-        S2jzIf2v/yGSyeGH+9u7e7EP0XX3w+GEQDAjXzsTFZkL+chOBkjp/upMDX/J
-        bwUg+OsQqswLurZ/4GX6A5/JnOiLN0wSUYT+dxuifM0EkxAgwF4+slQA5u6v
-        /5fThBWLJ+436JgofOJj+l+HO/kT+p/5cLDz4x+s6/yDMWD5oKb442dBNGPY
-        O3a6fk0jWWA6/t+JKXGimKcuj/9cochIDpue59lbiI4/CiDXGxdmAG3Naiy9
-        449OBIXlNjpQ1aqED2HTAe3ghDC/PiDnJFCLiJNwA2SGvZlkx8usvCYlD8jU
-        h8UCwHp4ZV+PZsoc3lwSWgOg75r5eU0y8nUn6b067KzO/xC7ukuebJtRXqjv
-        wf5wer1LkVH7OmveVG8pVf2zgIODF8L+cIBfSzJu04OF+zUhMszNMsesTdD9
-        ngGwh4uZQmrrY/JNzIwBffe8qPOrrCxfrUtC4pvvyMELYX84wP9PsgC1kayv
-        3ydA9bAg9+Dm8E0niD7uOJT8xbB7R+b1gIJ1D2lCuYPAWdV+ez0Brj9LXXKn
-        g3R6Q47r82xCgH28AK2HKVGnh2bHyVX0GG+4xN5vkQHo78z5xpHGJ/YPvDg4
-        zPvbez470CA7+OZLWheolgty3f8/hTd1916CEUI0fh39D85JH7yD+DWgbwTo
-        VEUXtiEYfay/MelAJ/rd/BYldW+mhMRoYv/A27elN49gQByq6Rrc8vQJQfYH
-        CWi9YcOFmmSNtfj0TjBkICWD60gwf2H/wkCkGf+mg+yN2qUj0Sz4wLalT02c
-        erakzAL9zd/pX0MEogj0gJrSH/Qb/S/ONp3hQmX+/33IhO0AO/N4eAT/Hxwo
-        D3VIAhbks77KL8hjlaHTyz5VALpHpxm/1SPSRVlNsnITai5eRWKNUCPEOrDb
-        avU8v8xLwexnpw/2AaSDTV7AN9IXYgHp6lU+rRakbkiwGNDPRm+XxEQEPzc9
-        unk9W55X9YJ/JTDffM8XOYU+1PPrpnqV/6I1iQW98813Q3JGvfCbHw6eOxgQ
-        jGv6nOL357cL4ctps6qrn6b1EzQP8OpkHSHxRg/w76wuxKzhb/sHNAv9IfrG
-        qAJuLB9ZpcOQwxZ41zXgv/hzbgrtYjAI3kL39Btb6i9eP3vDKNAH5k/9PvhT
-        4fAHHbycUkPL4AOLx+B00f92t7NyNQd0+Qgz2PnoXv8jTC1Z/+KSeNE4AZ3v
-        Ih9O8rYDQqAyhwzPNYJ+LJpV/VTDj6adWwYfWDz+Pz/tZbWezfJVWV2TQv+R
-        zNtu3VyjZfCBxeP/i5NPoxswOz+aam4ZfGDxGJxqJreZlY2G+PSSxkAJE+rA
-        nxPA6s2ShdCbJYfbBmTj9HK/MeUc0YQewSsMK/yI31Uy8tfoynzQYR7hDLxh
-        /0B39If0ZWmPT81fURKT3PBaERO2QyX2fjmcA6k2OMBRyDR5buFpUzeEW1xk
-        3gcsA7bTSlAdYzzLs5aWKwGd/rU9A2APl3PX9kZMqHNg4nEnoUDv+vDIEFwW
-        M3rv6wFkkP6oyNPUUVHIU1zM2aL4fQJWDwsKJ1bVkpgNrX00fD6OokTUpv85
-        agM/+wf9D6QnFDv9XeWTlhjvh9QbxRB1QQP/JjqLwc/KvG7rWHqepYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP5nSNYh2bqtmikRrsnbtlhe3Ew5gimjtLTC2N1fwNwQijEE
-        0uYDIRaa2D/wNv0hMANq8NvhR3iTfvt/A+Uoo7FsW/q9S7LbgN3Fkr35Q76J
-        9eHAhl0YOnzgECxIl/V99T4LRAL5xm4s8K8F9lP/D/pfvA/wMaVC8tnpuxVx
-        0usfcXOUmPS/OP0oAXmxrJq2mP48JJ3pQfKwDqD5G5jpH0NUfjBE2EXe1sX0
-        aX5eLAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+
-        yYwMAcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZh
-        fwyWf5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6T
-        T+v8R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XVbsYeVSPIkf47AA5
-        xqID1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdr
-        ZeyAC4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGw
-        s8/z+r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jq
-        t3m7KunzL2vKkpCDSFB8pNBXD83sos7zaDqdCRPOJCiN34aGwALMOHZ6eW9i
-        KCSGFR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8
-        wfAClsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fH
-        sxl90xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJ
-        lVNf59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/
-        RNtvhLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhH
-        wpCcP4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsf
-        Ci7rJrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT
-        +xc3U71hhdZ8IG8GioLbhB/pH/IHw/v/miLxKfs6ry+Laf6yri4LSmh1Kfyz
-        iMVs2fygWva4+KOLsppk5eD46X/7t4J79/hnDzI9P2vAT14cf3H6swb95ZtX
-        P2uwv/i9f9ZAv/m93/yswX796ie/adgkzefnxXSRLUlP16u6Oi8iYeYNvexv
-        7x1s7GUKi/RGuvpCurrBOL1nl9zpQGa4agvqliF/ez3B2HzsALOHr4WE1gFa
-        TgFu0Ihx1et+YyUMjUu/02+30+b8rup//hpdmQ86elt0Ot6wf6A7+kP6slYG
-        n5q/oqTe3955SPqRSEwEHqTS3WWfyD8i2wDZWBjA/ky7TTLgiKQ4uQ8YZQyF
-        Pu2P1//t/ydUo5fijp1HFMXBfcAoAnX6tD8+/7f/T1KJ6WSlkIjktN6XhlxZ
-        ebZsios5u6Q+TQGuR2VkbRgYWgdUBuYy6hsRJPV8b3tvh5rSH+Rg7dJatP1j
-        h/5HqBPina6btqrJMCi2J9XyvLjoYhHtbhPQsli+fZPVFzkP3wdlBxSF2R3C
-        YAdEBKFzF34ULEFiYmycOoocuQdA9HsDkF7/DSnbaV2spNtboEAj26X/UVP6
-        g1iJ/rfZ+w16uEsewnu53x/Sl6UttXqPWPr9ujR/xhcsbi/u/KVr9jU1irRS
-        4dLX7V+iNQDe/oEG9EdH18QVoPtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJdWQO
-        Sf6z0VebXbCo0fvffFdQMT87kGnWhf/fC/xG3fKanI/Zusxrguj3BiC9/n+6
-        mkyrshzIOQurGkZh7hUeCj6SVpaFmeXsX+BDIz/8LjjVfMBNGQY3498Cppc/
-        8CX90ZGAAAc0od9YIHtC4D7gd4EBfcq/K/c7aOZvIKB/RKeCZvaApuLrTa6S
-        zPTJIxB0go+klSUlo2T/wtgMHfldDMt8wE0ZBjfj34SW+Mb+gS/pj/+XE5ZJ
-        O8DreVZPgbNPeUDqzUXDLTXB1JsPRsofL/22kfo8RozXUJzf09/lTTNwBsbt
-        w49kCgCW/nCUBCD6YGBONhCOlMPB9u5Daix/7FH4LH8QSR9s39vdfmlJSgTt
-        0IeUxpRW9pk8CFw2xCxDvX+NDr9mTzzOGFCanLjEbYTEONMfPIAb+I0J9GQN
-        +H7fANnDxsJAax+b/nS7D3jGwVn0qZl15he0DH5jmQT/0O/02+24jt9VPuWv
-        0ZX5oMN0wqF4w/6B7ugP6ctKAz41f0UpTQyh8QyRtkMlywhMqq/FDQSZ53BT
-        N4Tb+7IGQeqAZcB2Wgmqxxq/qKTWfqeAdXs0hIg8R0z/yLTplAdfyEwEH2lb
-        85vOLQP1JzuYUPkD7ekPganzGc5uj0cc4+rL7gNugh7pU4Og6C+Faf7ghvpX
-        dDZoAuh/ziaYWaH/YVZoTjpUdoT9EZH1D26of33DRL47pYGxyBbE9D+iuP7B
-        DfWvb4biVlVu0JKCA9NJEDA48kcYDf32I4LfjuAN2XsCQQ1/RGL+gxvqX98o
-        ie/OsjabZM3/PxUIkeFnldjvS2z8JD/2y8lPI/K//BHRfxgcns0WxbIAQpQG
-        /xHF7R/cUP/6WaS4XS6h5Hsk1Sw4Md0EIYMzf4TR0W8/moD3mwD6mCifTcr8
-        KaG/ymdPf6Tl6W+Gaf7ghvrXN039aUW/MPl/RHf6m2GaP7ih/vXN0r1YrGgs
-        1P5HlOY/uKH+9bNB6dN3+PdH+p0QFCIrTPMHN9S/vln6E8o/orkQVmGaP7ih
-        /vXN0vy8qPOrrCxrWuP7EcHtH9xQ//pmCW4i09f5dF1TwuVlVRbTH2W6CKb5
-        gxvqXz+7tP8ib+ti+iPS2z+4of71zZI+W88oobu8+BG7098M0/zBDfWvb5bm
-        8NgXi3w5y2enJWFSTF9WVfkj0ts/uKH+9c2S3miaHzE+PlUSK0zzBzfUv362
-        qD+tlkskJavlj+hPfzNM8wc31L9+tujf/MjSKoUVpvmDG+pfP1vEx29fZM3b
-        H2kfUFlhmj+4of71Q5yAuz8KtBim+YMb6l/f7DSYj1c/8nkA0/zBDfWvb5bg
-        ufiYP6I3wzR/cEP965ul97rJLn6kSn4YlIYeF42+YD/maX5OK4FC8v8fkp/G
-        9P9q8v+I6PYPbqh/fbNE97X5j+hOfzNM8wc31L9+1uk++5G64c4ZpvmDG+pf
-        3+wMOHXTVqufWOc1ue309o/ozn9wQ/3rZ5/ud38R/bx+k78DXj+aAf6DG+pf
-        X2cGeA6W2SJvVtkUE/BFMa2rpjpvx6/bqiankt7w5whw+7MmTY+n02q97K/V
-        YngeVXUu7O/p1uuW3r5Dn/HYuCX/ZinHbZX4PGTQxnwQTID8gbfpD5kNQ0CG
-        y2+HHwV/yCu2468zZdF5uL+98+n27n16Rf6g/7lJ4Vno0JT6lwXwLjm/GfDR
-        gOGbAT2d59O3L4inji+zoswmRUlJP3r9m++pw3d3oT2KaW9Ywj48vWAM+U0/
-        67OfnfsOK/ALynJ2ss0HwnZoYv8AMPpDoAQ8xm+HH+FN+o0FI/jCMRiaBB8w
-        GCBBnwZ8GiUuCTz9DzJ/ezqqz7EhxAFSgiiGK7/pZz8PKcu0HdKmdZ4tjpdZ
-        eU0eHejozwFARWYFr1C+8KerCV4ICB8MBQTpkFNHLDSyXwn90ID+4Lf4fR4c
-        xmuIzh9E6KhfCxi8T39IF/22/JujKT4LPuA+0Cl9GhDZzdMGu3Z/e3cHRDe6
-        4qH/x6f+H/Q/9wdPlPnjHv1h9Qt/SF/T/zCVNJGd6XDk70wF6OBIbHDn4WPQ
-        9NuPpkL+oP+5P5jQ5o9gKjZSn7zAqs26k/BzhxjR0EnpXSLSxbJC0PY6b7HU
-        20XUmxD9zWMOQ2z+Wj6y/IIpdn9tnCVtzFDMN/wHNw97Ef4BKvYPvEx/4DPD
-        ZfwiGMR84HgHzYIPbNs4txB16X9xESMQHi3fw/jobz8ipSUljS3uPsqA7Oj5
-        L0Y/GAtQod88gto3ZGRoQH9YDM1o+IOQLmhqvpaX0Sn9IYD7bfk3RwV8FnzA
-        faBT+nTj7EWptlErHNAfVtzNh7dRFfQb/Q9zwbPhOwEL6wQ069WKxkxv+LMF
-        xN5j/iJU49GHHwV/gN5uAgWA/ZO/5GYgdPAbT79MGT6xf+AV+qNDe/6JaTGT
-        jXfM72728GnwgX1vaL52HhBlt192ZgWamchNxO6QTqlMOvht3g9GZfQBeRiB
-        8KPgDwzX0UsA2D/5S26GgQW//X+BfEzAOLdeFs06K5t2PSsqes2nMoD36J5J
-        +EBNvwbBMSz5DdSR34IGAiYku/2L31ZSMXDQw3wgREcT+wfepj86M+Boyo2j
-        5CQhp/91dAR9sre99ymRk4gZp8rdVV39dD5Frz9/qcP08ZnNxUffzSfU2qcd
-        YPao2RQthaWUAsyX0m+HnB2cgakZKP/OxJJR4m/7hw5ZyLiJsgw5bIF3XQP+
-        iz/npj6pg7fQPf3GOuKL18/eMAr0gflTvw/+VDj8QQevzuz4H1g86FN8SVCD
-        2Jw/A2jvM4eq9yFjKJbVtTB/cy/6V5Q3SOfAulJT+QNayf5xGxNLf+zZP/a3
-        d3e9PzwA9Af9r8+D9D8oPOLAKE81ZUWZjx9x1o8465vmrGLZtNmS0mn0wnuz
-        lHIRKEmvyx+gFv0h82SoxRMqH9mpE8oFLfCua8B/8efcFFPJ80Uf6FvyLbqn
-        337EUvyH4wj6g/7n/mBOMH/8LLKUKKsfMdaPGOsbZizLUj+yhPRBBy/HTGgZ
-        fGDxoE/xJUH9EXf1uKujtn7EY/RBBy/HUmgZfGDxoE/xJUH9EY95PLZaT8qi
-        mVP6+CtawPwRS5luHQehZfCBxYM+xZcE9Ucs5bEUsRMt5iBjkV1mRZlNShD0
-        R2yFbh0XoWXwgcWDPsWXBPVHbOWxlfxxUtF4qvJHisp06xgILYMPLB70Kb4k
-        qD/iKDCRcpRVTzTQ6dsfsZTp1nEQWgYfWDzoU3xJUH/EUh5LkS/Vvobbftw0
-        xcUyn72pvk3G8AUZQ3r5R+yFbh03oWXwgcWDPsWXBPX/0+wVYxGJ6uAigSue
-        FITG8uJHysd065gBLYMPLB70Kb4kqP8/5Q6J+X/EI+aDDl6OJdAy+MDiQZ/i
-        S4L6/zseISLUygU/4gjp1jEAWgYfWDzoU3xJUP8/zRH8xzfoskzzui3OC+Ki
-        H62J2G4d+6Bl8IHFgz7FlwT1R/zk8ROlES/z+llWL37ETqZbxz1oGXxg8aBP
-        8SVB/RE7+ewEh4ia/X+JkYT2zB48fTRPP2Ik/OH4gP6g/7k/eP7NHz97jCSe
-        NTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK+XbbHoqab/Nwwiiq+w/yJv62L6
-        /0mkn+bnxbIQlP8/hT6rHB3E/4dR//8i/Z0rqoP4/zDq/1+kPzNRnU+rxSJf
-        zhTh//ch/x5a//9HY7nIqzq/YEz/vzwMYTJqvigoLTabAeVwPD/y7/7/6d/F
-        uAE5c8qVny4vi7pakqT+/8XbdzOHT4MPLBD6FF/yK94M8WeA733m+vE+ZLxk
-        slwL8zf3on9941Np/ngPDXHb6b+7WJdt8aoq85dVVf6IG/gzwPc+c/14HzJe
-        Mt+uhfmbe9G//j/FDVdV/Tavf8QKmGH+DPC9z1w/3oeMl0y2a2H+5l70r/9P
-        sYL41V02+P/gEP4/GBpEBxMoah3b//9G9P+T2fIUqQ7s/2fD+f/JPHV4sFg2
-        bbac/r8ycXn7oO99BqrT+fNuwP/v5t8PG7ovrXbcBOrnwSh1dn9+jfb/L7y8
-        yJbkUs++3R8+vesP60fBCD5z/XgffjenhhJuuBbmb+5F//o5Y42buGCWr8rq
-        GtP+3E55OP3/b0D99lxdNCrPuWPoZbbIs8usKLNJCW76/+7opmXWNMX0i2pS
-        lPlrWpcpSC/Ra//fHRGh+gUrIkzU8XRa0Vp2d0T/H1VAnAV3L/Kf+n3wp8Lh
-        Dzp4OZWFlsEHFg/6FF8S1J8bHcassF1PqbX3t2GAW8/53Wm1XOZTmfMfzb90
-        66YbLYMPLB70Kb4kqP9/mf/j6f9fEqI8p+5F/lO/D/5UOPxBBy8342gZfGDx
-        oE/xJUH9/zYL0Kc+H/i//4gnPLwcC6Bl8IHFgz7FlwT1//M88aO59/ByU42W
-        wQcWD/oUXxLU/8/PPf/zIwbw8HLzjZbBBxYP+hRfEtT/7zMAwfjRxKNbN89o
-        GXxg8aBP8SVB/f/+xHvW/0dMYLp1c46WwQcWD/oUXxLU/3cyAbMBkjLNKpuC
-        B17kV6/yspiOj19+QS/5HAKofZ5RNqG2AVcIrQzGTFRBN/iIh8e/MUX4N3nT
-        Upmb2L8YBgjL1KMP+D3+PUoBSo/s0IipIf9hkh+9Yb/Ol7OLupiNTxeUnKLm
-        /jAB7NYDdwgNYcuj1N+YF3mI/KmMPSARwwg/Cv6QVyyBGJb9SyQNfdk/0ID+
-        6EitY11t7D7gJhhEnMKUjQJPRYm6nlJOrHlCmfq3zfikzLP66ROC7VMSYHq0
-        nWVtNska+rJD3A7WASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovf
-        ixHO/1S75y/9HqPEJXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B8odcxFlVwEA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -417,22 +35,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1d0a4741-af37-4e82-9a1f-ff1b9ac5d990
-      - 87baf32b-2a0e-46d1-b970-f4419d81bfed
+      - 937799eb-4a9a-4659-9b9d-fc519c7b91c4
+      - a9086079-4297-4a4d-8650-20ee7ab3a72e
+      - bdf87db2-52fc-4ba1-a5c0-44643471d019
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14893'
       X-Ms-Request-Id:
-      - e9b6fa23-f3d7-416f-b261-41394d8f215a
+      - 6fc9eb58-89a8-46f9-9ea2-b37de2c9fe97
       X-Ms-Correlation-Request-Id:
-      - e9b6fa23-f3d7-416f-b261-41394d8f215a
+      - 6fc9eb58-89a8-46f9-9ea2-b37de2c9fe97
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135012Z:e9b6fa23-f3d7-416f-b261-41394d8f215a
+      - NORTHCENTRALUS:20160203T194414Z:6fc9eb58-89a8-46f9-9ea2-b37de2c9fe97
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:11 GMT
+      - Wed, 03 Feb 2016 19:44:13 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -443,61 +62,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -507,11 +136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -530,22 +159,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0ea23d81-5a50-48e0-a1b5-1dd330196ab7
-      - 28475699-fe57-4571-bcd9-14c98d26b579
+      - 184f41b1-2bdd-41ee-9932-317bd4d69847
+      - 4cd1306c-902b-4dd3-bf59-b4f458547299
+      - 896f2adf-6d80-435c-a9d2-4845b38e6c02
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14900'
       X-Ms-Request-Id:
-      - a9736a6e-b49c-4473-bc5f-b724a265f200
+      - a91f2fb7-b529-497e-b4c9-5cd79d38c866
       X-Ms-Correlation-Request-Id:
-      - a9736a6e-b49c-4473-bc5f-b724a265f200
+      - a91f2fb7-b529-497e-b4c9-5cd79d38c866
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135012Z:a9736a6e-b49c-4473-bc5f-b724a265f200
+      - NORTHCENTRALUS:20160203T194415Z:a91f2fb7-b529-497e-b4c9-5cd79d38c866
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:11 GMT
+      - Wed, 03 Feb 2016 19:44:14 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -556,61 +186,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:14 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -620,11 +260,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -643,22 +283,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6998a073-a5a6-4cfd-b378-3e2ac5196b2f
-      - eccf7d3d-0a4a-4ae0-b114-42e2b4241ae6
+      - 421d02d0-1345-49e8-9f63-aebdfae5f93b
+      - 63a05521-356a-449f-8f9d-e5c7bc8c7e18
+      - fba99655-b39d-42cd-9c36-85c5118f86dd
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14903'
       X-Ms-Request-Id:
-      - cb545084-4aa3-49ce-b186-4ffa9433069c
+      - 973c5de9-304e-45cd-8491-849632032413
       X-Ms-Correlation-Request-Id:
-      - cb545084-4aa3-49ce-b186-4ffa9433069c
+      - 973c5de9-304e-45cd-8491-849632032413
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135013Z:cb545084-4aa3-49ce-b186-4ffa9433069c
+      - NORTHCENTRALUS:20160203T194424Z:973c5de9-304e-45cd-8491-849632032413
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:13 GMT
+      - Wed, 03 Feb 2016 19:44:24 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -669,61 +310,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -733,11 +384,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -756,22 +407,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 23ace418-be94-41d2-8284-35507d6a248b
-      - 5d0147b0-9854-4091-b4b9-31ffaa2d1dcf
+      - 681533c8-0231-4757-9a78-86ccbf0bcc26
+      - d6385659-5f43-499d-8247-5656571a506b
+      - faa92dd4-efa0-4cc3-953d-ed1d1bc0ef8f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14906'
       X-Ms-Request-Id:
-      - 90963331-32b5-46f6-a6d6-02cb7ba1c092
+      - 0abb19d5-8335-4b26-8359-c8646409a470
       X-Ms-Correlation-Request-Id:
-      - 90963331-32b5-46f6-a6d6-02cb7ba1c092
+      - 0abb19d5-8335-4b26-8359-c8646409a470
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135013Z:90963331-32b5-46f6-a6d6-02cb7ba1c092
+      - NORTHCENTRALUS:20160203T194425Z:0abb19d5-8335-4b26-8359-c8646409a470
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:13 GMT
+      - Wed, 03 Feb 2016 19:44:24 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -782,61 +434,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:15 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -846,11 +508,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -869,22 +531,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - e26ea62f-bdbe-4654-9ae9-fcc124fc87c7
-      - f43e06dd-80c8-454a-a242-adf40b6dc714
+      - 1e9ddb26-161c-415f-bebc-1b4288948170
+      - a298ebae-b21c-46b5-8775-ae39c834a0df
+      - d5e3b564-a9d5-4e1d-bb21-7c07bf75fbc6
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14902'
       X-Ms-Request-Id:
-      - e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      - 2594762b-3cd5-4a9b-aaee-bb3077463d92
       X-Ms-Correlation-Request-Id:
-      - e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      - 2594762b-3cd5-4a9b-aaee-bb3077463d92
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135014Z:e8a7fe54-643f-45ee-8b7b-eb3425bc7fa6
+      - NORTHCENTRALUS:20160203T194425Z:2594762b-3cd5-4a9b-aaee-bb3077463d92
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:14 GMT
+      - Wed, 03 Feb 2016 19:44:25 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -895,61 +558,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:16 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -959,11 +632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -982,22 +655,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 00c98da7-71b4-4763-bdfb-cae9e978e7b5
-      - 90cbfc43-cbc1-4113-b501-c39eeceaf370
+      - 3e5e6331-e15a-4713-a724-4bd2ef117baa
+      - 567284f0-9b50-41a2-b681-c2d8dd31d9d9
+      - fbab5344-6ef2-4e78-a236-572258ac4c0c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14907'
       X-Ms-Request-Id:
-      - 5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      - 4f7c72ae-76d5-40d2-abb3-a24a29c7fbae
       X-Ms-Correlation-Request-Id:
-      - 5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      - 4f7c72ae-76d5-40d2-abb3-a24a29c7fbae
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135015Z:5cacbb7c-2bf1-4b8a-93e2-46b5a1682700
+      - NORTHCENTRALUS:20160203T194426Z:4f7c72ae-76d5-40d2-abb3-a24a29c7fbae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:14 GMT
+      - Wed, 03 Feb 2016 19:44:26 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1008,61 +682,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1072,11 +756,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1095,22 +779,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - aa460d34-332e-4f5c-9cfe-4a9d7e43987b
-      - d8da3728-f7ba-4a0f-882c-dfa9521e8ec4
+      - 4557001f-335f-4de6-a8cc-5d4ca01b1cdb
+      - 47b0bb50-2961-4634-b129-de93741fee8b
+      - 7a1136fe-af05-4292-85f2-9864e5b9f7d8
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14900'
       X-Ms-Request-Id:
-      - a4adabee-c88a-4705-b28e-2a67119dad44
+      - b04ff902-de7a-44dd-bcc8-1ec8dd44599a
       X-Ms-Correlation-Request-Id:
-      - a4adabee-c88a-4705-b28e-2a67119dad44
+      - b04ff902-de7a-44dd-bcc8-1ec8dd44599a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135015Z:a4adabee-c88a-4705-b28e-2a67119dad44
+      - NORTHCENTRALUS:20160203T194427Z:b04ff902-de7a-44dd-bcc8-1ec8dd44599a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:14 GMT
+      - Wed, 03 Feb 2016 19:44:27 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1121,61 +806,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:17 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1185,11 +880,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1208,22 +903,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 88df9987-90e3-444c-86c6-f0222d5cfd27
-      - a34235fa-be56-423d-b46d-c223db1444c9
+      - 0312919b-8760-41a4-a76a-1a0504c34ee3
+      - 29e5b47c-9e26-447c-ae0f-bb4989cb7f52
+      - 7ea5c069-a344-4253-8c3b-f63677c4e566
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14896'
       X-Ms-Request-Id:
-      - 278753a3-8f94-4ae0-9b82-eb5909914266
+      - 19d46755-c9e4-4fa7-98af-ebae45eb05f7
       X-Ms-Correlation-Request-Id:
-      - 278753a3-8f94-4ae0-9b82-eb5909914266
+      - 19d46755-c9e4-4fa7-98af-ebae45eb05f7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135016Z:278753a3-8f94-4ae0-9b82-eb5909914266
+      - NORTHCENTRALUS:20160203T194428Z:19d46755-c9e4-4fa7-98af-ebae45eb05f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:15 GMT
+      - Wed, 03 Feb 2016 19:44:27 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1234,61 +930,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:18 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1298,11 +1004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1321,22 +1027,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 03d0dbf5-2aa5-41a3-b00c-3e15d005d062
-      - 99184579-24f2-457d-9979-e7a8ceaea6b7
+      - 04a5ee8a-eba4-4096-98f9-4683aa453028
+      - 7bbd525f-069d-4050-b65c-cf08549aea53
+      - 896ed810-01a8-44bb-82e1-387709e5968b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14897'
       X-Ms-Request-Id:
-      - dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      - 96a3007e-f324-44a8-bb11-bba148ba308a
       X-Ms-Correlation-Request-Id:
-      - dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      - 96a3007e-f324-44a8-bb11-bba148ba308a
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135016Z:dc3945b4-99dc-4678-8f9a-0aacb8168b5a
+      - NORTHCENTRALUS:20160203T194428Z:96a3007e-f324-44a8-bb11-bba148ba308a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:16 GMT
+      - Wed, 03 Feb 2016 19:44:28 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1347,61 +1054,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1411,11 +1128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1434,22 +1151,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 437aa9c5-cbec-4fa9-9359-8afbeb9f1749
-      - 90f086bc-6c6e-4fbb-8b17-ee450f4d4817
+      - 1d0dede1-3443-4221-b22c-10652f7946cb
+      - 421e098a-c68e-4e0c-a06f-a61a7a82f33f
+      - ed905855-f525-42bc-9717-0498e8ca0d47
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14889'
       X-Ms-Request-Id:
-      - 4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      - 45df2f08-23d5-44ac-a3e3-95f3ea634ae4
       X-Ms-Correlation-Request-Id:
-      - 4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      - 45df2f08-23d5-44ac-a3e3-95f3ea634ae4
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135017Z:4725f080-6eee-44dc-a1f3-b8d07aa5ea4e
+      - NORTHCENTRALUS:20160203T194429Z:45df2f08-23d5-44ac-a3e3-95f3ea634ae4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:16 GMT
+      - Wed, 03 Feb 2016 19:44:29 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1460,61 +1178,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:19 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1524,11 +1252,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1547,22 +1275,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b4f8dbd1-81f7-483e-a33a-de86ce0400d9
-      - be0f0c40-dd14-451b-b2d2-cdebd39eaf3e
+      - 59fa2eac-dbe4-4b07-8834-5ed84220f0b9
+      - 8ab775e1-085e-447e-8296-3abfa55736bd
+      - c5407cc7-7702-4d63-a759-f5fff290d804
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14902'
       X-Ms-Request-Id:
-      - ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      - f783a39c-d27f-451d-a2c2-a4fa4e2188c7
       X-Ms-Correlation-Request-Id:
-      - ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      - f783a39c-d27f-451d-a2c2-a4fa4e2188c7
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135018Z:ceb367ef-5bf6-4470-9916-bf9abcb2313f
+      - NORTHCENTRALUS:20160203T194430Z:f783a39c-d27f-451d-a2c2-a4fa4e2188c7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:17 GMT
+      - Wed, 03 Feb 2016 19:44:29 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1573,61 +1302,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1637,11 +1376,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1660,22 +1399,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3dac3105-2708-4892-afed-3aa03c12f9e3
-      - fe357ca0-5f78-4dea-9695-616b4fb609e0
+      - c3b6749b-e7ee-4577-bec5-979e580a1bd0
+      - c7aedb2f-0c94-45aa-b372-41a169dbb30c
+      - e9b1cefb-a172-45f6-a426-1c4e381f4e3a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14904'
       X-Ms-Request-Id:
-      - 99cc57a1-b092-4d27-9d29-42dc905de53c
+      - c01d0b19-4612-4069-9325-c1c192d83f4e
       X-Ms-Correlation-Request-Id:
-      - 99cc57a1-b092-4d27-9d29-42dc905de53c
+      - c01d0b19-4612-4069-9325-c1c192d83f4e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135018Z:99cc57a1-b092-4d27-9d29-42dc905de53c
+      - NORTHCENTRALUS:20160203T194430Z:c01d0b19-4612-4069-9325-c1c192d83f4e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:18 GMT
+      - Wed, 03 Feb 2016 19:44:30 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1686,61 +1426,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:20 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1750,11 +1500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1773,22 +1523,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3bf71381-b0e0-48ba-b309-2d5aa670bbd2
-      - a8a4cd8f-d064-4ce4-a853-e20e1d398697
+      - 1512bd92-eac2-4bf1-8486-6de376cebb05
+      - aa21176a-872e-4d8b-9711-f1db14ddaf35
+      - be432db3-06a9-4afd-8999-fd0ea941a29f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14890'
       X-Ms-Request-Id:
-      - eea5294d-3347-4abb-a227-1185d37130cd
+      - c194cc9d-1fda-4309-99aa-24ca498d0fe0
       X-Ms-Correlation-Request-Id:
-      - eea5294d-3347-4abb-a227-1185d37130cd
+      - c194cc9d-1fda-4309-99aa-24ca498d0fe0
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135019Z:eea5294d-3347-4abb-a227-1185d37130cd
+      - NORTHCENTRALUS:20160203T194431Z:c194cc9d-1fda-4309-99aa-24ca498d0fe0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:19 GMT
+      - Wed, 03 Feb 2016 19:44:30 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1799,61 +1550,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:21 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1863,11 +1624,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1886,22 +1647,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a4894e74-58f4-4965-a413-9253c0a1ab15
-      - ecd39004-0352-49c2-b11f-2942b03cddfe
+      - 38c7f32d-a4d8-41b0-9b1d-143cfb3e789d
+      - b9d5368e-3468-4a90-8ab3-08ad1119af35
+      - da2bcb54-d99c-4589-884e-9726314c8291
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14892'
       X-Ms-Request-Id:
-      - ef2f97c2-591a-4318-9101-7c2b9d49e707
+      - a75ace57-5d52-4164-8137-3390c54ac05b
       X-Ms-Correlation-Request-Id:
-      - ef2f97c2-591a-4318-9101-7c2b9d49e707
+      - a75ace57-5d52-4164-8137-3390c54ac05b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135020Z:ef2f97c2-591a-4318-9101-7c2b9d49e707
+      - NORTHCENTRALUS:20160203T194432Z:a75ace57-5d52-4164-8137-3390c54ac05b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:19 GMT
+      - Wed, 03 Feb 2016 19:44:31 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1912,61 +1674,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:22 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1976,11 +1748,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1999,22 +1771,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2b1e723b-0fc2-47e6-8dcc-4a61cc497977
-      - 76505311-77f6-4368-b77b-b0cfcb82c44c
+      - 1e907976-8a76-4621-96f8-6e8e36c33d91
+      - afb54163-fb5d-466c-ad70-f0c39bbacfc7
+      - afc07ecb-46af-4820-9a15-ed0afab674ac
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14899'
       X-Ms-Request-Id:
-      - ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      - 7241fcda-3159-4c47-aedc-04ce5b969a3c
       X-Ms-Correlation-Request-Id:
-      - ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      - 7241fcda-3159-4c47-aedc-04ce5b969a3c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135020Z:ad73d41d-7aec-44fb-b37b-80e4235e9bb3
+      - NORTHCENTRALUS:20160203T194432Z:7241fcda-3159-4c47-aedc-04ce5b969a3c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:20 GMT
+      - Wed, 03 Feb 2016 19:44:32 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2025,61 +1798,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:22 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2089,11 +1872,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2112,22 +1895,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 102182a0-1285-4666-aa24-0e09dcf695eb
-      - f3edb2fd-5273-4bcc-9299-67d70fdb17cc
+      - 0883556d-2992-48a9-a3fd-00490de11306
+      - 29518d1e-b1d2-47bb-9cfa-73cd20af60ca
+      - 8356f581-cc00-4a63-bdae-8c2c7c80cf5b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14901'
       X-Ms-Request-Id:
-      - 9d29a6a4-6420-4f09-9007-b536d620bd8c
+      - dbed74dc-5299-458f-b42a-88600f7e97db
       X-Ms-Correlation-Request-Id:
-      - 9d29a6a4-6420-4f09-9007-b536d620bd8c
+      - dbed74dc-5299-458f-b42a-88600f7e97db
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135021Z:9d29a6a4-6420-4f09-9007-b536d620bd8c
+      - NORTHCENTRALUS:20160203T194433Z:dbed74dc-5299-458f-b42a-88600f7e97db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:21 GMT
+      - Wed, 03 Feb 2016 19:44:32 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2138,61 +1922,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:23 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2202,11 +1996,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2225,22 +2019,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 8223b929-226e-4cdb-8cfb-603df9bcd5c2
-      - d71eb8a1-ccbc-4289-9614-5c3b16729754
+      - 8a553726-db05-416b-8d0d-13fe1a814f90
+      - d9aa7eef-89a5-4ad8-8aac-7d9e581f8337
+      - feca245e-42eb-43d2-b48d-1280286d10af
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14901'
       X-Ms-Request-Id:
-      - eb41f472-5c50-4326-b443-3e19a7061c0a
+      - a4dcd262-e5ae-4104-a28e-8288b13a61e6
       X-Ms-Correlation-Request-Id:
-      - eb41f472-5c50-4326-b443-3e19a7061c0a
+      - a4dcd262-e5ae-4104-a28e-8288b13a61e6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135022Z:eb41f472-5c50-4326-b443-3e19a7061c0a
+      - NORTHCENTRALUS:20160203T194434Z:a4dcd262-e5ae-4104-a28e-8288b13a61e6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:21 GMT
+      - Wed, 03 Feb 2016 19:44:33 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2251,61 +2046,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2315,11 +2120,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2338,22 +2143,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6839b79b-eab5-4e6d-b5d4-7461e88db4fc
-      - 8255009f-180c-4dc9-8137-6d5373a16422
+      - 520f55f6-a7f1-4a78-a13f-5e511d38f64f
+      - 61cc1415-2a41-417c-baaf-1c7502780996
+      - b23af7db-6f81-4df2-8b0d-c3b39c0a7339
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14899'
       X-Ms-Request-Id:
-      - eba47ed1-04f7-43c1-b494-cc41825c4311
+      - 4640e224-8225-4000-8f80-6a303dfc2adf
       X-Ms-Correlation-Request-Id:
-      - eba47ed1-04f7-43c1-b494-cc41825c4311
+      - 4640e224-8225-4000-8f80-6a303dfc2adf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135022Z:eba47ed1-04f7-43c1-b494-cc41825c4311
+      - NORTHCENTRALUS:20160203T194434Z:4640e224-8225-4000-8f80-6a303dfc2adf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:21 GMT
+      - Wed, 03 Feb 2016 19:44:34 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2364,61 +2170,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2428,11 +2244,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2451,22 +2267,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 260f24b1-29a2-4c50-95e8-a3382617d250
-      - a734b6ac-adfa-4f61-a7f3-e2a48ef88c37
+      - 19cc306b-fd1a-4bf8-bc59-e64fecf8821c
+      - 45576227-e36f-4ea0-9daa-350e7d4aff90
+      - 4b8bea47-1c3d-4aab-8fde-eb16ccff2109
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14902'
       X-Ms-Request-Id:
-      - ad13d1ac-9e52-4253-b328-c96e18a926cb
+      - f43e8f1a-2e40-4789-a137-7e4791b43f62
       X-Ms-Correlation-Request-Id:
-      - ad13d1ac-9e52-4253-b328-c96e18a926cb
+      - f43e8f1a-2e40-4789-a137-7e4791b43f62
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135022Z:ad13d1ac-9e52-4253-b328-c96e18a926cb
+      - NORTHCENTRALUS:20160203T194436Z:f43e8f1a-2e40-4789-a137-7e4791b43f62
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:22 GMT
+      - Wed, 03 Feb 2016 19:44:36 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2477,61 +2294,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2541,11 +2368,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2564,22 +2391,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 439ef071-c6c8-40fb-aa91-78ca766cb05f
-      - abb0411d-7764-45e3-b12e-9bf4f8930255
+      - 3a80f654-d0cf-4edb-a5d0-2f94eaa2960b
+      - 7869e328-d993-4119-9469-b09537d67bec
+      - d6b1d6a6-d765-43b4-b6d8-d4782c6a10fe
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14905'
       X-Ms-Request-Id:
-      - 9f622c66-2391-4fc8-9f75-81deb95e524f
+      - 695fffff-2674-46b6-aaba-6d4448b13d73
       X-Ms-Correlation-Request-Id:
-      - 9f622c66-2391-4fc8-9f75-81deb95e524f
+      - 695fffff-2674-46b6-aaba-6d4448b13d73
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135022Z:9f622c66-2391-4fc8-9f75-81deb95e524f
+      - NORTHCENTRALUS:20160203T194436Z:695fffff-2674-46b6-aaba-6d4448b13d73
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:22 GMT
+      - Wed, 03 Feb 2016 19:44:36 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2590,61 +2418,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:24 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2654,11 +2492,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2677,22 +2515,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 87700af0-bbf3-4143-9a0d-2ae6fc7eb5f2
-      - b2a2f01d-2a83-4fa3-9173-6d8b8f2b95d9
+      - 52dc3f36-3522-4ad4-b9d8-f7d4d4425d92
+      - 57b2d79b-99c5-42a7-8019-354f9f48c1d0
+      - 6b512fe6-feab-48ff-ba96-819cae96951e
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14901'
       X-Ms-Request-Id:
-      - 54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      - 80478215-a63c-410f-9852-832a153bcf6d
       X-Ms-Correlation-Request-Id:
-      - 54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      - 80478215-a63c-410f-9852-832a153bcf6d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135022Z:54f784cd-98e6-489e-b3b1-3170be3d4e0f
+      - NORTHCENTRALUS:20160203T194437Z:80478215-a63c-410f-9852-832a153bcf6d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:22 GMT
+      - Wed, 03 Feb 2016 19:44:37 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2703,61 +2542,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2767,11 +2616,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2790,22 +2639,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0bdc2daf-3719-49b7-82c6-f4a8a27d04e4
-      - bae1df5f-d4e6-46d0-9b26-9b2080393946
+      - 09d752bd-e0e5-4b59-9c9c-45db7d0623c6
+      - 87895a02-3870-41cd-b165-7a9427c1dbae
+      - f239cbf8-c422-4531-a0e9-cffe55e1968f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14906'
       X-Ms-Request-Id:
-      - 46c03546-1bff-4d13-874c-63379281b398
+      - e14462ab-e19b-45d9-9b1b-8ceaf9fc83cf
       X-Ms-Correlation-Request-Id:
-      - 46c03546-1bff-4d13-874c-63379281b398
+      - e14462ab-e19b-45d9-9b1b-8ceaf9fc83cf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135023Z:46c03546-1bff-4d13-874c-63379281b398
+      - NORTHCENTRALUS:20160203T194438Z:e14462ab-e19b-45d9-9b1b-8ceaf9fc83cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:22 GMT
+      - Wed, 03 Feb 2016 19:44:37 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2816,61 +2666,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2880,11 +2740,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2903,22 +2763,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 95df7a19-77ea-4081-8231-3b4a72781e02
-      - a95f5d86-1d7c-4372-8f90-ad4cee7ef191
+      - 832c11ec-7697-410b-8a8a-321e01b6fe57
+      - e486a76d-35f1-4f98-b1e4-fa3a77422363
+      - ff0d8ed5-62fe-438d-a79a-1f62c52a1f33
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14899'
       X-Ms-Request-Id:
-      - 096d82db-d76c-464f-b8c2-4d5616a2bc41
+      - 1792c895-38f4-4edd-887c-d5b72f2b1048
       X-Ms-Correlation-Request-Id:
-      - 096d82db-d76c-464f-b8c2-4d5616a2bc41
+      - 1792c895-38f4-4edd-887c-d5b72f2b1048
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135023Z:096d82db-d76c-464f-b8c2-4d5616a2bc41
+      - NORTHCENTRALUS:20160203T194438Z:1792c895-38f4-4edd-887c-d5b72f2b1048
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:23 GMT
+      - Wed, 03 Feb 2016 19:44:37 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2929,61 +2790,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:25 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2993,11 +2864,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3016,22 +2887,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - b5d886e7-b939-49b8-8b71-a30c1be7d39a
-      - f77e93d8-2991-4453-aeae-b32a08c3fef6
+      - 0508e973-60a2-43b6-98ce-e904dad0d8b4
+      - 57969eb4-4b64-4a69-ad58-c58298a37f84
+      - 5d1df37e-ff87-4ab3-a5d3-c1341b23836a
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14895'
       X-Ms-Request-Id:
-      - 16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      - c1a304da-c5a2-4230-a7b6-0f44bd89160c
       X-Ms-Correlation-Request-Id:
-      - 16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      - c1a304da-c5a2-4230-a7b6-0f44bd89160c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135023Z:16ab808c-7a30-4a54-8d9f-8e3baa7adc58
+      - NORTHCENTRALUS:20160203T194439Z:c1a304da-c5a2-4230-a7b6-0f44bd89160c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:23 GMT
+      - Wed, 03 Feb 2016 19:44:39 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3042,61 +2914,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3106,11 +2988,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3129,22 +3011,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - a8b7bdcd-40d0-4bc8-8493-8123139bb2df
-      - b310ade8-0aef-462f-a9da-299f49e5ea80
+      - 5b583ebd-915d-46fd-8cbc-14c5c4c8729c
+      - 7024d71a-7a97-4da5-8aba-3c632fecc8ce
+      - fd65cbee-2d18-4ea6-bf60-1cc2aaaecf8b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14896'
       X-Ms-Request-Id:
-      - bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      - 0803ff78-c882-4bd7-9849-557573ed7a26
       X-Ms-Correlation-Request-Id:
-      - bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      - 0803ff78-c882-4bd7-9849-557573ed7a26
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135024Z:bac5d16c-6a92-4a46-993e-c49fe6c25e67
+      - NORTHCENTRALUS:20160203T194439Z:0803ff78-c882-4bd7-9849-557573ed7a26
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:23 GMT
+      - Wed, 03 Feb 2016 19:44:39 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3155,61 +3038,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3219,11 +3112,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3242,22 +3135,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1f8122f8-558c-4ae4-9a2e-25204d18af04
-      - 8494e868-c577-4baf-a9d1-5423268d137a
+      - 78b2b196-d805-4028-8bde-0b2bb373bc7c
+      - bea7ee73-6011-4d14-9841-c327ade753d1
+      - cb0421b9-79e4-411d-aaf2-35a90971c54c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14901'
       X-Ms-Request-Id:
-      - 6014a524-2663-4794-985a-8551601c720f
+      - 5c28872c-5895-4dfa-8721-db385d164735
       X-Ms-Correlation-Request-Id:
-      - 6014a524-2663-4794-985a-8551601c720f
+      - 5c28872c-5895-4dfa-8721-db385d164735
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135024Z:6014a524-2663-4794-985a-8551601c720f
+      - NORTHCENTRALUS:20160203T194440Z:5c28872c-5895-4dfa-8721-db385d164735
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:23 GMT
+      - Wed, 03 Feb 2016 19:44:39 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3268,61 +3162,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3332,11 +3236,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3355,22 +3259,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 338d1dce-520d-4255-94bd-5b1a50a07690
-      - 6c77558a-6118-4cc2-b51e-dea94bea99da
+      - 6c8891aa-f8f2-4299-afec-5dbdf273b901
+      - b11b6a18-74e4-4e2d-8483-bd590d561c5e
+      - f76067c4-9dbe-4a7b-91ce-eb0d2a39c519
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14903'
       X-Ms-Request-Id:
-      - 6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      - 8b8ba80a-3966-44dd-9f13-f2b156910540
       X-Ms-Correlation-Request-Id:
-      - 6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      - 8b8ba80a-3966-44dd-9f13-f2b156910540
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135024Z:6f99b1ed-f696-46ba-b71a-2b5370f44b57
+      - NORTHCENTRALUS:20160203T194441Z:8b8ba80a-3966-44dd-9f13-f2b156910540
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:24 GMT
+      - Wed, 03 Feb 2016 19:44:41 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3381,61 +3286,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3445,11 +3360,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3468,22 +3383,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - ce6adbe5-41cb-4b70-9a28-4aea20e3055d
-      - d303e81c-829e-4272-abdf-1cd7f5ca806c
+      - 457740fb-cdd5-44e9-a5d8-dffc723df236
+      - 7e095786-61c1-44ec-a6c5-3fa9f3aab887
+      - 81b94ccd-4fbb-4e0e-9285-e056b54efc32
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14891'
       X-Ms-Request-Id:
-      - 486e58df-e045-40a8-80b2-37cb57b8c047
+      - 176bf09a-b952-4d1c-9b65-39a2fbb51e84
       X-Ms-Correlation-Request-Id:
-      - 486e58df-e045-40a8-80b2-37cb57b8c047
+      - 176bf09a-b952-4d1c-9b65-39a2fbb51e84
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135025Z:486e58df-e045-40a8-80b2-37cb57b8c047
+      - NORTHCENTRALUS:20160203T194442Z:176bf09a-b952-4d1c-9b65-39a2fbb51e84
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 13:50:24 GMT
+      - Wed, 03 Feb 2016 19:44:41 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3494,8628 +3410,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8ec1f6d9-6d7c-4c6e-bdee-7fc75210bd85
-      - a9e5a556-608f-4cb7-8468-795669e4285d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - aef29501-5b22-4d6a-918a-0c6dcb80d1f1
-      X-Ms-Correlation-Request-Id:
-      - aef29501-5b22-4d6a-918a-0c6dcb80d1f1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135025Z:aef29501-5b22-4d6a-918a-0c6dcb80d1f1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:25 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 5002ceae-860c-4190-b898-31b79e672c52
-      - fe7a41f4-ace2-440e-906b-2f3c291583d5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
-      X-Ms-Correlation-Request-Id:
-      - 1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135025Z:1684ccd3-48ee-4f98-b7d9-9eaca9afda4f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:25 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6ee70a04-f616-446e-b7cc-a3a44acce863
-      - a8bab030-bde4-4ef8-99dc-84a576b1408a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - c7394779-43b0-461a-968e-6b9059895f62
-      X-Ms-Correlation-Request-Id:
-      - c7394779-43b0-461a-968e-6b9059895f62
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135026Z:c7394779-43b0-461a-968e-6b9059895f62
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:25 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 60fa198b-cde6-4a0f-9203-f4b813352630
-      - ebc8fc79-ce93-4d4e-8ba6-cc682d550cf8
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 8b5c42d1-8038-4637-9dfb-72fd3302e1f1
-      X-Ms-Correlation-Request-Id:
-      - 8b5c42d1-8038-4637-9dfb-72fd3302e1f1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135026Z:8b5c42d1-8038-4637-9dfb-72fd3302e1f1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:26 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 448c2aac-246c-4572-bec9-211e8d6d565a
-      - c28a0d1f-ddc4-4e16-b2d1-2805687ff016
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - fd2c1ec9-73c5-40f4-8a85-f264c04e928a
-      X-Ms-Correlation-Request-Id:
-      - fd2c1ec9-73c5-40f4-8a85-f264c04e928a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135026Z:fd2c1ec9-73c5-40f4-8a85-f264c04e928a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:26 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8a5dfe00-5236-4f2b-93f6-fc99a6c94a07
-      - 8d49a274-15e7-4e28-8ec4-9f059be6f0de
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - c9aba678-046c-4858-9761-2b01b05a0070
-      X-Ms-Correlation-Request-Id:
-      - c9aba678-046c-4858-9761-2b01b05a0070
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135027Z:c9aba678-046c-4858-9761-2b01b05a0070
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 213f6813-590e-4fe5-b5fb-8b22daed0f78
-      - 3e9f60dd-aa59-482a-8bf1-46f39b0dbead
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 790ea311-d9a4-44c9-8885-7e0de5599ca1
-      X-Ms-Correlation-Request-Id:
-      - 790ea311-d9a4-44c9-8885-7e0de5599ca1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135027Z:790ea311-d9a4-44c9-8885-7e0de5599ca1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:26 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 3163925d-5f37-40c2-a0dc-75f57a072e9e
-      - 8fbf9dcc-e4b9-431e-9e3e-87393275172a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 5238e877-4c15-493c-8fc1-11a68a1c8e34
-      X-Ms-Correlation-Request-Id:
-      - 5238e877-4c15-493c-8fc1-11a68a1c8e34
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135027Z:5238e877-4c15-493c-8fc1-11a68a1c8e34
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:26 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - be9c1ca8-8f67-4d16-a491-9a77cdb44d4e
-      - e94a6e33-0f5f-4981-9b60-86f90c99db5f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - c8821fa2-2398-4567-a9e3-63c136f08428
-      X-Ms-Correlation-Request-Id:
-      - c8821fa2-2398-4567-a9e3-63c136f08428
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135028Z:c8821fa2-2398-4567-a9e3-63c136f08428
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 54c1f786-ed34-4e13-b718-bdf22ed73206
-      - eb30b569-2d80-4493-9c44-e9e92132684a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 61bf01c4-bc36-4768-bac6-fd36444880be
-      X-Ms-Correlation-Request-Id:
-      - 61bf01c4-bc36-4768-bac6-fd36444880be
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135028Z:61bf01c4-bc36-4768-bac6-fd36444880be
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:27 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - afdd4ce2-19be-414e-9a7d-027fb866fb22
-      - b1610139-5359-40b3-bd95-b37b71ef62a2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
-      X-Ms-Correlation-Request-Id:
-      - 10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135028Z:10e4e61d-cd8d-4dab-a199-f8fb4bc6332d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:28 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 56ef9880-8c0a-482a-9c13-e6113629a5fe
-      - e4ad4830-8f7a-4f7c-94cf-e09842fdbfc5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 7a3dba2e-49fe-4ce6-8415-21990854f2ca
-      X-Ms-Correlation-Request-Id:
-      - 7a3dba2e-49fe-4ce6-8415-21990854f2ca
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135029Z:7a3dba2e-49fe-4ce6-8415-21990854f2ca
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 290ecfec-7e7c-4525-aa53-7f780ad9ad6f
-      - 3b5d50c6-bc7c-4946-a539-478c94efc9d2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 8430505b-2298-4189-9541-60bcafc2ebe9
-      X-Ms-Correlation-Request-Id:
-      - 8430505b-2298-4189-9541-60bcafc2ebe9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135029Z:8430505b-2298-4189-9541-60bcafc2ebe9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - a6552e44-5d23-408d-9c8c-0b96d6d1f2d6
-      - f54c203b-3f83-477c-a4ce-555b558080bf
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 19361343-ec89-41a5-952b-5a53ece28c6b
-      X-Ms-Correlation-Request-Id:
-      - 19361343-ec89-41a5-952b-5a53ece28c6b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135029Z:19361343-ec89-41a5-952b-5a53ece28c6b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 325eaabc-597a-4b49-91e2-d307688bd7c2
-      - f7471b65-f111-46e0-a4bd-83effbffb26d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - 3ca977af-0226-48dd-8dfd-5695a2957ff0
-      X-Ms-Correlation-Request-Id:
-      - 3ca977af-0226-48dd-8dfd-5695a2957ff0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135030Z:3ca977af-0226-48dd-8dfd-5695a2957ff0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:29 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4ed5e28c-47be-4535-a9ca-e3085bba4686
-      - 75a121db-2ea3-4266-9bfe-c5485c63fb84
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 7e6f063e-7da9-420c-99bd-462c7fd7edfa
-      X-Ms-Correlation-Request-Id:
-      - 7e6f063e-7da9-420c-99bd-462c7fd7edfa
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135030Z:7e6f063e-7da9-420c-99bd-462c7fd7edfa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 62531baa-d171-41f3-877e-232b806fecfb
-      - 9e98b1bb-ddaf-434d-a430-10302573c349
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 8ec4bd42-cd78-4479-b119-c7f4c9099b0d
-      X-Ms-Correlation-Request-Id:
-      - 8ec4bd42-cd78-4479-b119-c7f4c9099b0d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135030Z:8ec4bd42-cd78-4479-b119-c7f4c9099b0d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1894e8fe-39f6-4eb8-b099-badfd7e089aa
-      - a4bc56ca-eb5b-49c5-ac03-3a4424e7434f
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 68260ff7-6a05-4f20-be26-c8e1545774e1
-      X-Ms-Correlation-Request-Id:
-      - 68260ff7-6a05-4f20-be26-c8e1545774e1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135031Z:68260ff7-6a05-4f20-be26-c8e1545774e1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 06ffe0d4-0f15-4255-9223-a49397ef6964
-      - 8a957ca3-d599-485c-9256-d8bc57d79026
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 48fd65a2-559e-4f19-947f-5be900fdf538
-      X-Ms-Correlation-Request-Id:
-      - 48fd65a2-559e-4f19-947f-5be900fdf538
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135031Z:48fd65a2-559e-4f19-947f-5be900fdf538
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:30 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2987bc22-86c9-43d3-8843-64060fe9ed06
-      - 486d37db-2ff2-4f88-8b82-36f969fad3d5
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - d26b8b47-5292-4cbe-9408-1a265b0ba38d
-      X-Ms-Correlation-Request-Id:
-      - d26b8b47-5292-4cbe-9408-1a265b0ba38d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135031Z:d26b8b47-5292-4cbe-9408-1a265b0ba38d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 032b4904-1902-4216-9d5f-cad1d0b4eda8
-      - 75a36e91-f65b-4675-97ac-8a61ef7d5d47
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - c57450b8-1615-46ec-a41c-e4cfbef8d300
-      X-Ms-Correlation-Request-Id:
-      - c57450b8-1615-46ec-a41c-e4cfbef8d300
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135032Z:c57450b8-1615-46ec-a41c-e4cfbef8d300
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4fd7d051-a779-4050-ae7f-ef9a66d9648b
-      - ad237d25-0ca7-4230-b805-2fe18255e551
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 69b7de07-aaa9-4837-a192-2059357a9c3f
-      X-Ms-Correlation-Request-Id:
-      - 69b7de07-aaa9-4837-a192-2059357a9c3f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135032Z:69b7de07-aaa9-4837-a192-2059357a9c3f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:31 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2c200486-8b0f-460f-953d-4b0b1b86b32a
-      - 6ade8011-fc29-48a9-b091-36ba2ce34f35
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - de65e4f8-e501-46a2-8f28-ea18beea66d0
-      X-Ms-Correlation-Request-Id:
-      - de65e4f8-e501-46a2-8f28-ea18beea66d0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135032Z:de65e4f8-e501-46a2-8f28-ea18beea66d0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - ac3af394-4e5e-42a5-b0b7-54895ded8059
-      - ca577469-17a0-42a7-b039-0edece6d0b5b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
-      X-Ms-Correlation-Request-Id:
-      - 55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135032Z:55e95ec4-a57e-4daa-8d65-aaafc74f5b9b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:32 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - aa2bcdd6-ec0d-4587-9857-e16fc2adcc69
-      - df0da330-2d9e-4bbb-9ad8-e0aed03e22df
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - 4ba194e1-528c-477f-9668-55f50ea1538e
-      X-Ms-Correlation-Request-Id:
-      - 4ba194e1-528c-477f-9668-55f50ea1538e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135034Z:4ba194e1-528c-477f-9668-55f50ea1538e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - e1a0ef7f-1125-4b73-88e9-774d0b757844
-      - ecb23c75-49d4-49d0-8d1f-9522ea7b25f2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - e081b084-2949-4b76-abb1-8058f1df84ef
-      X-Ms-Correlation-Request-Id:
-      - e081b084-2949-4b76-abb1-8058f1df84ef
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135034Z:e081b084-2949-4b76-abb1-8058f1df84ef
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 3ab517fd-fa31-4707-ad1d-71a49708e73f
-      - 652118df-f113-4dc0-9c87-6efdfc8c5a31
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - ab0ab341-6c64-4c80-af85-d5962e62f7ab
-      X-Ms-Correlation-Request-Id:
-      - ab0ab341-6c64-4c80-af85-d5962e62f7ab
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135034Z:ab0ab341-6c64-4c80-af85-d5962e62f7ab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:33 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - ec398627-607e-43f9-9fb4-98af0cc9bdf8
-      - f95d2c9b-3915-4bb8-aadc-6b4b1db3c0a2
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - 7efd3aac-ba0f-4239-a687-5976607f4eec
-      X-Ms-Correlation-Request-Id:
-      - 7efd3aac-ba0f-4239-a687-5976607f4eec
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135034Z:7efd3aac-ba0f-4239-a687-5976607f4eec
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:34 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - d24c2533-14d0-43ee-a111-9529b4451a8b
-      X-Ms-Correlation-Request-Id:
-      - d24c2533-14d0-43ee-a111-9529b4451a8b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135035Z:d24c2533-14d0-43ee-a111-9529b4451a8b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:34 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - cea430a8-8ca2-436b-a46d-132b79a2c4c6
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 48cb8de6-263e-4aa5-8e80-3c5239606381
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135035Z:48cb8de6-263e-4aa5-8e80-3c5239606381
-      Date:
-      - Fri, 30 Oct 2015 13:50:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 6a5bffcd-5724-4255-9280-9d7225d06684
-      X-Ms-Correlation-Request-Id:
-      - 6a5bffcd-5724-4255-9280-9d7225d06684
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135036Z:6a5bffcd-5724-4255-9280-9d7225d06684
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:36 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 771b475b-9ebf-4c73-be22-1a082adfa2db
-      X-Ms-Correlation-Request-Id:
-      - 771b475b-9ebf-4c73-be22-1a082adfa2db
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135037Z:771b475b-9ebf-4c73-be22-1a082adfa2db
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:37 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 4ac85fb1-2530-435c-980d-ff70ef60bee2
-      X-Ms-Correlation-Request-Id:
-      - 4ac85fb1-2530-435c-980d-ff70ef60bee2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135038Z:4ac85fb1-2530-435c-980d-ff70ef60bee2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:37 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 43729edf-2eea-4fab-8b1e-4142a5591958
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 86779bc2-aa72-45b3-8a68-c414dba1b44c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135039Z:86779bc2-aa72-45b3-8a68-c414dba1b44c
-      Date:
-      - Fri, 30 Oct 2015 13:50:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 671f9ff1-f287-41c8-9f81-e8e558b19fee
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 9c0acff2-189d-48ce-89c6-c9231c70ce7f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135039Z:9c0acff2-189d-48ce-89c6-c9231c70ce7f
-      Date:
-      - Fri, 30 Oct 2015 13:50:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - bf232c4c-bdea-4f34-8253-d183bcaa3511
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 224c4d2f-dca4-4c24-a8bc-46c842137bbf
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135039Z:224c4d2f-dca4-4c24-a8bc-46c842137bbf
-      Date:
-      - Fri, 30 Oct 2015 13:50:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59G9h5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL19U88f53Xl3n9NL903UZp572O
-        ZwP9mvV0muezfOYg4nH0O1ueV53vCNOQfD7YdAhinDj7Dx7d3x9/evDg4f6n
-        HRoRZcyvTCf9+/sM9qNJVbVPi+xiWTVtMQUaOmQa7LKpyvz1tM7zZTOv2idl
-        NfmqLqjJR/O2XTWP7t69ypt2WmVNO5s09x9+ujeeUJvxtKrz8VWxnFVXzXiZ
-        t3fRycx1st38orLhKdjeufcwn033Drbv5wc72/s7O3vbk9n96fb+/YfZ/iy7
-        v7t3sH/Xn7Hxbd4YNxbp8WSxYlIoe+TvWvqCaIyh6kTriOlbwyNfFNO6aqrz
-        dnxGjS/mbTP+yS88Mr3O25YmqWHIBBs/lKB9PnLg34t/hnjn/flmI888uL9z
-        f/f+QcA0Qqso5tVVXqPn/O4sz8qymtKvfle3RppUgQ9BGgohf+Pkl/w/0KMt
-        +D8FAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1042c595-a74e-44b7-a429-f4bc703db2e3"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 37bb8fa7-d956-41f5-b563-1e7d52e65064
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - f3f9e9b3-ee62-450d-8ad2-3a8463b6e4ed
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135040Z:f3f9e9b3-ee62-450d-8ad2-3a8463b6e4ed
-      Date:
-      - Fri, 30 Oct 2015 13:50:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7s7+
-        3vT+w/vb2YN9Qmh/8mA72997uH2+P5k+2Lk3m+zl937fj/TF9nrFA75F1/pG
-        WU0zjBxvXeVNuzZf0DhWed0W1PJRyuSUDy+LhpoXy4vXbdZyZ6/X02mez/KZ
-        vEnNLH3WQuOdSXY/29mfbU8fPry3vX/wYLqdTe/tb9/b383PH8wOZrsP9+3L
-        xeqkWp4XF+uaEUP335OvUoMHHju5xWrK7XcNBDz/b5zcu92R0Qcx1L/u7MuD
-        OepNnDz46hbTJw81Li6pydnL49mMaAJohM743nhnbCdLHq9pafjpi7ydVzwH
-        T69ppopp95X1pCym9IYFHqBKLX74M9jBiWbw9U88f80z+DS//MjH75eEoyEk
-        afoJ35/7QVwWdbvOSv2z8yLhQXg2d2f5ebYu23BI7g/7q/7yfR3tR7Nl8zpv
-        W2KfYMbkc9AJH3/PNKcvstWqLPLZ0/B7+drQ8KN8mU1K4p5nVX2V1TOCTq3O
-        MxIe04KQxmhe59N1XbTXTBNq4xD44dM5hlKUYewwdWa+yKbzYgnR+9lA//T1
-        m5Mvj1+/efrkdRT9k2qxWre5YRNFJo44ftA/v+T/Adj3QZ5NBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b674e115-ca91-4ee7-bc7f-59cf1bbcc72e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
-      X-Ms-Correlation-Request-Id:
-      - 4c801b82-c133-4b77-a806-42c28b126865
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135040Z:4c801b82-c133-4b77-a806-42c28b126865
-      Date:
-      - Fri, 30 Oct 2015 13:50:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 7ac58a5d-0de8-4326-bfcc-906435adb4a3
-      X-Ms-Correlation-Request-Id:
-      - 7ac58a5d-0de8-4326-bfcc-906435adb4a3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135042Z:7ac58a5d-0de8-4326-bfcc-906435adb4a3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:41 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - fcec968a-8c13-4e74-89eb-d4baf00254d4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - f01b810a-4e98-4b46-93ce-9f2dd15d6a76
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135042Z:f01b810a-4e98-4b46-93ce-9f2dd15d6a76
-      Date:
-      - Fri, 30 Oct 2015 13:50:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - ab4e254b-b5a7-48a3-819f-20167cb477f5
-      X-Ms-Correlation-Request-Id:
-      - ab4e254b-b5a7-48a3-819f-20167cb477f5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135043Z:ab4e254b-b5a7-48a3-819f-20167cb477f5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Request-Id:
-      - c1e7fed6-d66e-4289-b145-66c36a67a80b
-      X-Ms-Correlation-Request-Id:
-      - c1e7fed6-d66e-4289-b145-66c36a67a80b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135043Z:c1e7fed6-d66e-4289-b145-66c36a67a80b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:42 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - e07f481c-2952-4f6e-bf86-20a18c9289fd
-      X-Ms-Correlation-Request-Id:
-      - e07f481c-2952-4f6e-bf86-20a18c9289fd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135043Z:e07f481c-2952-4f6e-bf86-20a18c9289fd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
-      X-Ms-Correlation-Request-Id:
-      - 59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135043Z:59df7f4b-03cf-4c27-a7a4-e4ce5dde639f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 23204060-f11e-4ec0-a735-0dc7cd1a7da9
-      X-Ms-Correlation-Request-Id:
-      - 23204060-f11e-4ec0-a735-0dc7cd1a7da9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:23204060-f11e-4ec0-a735-0dc7cd1a7da9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 86986549-991d-4da6-8bdc-97e80560bc11
-      X-Ms-Correlation-Request-Id:
-      - 86986549-991d-4da6-8bdc-97e80560bc11
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:86986549-991d-4da6-8bdc-97e80560bc11
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - bbb8a592-6f7d-4d3e-a262-75c72607b5c6
-      X-Ms-Correlation-Request-Id:
-      - bbb8a592-6f7d-4d3e-a262-75c72607b5c6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:bbb8a592-6f7d-4d3e-a262-75c72607b5c6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - e0fe3a32-acf7-40fc-aedb-12c8d4978e92
-      X-Ms-Correlation-Request-Id:
-      - e0fe3a32-acf7-40fc-aedb-12c8d4978e92
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:e0fe3a32-acf7-40fc-aedb-12c8d4978e92
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - b88d7f93-4010-4c56-b20f-14d3a7453729
-      X-Ms-Correlation-Request-Id:
-      - b88d7f93-4010-4c56-b20f-14d3a7453729
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:b88d7f93-4010-4c56-b20f-14d3a7453729
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - a041d918-39aa-4de5-92a1-b93bfe80a4ed
-      X-Ms-Correlation-Request-Id:
-      - a041d918-39aa-4de5-92a1-b93bfe80a4ed
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135044Z:a041d918-39aa-4de5-92a1-b93bfe80a4ed
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:43 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - ebaf521c-03a9-4293-ad98-a59a410a4d16
-      X-Ms-Correlation-Request-Id:
-      - ebaf521c-03a9-4293-ad98-a59a410a4d16
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135045Z:ebaf521c-03a9-4293-ad98-a59a410a4d16
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:44 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:47 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB271C:6793:2761259:563375B5
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 13:50:45 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6231-ATL
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 2ad315f718eb548c7b8416390773455fdad2e956
-      Expires:
-      - Fri, 30 Oct 2015 13:55:45 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
-      X-Ms-Correlation-Request-Id:
-      - c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135045Z:c159c8ce-c06c-42a8-bc16-1a8e2112bf7f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:45 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C1C:509B:353F7AB:563375B6
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 13:50:46 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1029-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 78b5248bd42f96810fc28f61c49f42476b769f7d
-      Expires:
-      - Fri, 30 Oct 2015 13:55:46 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - a3b44499-d877-404d-8205-bff52d7543f6
-      X-Ms-Correlation-Request-Id:
-      - a3b44499-d877-404d-8205-bff52d7543f6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135046Z:a3b44499-d877-404d-8205-bff52d7543f6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:45 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - C71B4C14:509A:33D9361:563375B6
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 13:50:46 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-jfk1031-JFK
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - bb05726da9e0ae80f4215cc5c22da2da4549e570
-      Expires:
-      - Fri, 30 Oct 2015 13:55:46 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 4da5f25c-91ec-441a-85af-419fdd3e751a
-      X-Ms-Correlation-Request-Id:
-      - 4da5f25c-91ec-441a-85af-419fdd3e751a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135046Z:4da5f25c-91ec-441a-85af-419fdd3e751a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:45 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 081fdc44-6da9-47c0-b164-7995bfcf6683
-      X-Ms-Correlation-Request-Id:
-      - 081fdc44-6da9-47c0-b164-7995bfcf6683
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135046Z:081fdc44-6da9-47c0-b164-7995bfcf6683
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:46 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4c546d80-67e6-4a74-8df0-747a1dcbae7c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - ef1c7afb-7358-4fdb-880c-bc37defe31d3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135047Z:ef1c7afb-7358-4fdb-880c-bc37defe31d3
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 545a181c-8582-458d-bab0-21856cc80dee
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - d011ccda-3b6a-46a8-aa90-37d7aa6c9bb5
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135047Z:d011ccda-3b6a-46a8-aa90-37d7aa6c9bb5
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 61f54201-55fc-4480-ab0b-94ad758e21f0
-      X-Ms-Correlation-Request-Id:
-      - 61f54201-55fc-4480-ab0b-94ad758e21f0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135047Z:61f54201-55fc-4480-ab0b-94ad758e21f0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:46 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - 30431b1f-cefd-4866-ab7d-10a94894a89b
-      X-Ms-Correlation-Request-Id:
-      - 30431b1f-cefd-4866-ab7d-10a94894a89b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135047Z:30431b1f-cefd-4866-ab7d-10a94894a89b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4cd8ccee-fd01-4c65-9ede-3acbd4f3582e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 16c64a28-3242-40c9-b094-e21a33486d76
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:16c64a28-3242-40c9-b094-e21a33486d76
-      Date:
-      - Fri, 30 Oct 2015 13:50:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 803a409c-ddff-4c23-b355-449159c05ab0
-      X-Ms-Correlation-Request-Id:
-      - 803a409c-ddff-4c23-b355-449159c05ab0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:803a409c-ddff-4c23-b355-449159c05ab0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - f972ca26-55f2-4546-9eb6-ae354d05740a
-      X-Ms-Correlation-Request-Id:
-      - f972ca26-55f2-4546-9eb6-ae354d05740a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:f972ca26-55f2-4546-9eb6-ae354d05740a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Request-Id:
-      - d8f7283f-dcf7-4f95-bb55-14730d40ec7c
-      X-Ms-Correlation-Request-Id:
-      - d8f7283f-dcf7-4f95-bb55-14730d40ec7c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:d8f7283f-dcf7-4f95-bb55-14730d40ec7c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:47 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 31ca7296-3253-4dcb-a522-df2c5b79d357
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 065f9f62-9cba-417e-8d95-ec0068789b4f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:065f9f62-9cba-417e-8d95-ec0068789b4f
-      Date:
-      - Fri, 30 Oct 2015 13:50:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 147f9a00-e9e9-43d2-a931-a01efdc50180
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - e4566485-5a88-4467-8e3f-64792d817e00
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135048Z:e4566485-5a88-4467-8e3f-64792d817e00
-      Date:
-      - Fri, 30 Oct 2015 13:50:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 58392b10-2837-4b45-b57d-aa1b6263d5a2
-      X-Ms-Correlation-Request-Id:
-      - 58392b10-2837-4b45-b57d-aa1b6263d5a2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135049Z:58392b10-2837-4b45-b57d-aa1b6263d5a2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:48 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 96ac4cb7-5c00-4349-9602-6647c9e4767a
-      X-Ms-Correlation-Request-Id:
-      - 96ac4cb7-5c00-4349-9602-6647c9e4767a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135049Z:96ac4cb7-5c00-4349-9602-6647c9e4767a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:49 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 7e1107b9-025e-4004-a0c4-44421112ba1e
-      X-Ms-Correlation-Request-Id:
-      - 7e1107b9-025e-4004-a0c4-44421112ba1e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135049Z:7e1107b9-025e-4004-a0c4-44421112ba1e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:49 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 2b83e7a2-b931-4015-b989-80734f48dc44
-      X-Ms-Correlation-Request-Id:
-      - 2b83e7a2-b931-4015-b989-80734f48dc44
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135049Z:2b83e7a2-b931-4015-b989-80734f48dc44
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:49 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - 0d7c2f36-a790-472d-b0cb-0a35b495bb9e
-      X-Ms-Correlation-Request-Id:
-      - 0d7c2f36-a790-472d-b0cb-0a35b495bb9e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135050Z:0d7c2f36-a790-472d-b0cb-0a35b495bb9e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 13:50:50 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 1719e474-58f7-4540-b675-ea41229c2f3f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - c9df3236-2e1d-4159-a6f8-df175cca693d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135050Z:c9df3236-2e1d-4159-a6f8-df175cca693d
-      Date:
-      - Fri, 30 Oct 2015 13:50:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 4e0604f2-5448-4803-8a75-55644af297e4
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 16bec0a7-7276-4c21-8a06-7ea62b390ad9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135050Z:16bec0a7-7276-4c21-8a06-7ea62b390ad9
-      Date:
-      - Fri, 30 Oct 2015 13:50:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tu/t
-        vNm99+j+Dv3vk52dRzs7H5nGv0R++T5+/BIGAUzfAkOliqXJR8tMoJ7M8/Nt
-        IsvM9Rmlpvcung0UbdbTaZ7Pcg8iHkfRs+V51fmO0AwJ6oNNhyDGKbP/4NH9
-        g/He/Xv37+/tdihEdDG/MpX07+8z3I/yd22+RKdAQUduR20p9kUxraumOm/H
-        Z9T4Yt4245/84mmRXSyrpi2mzeu8bQnrRjv1O+gT1oF/L4IOEfP9CbmRiPd2
-        dvY/PQiJKIwVxby6ymv0nN+d5VlZVlP61e/q1kiTtPgQpKEQ8jdOfsn/A/6g
-        cGNiBAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"043707df-d3a4-491d-974f-6cb82401deac"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b31019d6-6d04-40c9-91c7-36bac4f9e7fb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - d6602cb7-79bb-4f7b-b7c4-70de0756a599
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135051Z:d6602cb7-79bb-4f7b-b7c4-70de0756a599
-      Date:
-      - Fri, 30 Oct 2015 13:50:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PdvbvPdh5MDvfnt3L
-        9rf3H+7Oth8+2D/f/nQ6IVx2dmd5Nv19P9IX2+sVj/MW/eobZTXNMGa8lWdN
-        uzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJroe7e
-        waeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbnxcW6
-        ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++usXE
-        yUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7ynpS
-        FlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7pv0UY
-        EIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm9EW2
-        WpVFPnsafi9fG+p9lC+zSUkc86yqr7J6RtCp1XlWNrlpQUhjKK/z6bou2mum
-        BrVxCPyQKRzDx3tX6WoHqBPyRTadF0sI2s8G4t8+fbb98tWXT6OIn1SL1brN
-        DWsoJvRWF2X8oH9+yf8DYmP4yiYHAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8268c9b5-a9f8-4ed2-95f0-4c87d493bee0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 62f167e9-14ed-4ad0-bc43-9c9843d8a1a8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135051Z:62f167e9-14ed-4ad0-bc43-9c9843d8a1a8
-      Date:
-      - Fri, 30 Oct 2015 13:50:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - ed5091d3-dc80-462f-a4b9-d490790863c9
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 3fec0f0d-f521-40f4-8d0f-4536ca460c4d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135051Z:3fec0f0d-f521-40f4-8d0f-4536ca460c4d
-      Date:
-      - Fri, 30 Oct 2015 13:50:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H93U92dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6smraC+p6+2l+6bqN0s57Hc8G
-        +jXr6TTPZ/nMQcTj6He2PK863xGmIfl8sOkQxDhx9h88uv/p+ODe7qc7D+53
-        iESkMb8yofTv7zPcjyZV1T4tsoslkaWYAg8dM4122VRl/npa5/mymVftk7Ka
-        fFUX1OSjeduumkd3707n+fmqrmb3d/d2xhP6fjyt6nx8VSxn1VUzXubtXXQw
-        cx1sr+gn6D/bPp+e35tN8+n2+eRgtr3/8Pz+9sPZwXR7sns/n03Pzx/s7E/v
-        +tM1vs0b48YiPJ4sVkwG5Y38XUtfEIExTJ1lHS19axjki2JaV0113o7PqPHF
-        vG3GP/mFR6LXedvSDDUMmWDjhxKzz0QO/HsxzxDjvD/TbGaYh/t7u/f2AoYR
-        WsUw//I1us3vkgTndVYWPwj6uTXGpAR8CNJwuNeX1VVe4+387izPyrKa0q9f
-        t2MfgjSU6fuNk1/y/wAqG7qdsgUAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"0bc0c07c-1d50-43c4-b8bb-cf9238056209"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5720279b-ca8e-4e7c-bdf7-358f68fa9608
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - cba58a7f-e921-4ed3-9de3-415047b16619
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135051Z:cba58a7f-e921-4ed3-9de3-415047b16619
-      Date:
-      - Fri, 30 Oct 2015 13:50:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/amUx3pjsP
-        ptu7s/s72/v3pvvbk4PJZHt6/nDv3sHO/U/3dh7+vh/pi+31ikd7i671jbKa
-        Zhg23sqzpl2bL2gcq7xuC2r5KGVayoeXRUPNi+XF6zZrubPX6+k0z2f5TN6k
-        ZjQgIc5aCLyb5bv3JruT7YOD/Qfb+w8f0Bge7N/fvp9PpueTnXuTycMD+3Kx
-        OqmW58XFumbE0P335KvU4IHHzmyxmnL7XQMBz//rZvZud1j0QQzvrzv18mCC
-        erMmD766xdzJQ42LS2py9vJ4NqNBANpHuzvjvfHOWJnUPF7T0jDTF3k7r3gC
-        nl7TNBXT7ivrSVlM6Q0LPECVWvyQp6+DEE3fSzN9T/PLj3zkfkk4FMKQ5p6Q
-        /TkewWVRt+us1D/9twgDwrC5O8vPs3XZhoNxf9hf9Zfv6zg/mi2b13nbEtcE
-        EyWf15eEDn38PdOcvshWq7LIZ0/D7+VrQ72P8mU2KYlpnlX1VVbPCDq1Os/K
-        JjctCGkM5XU+XddFe83UoDYOgR8yhWP4RPnEjlHn5ItsOi+WELefDdy/ffps
-        ++WrL59GcT+pFqt1mxvuUEziWOMH/fNL/h9LzfwgOAcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 34f95b5e-70c9-484e-b3d2-cdedfcff004a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - b216066c-ff03-4703-bb9b-ce6f2a0c2346
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135052Z:b216066c-ff03-4703-bb9b-ce6f2a0c2346
-      Date:
-      - Fri, 30 Oct 2015 13:50:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - cc425656-96f8-4ee4-ab7c-de47e01db9c5
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - bf0c1748-8a0f-4ad4-93e3-c031304e35f9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135052Z:bf0c1748-8a0f-4ad4-93e3-c031304e35f9
-      Date:
-      - Fri, 30 Oct 2015 13:50:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9vU92dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4E6nefnTV5f5vWu6zVKOu9tPBvI
-        16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQ47TZ33t0//744cH9h5/uP+zQ
-        iChjfmU66d/fZ7gf5e/anKaApoGg6sjtqC3NviimddVU5+34jBpfzNtm/JNf
-        PC2yi2XVtMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcQ8dPxzv7BfoeGwllR
-        xKurvEbH+d1ZnpVlNaVf/Z5ujTNJhg9BGgodf+Pkl/w/d4Ym904EAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ec36b00e-1d84-4807-8c45-a59d8f936e11"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 027bfafa-474f-49b9-8a26-e74b460ed2a7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 3a12f67a-dccd-4cec-9b60-09d6e011a68c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135052Z:3a12f67a-dccd-4cec-9b60-09d6e011a68c
-      Date:
-      - Fri, 30 Oct 2015 13:50:51 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9KJ/e+3Sy
-        s5Nv784O9rf3D3YebB9M9+9vZ/cfzg7OH977NN/d/X0/0hfb6xUP9hY96xtl
-        Nc0wbLyVZ027Nl/QMFZ53RbU8lHKpJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
-        Sc0scdZC4Em+O9ub7U+2s3t70+396cHu9uR8Z7a9e+/Bp/cePsj2ZpPcvlys
-        TqrleXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig
-        3qzJg69uMXfyUOPikpqcvTyezYgggPbR7s4Y/90fbFoaZvoib+cVT8DTa5qm
-        Ytp5hWaF6EXfBxjSFz/sWbss6nadlfpn8BrhQDg2d2f5ebYu2498TH+J+8P+
-        qr98X0f60WzZvM7blogN4tmByufgCnz8PdOcvshWq7LIZ0/D7+XrX6LNPsqX
-        2aQkWj+r6qusnhF0anWelU1uWhDSGMvrfLqui/aa6UFtHAI/bBrHEKJ2Zz+h
-        7+8qae0YdVK+yKbzYgku/eHjrl8b/lBUApk2WOMH/fNL/h9nVwHSbgYAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 6ec6f168-4364-45ec-b83a-67067ea3ed0d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 409767aa-bd5b-49f3-87f5-1e98430de176
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135052Z:409767aa-bd5b-49f3-87f5-1e98430de176
-      Date:
-      - Fri, 30 Oct 2015 13:50:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9vU92dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6+uql6y1KMu8tPBvI1qyn0zyf
-        5TMHEY8j29nyvOp8RwiGVPPBpkMQ4zTZ33t0//744cH9h5/uP+zQhihifmX6
-        6N/fZ7gf5e/anEhP5CeoOnI7akurL4ppXTXVeTs+o8YX87YZ/+QXT4vsYlk1
-        bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyA1E/HS8s3+w36GhcFQM8S9fo9f8
-        LvFyXmdl8YOgm1sjTOLgQ5CGw72+rK7yGm/nd2d5VpbVlH79uh37EKShzN5v
-        nPyS/wf7Gka4vAQAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"26a13215-44d2-4d13-b683-a83fea9e083f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a04951e2-98a6-4634-bb6e-cc1a387a1874
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 0d718901-a6d2-4afe-8b2a-a3e286cfa8f0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135052Z:0d718901-a6d2-4afe-8b2a-a3e286cfa8f0
-      Date:
-      - Fri, 30 Oct 2015 13:50:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+36092m2e29v9/72/v5s
-        b5v6vbc9+fTg3nZ2cO88zx7mO/Tz9/1IX2yvVzy4W/Sob5TVNMNw8VaeNe3a
-        fEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWwNIRP
-        Zw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ/ffk
-        q9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlDjYtL
-        anL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1hgQeo
-        Uosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2d2f5
-        ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW+exp
-        +L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTGIfDD
-        pnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/8lQWOCQcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0b6d824e-58ef-4c18-8de7-299a35e387e1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - bd7030c8-508a-4235-a44a-8ac5f5975454
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135054Z:bd7030c8-508a-4235-a44a-8ac5f5975454
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - cd6ed12a-24b3-4863-aed5-4314790e513f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - e36bfbec-3c2e-440e-81de-fef4fff399e7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135054Z:e36bfbec-3c2e-440e-81de-fef4fff399e7
-      Date:
-      - Fri, 30 Oct 2015 13:50:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9/U92dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6xdlP7LnuojTzXsOzgW7NejrN
-        81k+cxDxOLqdLc+rzneEYUg2H2w6BDFOlP29R/fvjx8e3H/46f7DDnGIJOZX
-        JpD+/X2G+1H+rs2J9kR/gqojt6N2xCqmddVU5+34jBpfzNtm/JNfPC2yi2XV
-        tMW0eZ23LWHdaKd+B33COvDvRdAhYr4/ITcQ8dPxzv7BfoeGwlJRxKurvEbH
-        +d1ZnpVlNaVf/Z5ujTOJhA9BGgodf+Pkl/w/1lFaqkcEAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"86ae9cbe-172e-4618-a950-a33604937de9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3332ad0a-cb09-4d77-b899-702001ffd632
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - 8f25e893-de24-4097-af10-3c06dadbe464
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135054Z:8f25e893-de24-4097-af10-3c06dadbe464
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19Pzr4NMsfTif59u6D
-        PULj092D7ezh/Z3t7N69T3f2H957MMsf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
-        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
-        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
-        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
-        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
-        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
-        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
-        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
-        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
-        P1R9PzgPBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4b015884-271d-4053-8e06-2e611591de8e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - cc6ca31a-6bf9-49ca-a8f3-da1d6faa4ef8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135054Z:cc6ca31a-6bf9-49ca-a8f3-da1d6faa4ef8
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - ebcdecec-d7b6-4dd4-bbf5-802353a90c0d
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 0a77f22d-42bf-4a5a-961e-b7316dc1ce69
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135054Z:0a77f22d-42bf-4a5a-961e-b7316dc1ce69
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        93be7N57dH/n0f39T3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
-        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
-        GKfN/t6j+/fHB3sPP33w8NMOjYgy5lemE/2tIO3oLG1mWZsRXm9/RBn+QVC7
-        lNlzvf78ogx+fJ/hfpS/a3MSWxJdgqojt6O2FPuimNZVU5234zNqfDFvm/FP
-        fvG0yC6WVdMW0+Z13raEdaOd+h30CevAvxdBh4j5/oTcTMT9+/d2HoRE7LOS
-        xby6ymv0nN+d5VlZVlP61e/q1kiTOvUhSEMh5G+c/JL/B8HR3/ZIBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"15e05a07-0ca2-435c-8eec-b61e5da24da7"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4203e8db-6094-4cc4-a29d-354e1208768b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 49eb0f4d-acc1-46a3-9cb0-852664f1c8f4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135055Z:49eb0f4d-acc1-46a3-9cb0-852664f1c8f4
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR7v385372c6D
-        7Z1ptre9f+/+dPsgz6fbk0938/uzjDDKHvy+H+mL7fWKB3uLnvWNsppmGDbe
-        yrOmXZsvaBirvG4LavkoZVLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljhr
-        IfDew8ne7N7edPvBg3x/e/98mm9P9j79dPvBJDvIHpwffLq3u2NfLlYn1fK8
-        uFjXjBi6/558lRo88NiJLVZTbr9rIOD5f93M3u0Oiz6I4f11p14eTFBv1uTB
-        V7eYO3mocXFJTc5eHs9mRBBA+2h3Z4z/9gebloaZvsjbecUT8PSapqmYdl9Z
-        T8piSm9Y4AGq1OKHPX0djGj6vjj7CX139yMfuV8SDoUwpKknZH+uR3BZ1O06
-        K/XP4DXCgXBs7s7y82xdtuFw3B/2V/3l+zrSj2bL5nXetsQ3wVTJ5/Ul4UMf
-        f880py+y1aos8tnT8Hv52tDvo3yZTUpim2dVfZXVM4JOrc6zsslNC0IaY3md
-        T9d10V4zPaiNQ+CHTeMYQtSuxyl2jDopX2TTebGEwP3wcdevDX8oKtSijzV+
-        0D+/5P8B4BsgKTkHAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b12033a1-9310-4a08-b935-660ecf1b0abf
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 2218fb07-7bf0-43d4-ba9e-d7c41e65c4b9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135055Z:2218fb07-7bf0-43d4-ba9e-d7c41e65c4b9
-      Date:
-      - Fri, 30 Oct 2015 13:50:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 64153641-548d-4a83-a077-817cbdc1a892
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 576caf5a-9256-440d-94c5-9b4824f1650e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135055Z:576caf5a-9256-440d-94c5-9b4824f1650e
-      Date:
-      - Fri, 30 Oct 2015 13:50:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9+5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
-        8pmDiMdR7mx5XnW+IwRCwvlg0yGIcbLsP3h0/9Pxwb3dT3cedMlDRDG/Mon0
-        7+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAmH83b
-        dtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6HbbxzudjZ
-        zrPdB3m2t7+dzbLZ9v7+9N52dnDwcHtnZ//e+WRv9/7D8z3uYPsnv9gZ36b1
-        uLG4jieLFVNAGaI/vTpM+u69pnVoSt9/OjdP5cP9vd17e8FUylCimFdXeY2e
-        87uzPCvLakq/+l3dGmmSTR+CNBR++Y2TX/L/ABdFxPzQBAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ac03b5da-e835-4650-87ba-5953e106ba33"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cedd7e86-4a61-47a5-9966-e748981f6d22
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Correlation-Request-Id:
-      - 27efea35-7029-4858-b9cf-a8f55c865a9a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135056Z:27efea35-7029-4858-b9cf-a8f55c865a9a
-      Date:
-      - Fri, 30 Oct 2015 13:50:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1E23bk3uT/LtvOD
-        e/e39z+9v7N98GCSbd9/eP9evrvz6SS7d+/3/UhfbK9XPMRbdKpvlNU0w4jx
-        Vp417dp8QSNY5XVbUMtHKRNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s3RZ
-        C23vHzyc7u482Cc6zna39+9PJtsP9w4ebE+yB+effjrdf0j0tC8Xq5NqeV5c
-        rGtGDN1/T75KDR547HQWqym33zUQ8Py/aVLvdkdEH8RQ/rqzLg/mpjdh8uCr
-        W0ybPNS4uKQmZy+PZzOiBaB9tLszxn/3B5uWho++yNt5xbR/ek0zVEw7r9CE
-        EKno+wBD+uKHPWGXRd2us1L/1On6yRenb+4SCoRic/c1/9ze/cjH9JeEwymr
-        bPYkK7PlNK+fZNO3+XKmZHtZVSVoZ3lXns6wCcQPe+A+yjrs50/uTvrI39UB
-        4Y+QCEQG/8/vD9PkbDmp1svZi6x9tS6ZM/8/Qo8iRPzuq6cvt3/yi52NZHB/
-        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
-        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
-        OkpvnQ4jeIqKUtyRlilG//yS/wduCFLLtQcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 0e787c68-b7e6-4f5a-9887-d9ca4c41b2c2
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 45d2f604-a5d5-44d7-9b2f-487ec5814540
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135056Z:45d2f604-a5d5-44d7-9b2f-487ec5814540
-      Date:
-      - Fri, 30 Oct 2015 13:50:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzee3R/59H9Tz/Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
-        5TMHEY+j3NnyvOp8RwiEhPPBpkMQ42TZf/Do/oPxg51PPz349KBDHiKK+ZVJ
-        pH9/n+F+NKmq9mmRXSyrpi2mwEPHTKNdNlWZv57Web5s5lX7pKwmX9UFNflo
-        3rar5tHdu80qn+42bVXT1O6OJ9RgPK3qfHxVLGfVVTNe5u1d9DBzPWzjncvF
-        7vbO5H62l+2fb+/OPn2wvb87y7ez3b3p9r3d2c6D3U8f7n26R4Slxts/+cXu
-        +Datx43FdTxZrJgCyhD96dVh0nfvNa1DU/r+07l5Kj99uPvpp/eDqZShRDGv
-        rvIaPed3Z3lWltWUfvW7ujXSJJs+BGko/PIbJ7/k/wHy+oEj0AQAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"79a4e4b1-b793-46f8-a809-201f55afc502"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f4ec7fac-b415-4022-b06d-24c1a1ea3c18
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 23c36bf9-1b7a-429c-88a1-a5073d76ab01
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135056Z:23c36bf9-1b7a-429c-88a1-a5073d76ab01
-      Date:
-      - Fri, 30 Oct 2015 13:50:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9GDh9l+vj/Z3Z48
-        eHhve/9TQik72Hm4vbeze37/fnY+vb+z9/t+pC+21yse4i061TfKapphxHgr
-        z5p2bb6gEazyui2o5aOUCSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZuqyF
-        tg92Zvd37t/f297bO9/d3r//ab49me2dbz+c7J7v5vf2z8/zHftysTqplufF
-        xbpmxND99+Sr1OCBx05nsZpyeyWePP9vmtS73RHRBzGUv+6sy4O56U2YPPjq
-        FtMmDzUuLqnJ2cvj2YxoAWgf7e6M8d/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
-        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
-        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
-        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sZkM7g/7
-        uf5iKPTRbNm8ztuW5BC0sIOXz+tLwoA+/p5pTl9kq1VZ5LOn4ffyteHFj/Jl
-        NilJDJ9V9VVWzwg6tTrPyiY3LZTbv8im82IJ8Xddf3P0/vKLl1+9Of3JL15H
-        6a3TYQRPUVGKO9IyxeifX/L/AKug0K61BwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 61808bd8-2a44-43f8-8ffe-59331ac215d0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - a88dd0f4-4d70-4596-9752-bd33adf25a87
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135056Z:a88dd0f4-4d70-4596-9752-bd33adf25a87
-      Date:
-      - Fri, 30 Oct 2015 13:50:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        93be7N57dH/n0f1PP9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOrr
-        rMyb86qe5l+9dt1Gaee9jmcD/Zr1dJrns3zmIOJx9Dtbnled7wjTkHw+2HQI
-        Ypw4+w+IOOP793fuHewfdIhEpDG/MqH07+8z3I8mVdU+LbKLZdW0xRR46Jhp
-        tMumKvPX0zrPl828ap+U1eSruqAmH83bdtU8unt3eV1fPNw92B9P6LvxtKrz
-        8VWxnFVXzXiZt3cBfOaAbzeG9tvT2flOdv7gIeG/P9venz24t/1wOr2/fXD/
-        /u5k9+Fsmu88uOtP1fg2b4wbi+x4slgxCZQv8nctfUHExRB1hnWk9K1hji+K
-        aV011Xk7PqPGF/O2Gf/kFx55XudtS7PTMGSCjR9KyD4DOfDvxThDTPP+DLOR
-        WT7d3SPShRIltIpiXl3lNXrO787yrCyrKf3qd3VrpEkH+BCkoRDyN05+yf8D
-        JC9LKP0EAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"10151287-e86a-4dca-869a-8ebd68e2834e"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b81ab530-bf34-42c4-bcc4-6d45f380b306
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 2c943a95-6076-4e74-8c69-7a18ee3dedef
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135057Z:2c943a95-6076-4e74-8c69-7a18ee3dedef
-      Date:
-      - Fri, 30 Oct 2015 13:50:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHdn9/7u3sGD7fzg
-        02x7fzbNtg8+fUj/5JPZpwf53sG9/fz3/UhfbK9XPMxb9KxvlNU0w4DxVp41
-        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
-        2V4+vU9Iz+7dP6Ax7M+2s93d3e3pbn7vwb2dTycPJ3v25WJ1Ui3Pi4t1zYih
-        ++/JV6nBA4+d0mI15fa7BgKe/xfN6d3ugOiDGMZfd9LlwdT05ksefHWLWZOH
-        GheX1OTs5fFsRqQANEJnvDfeGX862LQ0bPRF3s4rJv3Ta5qgYtp9ZT0piym9
-        YYEHqFKLH97EdXChiXttJ+6r12cvP/Ix+yXhOAg9mnfC9GcN/ZN5fr79sq5m
-        G8dwWdTtOiv1T/8twoAwbO7O8vNsXbbhYNwf9lf95fs6zo9my+Z13rbEMsEs
-        yef1JaFDH3/PNKcvstWqLPLZ0/B7+dpQ76N8mU1K4phnVX2V1TOCTq3Os7LJ
-        TQtCGkN5nU/XddFeMzWojUPgm6NwtVit2/wnv2g2kjiGELU7+wl9f1dJa8eo
-        c/JFNp0XS8jazwLug8ytSBnGUCRC1jYI4wf980v+H9qMLAEjBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTI3MTAsIm5iZiI6MTQ0NjIxMjcxMCwiZXhwIjoxNDQ2MjE2NjEwLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.WY0mNzu-tPfV9wUCd2bRjKJyh6AmTRTu9U615XQIVyXS8ud51Kbczmr9olW0vmEv-aewUM0gBZMFDk-izEXXgVgqOuFpp7C_cz-LUEdGNf3sB3zRs_iqkWY3jnL3R9bpjpq_Cc3GGBBzkl4cXGsrwTL-9KdKKPS1B3u2o7zI9tZhruKPDSfFv9ZTKtshh-gFgfTs65xqPwdROnst14WgX8Sz1wInB4326XZCt6146YB3BlqxQK7JoazBLpBhdmAWtw6DCWBYl-_vCAzL8DXaw1tsgw1pHmx9zvTkhCcwXg6itJv6dbYP52RXgFvOWRiXbcaH8ZPmI4S_XWaG3_IBPg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e7a7e3b9-0acf-4c77-bd3e-a5519a899ff8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 3f1ae70c-89aa-46ec-952f-933f29b0f437
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T135057Z:3f1ae70c-89aa-46ec-952f-933f29b0f437
-      Date:
-      - Fri, 30 Oct 2015 13:50:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 13:50:59 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:44:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/discover/with_the_same_name_backup_name_and_secondary_backup_name.yml
@@ -1,127 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.windows.net/0123456789ABCDEFGHIJ0123456789AB/oauth2/token
-    body:
-      encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=0123456789ABCDEFGHIJ&client_secret=ABCDEFGHIJKLMNO1234567890abcdefghijklmno%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Length:
-      - '188'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/8.5
-      X-Ms-Request-Id:
-      - 75395283-d94b-4803-8ba2-81f9e5144e6b
-      Client-Request-Id:
-      - 687bd93f-29a9-4696-9c0b-205f7f4db39d
-      X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_14
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - flight-uxoptin=true; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=productiona; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Fri, 30 Oct 2015 14:10:30 GMT
-      Content-Length:
-      - '1218'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1446217832","not_before":"1446213932","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ"}'
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:33 GMT
-- request:
     method: get
-    uri: https://management.azure.com/subscriptions?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
-      X-Ms-Request-Id:
-      - a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
-      X-Ms-Correlation-Request-Id:
-      - a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141032Z:a0fb5c5b-8b0e-4ae3-9fc9-1d8e0c033b40
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9z/aPSR
-        /9IZwNzyvVnRrMrs+kW2IBQ++smiWWdl+rpdz4oq/apsi0XW5ulV0c7TL14/
-        fUEvNC19Qk2fFk02KfMZPvL6flmVxbTIm48e/eKPymqa8WdlNs0X+bJlxF6u
-        J9Tk99/b2d3f3nm4vbNLEH7Rumoz/ha9+N/9kl/y/V/y/wC6npQ5IwEAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/providers?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -131,274 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
-      X-Ms-Request-Id:
-      - d7d26ffa-ecae-419c-a5ef-b411b020cc3c
-      X-Ms-Correlation-Request-Id:
-      - d7d26ffa-ecae-419c-a5ef-b411b020cc3c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141032Z:d7d26ffa-ecae-419c-a5ef-b411b020cc3c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRMlvkzSqb0l8ffVFM
-        66qpztvx8dNvX0/qYvbtPCvb+eu8viyoxeijOm+qdT3N31yv8obf9z8hEI00
-        bahtWU2ztqiWaPfRd/OmTb96/dH3Rx9lq+In87ox3+zt7O5v7+zS/z76/i8Z
-        9QBOq+V5cbGuGdQ3BrVa5QLxm0M0u8iX7TcILps169Wqqttp1nyD9KxzwPzm
-        4JXVxTcHLFtWy+tFtW7otTWx0teFzLAHOHtVfJEtabIWNF0E3scAgHo4ERrg
-        aGoaYHK8bto6K4ssPc0aAHIfvK7W7TyXT0+oF/oUOI8+Qsvgt3SPfn9B8zFP
-        g4YMIfzIjNy0P13XxMT0J39h/2LAx02R0e8MBXiYD76TrbKlwVf+wNv0x5M6
-        +0FRCuaDxN3b3t0n4hJpOyQibVLMsjZXPfGCCE8wfXK9N8jpPJ++9eAdX2ZF
-        mU2KsmivvxHY3zRQkatneT6bZNO3HwqNUTTAXuW/aF3U+exDgRKHxJXeDZAY
-        1pA0rXSSCKTfHaD0EKBOstWq27vwLLM2uFF+Y04MJaDD9/xWjLEZiG3GgPpC
-        gEb0h8AMugn+CORC+1Sxjcu7+xRt6QN0lJ4tZ9w3t7R/mZ7k7+gk3N/euUcq
-        bXtV55dFfkUveR9O8hZgvE+ycjUnSJivHulXZzPqr2gLmpsfTQD/ZXqSv392
-        J+CC9ONVdv0j2utfpif5+2eX9rN8VVbXMPhtvliVNBPdaXj//od7I9K/h5o1
-        8DZ2wt0MaGAialUXP+Be6G0fGfTRQ6+uyvy4aYqLJQhyWxwfEDrUVP741P+D
-        /tfBfn97dyfyIcPofUj/cx/yOCP4Ps3PiyWpLqD0/3Z8p2VG1J0ezxaEMuSh
-        rXp+7BDWP1REiU0XBaEKDG6HHvqhpvLHDxVXwu7tbbHUGKAP5L0FE7hSU/mD
-        wfIfQ0NjisQ6XlVlMb1+byYOexkG/N7SfAvAdXVZzPL6y69DMguZCaMfUjfc
-        0aAWqxYMnF7ycQHoHnaZbX08nVbr/rjVzqkVwg9juNgiDdtH/iA0iRus5Gbb
-        BYaxpOCx3ziMu/V6OamqHqv/f3Y8Qfbm/5ujIhwG0O+hccs+uJe4HDzJ2il8
-        LR8HAOphNUFDQ2Z6IUAsJJ8S1v3mSMyfRkjX8fykhQUYNGWYOi/BfDpnkMFg
-        /uhTaYLO6Q/7hQHAH4SoODAKV9rIpDpczN+ArH8MzcZDmg1qKX+wauI/SIHT
-        35in4pI8RDddNFkd4jtih4Tf2ONGQHd/0bpqsy48GY2lOwggRNHffjSRICsT
-        dkCciovjZVZet8UUtPWpDzi9+cgGBAoY0yiI3kO4HBAuxDrCM8pPbGYJQUJv
-        oJ+7lDXLnmdv8yFJfs+ON/bVkCNKec+fg65gBtqsWBLEn5te75bkib/OmjfV
-        25xgf/M4OHgh7FsBvJFdLMS7JLdijKjFuuxN4jfTne3kmwDPHQxJ5/Lii4zz
-        gT4GANzDaZGtKHOPpj5CoiVo6rZeZnVLM32HGuhng5NJKp9mGmh1+njvcQ9C
-        ArudVIvFelkIlJd1fp7X+ZIo8IGg1yvSGfk3ApzBD03ND95kpUnAgx4+GgDV
-        Q0xfoaY+Cka46GMzLz0zxF/Yv9gs+LaEIejv8qaxFQwsMETyB96gPxiS3zhK
-        D7L79D/HvxvpcpJRZp5A+2MHoB41XuWzPrdGsO/h6Cwh/4FxOdoIAPsnf8nN
-        MOLgN1JmHWrIH3iF/uj4BfxziOY9w+0+sO/RpwZtsdmKnPmDG+pf0VkgroQW
-        oabyB9Jf8gdNDv3PzU/woSTI/I9o/mj2OrNBk/b1VnwIk59FtGgW30/hfEO4
-        xHBhhj3hcM0lKr42WoM93F3kbV1MXRfdoSuPG25inhbuCT4CKwa/McMzz/Gn
-        /cbKzQwLLGs+kP5CmbJ/idDgffsHGtAfHQmKy4T7VEEYtEQStDfzB7+pf0VJ
-        TYxE/9tEXXr1Ylk15O++ztuW7GuPvEDEo4oSTohgsOOv5SNLCcbU/tUZPX/J
-        bwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSGipf5gxvqXzeQ
-        lwk8YAFmkAqf+Hi9Nx2UQDsvSvquQ36DIRMDYwl+G5oLQT34iIfGv0l7OzX8
-        hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIYTosqje7my9mq
-        KshlJ8g/otatqXWX1n0uCnr5R1R7H6pNCW61mFGq8ke020g7wlDcE/o8Emz6
-        tPpg2Hd1ovTPH2JXljP075/DrlWg9a+fS0R8GdHPvkl0buOPf1AHdrzfKNr5
-        7CJfVrONVv0GoAx2wLOQhWMK7VfrFrrB7x2QevjI/ICOPYygB4wasSrAfMBf
-        Eq72N9ZrUC30O/0mGssblMIIPwr+kFesWmNY9i9RXejL/oEG9MfX0WMGGfHk
-        HB7mb4C2fwAOYZjupVuvW0oOIkEkuJrX6Evz1cDcSSrLxDc8kfwHOYvBH1jm
-        oSmmCe7ME7P7UztZG5j+ZwsDj1PuNmXVl2amk7IHkxekNh/wlzzN+tuP+IW/
-        +qHN1t26Ih+GXvzRnMnfAG3/ABzC8P+Vc3ZjviOKD3VE//s6HX0w+MuibtdZ
-        +QUlOmnppAtOaK0sxlOE6TIf8JfMKvrbj3iOv4pOwu15jv7n/hhkwCmNn21K
-        0Zu1r9l/rJfoOvXXhG/+GBxShxd/vme3+HfLgaZj8zc6sn8ADqH0AexJ80L/
-        u928iOoZ1nEGHfpYf/vRtCjtzZDNa/Sl+eobmpbeZHQ7pO9lCMFHiqr7jaeM
-        R8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB/dGZbUd7bew+4CbokT7l3y29
-        DZLmb4C2fwAOof+zNBk0vHgEGoV0e2VJ/3N/DGpO/89vCIHbxK4v8vaqqrEG
-        HCIQiV2VWfWNLo4yOcpAPKeYX/MBf+kYj6Yp5M3uLNJHDCP8KPhDXrFsybDs
-        X8KX6Mv+gQb0x/8HmDQ6meaPTQxEa//57Gz1o6n5f9nUvI8LFoIM/hiEf5G1
-        +VV2/Xq9WtFo8tlTWuCekhD/rHVIM/leqjIEG/xB/3N/aIfc5Ua19bqtapol
-        etHHDB32cKW0KJoeT6fVmhYT6BUfYeEJFQVmJbCV+YC/ZJbW3362ZOMm2fj/
-        vGzQ/3a3J3mLrtwn9g+deJr2zuz9bIsOJ/qUm5RF3j/ZF/YV/DHYcYct70J5
-        R4RWJolZ0M0D/SEzG3wkuhTzaP/Ay/QHPjMszS+CPcwHjnPQLPjAtqVP+XfL
-        LaZj8zc6sn8AjqCkv7HUdJnJfmQtAwOxfwUcHyU8kZf+937kVRd7OPL5pnv6
-        xuEL2J/FAUgHHwz2/bMboeTwHzHAs6LpeZ8fBrFY0Pi/WZBVc/azAPTnzuze
-        fokr89QnJX26qBqdQB/rb6wdWPb504iGCD5ihRB+JK2s5mBY9i/uRXUdvwuF
-        Zj4QNYkm9g+8TX84Lajfug8sFPr0Zi3F07B7n9rKH/S/3e1VTS5afkVEJ5J3
-        CKhxlkkK0Is/ot8H0O9u/q7NlwLxR6T8MFKSff9a6VwMhH6n3yLECj5i7MOP
-        pJUlIsOyf3EvSkF+F8QwHwgV0cT+gbfpD0dB/dZ9YKHQpzeTlLQn/Q/a82bq
-        iWEdttwyGB6z/vYj4inxXk+zMiee+3lPMhLZDxFhS8cfaUUZrFDxmyFp+PmP
-        6PpN0XUpGeezZZvX5+SZ/oiy3xRlw89/ROkPp7SjVki5bxj6XSJPPBQUkjFl
-        9bcfTdEQES8Xr4sf/IjJiWJfl4LrJpLkkAHxuPW3HxFwiICr9aQsmjnBo7ft
-        x4ALnGTs+tuPiBgSkdCOq8CvA547iOe+nmZtdlItl/kUA/GRAOweWlNpSl1/
-        kS1JOvozC8phQobwPAhRI8Q6XThoP2uQnYF5lTfrsh94fXBXvPLygii+Yb3l
-        fXvhfoZn8Vk2pVw3OvFxAbgedjPbvJ++tlj1JAoiIF/obyyz0iiQRIZgXwuE
-        oyPZ/GH4ssgferB/AB79gc+MyPKLkD75YICCuztEQWrNf+w89P8Abe0fD+gP
-        S2jzIf2v/yGSyeGH+9u7e7EP0XX3w+GEQDAjXzsTFZkL+chOBkjp/upMDX/J
-        bwUg+OsQqswLurZ/4GX6A5/JnOiLN0wSUYT+dxuifM0EkxAgwF4+slQA5u6v
-        /5fThBWLJ+436JgofOJj+l+HO/kT+p/5cLDz4x+s6/yDMWD5oKb442dBNGPY
-        O3a6fk0jWWA6/t+JKXGimKcuj/9cochIDpue59lbiI4/CiDXGxdmAG3Naiy9
-        449OBIXlNjpQ1aqED2HTAe3ghDC/PiDnJFCLiJNwA2SGvZlkx8usvCYlD8jU
-        h8UCwHp4ZV+PZsoc3lwSWgOg75r5eU0y8nUn6b067KzO/xC7ukuebJtRXqjv
-        wf5wer1LkVH7OmveVG8pVf2zgIODF8L+cIBfSzJu04OF+zUhMszNMsesTdD9
-        ngGwh4uZQmrrY/JNzIwBffe8qPOrrCxfrUtC4pvvyMELYX84wP9PsgC1kayv
-        3ydA9bAg9+Dm8E0niD7uOJT8xbB7R+b1gIJ1D2lCuYPAWdV+ez0Brj9LXXKn
-        g3R6Q47r82xCgH28AK2HKVGnh2bHyVX0GG+4xN5vkQHo78z5xpHGJ/YPvDg4
-        zPvbez470CA7+OZLWheolgty3f8/hTd1916CEUI0fh39D85JH7yD+DWgbwTo
-        VEUXtiEYfay/MelAJ/rd/BYldW+mhMRoYv/A27elN49gQByq6Rrc8vQJQfYH
-        CWi9YcOFmmSNtfj0TjBkICWD60gwf2H/wkCkGf+mg+yN2qUj0Sz4wLalT02c
-        erakzAL9zd/pX0MEogj0gJrSH/Qb/S/ONp3hQmX+/33IhO0AO/N4eAT/Hxwo
-        D3VIAhbks77KL8hjlaHTyz5VALpHpxm/1SPSRVlNsnITai5eRWKNUCPEOrDb
-        avU8v8xLwexnpw/2AaSDTV7AN9IXYgHp6lU+rRakbkiwGNDPRm+XxEQEPzc9
-        unk9W55X9YJ/JTDffM8XOYU+1PPrpnqV/6I1iQW98813Q3JGvfCbHw6eOxgQ
-        jGv6nOL357cL4ctps6qrn6b1EzQP8OpkHSHxRg/w76wuxKzhb/sHNAv9IfrG
-        qAJuLB9ZpcOQwxZ41zXgv/hzbgrtYjAI3kL39Btb6i9eP3vDKNAH5k/9PvhT
-        4fAHHbycUkPL4AOLx+B00f92t7NyNQd0+Qgz2PnoXv8jTC1Z/+KSeNE4AZ3v
-        Ih9O8rYDQqAyhwzPNYJ+LJpV/VTDj6adWwYfWDz+Pz/tZbWezfJVWV2TQv+R
-        zNtu3VyjZfCBxeP/i5NPoxswOz+aam4ZfGDxGJxqJreZlY2G+PSSxkAJE+rA
-        nxPA6s2ShdCbJYfbBmTj9HK/MeUc0YQewSsMK/yI31Uy8tfoynzQYR7hDLxh
-        /0B39If0ZWmPT81fURKT3PBaERO2QyX2fjmcA6k2OMBRyDR5buFpUzeEW1xk
-        3gcsA7bTSlAdYzzLs5aWKwGd/rU9A2APl3PX9kZMqHNg4nEnoUDv+vDIEFwW
-        M3rv6wFkkP6oyNPUUVHIU1zM2aL4fQJWDwsKJ1bVkpgNrX00fD6OokTUpv85
-        agM/+wf9D6QnFDv9XeWTlhjvh9QbxRB1QQP/JjqLwc/KvG7rWHqepYvgq/Dy
-        bxsEUJupSLMs+zIucowm9g+8TX8ITG9A+nb4Ed6k31j5BF84FYYmwQcMBkjQ
-        p4GOGSIZEcqRjP5nSNYh2bqtmikRrsnbtlhe3Ew5gimjtLTC2N1fwNwQijEE
-        0uYDIRaa2D/wNv0hMANq8NvhR3iTfvt/A+Uoo7FsW/q9S7LbgN3Fkr35Q76J
-        9eHAhl0YOnzgECxIl/V99T4LRAL5xm4s8K8F9lP/D/pfvA/wMaVC8tnpuxVx
-        0usfcXOUmPS/OP0oAXmxrJq2mP48JJ3pQfKwDqD5G5jpH0NUfjBE2EXe1sX0
-        aX5eLAuh5Y/oav4GZvrHe9O1rC5+RFQgZwCav4GZ/nEDUZmsvs/qPPHfK7/+
-        yYwMAcHz6Q4YvZm4RMPeDEQogzHKb/KlJT6jbP/iZkp5HiqoYD7gL2Ok5JZh
-        fwyWf5M5w7v2D3xJfziC67fuA4aIvunTYAaGyOpbqt297d2HXnxAlI6S7W6T
-        T+v8R+R7b/LRYN/PqdgEnjsYkIRqCcL5vQNoD5+31E7XVbsYeVSPIkf47AA5
-        xqID1sEJYX59QM7XoxZgwfeDzLDjpHpeXRRTgkZwbc8A0MPlqqrfnpfVVbdr
-        ZeyAC4M/mIHC7+UVy/3gS/cXE15Zn98FP5oPuCnD4Gb+bzRTHUaXP/A1/RGw
-        s8/z+r37gJug0/jME1simLWcyOxJH3ZyaUTxDgVpeDKHXRJ+SDfcUXxqv8jq
-        t3m7KunzL2vKkpCDSFB8pNBXD83sos7zaDqdCRPOJCiN34aGwALMOHZ6eW9i
-        KCSGFR/vi7wFkxI8vy+A6PV+WdTtOiv1jS4KdlSWt+i3r8+z8mZANm4TfhT8
-        wfAClsYn9g90Tn98kyz96fbufXpF/qD/OR7jD0mXdBiPpqFD1NV6UhbTs5fH
-        sxl90xDlf0TWb4CsS2HSs2Wb1+fE8z8i6zdC1rLKZk+yMltOCTq99iOSfjBJ
-        lVNf59N1TcsYn9fVevUj0n4jpCVStvmbbEI5X3rpRwT9YIKGHsDnlIW8yq5/
-        RNtvhLYg4Y8o+7NB2Wm1XOZTIeKPCPoNEDRbrchnZSr+iFNpsEQ2IuQ3QFhH
-        wpCcP4wuXbbk57b391uX+0ZxOJnn07dPl80LipSPL7OizCZFST4ZwbKNqOsf
-        Ci7rJrvouS0/iz1b+v8Q+8zf0bdN84pEKz8p6um66M27aAlfouk3UQdWdXAT
-        +xc3U71hhdZ8IG8GioLbhB/pH/IHw/v/miLxKfs6ry+Laf6yri4LSmh1Kfyz
-        iMVs2fygWva4+KOLsppk5eD46X/7t4J79/hnDzI9P2vAT14cf3H6swb95ZtX
-        P2uwv/i9f9ZAv/m93/yswX796ie/adgkzefnxXSRLUlP16u6Oi8iYeYNvexv
-        7x1s7GUKi/RGuvpCurrBOL1nl9zpQGa4agvqliF/ez3B2HzsALOHr4WE1gFa
-        TgFu0Ihx1et+YyUMjUu/02+30+b8rup//hpdmQ86elt0Ot6wf6A7+kP6slYG
-        n5q/oqTe3955SPqRSEwEHqTS3WWfyD8i2wDZWBjA/ky7TTLgiKQ4uQ8YZQyF
-        Pu2P1//t/ydUo5fijp1HFMXBfcAoAnX6tD8+/7f/T1KJ6WSlkIjktN6XhlxZ
-        ebZsios5u6Q+TQGuR2VkbRgYWgdUBuYy6hsRJPV8b3tvh5rSH+Rg7dJatP1j
-        h/5HqBPina6btqrJMCi2J9XyvLjoYhHtbhPQsli+fZPVFzkP3wdlBxSF2R3C
-        YAdEBKFzF34ULEFiYmycOoocuQdA9HsDkF7/DSnbaV2spNtboEAj26X/UVP6
-        g1iJ/rfZ+w16uEsewnu53x/Sl6UttXqPWPr9ujR/xhcsbi/u/KVr9jU1irRS
-        4dLX7V+iNQDe/oEG9EdH18QVoPtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJdWQO
-        Sf6z0VebXbCo0fvffFdQMT87kGnWhf/fC/xG3fKanI/Zusxrguj3BiC9/n+6
-        mkyrshzIOQurGkZh7hUeCj6SVpaFmeXsX+BDIz/8LjjVfMBNGQY3498Cppc/
-        8CX90ZGAAAc0od9YIHtC4D7gd4EBfcq/K/c7aOZvIKB/RKeCZvaApuLrTa6S
-        zPTJIxB0go+klSUlo2T/wtgMHfldDMt8wE0ZBjfj34SW+Mb+gS/pj/+XE5ZJ
-        O8DreVZPgbNPeUDqzUXDLTXB1JsPRsofL/22kfo8RozXUJzf09/lTTNwBsbt
-        w49kCgCW/nCUBCD6YGBONhCOlMPB9u5Daix/7FH4LH8QSR9s39vdfmlJSgTt
-        0IeUxpRW9pk8CFw2xCxDvX+NDr9mTzzOGFCanLjEbYTEONMfPIAb+I0J9GQN
-        +H7fANnDxsJAax+b/nS7D3jGwVn0qZl15he0DH5jmQT/0O/02+24jt9VPuWv
-        0ZX5oMN0wqF4w/6B7ugP6ctKAz41f0UpTQyh8QyRtkMlywhMqq/FDQSZ53BT
-        N4Tb+7IGQeqAZcB2Wgmqxxq/qKTWfqeAdXs0hIg8R0z/yLTplAdfyEwEH2lb
-        85vOLQP1JzuYUPkD7ekPganzGc5uj0cc4+rL7gNugh7pU4Og6C+Faf7ghvpX
-        dDZoAuh/ziaYWaH/YVZoTjpUdoT9EZH1D26of33DRL47pYGxyBbE9D+iuP7B
-        DfWvb4biVlVu0JKCA9NJEDA48kcYDf32I4LfjuAN2XsCQQ1/RGL+gxvqX98o
-        ie/OsjabZM3/PxUIkeFnldjvS2z8JD/2y8lPI/K//BHRfxgcns0WxbIAQpQG
-        /xHF7R/cUP/6WaS4XS6h5Hsk1Sw4Md0EIYMzf4TR0W8/moD3mwD6mCifTcr8
-        KaG/ymdPf6Tl6W+Gaf7ghvrXN039aUW/MPl/RHf6m2GaP7ih/vXN0r1YrGgs
-        1P5HlOY/uKH+9bNB6dN3+PdH+p0QFCIrTPMHN9S/vln6E8o/orkQVmGaP7ih
-        /vXN0vy8qPOrrCxrWuP7EcHtH9xQ//pmCW4i09f5dF1TwuVlVRbTH2W6CKb5
-        gxvqXz+7tP8ib+ti+iPS2z+4of71zZI+W88oobu8+BG7098M0/zBDfWvb5bm
-        8NgXi3w5y2enJWFSTF9WVfkj0ts/uKH+9c2S3miaHzE+PlUSK0zzBzfUv362
-        qD+tlkskJavlj+hPfzNM8wc31L9+tujf/MjSKoUVpvmDG+pfP1vEx29fZM3b
-        H2kfUFlhmj+4of71Q5yAuz8KtBim+YMb6l/f7DSYj1c/8nkA0/zBDfWvb5bg
-        ufiYP6I3wzR/cEP965ul97rJLn6kSn4YlIYeF42+YD/maX5OK4FC8v8fkp/G
-        9P9q8v+I6PYPbqh/fbNE97X5j+hOfzNM8wc31L9+1uk++5G64c4ZpvmDG+pf
-        3+wMOHXTVqufWOc1ue309o/ozn9wQ/3rZ5/ud38R/bx+k78DXj+aAf6DG+pf
-        X2cGeA6W2SJvVtkUE/BFMa2rpjpvx6/bqiankt7w5whw+7MmTY+n02q97K/V
-        YngeVXUu7O/p1uuW3r5Dn/HYuCX/ZinHbZX4PGTQxnwQTID8gbfpD5kNQ0CG
-        y2+HHwV/yCu2468zZdF5uL+98+n27n16Rf6g/7lJ4Vno0JT6lwXwLjm/GfDR
-        gOGbAT2d59O3L4inji+zoswmRUlJP3r9m++pw3d3oT2KaW9Ywj48vWAM+U0/
-        67OfnfsOK/ALynJ2ss0HwnZoYv8AMPpDoAQ8xm+HH+FN+o0FI/jCMRiaBB8w
-        GCBBnwZ8GiUuCTz9DzJ/ezqqz7EhxAFSgiiGK7/pZz8PKcu0HdKmdZ4tjpdZ
-        eU0eHejozwFARWYFr1C+8KerCV4ICB8MBQTpkFNHLDSyXwn90ID+4Lf4fR4c
-        xmuIzh9E6KhfCxi8T39IF/22/JujKT4LPuA+0Cl9GhDZzdMGu3Z/e3cHRDe6
-        4qH/x6f+H/Q/9wdPlPnjHv1h9Qt/SF/T/zCVNJGd6XDk70wF6OBIbHDn4WPQ
-        9NuPpkL+oP+5P5jQ5o9gKjZSn7zAqs26k/BzhxjR0EnpXSLSxbJC0PY6b7HU
-        20XUmxD9zWMOQ2z+Wj6y/IIpdn9tnCVtzFDMN/wHNw97Ef4BKvYPvEx/4DPD
-        ZfwiGMR84HgHzYIPbNs4txB16X9xESMQHi3fw/jobz8ipSUljS3uPsqA7Oj5
-        L0Y/GAtQod88gto3ZGRoQH9YDM1o+IOQLmhqvpaX0Sn9IYD7bfk3RwV8FnzA
-        faBT+nTj7EWptlErHNAfVtzNh7dRFfQb/Q9zwbPhOwEL6wQ069WKxkxv+LMF
-        xN5j/iJU49GHHwV/gN5uAgWA/ZO/5GYgdPAbT79MGT6xf+AV+qNDe/6JaTGT
-        jXfM72728GnwgX1vaL52HhBlt192ZgWamchNxO6QTqlMOvht3g9GZfQBeRiB
-        8KPgDwzX0UsA2D/5S26GgQW//X+BfEzAOLdeFs06K5t2PSsqes2nMoD36J5J
-        +EBNvwbBMSz5DdSR34IGAiYku/2L31ZSMXDQw3wgREcT+wfepj86M+Boyo2j
-        5CQhp/91dAR9sre99ymRk4gZp8rdVV39dD5Frz9/qcP08ZnNxUffzSfU2qcd
-        YPao2RQthaWUAsyX0m+HnB2cgakZKP/OxJJR4m/7hw5ZyLiJsgw5bIF3XQP+
-        iz/npj6pg7fQPf3GOuKL18/eMAr0gflTvw/+VDj8QQevzuz4H1g86FN8SVCD
-        2Jw/A2jvM4eq9yFjKJbVtTB/cy/6V5Q3SOfAulJT+QNayf5xGxNLf+zZP/a3
-        d3e9PzwA9Af9r8+D9D8oPOLAKE81ZUWZjx9x1o8465vmrGLZtNmS0mn0wnuz
-        lHIRKEmvyx+gFv0h82SoxRMqH9mpE8oFLfCua8B/8efcFFPJ80Uf6FvyLbqn
-        337EUvyH4wj6g/7n/mBOMH/8LLKUKKsfMdaPGOsbZizLUj+yhPRBBy/HTGgZ
-        fGDxoE/xJUH9EXf1uKujtn7EY/RBBy/HUmgZfGDxoE/xJUH9EY95PLZaT8qi
-        mVP6+CtawPwRS5luHQehZfCBxYM+xZcE9Ucs5bEUsRMt5iBjkV1mRZlNShD0
-        R2yFbh0XoWXwgcWDPsWXBPVHbOWxlfxxUtF4qvJHisp06xgILYMPLB70Kb4k
-        qD/iKDCRcpRVTzTQ6dsfsZTp1nEQWgYfWDzoU3xJUH/EUh5LkS/Vvobbftw0
-        xcUyn72pvk3G8AUZQ3r5R+yFbh03oWXwgcWDPsWXBPX/0+wVYxGJ6uAigSue
-        FITG8uJHysd065gBLYMPLB70Kb4kqP8/5Q6J+X/EI+aDDl6OJdAy+MDiQZ/i
-        S4L6/zseISLUygU/4gjp1jEAWgYfWDzoU3xJUP8/zRH8xzfoskzzui3OC+Ki
-        H62J2G4d+6Bl8IHFgz7FlwT1R/zk8ROlES/z+llWL37ETqZbxz1oGXxg8aBP
-        8SVB/RE7+ewEh4ia/X+JkYT2zB48fTRPP2Ik/OH4gP6g/7k/eP7NHz97jCSe
-        NTX+ETuhW8c9aBl8YPGgT/ElQf0RO3nsVK+XbbHoqab/Nwwiiq+w/yJv62L6
-        /0mkn+bnxbIQlP8/hT6rHB3E/4dR//8i/Z0rqoP4/zDq/1+kPzNRnU+rxSJf
-        zhTh//ch/x5a//9HY7nIqzq/YEz/vzwMYTJqvigoLTabAeVwPD/y7/7/6d/F
-        uAE5c8qVny4vi7pakqT+/8XbdzOHT4MPLBD6FF/yK94M8WeA733m+vE+ZLxk
-        slwL8zf3on9941Np/ngPDXHb6b+7WJdt8aoq85dVVf6IG/gzwPc+c/14HzJe
-        Mt+uhfmbe9G//j/FDVdV/Tavf8QKmGH+DPC9z1w/3oeMl0y2a2H+5l70r/9P
-        sYL41V02+P/gEP4/GBpEBxMoah3b//9G9P+T2fIUqQ7s/2fD+f/JPHV4sFg2
-        bbac/r8ycXn7oO99BqrT+fNuwP/v5t8PG7ovrXbcBOrnwSh1dn9+jfb/L7y8
-        yJbkUs++3R8+vesP60fBCD5z/XgffjenhhJuuBbmb+5F//o5Y42buGCWr8rq
-        GtP+3E55OP3/b0D99lxdNCrPuWPoZbbIs8usKLNJCW76/+7opmXWNMX0i2pS
-        lPlrWpcpSC/Ra//fHRGh+gUrIkzU8XRa0Vp2d0T/H1VAnAV3L/Kf+n3wp8Lh
-        Dzp4OZWFlsEHFg/6FF8S1J8bHcassF1PqbX3t2GAW8/53Wm1XOZTmfMfzb90
-        66YbLYMPLB70Kb4kqP9/mf/j6f9fEqI8p+5F/lO/D/5UOPxBBy8342gZfGDx
-        oE/xJUH9/zYL0Kc+H/i//4gnPLwcC6Bl8IHFgz7FlwT1//M88aO59/ByU42W
-        wQcWD/oUXxLU/8/PPf/zIwbw8HLzjZbBBxYP+hRfEtT/7zMAwfjRxKNbN89o
-        GXxg8aBP8SVB/f/+xHvW/0dMYLp1c46WwQcWD/oUXxLU/3cyAbMBkjLNKpuC
-        B17kV6/yspiOj19+QS/5HAKofZ5RNqG2AVcIrQzGTFRBN/iIh8e/MUX4N3nT
-        Upmb2L8YBgjL1KMP+D3+PUoBSo/s0IipIf9hkh+9Yb/Ol7OLupiNTxeUnKLm
-        /jAB7NYDdwgNYcuj1N+YF3mI/KmMPSARwwg/Cv6QVyyBGJb9SyQNfdk/0ID+
-        6EitY11t7D7gJhhEnMKUjQJPRYm6nlJOrHlCmfq3zfikzLP66ROC7VMSYHq0
-        nWVtNska+rJD3A7WASGA+GY6CwHwif1DqSFEDMDJR5aS3CWoYLrAm+5r/ovf
-        ixHO/1S75y/9HqPEJXal/4G4RNoOkaYlwaTmBOxHNGIa4b//B8odcxFlVwEA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -417,22 +35,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 52e1dcbe-cf8a-4aba-9129-20f040c92660
-      - 616ffc3d-4e84-47bc-b846-4c5e088d59c2
+      - 18df39a7-1709-487b-8aae-75935f8ff360
+      - 3402a34d-499d-4ca0-96d3-01fa94c5eb04
+      - 753e64d1-5b16-42db-b76f-8770c94361e4
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14903'
       X-Ms-Request-Id:
-      - 4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      - feb6a95e-b233-4164-99be-d9b95060754c
       X-Ms-Correlation-Request-Id:
-      - 4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      - feb6a95e-b233-4164-99be-d9b95060754c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141033Z:4a1e07ef-0413-4dbd-a12e-79ef4be2bf8e
+      - NORTHCENTRALUS:20160203T194356Z:feb6a95e-b233-4164-99be-d9b95060754c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:32 GMT
+      - Wed, 03 Feb 2016 19:43:55 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -443,61 +62,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:35 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -507,11 +136,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -530,22 +159,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1ceda565-cc8d-4bbb-9bc2-6e1e860bee08
-      - 3c961fe6-a20d-4068-bb4d-7dbdfc2a4bdb
+      - 1bbd3aad-4571-4b47-9ec0-42e957dbddc4
+      - 8c6cee8a-e8d8-4ca2-9a7f-f253b1227a1a
+      - 962ae3c5-aa9f-4125-aca0-02a65bae42ad
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14902'
       X-Ms-Request-Id:
-      - d8448c40-63e3-4c90-81df-fc89266f8b39
+      - b1f33f8e-f512-4f1f-b1b8-392a836a513e
       X-Ms-Correlation-Request-Id:
-      - d8448c40-63e3-4c90-81df-fc89266f8b39
+      - b1f33f8e-f512-4f1f-b1b8-392a836a513e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141033Z:d8448c40-63e3-4c90-81df-fc89266f8b39
+      - NORTHCENTRALUS:20160203T194357Z:b1f33f8e-f512-4f1f-b1b8-392a836a513e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:32 GMT
+      - Wed, 03 Feb 2016 19:43:56 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -556,61 +186,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:35 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -620,11 +260,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -643,22 +283,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 3222289d-9ea8-48c9-bb38-8156d7e0adfa
-      - 52cf3f9c-c6a8-4a50-8e84-99016d8192ce
+      - 31475a67-bade-416d-a40f-6693aee9fb6c
+      - 335e3a19-24ac-47fe-99d2-79649bfc6d6c
+      - 79e5c4b9-d146-43f0-ae49-c9254c07aae6
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14905'
       X-Ms-Request-Id:
-      - 1e390ab7-ea31-489e-82c4-5d425165fe69
+      - 3d2e80d8-caad-4a86-8ff4-1ca17ecaee5b
       X-Ms-Correlation-Request-Id:
-      - 1e390ab7-ea31-489e-82c4-5d425165fe69
+      - 3d2e80d8-caad-4a86-8ff4-1ca17ecaee5b
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141034Z:1e390ab7-ea31-489e-82c4-5d425165fe69
+      - NORTHCENTRALUS:20160203T194357Z:3d2e80d8-caad-4a86-8ff4-1ca17ecaee5b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:33 GMT
+      - Wed, 03 Feb 2016 19:43:57 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -669,61 +310,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:36 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:57 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -733,11 +384,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -756,22 +407,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0a214414-f6b8-48c7-98e7-5b03724a5480
-      - fa274e59-8fc5-4d96-b7a2-2c47ecdd3729
+      - 28b55b82-86d3-427a-8ea8-9a304b0f22b3
+      - 2b38822c-22b5-4a49-98e4-ac50ed82a0ea
+      - c807e0de-d957-42c1-b536-89efc43b0f3c
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14908'
       X-Ms-Request-Id:
-      - b217c8e0-0e83-4015-85bb-9442b4847047
+      - 0d11cf55-f772-4404-bb46-2c70294c9f2e
       X-Ms-Correlation-Request-Id:
-      - b217c8e0-0e83-4015-85bb-9442b4847047
+      - 0d11cf55-f772-4404-bb46-2c70294c9f2e
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141034Z:b217c8e0-0e83-4015-85bb-9442b4847047
+      - NORTHCENTRALUS:20160203T194358Z:0d11cf55-f772-4404-bb46-2c70294c9f2e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:34 GMT
+      - Wed, 03 Feb 2016 19:43:57 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -782,61 +434,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:36 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -846,11 +508,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -869,22 +531,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2403ed6d-a124-4e7e-8e98-1b9e1218a251
-      - db5af182-cffe-46f1-bf6c-b3f73e395b97
+      - b5cf03a6-f61e-45c6-a7d8-24a96cff9532
+      - ce3d16dd-0452-4c0f-95f0-02d011c0d94d
+      - f64db1f7-1490-4ab9-85b5-90c928ab2b69
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14904'
       X-Ms-Request-Id:
-      - 32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      - dd01bec4-dd33-410a-907f-fbb09c09a7dc
       X-Ms-Correlation-Request-Id:
-      - 32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      - dd01bec4-dd33-410a-907f-fbb09c09a7dc
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141035Z:32514ea1-7d23-4aa8-bf53-d570c012a2fc
+      - NORTHCENTRALUS:20160203T194358Z:dd01bec4-dd33-410a-907f-fbb09c09a7dc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:34 GMT
+      - Wed, 03 Feb 2016 19:43:57 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -895,61 +558,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:37 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -959,11 +632,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -982,22 +655,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 21ddcf78-9d1c-4d15-a770-38d12bc896ad
-      - 30b09d04-a3cd-434f-94b6-9b3cb36f604e
+      - 2ffdb670-641e-4477-99f2-6b86a341f498
+      - 7d3bacaf-e508-4037-b33e-ceda40e1d79a
+      - 8f260052-95b2-41b3-91c2-f59875e5116d
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14909'
       X-Ms-Request-Id:
-      - 8ec0ee61-265a-4167-a996-e7659a5f7d73
+      - f7a315c3-08f2-4813-bb9b-6ee9eca6fff5
       X-Ms-Correlation-Request-Id:
-      - 8ec0ee61-265a-4167-a996-e7659a5f7d73
+      - f7a315c3-08f2-4813-bb9b-6ee9eca6fff5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141035Z:8ec0ee61-265a-4167-a996-e7659a5f7d73
+      - NORTHCENTRALUS:20160203T194359Z:f7a315c3-08f2-4813-bb9b-6ee9eca6fff5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:35 GMT
+      - Wed, 03 Feb 2016 19:43:58 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1008,61 +682,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:37 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1072,11 +756,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1095,22 +779,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 365d8a8f-1ae8-402d-84ee-720a031fbca2
-      - efd13ec2-9244-4333-8572-536a54ec6676
+      - 371d0745-9773-45fe-b3e0-e6e0ba802720
+      - 8096c3aa-ebe4-4733-9314-7c91fe4c9ed2
+      - 9df193a8-d973-44c3-ade8-558527c68fd2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14902'
       X-Ms-Request-Id:
-      - b284adc7-4294-4fd2-b476-de75e74eab36
+      - 98133f1b-5a5a-41bd-b37e-d19057605e4c
       X-Ms-Correlation-Request-Id:
-      - b284adc7-4294-4fd2-b476-de75e74eab36
+      - 98133f1b-5a5a-41bd-b37e-d19057605e4c
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141036Z:b284adc7-4294-4fd2-b476-de75e74eab36
+      - NORTHCENTRALUS:20160203T194359Z:98133f1b-5a5a-41bd-b37e-d19057605e4c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:36 GMT
+      - Wed, 03 Feb 2016 19:43:59 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1121,61 +806,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+  recorded_at: Wed, 03 Feb 2016 19:43:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1185,11 +880,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1208,22 +903,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 312767f0-f25e-46bd-afce-a931a4b502b8
-      - 9eb79827-98dd-4f45-9daf-5c31e5df381d
+      - 26f1f3de-1ff1-45d6-967c-2f776fcf7a04
+      - c029dd44-f2b7-45b4-a4df-502bca749495
+      - d6d6f1ed-b62d-423f-ac1f-1cd6e5da2804
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14898'
       X-Ms-Request-Id:
-      - 8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      - 0b70bad8-0eb8-4dc5-bcd2-0e51041df26f
       X-Ms-Correlation-Request-Id:
-      - 8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      - 0b70bad8-0eb8-4dc5-bcd2-0e51041df26f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141036Z:8fed6ad2-c122-49d7-94f6-4c39858bc8b4
+      - NORTHCENTRALUS:20160203T194401Z:0b70bad8-0eb8-4dc5-bcd2-0e51041df26f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:36 GMT
+      - Wed, 03 Feb 2016 19:44:00 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1234,61 +930,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1298,11 +1004,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1321,22 +1027,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 8bce60d7-b01b-4019-8adb-9e8a891cc70e
-      - b8937aa5-c4bb-49ec-a758-979e0fb2a886
+      - 282feb2b-c134-4d22-a288-dbde9f140c43
+      - 5fcbaaa1-8f10-4f8c-acb2-b9252be5d63d
+      - 9a0e62f0-67a2-4b47-aa7e-3a9a4019ee17
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14899'
       X-Ms-Request-Id:
-      - 5aed2393-f06d-4589-ab43-5bfd048d76bd
+      - 0e1441dc-8a61-4eac-b438-3052c4f894e6
       X-Ms-Correlation-Request-Id:
-      - 5aed2393-f06d-4589-ab43-5bfd048d76bd
+      - 0e1441dc-8a61-4eac-b438-3052c4f894e6
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141036Z:5aed2393-f06d-4589-ab43-5bfd048d76bd
+      - NORTHCENTRALUS:20160203T194401Z:0e1441dc-8a61-4eac-b438-3052c4f894e6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:36 GMT
+      - Wed, 03 Feb 2016 19:44:01 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1347,61 +1054,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:38 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1411,11 +1128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1434,22 +1151,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 5ab3d07e-2099-4ebe-86e2-33edd07ab34f
-      - cadbe5e0-da3c-45ea-b439-c389092f3630
+      - 8d622ef8-6e4d-4425-8127-8a94df57d1be
+      - 8dac32ae-5f01-40bc-8b33-36f59fddf9eb
+      - 9ea32909-95f8-4582-aeb9-1bbef33ef0db
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14891'
       X-Ms-Request-Id:
-      - d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      - abec6487-db1a-4c56-a185-03aca36a54db
       X-Ms-Correlation-Request-Id:
-      - d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      - abec6487-db1a-4c56-a185-03aca36a54db
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141037Z:d6d57206-c2a0-44c3-8e9d-310c20ecd9d4
+      - NORTHCENTRALUS:20160203T194402Z:abec6487-db1a-4c56-a185-03aca36a54db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:36 GMT
+      - Wed, 03 Feb 2016 19:44:02 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1460,61 +1178,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:39 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1524,11 +1252,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1547,22 +1275,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 07107201-3fd3-4d94-8a94-f1da39c1511e
-      - 1bd6afa8-9404-40ec-983f-d938377d10d6
+      - 322dff97-973b-4676-b17a-30700f9b61e3
+      - 4e2f5466-ca20-46bf-880d-1dc779490664
+      - efbe2d5d-28a3-4ce9-944f-e10e1bbc5c8f
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14904'
       X-Ms-Request-Id:
-      - 27d65844-5515-485c-8573-86a8cde826d5
+      - 50e9c955-d4bc-4c00-93eb-872c83b27baa
       X-Ms-Correlation-Request-Id:
-      - 27d65844-5515-485c-8573-86a8cde826d5
+      - 50e9c955-d4bc-4c00-93eb-872c83b27baa
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141037Z:27d65844-5515-485c-8573-86a8cde826d5
+      - NORTHCENTRALUS:20160203T194402Z:50e9c955-d4bc-4c00-93eb-872c83b27baa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:37 GMT
+      - Wed, 03 Feb 2016 19:44:02 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1573,61 +1302,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:39 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1637,11 +1376,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1660,22 +1399,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 05b7b68d-d46d-4bd6-8489-0b5256c287de
-      - 5f7d860c-515e-4612-a741-692eeee70811
+      - 5c979fd0-2d1e-4b7c-8988-bf81c0614d34
+      - 60851e43-b2c4-4ea5-826c-d9a321a70d74
+      - f390388f-366c-470a-9c06-03025f8d8f19
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14892'
       X-Ms-Request-Id:
-      - 7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      - dc3bb7fc-17a4-490f-9249-2438e56dbde3
       X-Ms-Correlation-Request-Id:
-      - 7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      - dc3bb7fc-17a4-490f-9249-2438e56dbde3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141038Z:7a79fe8c-1748-49ce-a8a2-e1fd7ac7a0fa
+      - NORTHCENTRALUS:20160203T194403Z:dc3bb7fc-17a4-490f-9249-2438e56dbde3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:37 GMT
+      - Wed, 03 Feb 2016 19:44:03 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1686,61 +1426,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:40 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1750,11 +1500,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1773,22 +1523,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 26c3d95d-22e0-4ea5-b24c-b3efa84ad819
-      - d9e48dc2-cb63-499e-b6d2-38f82da4a789
+      - b788172e-ae38-400b-be19-7aded85a452e
+      - d8080536-6b1d-4119-bd7a-ca4facb55c4b
+      - f1f1777a-f074-4136-bc06-46015d6c3e5b
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14894'
       X-Ms-Request-Id:
-      - f4795dda-c5e1-4541-b353-0f66244d4c7a
+      - 73524878-0292-43b0-a501-cd7650b2e3c5
       X-Ms-Correlation-Request-Id:
-      - f4795dda-c5e1-4541-b353-0f66244d4c7a
+      - 73524878-0292-43b0-a501-cd7650b2e3c5
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141038Z:f4795dda-c5e1-4541-b353-0f66244d4c7a
+      - NORTHCENTRALUS:20160203T194403Z:73524878-0292-43b0-a501-cd7650b2e3c5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:38 GMT
+      - Wed, 03 Feb 2016 19:44:03 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1799,61 +1550,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:40 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1863,11 +1624,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1886,22 +1647,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1c7743c8-b37a-4554-b361-60359b9eb77a
-      - f7b761f9-d079-4f70-a3b1-c5ed6902996b
+      - 69120893-9129-4feb-ab9a-ae1b7739f654
+      - b98bd0f6-824e-41ac-918c-15203dc286e6
+      - e69135e0-bb35-494f-937b-b0f0c0375eb3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14900'
       X-Ms-Request-Id:
-      - 1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      - b044edfb-c87d-4d97-a3cd-5db70013c339
       X-Ms-Correlation-Request-Id:
-      - 1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      - b044edfb-c87d-4d97-a3cd-5db70013c339
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141039Z:1f16198d-c9a9-4bed-a946-7e6a3fd70538
+      - NORTHCENTRALUS:20160203T194404Z:b044edfb-c87d-4d97-a3cd-5db70013c339
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:39 GMT
+      - Wed, 03 Feb 2016 19:44:03 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1912,61 +1674,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1976,11 +1748,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -1999,22 +1771,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 05f369c2-11ae-4e13-84b9-678955e89d73
-      - 323e481d-0b59-472d-97b9-5b3bfa5f16e6
+      - 010ce89d-9fd4-4cf7-8fe4-c4a9ae959d87
+      - 17066b4b-7141-453c-ad8f-05af9a6adb69
+      - 3875620a-da2e-4d77-8a38-cf085c4badbf
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14902'
       X-Ms-Request-Id:
-      - 692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      - 614e67f6-754b-499b-bb0e-2480f193a6fb
       X-Ms-Correlation-Request-Id:
-      - 692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      - 614e67f6-754b-499b-bb0e-2480f193a6fb
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141039Z:692a41ba-99bc-467a-a1d1-d8ab739a60b5
+      - NORTHCENTRALUS:20160203T194405Z:614e67f6-754b-499b-bb0e-2480f193a6fb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:39 GMT
+      - Wed, 03 Feb 2016 19:44:04 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2025,61 +1798,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2089,11 +1872,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2112,22 +1895,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 6ee36960-4ce5-4a43-bae1-3e572b93e115
-      - bbeb6c98-9a87-46f5-b48e-7e1102e1ddaa
+      - 3233aa61-aa37-463d-9c6b-73c223883905
+      - 7f0358d5-189e-4fbe-8a55-f783db95bdcc
+      - cd303ad9-a554-40a9-ae81-7a8e65d9e871
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14902'
       X-Ms-Request-Id:
-      - 35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      - 11d35f62-b1c5-4341-9879-f5aeb9904fdf
       X-Ms-Correlation-Request-Id:
-      - 35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      - 11d35f62-b1c5-4341-9879-f5aeb9904fdf
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141039Z:35b43f0b-7526-4c24-a35b-7855a0b03fa3
+      - NORTHCENTRALUS:20160203T194405Z:11d35f62-b1c5-4341-9879-f5aeb9904fdf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:39 GMT
+      - Wed, 03 Feb 2016 19:44:05 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2138,61 +1922,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:41 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2202,11 +1996,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2225,22 +2019,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 69c23cfa-2996-4381-b0fc-91547b41ed08
-      - 7d13b80c-6f5e-4584-b1a2-f0ced454dde5
+      - 2f1cf3fe-8238-40b8-8445-f2b069b94d23
+      - e3bfdf52-12ba-4a8e-ac4c-6dc54065736b
+      - e62e0fc2-4121-4305-83dd-b73be9c7b8f5
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14901'
       X-Ms-Request-Id:
-      - 244c99cf-d479-444f-bf88-5030187ac262
+      - b4f98b36-8e93-4c9e-accb-1dad7672b857
       X-Ms-Correlation-Request-Id:
-      - 244c99cf-d479-444f-bf88-5030187ac262
+      - b4f98b36-8e93-4c9e-accb-1dad7672b857
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141040Z:244c99cf-d479-444f-bf88-5030187ac262
+      - NORTHCENTRALUS:20160203T194406Z:b4f98b36-8e93-4c9e-accb-1dad7672b857
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:40 GMT
+      - Wed, 03 Feb 2016 19:44:05 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2251,61 +2046,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2315,11 +2120,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2338,22 +2143,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 80078e8b-e726-4137-8374-0f1b17b0b2cf
-      - d7c2cc7b-077d-4061-85b7-7667476239fd
+      - 14b7772b-3ac9-483a-8ca6-87c3f3f9ff54
+      - dbd836e4-ee67-4bbe-bef2-3d2642ebdc7d
+      - dec6dbef-a7da-48e2-8ce0-90e475c843a4
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14904'
       X-Ms-Request-Id:
-      - 70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      - 7aa6e154-9c88-472a-8890-9767d468b592
       X-Ms-Correlation-Request-Id:
-      - 70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      - 7aa6e154-9c88-472a-8890-9767d468b592
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141040Z:70db8502-35e1-4a2d-b39b-9b7f940f67f0
+      - NORTHCENTRALUS:20160203T194406Z:7aa6e154-9c88-472a-8890-9767d468b592
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:39 GMT
+      - Wed, 03 Feb 2016 19:44:06 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2364,61 +2170,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2428,11 +2244,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2451,22 +2267,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 0bd9635c-886d-4c88-97bc-c9c09363abbd
-      - 6c7445c6-daaf-42fc-a714-19a26c75f6cb
+      - c96b97ab-91ec-4b33-8124-6c2e3f69d4a5
+      - e13e3cbc-2514-41b8-9d50-2767da7a1178
+      - f3e90823-6b51-4402-8d04-7ac4cda925a3
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14907'
       X-Ms-Request-Id:
-      - ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      - 288563b7-cc9c-49e9-9df6-bcef1a2a8d87
       X-Ms-Correlation-Request-Id:
-      - ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      - 288563b7-cc9c-49e9-9df6-bcef1a2a8d87
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141040Z:ce5e5647-f8a2-4f68-8ad6-9d71a77c7e92
+      - NORTHCENTRALUS:20160203T194407Z:288563b7-cc9c-49e9-9df6-bcef1a2a8d87
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:40 GMT
+      - Wed, 03 Feb 2016 19:44:07 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2477,61 +2294,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:42 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2541,11 +2368,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2564,22 +2391,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 042d4e33-5984-4ae5-9fcb-07375b62f9f0
-      - cacc6787-c648-48c3-a3d7-a19d5a49d869
+      - e1e1a107-a3f4-4893-ab09-c2644add093a
+      - e21dc5de-685d-456e-a652-8374ae1b2edd
+      - fa7b68f4-a24b-415d-bb39-0153c779f760
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14903'
       X-Ms-Request-Id:
-      - dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      - 6c660f30-18b8-4f50-ac0a-d70700cab6ab
       X-Ms-Correlation-Request-Id:
-      - dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      - 6c660f30-18b8-4f50-ac0a-d70700cab6ab
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141041Z:dac2ba9a-6f2d-4d54-a970-e2862b69d9cd
+      - NORTHCENTRALUS:20160203T194408Z:6c660f30-18b8-4f50-ac0a-d70700cab6ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:40 GMT
+      - Wed, 03 Feb 2016 19:44:08 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2590,61 +2418,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:43 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2654,11 +2492,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2677,22 +2515,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 4fe85cab-2c44-4068-93d7-487d47e2f8a4
-      - 840cfa36-f52a-497c-a18b-e08a443a7f22
+      - 07ac1ba9-8abf-4e65-ad5b-c187d4105b3b
+      - 0c99b7f1-319c-4340-8f2d-801ae414d7d5
+      - 95ca774f-9232-42b6-b5a4-fec081c16fe9
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14908'
       X-Ms-Request-Id:
-      - 111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      - 8bed8346-9df5-4d3f-85e9-650616013d06
       X-Ms-Correlation-Request-Id:
-      - 111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      - 8bed8346-9df5-4d3f-85e9-650616013d06
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141041Z:111999e4-e84d-453b-8bc1-5a42dcbbb5da
+      - NORTHCENTRALUS:20160203T194409Z:8bed8346-9df5-4d3f-85e9-650616013d06
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:41 GMT
+      - Wed, 03 Feb 2016 19:44:09 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2703,61 +2542,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:43 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2767,11 +2616,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2790,22 +2639,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 51911a30-392e-4e9d-80bb-176ed679a078
-      - af01181b-4147-470e-b4bb-3c755313b1ee
+      - 202bf31f-c4a5-474e-9062-8b96102ce2ee
+      - 7b0a39fa-67d7-478b-b419-ee49c62a8bfd
+      - 96d74337-d542-45be-9219-e77fdb4a8131
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14901'
       X-Ms-Request-Id:
-      - 1b5688d9-6d22-4a67-be66-eeba650fba58
+      - cf3dbddc-31e6-427d-90fe-ffa306adb612
       X-Ms-Correlation-Request-Id:
-      - 1b5688d9-6d22-4a67-be66-eeba650fba58
+      - cf3dbddc-31e6-427d-90fe-ffa306adb612
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141042Z:1b5688d9-6d22-4a67-be66-eeba650fba58
+      - NORTHCENTRALUS:20160203T194409Z:cf3dbddc-31e6-427d-90fe-ffa306adb612
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:41 GMT
+      - Wed, 03 Feb 2016 19:44:09 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2816,61 +2666,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2880,11 +2740,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -2903,22 +2763,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 10db4bf1-982d-4ac6-a9ad-d3a57b38684d
-      - f3f19c75-4aa9-4638-858d-b91c4e736a5b
+      - 3e2bc58d-d8c9-4d5f-83e2-bd62f895d9e9
+      - 4d0123cf-9002-42d9-907c-db6283fcec37
+      - f3725816-3144-4051-9cb1-d2513449f520
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14897'
       X-Ms-Request-Id:
-      - eb9894a8-3fdd-4b34-888f-e0df43001b35
+      - d0d8afcb-b9fb-4144-9378-4338b129998d
       X-Ms-Correlation-Request-Id:
-      - eb9894a8-3fdd-4b34-888f-e0df43001b35
+      - d0d8afcb-b9fb-4144-9378-4338b129998d
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141042Z:eb9894a8-3fdd-4b34-888f-e0df43001b35
+      - NORTHCENTRALUS:20160203T194410Z:d0d8afcb-b9fb-4144-9378-4338b129998d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:41 GMT
+      - Wed, 03 Feb 2016 19:44:10 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -2929,61 +2790,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -2993,11 +2864,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3016,22 +2887,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - de810f62-2f7c-47bf-a467-47fe97d800b1
-      - e1cd6f5b-0b70-4e18-bfc0-2b6c12e4d6c9
+      - 2e807f48-ff4c-449e-b87e-83fb488b8f87
+      - 5d1a2843-6b23-487c-b2f4-0c94665631c1
+      - 64686ba3-d209-4d49-94b0-d4f8b5838cf9
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
+      - '14898'
       X-Ms-Request-Id:
-      - 1da49536-f400-4140-8577-ed6d928596d7
+      - 5664951c-4c9c-487b-909b-3f54b98b53c3
       X-Ms-Correlation-Request-Id:
-      - 1da49536-f400-4140-8577-ed6d928596d7
+      - 5664951c-4c9c-487b-909b-3f54b98b53c3
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141042Z:1da49536-f400-4140-8577-ed6d928596d7
+      - NORTHCENTRALUS:20160203T194410Z:5664951c-4c9c-487b-909b-3f54b98b53c3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:42 GMT
+      - Wed, 03 Feb 2016 19:44:10 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3042,61 +2914,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3106,11 +2988,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3129,22 +3011,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2805ffa2-988b-4d46-a99e-9a4272a722fa
-      - 4da9d5e1-7dff-483c-a7fe-0e5fe0959d54
+      - 251d9f8e-b658-4ccd-92c7-97c00cec97a1
+      - 43d6add7-7385-46e3-be06-422722317f5e
+      - ac7c6f0d-6f18-4a27-884e-7eadf334b1bb
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14890'
       X-Ms-Request-Id:
-      - 2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      - dad9cab5-2c15-45a3-b6b4-0109c9c395db
       X-Ms-Correlation-Request-Id:
-      - 2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      - dad9cab5-2c15-45a3-b6b4-0109c9c395db
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141042Z:2f822ebb-cccc-4d29-9f2b-e37ed2a7b554
+      - NORTHCENTRALUS:20160203T194411Z:dad9cab5-2c15-45a3-b6b4-0109c9c395db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:42 GMT
+      - Wed, 03 Feb 2016 19:44:11 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3155,61 +3038,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:44 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3219,11 +3112,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3242,22 +3135,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 1a5c4cbd-f6f2-4597-939b-35d6971c8aa7
-      - b91d5730-15e6-4f88-84dc-20ce220e4576
+      - 093ede05-a5e9-4a7a-bcd0-62211c6e0df6
+      - 3d3e5b2b-2628-4b03-af5e-7a5232b5b78e
+      - 59e8d075-cff8-4ac0-b792-2252456225e2
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
+      - '14903'
       X-Ms-Request-Id:
-      - 04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      - 5d2031ed-716c-4776-8b92-b703c23f0b0f
       X-Ms-Correlation-Request-Id:
-      - 04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      - 5d2031ed-716c-4776-8b92-b703c23f0b0f
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141043Z:04bc53fc-8d89-4aef-9e03-e86f4843b8c6
+      - NORTHCENTRALUS:20160203T194412Z:5d2031ed-716c-4776-8b92-b703c23f0b0f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:42 GMT
+      - Wed, 03 Feb 2016 19:44:11 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3268,61 +3162,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3332,11 +3236,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3355,22 +3259,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 2b6ddb91-fe4a-4628-a1ac-1c41f2e96d9a
-      - 52c8c39a-4d15-4473-bfe5-f0591d612b66
+      - 24ecd610-97dd-43c5-887d-491b6b9a9151
+      - 353f59aa-7fb5-4ca6-a3ea-67f39f0c68fc
+      - 7050c6f1-c35b-4fb2-8a59-d370accc84be
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
+      - '14905'
       X-Ms-Request-Id:
-      - 44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      - 8b6c14a5-d456-4396-b285-e0ce67795a53
       X-Ms-Correlation-Request-Id:
-      - 44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      - 8b6c14a5-d456-4396-b285-e0ce67795a53
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141043Z:44b5b02e-93fd-43d5-85a7-8e0adf9432fb
+      - NORTHCENTRALUS:20160203T194413Z:8b6c14a5-d456-4396-b285-e0ce67795a53
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:43 GMT
+      - Wed, 03 Feb 2016 19:44:13 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3381,61 +3286,71 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
     http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
+  recorded_at: Wed, 03 Feb 2016 19:44:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3445,11 +3360,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MjgyNzYsIm5iZiI6MTQ1NDUyODI3NiwiZXhwIjoxNDU0NTMyMTc2LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.QcmL6WhZ-B1PDEdilaH5v7q5C-Hs88SCad4eGDSmZyJD7r1qXgz0XQSoaoGGejdsrFmHJng6EmVjQ2jSIFQLPYjuRwebgEbCQz5RMkCy7fAMEpi53npKCIDqLuVv1YJw6lGckyCIP0WzRekVNvnyOUmQGhjX3QswqN0KhRI9FhQml46NqBz0aEAjZIOi82us5MntJFh1L9SP7fkbRxn6LM7JvDNrjdkGFQ6y7jsZn-Jv344wD1ysxE0JxujbINfxxo9ggkULqjaJREyg5eR9VqWDK7-N8F0yTO-3kyuwBrEPRExHNir2mBatudxPNoQambXQyFkUVuzQVqpnP2x4bg
   response:
     status:
       code: 200
@@ -3468,22 +3383,23 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Original-Request-Ids:
-      - 729ba952-3fa4-48c6-b62f-eed6becda240
-      - c66f8630-9080-49d5-b1ec-a0bdbc351963
+      - 2138a0bb-e73d-48ba-8d5b-8dd4e3eab007
+      - 7a5138e0-ea00-4545-b1c5-fb6272094aa5
+      - e8b5449d-0add-4596-bf2a-477cb537ef74
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14891'
       X-Ms-Request-Id:
-      - 39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      - c0ad8344-175f-4a71-a23a-df89b01ac818
       X-Ms-Correlation-Request-Id:
-      - 39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      - c0ad8344-175f-4a71-a23a-df89b01ac818
       X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141044Z:39aff4da-ecc4-449e-b514-8cd57f9f82d2
+      - NORTHCENTRALUS:20160203T194413Z:c0ad8344-175f-4a71-a23a-df89b01ac818
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Fri, 30 Oct 2015 14:10:43 GMT
+      - Wed, 03 Feb 2016 19:44:12 GMT
       Content-Length:
-      - '2557'
+      - '2997'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3494,8628 +3410,66 @@ http_interactions:
         lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
         pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
         XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 95e6bbac-a1a7-4e37-9dc5-11e52986f2f6
-      - aa8aa458-8f11-4f11-a811-391e4ac2df57
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
-      X-Ms-Correlation-Request-Id:
-      - c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141044Z:c92ad08e-4ff2-4470-9f3c-45f75d2e5c04
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:43 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - aad2d84c-ef55-4707-8466-e071aa15fde1
-      - aaee80a2-27ce-4c85-9f32-27bf68a13044
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
-      X-Ms-Correlation-Request-Id:
-      - a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141044Z:a29479b0-4418-4b1d-bdc2-dbb1c4a4c2df
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:44 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - ef8f13ba-3fc7-4328-a8a4-042d870f0c00
-      - f98db7b7-366b-4a35-bc82-fab50f520f05
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 8432a1a8-3b65-44b6-b4a0-0fa098dc7608
-      X-Ms-Correlation-Request-Id:
-      - 8432a1a8-3b65-44b6-b4a0-0fa098dc7608
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141044Z:8432a1a8-3b65-44b6-b4a0-0fa098dc7608
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:44 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 9b6ac8e9-2dd7-4310-8c90-f419bd490076
-      - afb5ea48-d22c-4b5e-98fb-1f8b53973b32
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - fbea64a9-0c84-4483-a96c-c5df11c9ec71
-      X-Ms-Correlation-Request-Id:
-      - fbea64a9-0c84-4483-a96c-c5df11c9ec71
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141045Z:fbea64a9-0c84-4483-a96c-c5df11c9ec71
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:45 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8983e021-5b99-4246-98e6-2241d3732b39
-      - 8c3d48ec-d831-4452-b502-b454a6c0cd7d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 11bec435-ec8a-4d0a-983e-3a2600f11720
-      X-Ms-Correlation-Request-Id:
-      - 11bec435-ec8a-4d0a-983e-3a2600f11720
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141045Z:11bec435-ec8a-4d0a-983e-3a2600f11720
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:45 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 3cb47dcc-59eb-4d98-b4e9-a31ab16ee9f4
-      - 66de0fe5-cf49-4d0b-925c-a8fb1dea98f0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - b2496119-b7ea-4789-9e9e-0ee7efc236ab
-      X-Ms-Correlation-Request-Id:
-      - b2496119-b7ea-4789-9e9e-0ee7efc236ab
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141045Z:b2496119-b7ea-4789-9e9e-0ee7efc236ab
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:45 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8ce99ea0-a662-42aa-b045-fc8cd20e2bef
-      - e15b4114-0308-4719-9056-e044929c2931
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - e66b01f9-ec5b-49d4-9464-60b72b7c8d14
-      X-Ms-Correlation-Request-Id:
-      - e66b01f9-ec5b-49d4-9464-60b72b7c8d14
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141046Z:e66b01f9-ec5b-49d4-9464-60b72b7c8d14
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:45 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 203bbf29-f286-4bc0-90d3-034a6e1bc514
-      - b725af00-fe4a-4d5b-86d4-04ce0ab7c56c
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 9235a5ec-502d-4fbb-b448-19a9f6476d24
-      X-Ms-Correlation-Request-Id:
-      - 9235a5ec-502d-4fbb-b448-19a9f6476d24
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141046Z:9235a5ec-502d-4fbb-b448-19a9f6476d24
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:46 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 07705970-404e-4bc6-b6a6-3a6ed4e16f34
-      - 5d548f74-fe57-4133-807f-644fb8423bb4
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 3f81002b-2007-4d66-8ee1-38e77c1bf517
-      X-Ms-Correlation-Request-Id:
-      - 3f81002b-2007-4d66-8ee1-38e77c1bf517
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141046Z:3f81002b-2007-4d66-8ee1-38e77c1bf517
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:46 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2d98266b-7ff9-4ed9-aead-aea7bbd7773a
-      - 93355ce4-4c2e-491b-a371-3f108006a361
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - aa872684-c8a9-43c7-8b7c-5287f19dfd7b
-      X-Ms-Correlation-Request-Id:
-      - aa872684-c8a9-43c7-8b7c-5287f19dfd7b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141047Z:aa872684-c8a9-43c7-8b7c-5287f19dfd7b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:47 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 9e7a2e82-ba83-4d9f-9fc8-c816229ba369
-      - c0c174b5-ebcb-44a7-bff2-d035eb5048d8
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 25e1c66a-5ad7-40e8-88d9-142b8bec3725
-      X-Ms-Correlation-Request-Id:
-      - 25e1c66a-5ad7-40e8-88d9-142b8bec3725
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141047Z:25e1c66a-5ad7-40e8-88d9-142b8bec3725
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:47 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 4a2def83-2501-417e-888b-ccddee2e519a
-      - e0b400b3-3042-41cd-b929-b700a15d3282
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 4d48ab42-c417-4898-b30f-b457efe36fff
-      X-Ms-Correlation-Request-Id:
-      - 4d48ab42-c417-4898-b30f-b457efe36fff
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141047Z:4d48ab42-c417-4898-b30f-b457efe36fff
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:47 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 2f15b896-f85a-4686-8d78-eab1113d9c27
-      - dcbaabe1-a771-48ee-81d8-d58ed9659b58
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - ade7663c-c647-43d4-9e54-406a69d064c3
-      X-Ms-Correlation-Request-Id:
-      - ade7663c-c647-43d4-9e54-406a69d064c3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141047Z:ade7663c-c647-43d4-9e54-406a69d064c3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:47 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - baef2c8b-f404-4624-ac7d-ed84cfd910f6
-      - cc5b1715-178b-4f04-8e59-d10e265dd9a4
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - c9beacc5-bc88-48fe-b503-a8db75058732
-      X-Ms-Correlation-Request-Id:
-      - c9beacc5-bc88-48fe-b503-a8db75058732
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141048Z:c9beacc5-bc88-48fe-b503-a8db75058732
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 762af3db-998a-4082-b6b9-cafc6ead770a
-      - 7935ae01-c366-43ae-ae72-b1256774ad6b
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 93b6b471-6b74-46e1-a08d-723533e4fb55
-      X-Ms-Correlation-Request-Id:
-      - 93b6b471-6b74-46e1-a08d-723533e4fb55
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141048Z:93b6b471-6b74-46e1-a08d-723533e4fb55
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6ad28647-2855-428f-bc0b-31aa2d434d2b
-      - edf2acde-9019-4c57-a174-7ca362365f42
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - d4a1590a-13ee-442f-9550-ef84b9c97b5c
-      X-Ms-Correlation-Request-Id:
-      - d4a1590a-13ee-442f-9550-ef84b9c97b5c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141048Z:d4a1590a-13ee-442f-9550-ef84b9c97b5c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - a73d495d-6a04-4417-a090-be841acfa04c
-      - f826eed3-fbcf-48c3-b0f6-156bd497a35a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 5e467376-0114-4aee-b4c2-20f10fd540ce
-      X-Ms-Correlation-Request-Id:
-      - 5e467376-0114-4aee-b4c2-20f10fd540ce
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141049Z:5e467376-0114-4aee-b4c2-20f10fd540ce
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - a090cc5d-b2fb-4e4b-8ea1-4673bcc12f8a
-      - bcca837a-83b3-47ab-aab4-48e800665b2c
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - b8742ffe-16d4-46c0-b0bb-228f73ac8189
-      X-Ms-Correlation-Request-Id:
-      - b8742ffe-16d4-46c0-b0bb-228f73ac8189
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141049Z:b8742ffe-16d4-46c0-b0bb-228f73ac8189
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8f8c4487-e6a1-40ff-bb18-444556659453
-      - e4759213-74b8-43fa-90a1-89d177dd7694
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
-      X-Ms-Correlation-Request-Id:
-      - bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141049Z:bf6dc6e6-fb3d-4c43-b4f3-56625d6c02bd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:48 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 152ee9f7-bb01-4e6f-b723-b647208824f3
-      - 90a94a23-4158-4c88-96f8-fd3fae3691af
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 5c1b0976-06b8-4022-bf28-f28a69b6582f
-      X-Ms-Correlation-Request-Id:
-      - 5c1b0976-06b8-4022-bf28-f28a69b6582f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141049Z:5c1b0976-06b8-4022-bf28-f28a69b6582f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:49 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 009a8dea-b07c-43d1-9815-634bf75902bd
-      - c563b92b-41b7-4faa-b738-20e376be9343
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - 6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
-      X-Ms-Correlation-Request-Id:
-      - 6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141050Z:6f955059-a1ef-4cbf-b5b9-d8d1e55642d6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:49 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 0b7ed963-e2d6-4d70-8d69-6ff6f1c3ea25
-      - 377b277b-fd4e-409e-abd4-21fcb2f90d34
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
-      X-Ms-Correlation-Request-Id:
-      - 693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141050Z:693f11fe-6b5c-4ce3-81c5-8b9564efc5a7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:49 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 1ab5cefb-3061-4f85-9c11-da11ced0453a
-      - fd5ee161-8a62-4b8c-a8b9-eb9ae4c8370a
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 608237d4-c86d-4381-8f48-3703a68ff3e9
-      X-Ms-Correlation-Request-Id:
-      - 608237d4-c86d-4381-8f48-3703a68ff3e9
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141050Z:608237d4-c86d-4381-8f48-3703a68ff3e9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:50 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 09b112fe-8e9f-4716-b164-bd440c21469d
-      - e0995b5d-875a-4072-ba62-7b20c403f43e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - c7389bd6-0490-4155-9ed9-a453c7e7019a
-      X-Ms-Correlation-Request-Id:
-      - c7389bd6-0490-4155-9ed9-a453c7e7019a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141051Z:c7389bd6-0490-4155-9ed9-a453c7e7019a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:51 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 8276ba7f-f8f0-4cc9-9fdb-937a360680fa
-      - a16a5aaf-abb5-450f-9c26-216657816eaf
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - 8a71dda9-0298-417a-9a53-b31e3ab072b7
-      X-Ms-Correlation-Request-Id:
-      - 8a71dda9-0298-417a-9a53-b31e3ab072b7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141051Z:8a71dda9-0298-417a-9a53-b31e3ab072b7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:51 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 46742bff-2d14-4b4d-a053-802f2e661e82
-      - 52f31494-49e7-4116-b16e-98564c4b495d
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - ed786c14-9afe-47b8-9454-744891e02945
-      X-Ms-Correlation-Request-Id:
-      - ed786c14-9afe-47b8-9454-744891e02945
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141051Z:ed786c14-9afe-47b8-9454-744891e02945
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:51 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 35986c9d-0bd8-4b44-8bf1-97c70cda7b0a
-      - 75989e36-5390-4fdf-a5c3-f9d9844705f9
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - ef0ec638-9717-4aa2-85e9-04e7011fe632
-      X-Ms-Correlation-Request-Id:
-      - ef0ec638-9717-4aa2-85e9-04e7011fe632
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141052Z:ef0ec638-9717-4aa2-85e9-04e7011fe632
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:51 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Original-Request-Ids:
-      - 6b61db29-bff6-4d39-b19a-07875d1a0360
-      - 8b16f9ae-57b2-45c0-bc0f-800705fa3b7e
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - e2954800-ee51-41cc-9fd1-b31fc065ab93
-      X-Ms-Correlation-Request-Id:
-      - e2954800-ee51-41cc-9fd1-b31fc065ab93
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141052Z:e2954800-ee51-41cc-9fd1-b31fc065ab93
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:52 GMT
-      Content-Length:
-      - '2557'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/zRqq5Wed0WefPRI/p8
-        cTb76NFH9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gXp7NHnx6cJ5NPhp9
-        lF1mRZlNirJor1/nLQAUeP1us54007pYtUW1bO7uf7p3vpedH2znnz7It/d3
-        pp8StMn59s7ewd7+bHc22z+4f7fOm2pdT/PP62q9au6efPv02fbLV18+vUsI
-        XhazvG7uflFM66qpztvxSbVYrdv8bgeB5u7xTx6fPT9+cvb87M3v8/r0zd5H
-        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvH71us+WMvv/9j3fQtGmrOrvwWxYL
-        +vtVfp7X+XLKn6zWk7Jo5nlNr0/n+fk2MAJ8Ikh1Tg3t53l9SX8R1Ldr/Wxy
-        XZX0AX3cEGXowzJr86ZF11XztGjeooOqeXO9oq4+el4s1++o+TJb4M8TArBN
-        qM3oo2md05tfMoHpq2d1tTgDpvTV5Zym4Bd/tK4L+mLetqtHd++ib6Lj7P7u
-        3s54UlaT8bSq8/FVsZxVV814mbd36TWiOrXjLsb0J7CaZtN5sbwgSK9o4r9b
-        F22Oj2dZmwFd4pnvfZ/+rhp6yZBsKpNTv+ijnc0WxfIrIowOaVJXy+xi3tBX
-        JQZ7Ui3Pi4t1ncm4fvFHs6LJJmX+Mmuaq6qeHa/beb5si6k2OM/KJqf+m5wI
-        0hpsaDjU+C31aVDST86WhNZ5NgWvE+t/Y7xqRhjl1RfS990eDjwr2/TK7P4e
-        cR8wpz8uC7AG0ZxYk4hNLLqeTvN8lvN8mJ6/4QHcStgui7pdZ+UXGViC0HfD
-        zt+1+RJo+6+d0ScX87YZ/+QXT4vsYlk1NG8NSWlLg2tovKP/t+BP3Kf86H/U
-        ihDeCIealpVhyI/yrGnX+GxVZvQ3sZ5Axlyr9G9SIIT/bD0lTarfiAr5Jb9k
-        RHonpqjPp+f3ZtN8un0+OZht7z88v7/9cHYw3Z7s3s9n0/PzBzv7UwLb0ZMA
-        8MOlfQeBH7qithh9V1TeayEsaS7V2N3PRWfv7ewcbL/a2379cpc+o2/A5PT5
-        RrWtoOgFnfuXxPoXRLbtp/klfUqqil7/xnW338s3qL59sIThBg2uGPV0OCEv
-        Su0nvzi+IO390aO2Xuejj/IlVDup9GpBbadfrQgtMDe+JaT+v6nTV4Zcs/xy
-        /959UnOE/MzpPwJpBjCpqtbTjPhISEJDAA2IBMLlX70fO0BdOKLT9JPs0LyT
-        DK3/X2pJfB77/6gx8YdAsqDS0fn0g0zKoA042P30wcMH053tTyf3aJDTvd3t
-        g3yP3PaD2d7DT2cHs3x3jyB2VDAAfGMk+/KLl1+9Of3JL15vpFkHg54R2KUx
-        3tIIkGBZ8fBabjYCEB3f2BrdL5+Hmh+fqb2mj8GO9OFGtd/x1gFAYMJ0kCqj
-        d2+v84Vil4tm997DvbiYi9b3uvkGlb4HlTDcoPP/v+y1y5B/8gtS2hGmHVbx
-        HnEOPr1HuoeQZwjgEiI8cSlRnLh1/bOvbm8neB314o/g517dfvAQiA2VMcMP
-        P0jb0pT+UBz46XR3lyz53van2V62vX9+j3z3g0m2nU9nn356/vBg9/7Bz7YD
-        f7sJ6GDwIcqbm76v8j7JliRd0wwTYBT3V5P1sl13fPbd/fHO/vje9vM3r+kz
-        +gbMTZ+/j/I+ffWS/iDtRO/8LChtAv8NKmuCRhj9SEn7SNzN69X9HfISgDS/
-        CS4gQhMXEoWJG9f/b1XONJ3/X1XKhDqxmzKg/PFBSnhQa376YOfT/enBA3J0
-        Hz6gMU0ebmcPPyUPeH96f7Y/mZzPdu8RxI7OAoAfMoU6GHyI1vxaeY8fqtb8
-        4uwnEGiQvqCXfhbUJuB/g3oT4AinHylOH4m7i+IX7T3Ye0DqhLDmV8EJRGri
-        RKIxceT6/62aExP6/1XVCdyJ45QH9a+fHeU5+5S0xc6D/e3ZQU6jOj8/357k
-        pEEP9umLnU9nO9ke3Od5dhutxInb99VKdkA/WTQ0jNftelZU1KXRUC6DKsrp
-        YLy7fQoWXdVFk2+/oC9uqaEcJEdZJSLGSBJKb//sqCrTzXtorF/8UbkmPHYs
-        tviS1M3bCK6ni1V7TR8D+tfH03bQx/JFtQQd8C1m/fMnHz3aBU8xirs9FMGv
-        P6soRlR/BMV7rLduUPtmaujdDdpfMenpfxIqUYo/jHw2deYkmN77RtQU1JSQ
-        4GvZByXo7v7ep6Q6CSmGAIrQtJBqIMYmFbH+f7GZ0K92/z9sLfQr8LCybvjh
-        B9kOej2jkRLHQeIJM8eDZATYiuTZ7oM829vfzmYZrTzuT+9tZwcHD7d3dvbv
-        nU/2du8/PIdK6DjAAPBDpl0HA2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7
-        Y+Ts52Lq9nZ297Di+JS03pSUC39FDcCj9PX7GbuqgWqkv0nz0ItWMd9k55pV
-        Pt3VAe9u0s3SwU5fMw+aOKiLTdoZXW//5Bc7hFlXNdNvRAj+lL5VXH5utfM3
-        xspChPfXxkwuCvAoOATe3+RCI0DfwATIazqC08yTzNCUk+ysPeX/jRHpdvLe
-        0W88DuUow0jukw/SkoO6cWdyn7K5++fbu7NPKT2xO8u3s9296fa93dnOg91P
-        H+59ugfR62gmAPgh06qDATX5kW78ZnVjxLH+UN0I685a8Ee6kVj5Zt1ILAq8
-        f6Qbe1qNx6EcZRjJffKzoxuns/Od7PzBw+17O/vkN84e3Nt+OJ3e3z64f393
-        svtwNqXUBEGcZ8Pa50nWFNOvmRC1o1GFYFXMTapn5wCq5/VLUIa+waTS5++n
-        c15nZd6cVzRtXyHLSlJFr99a8yyv64uHuwf7cX4TpeP38A1qHh8sYcd6xtM+
-        /28Lmr8pqXrx+7z6PCpPG5SOpdS6OTj45jXPZia4ndIxo6Q+fxjEGlAbAa/+
-        nAfiH4Q98b1KQufTnx0VunPvYT6b7h1s388Pdmh8O3vbk9n96fb+/YfZ/iy7
-        v7t3sE8QO84dAHxT1Pru6es3J18ev37z9Mlmg9PBwXvz+L3czNdkxK1AeE1v
-        qexf/8Rzq9CNoqfPyKHc3/7ua/qx9wrJCtH1LtNMH9E74Er6+D1VvenxaX5J
-        n5IWo9dvp+obEvMr6mpaZU07mzSfPjz4NC7uqvO9rr5Jne+BJTR/vuj87xLl
-        T0D5p0/e2+H8RbTyB4rN8svdA1oZAf7fmPLvssX9h5/uDbDFz6UZsAJ+k2ro
-        qMCAjX/OzcE3MgoSDRWWzqdfzyxg8mEWvv9L/h8Nm/AjwDcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 0fd455e0-191d-49e8-afe7-b35e1bba0a4c
-      X-Ms-Correlation-Request-Id:
-      - 0fd455e0-191d-49e8-afe7-b35e1bba0a4c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141052Z:0fd455e0-191d-49e8-afe7-b35e1bba0a4c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:52 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/westus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 767d1e5a-2c62-485e-95b9-0d3b77df2f30
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 94ee99cc-67f0-41df-8c32-faaf84b9e0c2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141053Z:94ee99cc-67f0-41df-8c32-faaf84b9e0c2
-      Date:
-      - Fri, 30 Oct 2015 14:10:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wzk/oaBeGh+7YFsnJHd/Xv3PvW+64/kPaZkf8NIPHJ97ZF8uvvw/t7XH8nu
-        p/LtbYby6Yah/Kxz197Bpw88EJGhvAd7Pdgwkp/1Sbn/4N6+R67ISG6elCdZ
-        U0z/P25HdAw/20Zkf+fhp0Nj+HAjooP42bYgn+7uD0rGhxsQHcTPtvXY3ds7
-        GGanD7YeOoqfbYW7t3//wTBDfZMK9+nu73+5ibG+Cem4v7u3MzSYGxnrRulw
-        Q9nbPBQP0a89lN0dMulDY7mRvW4UEjeWe5vH4tHsa4+FFe/QWG5mshtlxQ1m
-        f/NgPKJ97cGwBh4azM12/X0k5v7m0ex6ZPvawznYfTgsMzcb93vvITW7N2gA
-        D9mvPZyNYnMzq72H3OzeoAQ8un3t0WwUnJt57T0EZ/cGNfCzLjk3s9r7SM7u
-        DYrgZ190dnf3Pz3wqBYZ0HvJzqbBuK++9lh+aJZzwzg8LL/2ODbK/zdqNjcM
-        xKPW1x7IRtG/WZG9h+j/bLuYG8X+ZiX2XmK/SUy8br72WHY3sdfNs/Ie/LW7
-        SVJ+1hns5ml5Dwbb3SQrP+sc9k0blg1j+f+aVTk+2DAYr5evPZZ7D3dDleuP
-        5RudmOOHG4byjczLxrHcYl7eZzC7m1JhXjc/O4P5Zidmd5NO/v/azHy+aTAe
-        ph8wlnt7PlGCsdyslW9vYD7/2bYvDw4+3b/nNQtGcjOL3d6+fP6zbV527z8g
-        yvvo+kP5hhnsZ92+3NullN+ej7A/mr29h/ceeN1ERvMeBubzTStfPnN87dF8
-        Ssss+/d9hP3R7N8/eOADiYzm0/cQmdc/29LfFQt/LMSC35zwv94g/d+I9Pek
-        wh9Kd5j9obyH9L/+2Rb/nkj4Q+mNsz+W95H+1z/r4t8TCX80vaH2R/M+0v/6
-        Z138H+4+uL/js5I/mt5Q+6N5D+l/ulH6v4kcTCc94Q/lm0zBbJR9D8uvPY69
-        gwefeq2CgXTG2B/I+0zIJsn3yPWzMpCbg/3b67CnG8Xeo9fXHglZ/EDj+iO5
-        2bC8hwYjKdkkJl4/X3ssXXz9sdw8K+/DXz/rOZiuIfSH0h1mfyjvw2A/6zmY
-        niH0x9IdZ38s78dim8TlG7GSPUPoj6Y31P5wrJXEj+//xskv+X8AmsJ+7lUp
-        AAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 88770f5c-f234-48d3-a166-c880347e8eec
-      X-Ms-Correlation-Request-Id:
-      - 88770f5c-f234-48d3-a166-c880347e8eec
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141053Z:88770f5c-f234-48d3-a166-c880347e8eec
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:53 GMT
-      Content-Length:
-      - '2015'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7OR6OPltmC
-        kP3oG4C0qqtVXrdF3nz06Bd/tMpqgkxv819lNc0wfvzeXq/Q4+u2LpYX9J7S
-        66MrGuW6+eiX0CdF3a6z8otsOi+W+YsMGA6/ZxF+WVez/uuvix9Qqw2vt9ly
-        ltWz3//p6128nc0WxfKrJq+FMsMvTupqmV3MGeOmrersIj+eTqv1sr0JY4x0
-        ivmcTZpPHx58CgiK9Iu8varqtzdB8Dni4e69h4CwlFfPMGXn2fRGujW/qKRR
-        Et1o4mZ7Oz6M1/l0XRftNfPfTXB69GcKvsyahkCRBLg3ATXX99HuMivKbFKU
-        1NPr/EaqYcxMtWNqjPdnRXaxrJq2mDavvzb97z/8dA/AstmMpK55WefnxbtN
-        L+/ujO+Nd8Y7d3d53ki6iWg39TjLz7N1yVjLC+/Rz94+XlutJ2UxPVsdC543
-        ddiblM77b/i94fefXhP7F9OPfgm9uqhm+OhsOa1z6J2spIbENJdFQyJN75EI
-        tWjxjOYzn9GXbbEgEmeLFX0IJbG9u7O99+DN7v1H+zuP9u+NP723//DT3d2f
-        oqazda2a4aOXb+7tju/v3j/Y29t/TV9Nq7rOS/72jPjoo/08378/m+5sz3bu
-        H2zvTx7sbGd7uw+2708m51PSn+fnDyf0GmM2Y8VDOpiGkTcrEgcC4JTcSbVY
-        rQnn0UdEDFa1IIi84X9CL6lgqjZp6BWjzNCceYm01vd/yeimN+86fiUGbolu
-        w8AYXBx11RD0qt8dXh9CQN8Y7o366rxJHIpXrC55n3c7nPZe72q/rClIK7D+
-        GX6f/iMGylf5cpYvp2x4iAjyQfMlsRT99bNigy2LeRZYqXxXh+BId7enaMOp
-        I/xuAcV7SWQ/pr+/ueGCxkZFRoerGvduaPnCF9m2Obx7gx2A4b2iQ40AzVbF
-        TxJGNED6nnXMzqfbu/f/30cENjBuRN8MERToIBFILr4pItzI+KpL76q2seou
-        NEFuOD0KDADwXlEKhBAx0z9Hsj6A8c/+kP9fN68Ro3aXuHjZekO57egjsDwo
-        MYJoVz+HnGD0tQ5F/wxfZAfdDaRHDn2pC8N7RcfeA4qB/9CH2rPvIUd4aA+O
-        tAfCe0nHGsL8ORmo2uDQGXn/wUbBeC/GB/zDlPQOps7p+OG5Lt+nQONnaYpJ
-        M3xDCZN7BzQUeOWE5TcAiQb/c5sweZpf9t/+/32+BG93efSm9y3DzvLL3QNO
-        GCiIQKxvAtOlPNPuh5Ap6bz/koLq86pePENO4mm1yIrlCeZhE8x7G+B8tZpR
-        AuCWgMg77c6/qJLhVyhZsijWi9//+avXeNm5Cd9A3mcQ2E1IWTlQrP7/mkBS
-        Vu28fhN1vlb+6PV6Os3z2U0ppE8f7e2P9x98+unDSArpwRd7D8af7u7fP9i/
-        H0sizfZns4N72f72QZbdpyTS7P725N6D3e37+QEllB5SKml2Tq8xejCT7E7S
-        WCKZGHVjqTVRhM0PqCJv+J/QS6qtVMXCIhoFj+bMmKTJYxmRzptxH/m2wDry
-        O/wqvxwftUoJveoDx+u97kIpH+6N+tr85l0o34JcCc99uZEQy3VZbhyJ2g56
-        ze8dr/bw0VnQN7o9bRoJiSpesZbmfd7tyNx7vav9siWh2WbzNPw+/UdyxCHU
-        /ycyaWqGw5kj9G4BxHtJdGDEuP8QB6tK5G5XNPlNNlZsxB3SvZEOQfDe0YGG
-        IH+ow1St0c1yBZkydu0c0r2BDsDwXtFx9oD+v26o7H04vL+ZoTLQ/9cNlSfA
-        4f3NDFWBDuY/f+6IYAcQEIGnxo3omyGCAh0kAqn0HxonGCWkhtK6K4Eb6UbT
-        I8DA+94rSoAAIOb558hIDSD8sz3g/7fNacQN06SsG8htxx6B5UGJkEN7+jnk
-        ggG5/SHJ/g+VGwbQ7A3V+eqTsppEQRXLpriY07v9CTfgvdHflmCuY9dnvwMP
-        8ABZBW/XncVW+/sRv/2/aqhu2ttsUuZRWHYK+/xg4HvDvy3FXM+uz34HHuAB
-        uirirj+Lrnb4I477f9VQ3bz/onW+/v8kxwnirj+Lrnb4c8lxJnJX70D/DF/0
-        htijnb7Qfd97RakSAMSAf+hD7CV4At/Kw3hwkD0I3ks6zADkz8kwNQcT5qLe
-        e6hRKN6L0eH+MPVHB1GXcvph5a1osNW6Jdea0ne/+CNeXHrfhbkOP/VfQ0Jf
-        Onml2FAjox7cMIyL301KMRVZFYU5qP6bKr42OAjn9eu9F1GWXgzRATg4E73p
-        vPnlkGkDnDa93ZkN6vq2byoV9E8hu2He2HtDBqdrOT7kXWe92MOOiZC1Q5GJ
-        UvDfDAZiAH9OURCv74eMAifOKN3/S77/S/4fHM59kKoyAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271140/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 81cc037e-b96d-442a-87ea-ad6e90644676
-      X-Ms-Correlation-Request-Id:
-      - 81cc037e-b96d-442a-87ea-ad6e90644676
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141054Z:81cc037e-b96d-442a-87ea-ad6e90644676
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:53 GMT
-      Content-Length:
-      - '1495'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7v7O3WqV15ki
-        9uz4wf7x8YMn+/ce7jx7uPvR6CP77RkGEmmwqtGkLfLmo0e/GH9dFg01L5YX
-        r9usJSJ89CwrynxGTdtiQaPIFiv6EBhs7+5s7z14s3v/0f4O/W98b2f30539
-        n6KWs7V0Sg1fvtkf39vf29vdP3hN37R1Nn1LwBmd3cnew+zTfGf7Xk7UJELu
-        bz+c0T8PPt3bebC3ez+/f29C71Cf7bo5qWbA5kk2e5X/ojUhYr/5Im+a7IK+
-        /MUf5XVd1fhllreENo3pe98ffTSVV1+vJ8u8bV5U7dnydbbIf5L+IiA0KHld
-        G6Sz/Dxbl21a5+d5nS+n+SydXNNfMqHp3W+YG5jms7z2eeFF3l5V9du7hA5+
-        noEbzrNp3txtflHZMCvQa7O9nYd3i9VJtTwvLpTkDX0w5Q9206JJl1WbFsu0
-        nedpQ0NOf7Ko23VWptpBmjXyHY+8SavztKK/6/Qnv2jMe9klUTKbFGXRXqdN
-        3o4/+iW/hCYyqy/y9pWOCyT/WREVGmWPOCfVYrVu87uXMpYvsum8WBJprAC9
-        JNLQxBq4b65XhOBHNwLwXnlBtKJXQoi/hMb9szTMny2NcO/44bMHByf7T06e
-        PL336YNnNET7LYtgpAGRnJps0giv19Npns9uVgr37o/vPdg7eLh/v6cV7o33
-        P713//69+z2tsL/z6STfvTfZ3r9/f297f/IwI2J+SlDze58+fLi7tzfZO6d3
-        qFOSfdUKJ3VOqDE+P3d8qTJ1C6ElPA3wHnMOQvFeUvbsgf3/IIee7Oycntx7
-        cu/e3t7e/ad7T2iU9ltmh0gDGi41+WY4dHe8++nDB2QPexy6+2B8b29/5/7u
-        gx6Lfprv5geTyb3t3dn+ve39/ex8++H9Wb6d796/t3//fG+HcKV3qFfHol/+
-        XvTJ/wu4c7WelMX0bHU8mxGIhrjTTiJrOcdlg6zZA+G9pKwZwvz/IF8+efb0
-        09MnD+8f39t79umTXbCd/ZZ5INKAyE5Nvhm+3Bnv7R3s7tz7tM+Xn47Je3vw
-        6e5ejy9ne7NzItm97dm9++RQTacPtiefPpxsT+/PHuzcv3/wIN/doXeo1//3
-        8aXqu9f5dF2Tp6Gv24lkPnJsNsibUTDei/+/4c+nT/aPH54+Obj35PTg4acw
-        KfZb5oVIAyI/Nflm+HN3vLf78P7DCHuS2nywR5qzx53ZbEL/251tn+cZac3s
-        AXHnNN/dfvBwJ3uYESVnO/+v5U51FfXP8MWHu/dAXQN6kDU7MLxXlCl7QP8/
-        yJenT4739+5/+mTnYPd452T/Uxql/Za5INKACE9NvhG+3L0/Jubb2d3Z6zPm
-        +NN7+zt7EY/z4cP9ewe7u+Rs7t/b3d7fyx5sZ7O93e29T3eJXffu73y6c0Dv
-        UKc/NMa8oiFOMVezSZwxX7dVTVHr3UZ+Hk+n1Rpz6b/46cMDkNeA7jHmAAzv
-        FWXMCNBsVfwkYUQDpO95GnY+3d69//9Flj25d/Lwyd7Bg3sPn53snDx7QKOz
-        3zJ/RBrQlFCTb4plP/30/qc7DyMu6Pj+w517e59+GmHZg72d853J9v3zT/e3
-        988PptsPPyXm3dnZz6d7lG95+HBK71Cn/99iWbIo8JwN6G+GZRXoBpb9/i/5
-        fwAjSQ3n9RMAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Resources/deployments/Microsoft.SQLServer2014EnterpriseWindowsServer2012R2-20159271138/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 69938a43-6ea3-479b-9a71-da8c555770c2
-      X-Ms-Correlation-Request-Id:
-      - 69938a43-6ea3-479b-9a71-da8c555770c2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141055Z:69938a43-6ea3-479b-9a71-da8c555770c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:54 GMT
-      Content-Length:
-      - '2164'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d7+bN+1JlTXt0yfN3Vm+KqvrRb5sm7tfFNO6aqrzdvz6J56/
-        zuvLvN7b2d0/XbZ5vaqLJv9usZxVV439au/V3jb9uP9w78Hu7r2Du9UqrzNB
-        7MnuyfGnTx4enOzvPvh059MHH40+st+eYSCRBqsaTdoibz569Ivx12XRUPNi
-        efG6zVoiwkev19Npns/yGbVuiwUNJFus6HMgsb27s7334M3u/Uf7nz7auzfe
-        f7hzsLv38Keo6WwtHVPLl2/2vrh3b7x77+GnD+7tvqYv2zqbvqU+GKuH+/fu
-        3X843ds+mDzY397fnd3bPji493D7YGe2ezB9MLtPFKV3qN923ZxUMyD15e9F
-        n7RZfZG3r5TSwP9nZbqYKLO89ifrpFqs1m1+97Ko23VWfpFN58Uyb+7aSXya
-        X96dFdnFsmraYvo6b1sabnM3u6BZJ9RNf2+uV4T4RzcD7sPyoLzIFoASdC49
-        /ZJf8ktGP0tk+dni4v3T3b29+5+enp4enB7sPntK47TfMr9EGtAUUZNvgIvv
-        Pdp/OD7YOXh4sL/X4+L9L3bvje/tf/rp3qcPelz8YPZg5/zTT7Pt2b2d2fb+
-        fv5wO9vZu7e9/2A6u5cd3Jud796nd6jf/29xMWFowN6WWb1XIpz5/0WePP30
-        +Nne/aefnu7vfbq/9wTqyH7Lsx9pQASnJh/Ok/cePrr3YEwsSaDv93lyvPtg
-        l9TqvR5D7u1kO/ceZrPte9l9IuZefr6dPZjl2/cePLiX7ZzfpzFO6B3q9P89
-        DPm6rWpSXHcb+Xk8nVZrzOUVvTjFi7NJc//hp3t3G5q0Ykqs+ovW+TqPwiqW
-        TXExp5f7qtPAp8EaDHu8PYSK7dn12e/AA6wS0BuBIO76s+hqh/9fFJMHT48f
-        fHrv4OTes9NPTx98Cv/Cfss8GWlAZKQm34yYfDreub/34OBB3wEh7+Pg3v7+
-        /sOemEzy/NO9vYN727MH2WR7PyeByXank+2HO3lG9P30PL+3S+9Qp/9fFpNJ
-        WU2ioCzb9ZnYgKexGgR/6FLCeLvuLLba3/8XheT0yfE+uS9PyFM+3jnZ/5So
-        YL9ljow0ICpSk29GSO6PD3bpv4cHPSHZHX968OnD+/f6zs3OpxPyxe9NtvOH
-        +ZSIuftw++HDe59uZ5/Odg4+fbBzb+f+/ydtyacPD0BeA/q27O29EmFcBZqt
-        ip8kjGiA9D1Pw86n27v3/7/Isvd2TnbuPdinmPE+OTl78Ljtt8wfkQY0JdTk
-        m2HZ/fHD3Qc79+/19foeafx7u5/2g8pJPpnMHs6m2w/IX9/enx7sEccS0Fme
-        7ZCjnj0gTqZ3qM//b3Esa0WrXdtsUv5/0vsRxF1/Fl3t8P+LUnJy7+Thk72D
-        B/cePjvZOXkG58Z+yzwZaUBkpCbflJTsUF5n5+BBT0p2KXzYu38vEiTMKJJ+
-        8GD3wfank4wU+/37B9sP89397Z170+zhJNu/d3D+/0nFDiYjLA3o2/K398oA
-        51KL/x8p9r29e8ef3tvbffbw6dP9hw+PaXT2W+aPSAOaEmryjbDsHin2vYf7
-        lDLssSx9s7Pz6ad7fc1+/+HO5N6n+cH2dLZHiZYpqffsfPZgeye7N/t0b7qb
-        P5xO6R3q1LHsSZ0TaozPzx3fvsjbq6p+e3cpP88wYecZlGnzi0oo1rye5Ze7
-        B+AxA7vHuINAvJeUdbtQ/z/In/dPHnx6+nB//+mzhw/Iv4BbZb8VZug3INJT
-        k2+EP3c+HZOXu7+zs9/jz3tj0gY7n97b7/EnJQgn9/JP8+37D4iO+/ez3e2D
-        fHKwTV7Kw+nuJPv0/sN79A516vjz51qlmkRedpkVZTYpyqK9Jmsub7L6O6Y/
-        CUcDuMeXQxC8d5QtQ5D/H2TK42Pq+eGDnQef7j249+kJnF37LXNApAERnZp8
-        I0y5+4ACuP39vQcRO78/vr+3u3vQD+CyjLj1PDvY3pmdU046vz/bnpxPZ9vT
-        jDzje9PdT2fZ/+vsvFF1ml3WP8MXCUMDtseS+kL3fe8VjyMtwP8PMuSnDw72
-        TuFRnj54snd8AH6z3/LsRxoQwanJN8KQ9/aIIT+l9HQ/o7D3kBjy04ODh32O
-        PJ89zPYffkpO5/mDc/onf7CdTe7vbu9NZtn+/Xx6vvMAWXTq9f89HDngNf6Q
-        PM//D3ImxRwP79Oq86cn+3u79549oVHab5kLIg2I8NTkm+HMe+NPd3fu70dy
-        Xfd2xvcOdnZ2HvZjouz+/v7u7t50O6eVle39T2k9mjyMfHtnNzvIzx9O9if3
-        MgJHvf5/izM1L2VAfzOcyUD/P8iZT3YPTneePbi3f0ohzoN7pzRK+y1zZqQB
-        EZ6afCOcuftwvE+8t7e32+PM3U/Hu3sHpFH7nHk/3z+fTXYIzr0DCn0OsvtY
-        0nuwPXkwmTzcy4k7P0XP1Ov/ezhTze7d1XpSFtOz1fFsRiAainrsJGJR2DFZ
-        jy8HIXgvKWcGIP8/yJU7xzsP9k5oCevZ7i4pp/s0Qvstc0CkARGdmnxjXLlL
-        qaLIAhq48uBTWrvrr6DtPMgnu/nep9v3Pj0nrjy/f3/7IY1r+9PpJN99kGV7
-        D2YH9A71+v8+rtQw+nU+XdcUsejrdiLBRo7JBjkzCsV7cYA7v/9L/h/OKXRw
-        ayYAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4e7ecab7-1205-487a-9608-dbfdb0388d5b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - fd75102e-e4e9-49d2-9cf1-dbfec1ee07cb
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141055Z:fd75102e-e4e9-49d2-9cf1-dbfec1ee07cb
-      Date:
-      - Fri, 30 Oct 2015 14:10:54 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x99N2/akypr2qdPmo9G9utihi/vNutJM62LVVtUy+bu/qd753vZ+cF2/umD
-        fHt/Z/rp9sPzyfn2zt7B3v5sdzbbP7h/t86bal1P88/rar1q7vrw767q6rKY
-        5XVz94tiWldNdd6OX+TtVVW/vXtZ1O06K/XP8EUPsbzNLoDad+/+vh/tfPpw
-        Z5pnu9sHeba3vX/vYGf74cH+p9v5+YOD3U+z2cOdfOf3/ch7ub1e8aBv7N17
-        p6ymGYaP964Ip7X/JQ1olddtkTf0tSWufHFZNPRasbx43WYtd/t6PZ3m+Syf
-        OQjU1BJsLUSfnD+Y5JN7O9v7D6ZTovK9fPvhPv2Zf5rt5buT6e5B/iAAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMprKCeT7a3RnfG++Md+7ufvqR/9X33R+/xO+O
-        eGKZtz1IQbfUzDDYLD/P1mXrY4zn/2UcdpfwwKjuDqH7IXwnD3giyizy4Otb
-        sow84dSisZ3Jvf1I82J1Ui3Pi4t1zfwMJIIJlKeHF56fg8miycDPs2Wb1+fE
-        2DRDv6hs8voyr2f55e7B3t3ueOiDKX+wG7CxPL+k+5HH3XiC770/bDP9zEiC
-        JZPlc39kD3fvPXQz8HNAvU2s3kHOZ+zJ/v2d6b0H97c/3Zvc296fPZiQ6pke
-        bD/YO9+ffLp3cH5vFjD2/zcU6sGD6fmn+wd72/fu33+4vZ/t3t+e7Hx6vv3p
-        JM8mB/fOdx4+/DQAoIL1I4X6gVx2l3DByG6lVN+X9+QBX0QZRh58fUu2kSec
-        XjS2s/n/b6VKr832dh6SEg0HRB/8ELQqftCHv+T/Ac5i5Ge1CgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 38809190-9121-4043-9f61-dfd04da7c4cf
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Correlation-Request-Id:
-      - 0ff982ff-431e-4941-9cc1-ab100d4fc93f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141055Z:0ff982ff-431e-4941-9cc1-ab100d4fc93f
-      Date:
-      - Fri, 30 Oct 2015 14:10:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHOvYf5bLp3sH0/P9jZ3t/Z2duezO5Pt/fvP8z2
-        Z9n93b2D/Y9G3ovZZVaU2aQoi/b6dd4SDA8sfV8w2LvNetJM62LVFtWyubv/
-        6d75XnZ+sJ1/+iCnXqafbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar
-        5u5386Y9qbKmffqkuUvjuCxmed3c/aKY1lVTnbfjk2qxWrf53Q5G9Obp6zcn
-        Xx6/fnP8+vTNRw67X+KPY57Vs6uszl/W1XlRgnjhOC4Xr4sf4OOPXrfZckat
-        f/+nr3eHoDVtVWcXg8CKBX35Kj/P63w57X1NDVbrSVk087ym7z6yQ3z9E89f
-        5/Ulfer1heej6pxgoS012dvZ3d/+7mv6sfdqr9eyebtGu9Nlm9erumjyXguC
-        39AsoVWZtUR1b5DhMKlx1TwtmrfUtjuCqnlzvcLQPvpusZxVV02vn2W24O8J
-        ZRnV0/yy12ha54TDl8w3aPysrhZnoF6v5eUcnNZBgz5f1wV9/tG8bVfNo7t3
-        r2hAU7DRbNJ8+vDg0/GkrCbjaVXn4ytBdLzM27sErbnrYzamTwJCdElBXU2z
-        6bxYXqC7V3k2+25dtHnwTvjGR7OszUA+COP3vu++8psRIYe4aCoMX7+4kZAf
-        ZbNFsfyqyWtD9EldLbOLeWdWPlISnFTL8+JiXWdK9qBfasbiByb5yS+OL/Il
-        pL6t13kAi5rly2xS5sfrtloQpOlXKxowax409tv6A6b3mpymvUXDQarQHF1V
-        9VuPNOajM3D2eTZFR9/7xR9B//xQ1M8L6f5uD427zS8qifI0L7P8cvdg76Nf
-        8v1gKLMiu1hWDRFocKYnVdU+dc2631MLITWNlWnrgcdj1NFXw6Jw/+GnewOi
-        EHKw+yMYBFMEHEH8TwqS+J46er2eTvN8RmiZlu6djwx9MRq1U3iCgX2E2fvh
-        Wo/Lom7XWflFBlGmyfOF6m7+rs2XGKX/5hl9cjFvm/FPfuHNEVmelmjR2KHT
-        4M2v33dU+H/XAJ02uEE7f9Sqcr8RvvdOWU1JDbBC+Qi8tzbEYcKQpP+S/we6
-        Kwa0vggAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Compute/virtualMachines/SQLServerDev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 5ffc02c9-4850-43d7-8c1b-e9fdc5246e4b_130898280162986531
-      X-Ms-Request-Id:
-      - 6584c6ba-eceb-4934-a663-0439122da23a
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 1c777228-447e-42b8-a966-ef60f637c4ba
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141056Z:1c777228-447e-42b8-a966-ef60f637c4ba
-      Date:
-      - Fri, 30 Oct 2015 14:10:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdeXT/0092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6+ieev87ry7x+ml+6bqO0817H
-        s4F+zXo6zfNZPnMQ8Tj6nS3Pq853hGlIPh9sOgQxRpx7j/YfPLq/P/704MHD
-        /S6NiDLmV6aT/v19BvvRpKrap0V2sayatpgCDR0yDXbZVGX+elrn+bKZV+2T
-        spp8VRfU5KN5266aR3fvXuVNO62ypp1NmvsPP90bT6jNeFrV+fiqWM6qq2a8
-        zNu76GTmOtluflHZ8BRs79x7mM+mewfb9/ODne39nZ297cns/nR7//7DbH+W
-        3d/dO9i/68/Y+DZvjBuL9HiyWDEplD3ydy19QTTGUHWidcT0reGRL4ppXTXV
-        eTs+o8YX87YZ/+QXHple521Lk9QwZIKNH0rQPh858O/FP0O88/58s5FnHtzf
-        ub97/yBgGqFVFPPqKq/Rc353lmdlWU3pV7+rWyNNqsCHIA2FkL9x8kv+HyB8
-        XwU/BQAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/networkInterfaces/sqlserverdev182?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"1042c595-a74e-44b7-a429-f4bc703db2e3"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d241bf8c-20fd-4f0f-a842-6623b55d4474
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 0e99d48c-61b7-4c95-986d-3592f8244ec8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141056Z:0e99d48c-61b7-4c95-986d-3592f8244ec8
-      Date:
-      - Fri, 30 Oct 2015 14:10:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qPlFZZPXl3k9yy93
-        D/Y+GvG3xQzf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz
-        7Z29g7392e5stn9w/26dN9W6nuaf19V61dz9bt60J1XWtE+fNHdXdXVZzPK6
-        uftFMa2rpjpvxy/y9qqq395dys+zZZvX59k0b+7GMcvb7AK4fffu7/vR7s7+
-        3vT+w/vb2YN9Qmh/8mA72997uH2+P5k+2Lk3m+zl937fj/TF9nrFA75F1/pG
-        WU0zjBxvXeVNuzZf0DhWed0W1PJRyuSUDy+LhpoXy4vXbdZyZ6/X02mez/KZ
-        vEnNLH3WQuOdSXY/29mfbU8fPry3vX/wYLqdTe/tb9/b383PH8wOZrsP9+3L
-        xeqkWp4XF+uaEUP335OvUoMHHju5xWrK7XcNBDz/b5zcu92R0Qcx1L/u7MuD
-        OepNnDz46hbTJw81Li6pydnL49mMaAJohM743nhnbCdLHq9pafjpi7ydVzwH
-        T69ppopp95X1pCym9IYFHqBKLX74M9jBiWbw9U88f80z+DS//MjH75eEoyEk
-        afoJ35/7QVwWdbvOSv2z8yLhQXg2d2f5ebYu23BI7g/7q/7yfR3tR7Nl8zpv
-        W2KfYMbkc9AJH3/PNKcvstWqLPLZ0/B7+drQ8KN8mU1K4p5nVX2V1TOCTq3O
-        MxIe04KQxmhe59N1XbTXTBNq4xD44dM5hlKUYewwdWa+yKbzYgnR+9lA//T1
-        m5Mvj1+/efrkdRT9k2qxWre5YRNFJo44ftA/v+T/Adj3QZ5NBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:58 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/WestCoastDBs/providers/Microsoft.Network/publicIPAddresses/SQLServerDev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ffb2bdc7-0244-4a65-bd0e-a0ac512ba7d9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - da0d8f87-9b9c-459b-b259-b23e2c78e5f2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 82945cfa-2948-4f4a-8d7a-2061a60707dd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141056Z:82945cfa-2948-4f4a-8d7a-2061a60707dd
-      Date:
-      - Fri, 30 Oct 2015 14:10:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PVPPH+d15d5/TS/
-        /GjEXxUzfHG3WU+aaV2s2qJaNnf3P90738vOD7bzTx/k2/s700+3H55Pzrd3
-        9g729me7s9n+wf27dd5U63qaf15X61Vz97t5055UWdM+fdLcXdXVZTHL6+bu
-        F8W0rprqvB2/yNurqn57d7WelMX07OXxbEYgmry5G0Erb7MLIPbdu7/vR+fn
-        k73JbPqAut/f397PPr2/PZnt5NvZTja9v7s3yR7MHv6+H+mL7fWKh3qLfvWN
-        sppmGDbeuqJBrM0XNIhVXrcFtXyUMiHlw8uioebF8uJ1m7Xc2ev1dJrns3wm
-        b1Iz6kGIsxYC33+YfTq5N9vf3r23N93ez2fZdra3d7C9m92fPny4e3D+8N59
-        +7LFtDS4fZG384oBPb2mySymtm0xK/M3xSKv1u3Z8otiuW4Z3X37/eqkWp4X
-        F+uaAdFXOhJ8xxDv/hDnfik/z5ZtXp9nU5r75heVDc/9LL/cPdi728G3oQ+m
-        /MHuR4L3L8EP+ueX/D9+geC92wIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:10:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - befe1734-9a5d-4181-84a6-b0fb77e962d3
-      X-Ms-Correlation-Request-Id:
-      - befe1734-9a5d-4181-84a6-b0fb77e962d3
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141058Z:befe1734-9a5d-4181-84a6-b0fb77e962d3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:57 GMT
-      Content-Length:
-      - '411'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - dcff66ba-5c5a-44bc-a274-89484f0f62db
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - d37d5067-cd4d-428e-b28b-9528a812ea7d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141058Z:d37d5067-cd4d-428e-b28b-9528a812ea7d
-      Date:
-      - Fri, 30 Oct 2015 14:10:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+9brPlLKtnv//xzkcj9+16McnrL89PqjpvqNmu+6pqnhbN29fFD/Kz5RdP
-        8N3O/oP79/dcC3qlWtfTvNNub2f/YMe1WuSLqr7W7x58euB9k717mrUZXj+p
-        1suWvt+VL3+JNto0jN2f5WE82P10cBi7Dx56ACLj2JMvbzOOvQ3j8Dr52uPY
-        vXewtz80kHv3D/a9r/oD2ZcvbzOQexsG4nXytQey93D3YHAgmC3vq/5ADuTL
-        2wxkf8NAvE6+9kA+3X14f29oILv79+596n3XH8nup/Lt8FCeZE0x/f+4oOsY
-        fralfH/n4adDY/hwKddB/GyL+Ke7+4OC8eESroP42Rbv3b29g2F2+mDx1lH8
-        bMv23v79B8MM9Q3ItlNT9zcMxUP0aw9lo+G4eSg38pUbyacbRvJNsNZGy7F3
-        8OkDD0RkJDfylhvJgw0j+SbYa6PpuP/g3r5HrshI3oO9nv5sa977u3s7QyO5
-        UWndqHndOH62le/uDknJ0EBu1Fu3l5KnP9sKmM350EBulvfbS8nTn20lzEZ9
-        aCQ3y/t7SckmMfG6+dpj2d3EXjfPynvw1+4mSflZZ7Cbp+U9GGx3k6z8rHPY
-        N6yHN0nLrjf7X3swB7sPh1Xx7u7+pwceySKjuXd7bXx8sGEwXi9feyz3Hu6G
-        Ktcfyzc6MccPNwzlG5mXjWO5xby8z2B2NwWLXjc/O4P5Zidmd5NO/n/XzODH
-        93/j5Jf8PzIr3UrFEwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Request-Id:
-      - 9a13e92b-d481-4823-bb24-61ab6e67f5aa
-      X-Ms-Correlation-Request-Id:
-      - 9a13e92b-d481-4823-bb24-61ab6e67f5aa
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141058Z:9a13e92b-d481-4823-bb24-61ab6e67f5aa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:58 GMT
-      Content-Length:
-      - '1446'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Request-Id:
-      - b1ff1054-6d7b-4496-a2a8-16db09571159
-      X-Ms-Correlation-Request-Id:
-      - b1ff1054-6d7b-4496-a2a8-16db09571159
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141100Z:b1ff1054-6d7b-4496-a2a8-16db09571159
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:10:59 GMT
-      Content-Length:
-      - '1791'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - 75f80e07-2c8e-4480-9770-4eb1df45420c
-      X-Ms-Correlation-Request-Id:
-      - 75f80e07-2c8e-4480-9770-4eb1df45420c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141100Z:75f80e07-2c8e-4480-9770-4eb1df45420c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - bf159f8e-9dfc-4db2-bf0a-2b48c488db20
-      X-Ms-Correlation-Request-Id:
-      - bf159f8e-9dfc-4db2-bf0a-2b48c488db20
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141100Z:bf159f8e-9dfc-4db2-bf0a-2b48c488db20
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 2597e597-3ce1-496c-9dfd-0ddb3515de90
-      X-Ms-Correlation-Request-Id:
-      - 2597e597-3ce1-496c-9dfd-0ddb3515de90
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141100Z:2597e597-3ce1-496c-9dfd-0ddb3515de90
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '1160'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sOPRh8tswWh99HXfX1V
-        V6u8bou8+ejRL/5oldUEjtrxX2U1zTBM/N5er9DN67Yulhf0npLlozxr2nXz
-        0S+hT4q6XWflF9l0XizzFxnQGn7v9NXL/kuvix/Qd8MvvW6z5SyrZ7//8S5e
-        zmaLYvlVk9dCg+H3JnW1zC7mjGbTVnV2kR9Pp9V62d6Epp2r+wd7D/C6Ivwi
-        b6+q+u2tX8erS3nnDPNwTvNx08t5vXpw/8B783U+XddFe818dNPbSmCm0cus
-        aQgA8a9rD1i5vkXtQrK84UausTRzwO1EfP7qNd6eFdnFsmraYtq8DgDdhKUl
-        kKHvIKT3RSmbzUjumpd1fl682/Ti7s54d7wz3rm7+yneI/kmct+E9yw/z9Zl
-        6154j3729vHaaj0pi+nZ6ljwvKlDnc7OWzcR5ek1iUYx/eiX0KuLaoaPzpbT
-        OofKyUpqSOJ/WTQk4/QeUbBFi9fr6TTPZ/mMvm+LRd602WJFn0N1bO8cbO8e
-        vNk9eLS/92hvd3xv5+HD3Z2Dn6Kms3Wt2uKjl292d7/Yezh+sLe782DnwWv6
-        dlrVdV5ygzPiw4+I/7OHO/nD7ckkP98mVZlvT6af3tvenZ2fH8yybPf+/fv0
-        GuM3Y31EGpgGkzcrepUAOIV3Ui1Wa8J89BGRhBUtyCJv+J/QSyq9qm4aesXo
-        ODQ3yuz7v2R005t3HZ++ztuWqDcMjMHFUVcWp1f97vB6D4FQQL9Wb6q06FUf
-        Nl7v9abD1TeGe6O+Om+SLOAVq+Xe590Od7/Xu9ov6zWjI4ffp/+IY/NVvpzl
-        yylbPyKCfNB8STxMf33z9t5ys2ftlcR3FX9Ht7uq/8PZIpRu8a73kigWZ0x+
-        WONS1r7b4Vv3Fmt8h2dvcAMAvFd0aCFETOwPZ4Sqd+6qrFjVAFXtkOyNa+A1
-        7xUdF+Bgvn4uuHIAyW92bP9vmKmIIr9L3LZsPZxvO8wILA+KG7l28HM1t0Zr
-        KPb6p/eWh3Rv6Nq6+7L3io7TQcM4f7gj69kRzLSH4uCoei96L+m4AOmHPyLV
-        8KF1u+2ooi97L/oj+6HJZAc5Z7t+duwejatatyS1ZOl/MQUHFBW9b+TYYY7+
-        a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
-        dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
-      X-Ms-Correlation-Request-Id:
-      - dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141100Z:dcd399ef-ee8f-4795-a8d8-84cc38a9ccf7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 1982c2b4-6403-4224-95c1-9ba628f8e481
-      X-Ms-Correlation-Request-Id:
-      - 1982c2b4-6403-4224-95c1-9ba628f8e481
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141101Z:1982c2b4-6403-4224-95c1-9ba628f8e481
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
-      X-Ms-Correlation-Request-Id:
-      - ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141101Z:ffb42cc5-a7bc-4250-9d28-f7a76322cdc0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '1084'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/96PRR8tsQRh99L6vrepqlddtkTcf
-        PfrFH62ymsC0ec1/ldU0w4jwe3u9AvjXbV0sL+g9pcBHeda06+ajX0KfFHW7
-        zsovsum8WOYvMqAz/N7rrMyb84oI8NXr/tuvix9Qo+G3n2RNMf39j3fwZjZb
-        FMuvmrwWCgy/NKmrZXYxZ2Sbtqqzi/x4Oq3Wy/YmZJfX9cXD3YN9vKmIvsjb
-        q6p+e9ObJ/P8fPtlXc3w6lLeOVsSgc+z6Y00aiyN1s3BgQfhdT5d10V7zbxz
-        E5Qvzn7ipFqs1m2+CxBMrpdZ0xAg4l33HmDm+ja1Cyn0hhu5xtLMdfK6zZaz
-        rJ79/s9f8XTOiuxiWTVtMW1eB4BuwtYn9SCQ98WGxJMod1PXs/w8W5ctXlit
-        J2UxPVsdz2Ykp81Nb/rMfPYyAuAmhJ9eE/MW049+Cb26qGb46Gw5rXOogqyk
-        hiSml0VDskjv0ehatHi9nk7zfJbP6Pu2WORNmy1W9DkkfHt3Z3vn/pvdh4/u
-        7T/avT/eefjw3r2d/Z+iprN1rVL90cs3u/e+2H043rt/7+DTnfuv6dtpVdd5
-        yQ3OiD0+un9+79P98+zT7enBwXR7f3c23X54bzLd/vTT/OHk/vn+dHf6Kb3G
-        +M1Yb5BSpMHkzYo4nAA4haRcSK2JJKz7QBZ5w/+EXlIhU23Q0CtGF6G5UTrf
-        /yWjm96863jodd62RL1hYAwujrqyH73qd4fXewiEcvO1elPdQq/6sPF6rzdi
-        azS1KmW4P+qt826HRze8S/8R3+SrfDnLl1O2FYSKfNB8SZxEf32jhtCy090e
-        Ve72hny3oydDshFWt4DhvSTC3le+P4QhKpvd7fDQXasUHZa9oQ28672iA7PA
-        MKk/60NSob/blUtfZXo49oY18L73ig4rAIjZ+iGz5wCiP9sD/X/LHEYU7V1i
-        w2XrDeC2Y47A8qBEyKA9/RzMulEoPV0aEId8Aod/jwqDMLyXIoMmoD+U2Tfo
-        9XTmD0fv0hCrdUtsQkbnF4v3+r7Ofoew/dfgdkknrxQZamTYx41iiF39WaH+
-        vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
-        IA8AAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Request-Id:
-      - 7bf2bf00-f331-4600-8b13-8c878ee69b19
-      X-Ms-Correlation-Request-Id:
-      - 7bf2bf00-f331-4600-8b13-8c878ee69b19
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141101Z:7bf2bf00-f331-4600-8b13-8c878ee69b19
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:00 GMT
-      Content-Length:
-      - '502'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXdwt1rldSadf3q6//Tewc69B5/uf7pz+nD/
-        o9FH9tszIBtpsKrRpC3y5qNHvxh/XRYNNS+WF6/brKWBfvR6PZ3m+SyfUeu2
-        WORNmy1W9Dmw2N7d2d55+Gb34NH+p4/298af7j3YeXjv3k9R09laOqaWL9/s
-        jvc/3d89eE2ft3U2fUvgGaF8Mt3dO6fhP/j0HpHr4f3Z9sN7Dx9u7987n+zt
-        TB7u3384oXeoy3bdnFQz4HNS54QYY5PVF3n7SqkJ/L/5KWGKzPI6MiF3l/LT
-        Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
-        PiqhoAIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
-      X-Ms-Correlation-Request-Id:
-      - b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141101Z:b3008eb8-0fb9-4c17-8a0f-93ce3e404ce8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:01 GMT
-      Content-Length:
-      - '1685'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrk7xadNdd5eZXU+lr/y+jKv
-        8evkuiq393Z27z/YPdi9f+/g3t7dapXXmSDx6YP9B6cPHjzcPb23c2///rOP
-        Rh/Zb8+AdKTBqkaTtsibjx79Yvx1WTTUvFhevG6zlgb80bOsKPMZNW2LRd60
-        2WJFHwKH7Z2D7d2DN7sPH93/9NG9vfHu/r3dBw/3f4qaztbSK7V8+Wb3/hd7
-        e+OHDx/s3ru/+5q+bets+pZ6YJz2HuztT/aye9sHk7372/vn59Pth9mnn27P
-        HhzsTM6zvfv39qf0DnXcrpuTagaUTqrleVlMW/v5F3nTZBf01S/ujHh/9+Gn
-        9x5ku9u7e3sH2/sTmpKH9yc72/t7swe7D2affro/e2ChUHs7WPqkbt/QiOnD
-        cLD7u49298YP6PWDnfuf7Ow82tmh9vlyFm0N0uyM7x3s7u3u7rrWdV3VwHYq
-        A/rJL07ftfkSlCeGsFNwys1GHxHdZXgf+d+m1Xn6k1+kuXkz/fiLYlpX4J3x
-        GX1yMW+b8U9+8bTILpZV0xbT5nXetvRi83E6z5oU8zlLq3U7Tm3vabGkkZcl
-        UzBdZNfpJE/bDLOVtlWVltXyYpRWtdcrtSfapdNqXc7SZdXijWrSZsUyn40/
-        +iW/hOY7qy/y9pVyP4b9zYsQc+4sr5u7jggn1WK1bvO7l0XdrrPyi2w6J6T8
-        t2aWNoY0d4nOSzCW6enN9YpQ/uhmqH1YHpQXGfOG61m6+SVEnp8NanxDCuX+
-        s3vHxw/uf3p878nep6c7+zQg+y2LV6QBTQQ12aRQXq+n0zyfsZiBB4mBIjqF
-        xGznYPxwb+/+3t7Dvk754v6D8b3dnV2iR0+lHBxku9m96d723oOdB9v7n04e
-        bE92sp3tvYOH0+nB+b37OzmEkPolxlWV8uXvRZ/8v5ZRCTcD8Lb86L3SZb7/
-        t7Pds/2T42f3D+4/3Xn69Pjpsz0aiv2WJzjSgMhKTT6c7e4dPLq/M35w8OD+
-        vZ2IKRvvHjz49MHufo/nZnufZg/of9uTye7+9v6D2fl29iDf2X4wu5dPZ3sP
-        z+/dO6B3qFPHcyd1TqgxPj9HjPcib6+q+u3dpfw8W7Z5fZ5NifUwS9v0yuz+
-        HmTFQO1x3yAE7yXlvwDk/8tZ8ODZ6enDe093d57uPTl99uSERmO/5fmONKCh
-        UZNvgAUfPtrdHe8/PHhAT48F790f399/eP/g0097PPjg3u4BuRn3tu/f251u
-        7+8TDSd7k/vkT+3MHnx6Pp1MHuT0DvXqePDnVO+9bquaDOHdRn4eT8mJMBNH
-        7Wf3d4lTHB/1mG/gfe8Vj/UswP+Xs97x7rPd070nOztPj3dOPr3/lEZjv+Vp
-        jjSgsVGTb4D1Dh7tPxzv7+8d7DzY7bHe7j3iSuK8iMk9n0z2Jwd7k22KMHa3
-        97OHk+2D/ODBdp7tT8+nFGvs739K71Cv/y9hvY7eep1P13XRXnffJQwN2B73
-        bQThvag86GD+v5wBH56e7OzvPTzYv7d/enpwckpDsd/yZEcaEImpyTfDgAfj
-        e/fvPdw5uNdnwL3x/s79e58+7PHf5GC29+DBwe72wcE5Ee7Te59uT7KD/e17
-        ezt7szzL780+7UWR/6/gv9V6QpHs2ep4NqP3G7K89j3Cjj5ikIO813vde+n/
-        a3y3t/vgZPfpw53je/cfnjwkRd3lu0gDIi01+ab4bu/h7r39iN7bowD+04OD
-        h329dz+b7Gc75w+3z3fyGWUvpsSBD6ez7Vm+e//hvTzP7t07p3eo0/+X8Z1G
-        C/qn9xbhZgAOcl3nZe+V/6/x3O6Tvd2T3b37z56d7hw83Ycttd/yBEcaEFmp
-        yTfCc/cejHfuPSR11ee58e69PbKlez2Wu3dvZ5LPsmx7Z5cTWfez7Yxc6m2K
-        Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
-        jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 080fe0a3-6a95-40fd-b124-1cae6f71b6f1
-      X-Ms-Correlation-Request-Id:
-      - 080fe0a3-6a95-40fd-b124-1cae6f71b6f1
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141101Z:080fe0a3-6a95-40fd-b124-1cae6f71b6f1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:01 GMT
-      Content-Length:
-      - '501'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8brXK60w6frj39NmD44cnTz89Of5079NnH40+st+eAdFIg1WNJm2R
-        Nx89+sX467JoqHmxvHjdZi0N8qPX6+k0z2f5jFq3xYKQyRYr+nxvZ/f+9s7D
-        7b3dN3s7j3YPHt37dPzwwcO9g/39n6Kms7V0TC1fvtkdP9x9+OnDh7uv6Zu2
-        zqZvqQNGabKTf3r+8OF0e5adT7b3d/P97exhTmR7+GmWPdzP7k+5Y+q0XTcn
-        1QwYffl70SdtVl/k7SslI5D/WZgLpscsr5u7XxTTumqq83asX9/NLrOizCZF
-        WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
-        IniEAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:03 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"85a13945ec8e42f91e3509232ec0fc05a3c56a80"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB271D:5097:1FE1D13:56337A75
-      Content-Length:
-      - '358'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 14:11:02 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6228-ATL
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - 7cb6a11b16faee5457c90ccf5dc434a7a0668e24
-      Expires:
-      - Fri, 30 Oct 2015 14:16:02 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string",
-              "allowedValues": [
-                "East US",
-                "West US",
-                "West Europe",
-                "East Asia",
-                "South East Asia"
-              ],
-              "metadata": {
-                "description": "This is the location where the availability set will be deployed"
-              }
-            }
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "availabilitySet1",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[parameters('location')]",
-              "properties": {}
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - c87e1d57-1318-4901-9cd8-6e1811c59049
-      X-Ms-Correlation-Request-Id:
-      - c87e1d57-1318-4901-9cd8-6e1811c59049
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141102Z:c87e1d57-1318-4901-9cd8-6e1811c59049
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:01 GMT
-      Content-Length:
-      - '493'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug73tWbVs6YMy
-        b/O71SqvM+ny04Od3ScnB6cH+/ef7jx8+Oyj0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        9nYe7R482t8d7x3s3Dt4cO+nqOlsLR1Ty5dvDsafPrz/6cH9e6/pm7bOpm+p
-        A0ZpZ+/evf17s2z7wd6D+9v757tEpgefTghwtjN5ODn/9P7uAb1Dnbbr5qSa
-        AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
-        +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
-- request:
-    method: get
-    uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"93094327805ca8b2cddfd8a9dd81757360d148da"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB271C:509A:3468631:56337A76
-      Content-Length:
-      - '1004'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6229-ATL
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - e6b86669e9114825a4d86634441f20e4ac7f8f68
-      Expires:
-      - Fri, 30 Oct 2015 14:16:03 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: UTF-8
-      string: |2+
-            {
-              "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-              "contentVersion": "1.0.0.0",
-              "parameters": {
-                "childLocationParameter": { "type": "string" },
-                "childDeployName": { "type": "string" }
-              },
-              "resources": [ {
-                "name": "[parameters('childDeployName')]",
-                "type": "Microsoft.Resources/deployments",
-                "apiVersion": "2015-01-01",
-                "properties": {
-                  "mode": "Incremental",
-                  "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json",
-                    "contentVersion": "1.0.0.0"
-                  },
-                  "parameters": {
-                    "location": { "value": "[parameters('childLocationParameter')]" }
-                  }
-                }
-              } ],
-              "outputs": {
-                "siteUri" : {
-                  "type" : "string",
-                  "value": "hard-coded output for test"
-                }
-              }
-            }
-
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:04 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14993'
-      X-Ms-Request-Id:
-      - d0406c9d-76e0-49fc-aae3-957624a104f2
-      X-Ms-Correlation-Request-Id:
-      - d0406c9d-76e0-49fc-aae3-957624a104f2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141103Z:d0406c9d-76e0-49fc-aae3-957624a104f2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vug93tWbVs6YMy
-        b/O71SqvM+ny4N7BzoP9008/3T/YOz54eP+j0Uf22zOgGGmwqtGkLfLmo0e/
-        GH9dFg01L5YXr9uspeF99Ho9neb5LJ9R67ZY5E2bLVb0+d7O7v3tnYfbe7tv
-        dh8+2n/4aPfB+N7e/u6n+5/+FDWdraVjavnyzb0v9h+Odx7cv7dz/+A1fdnW
-        2fQt9cFYzWbTfDLZzbdne/v72/v39mbbkwcPd7cfPDjfezjdmexM8h16h/pt
-        181JNQNSX/5e9Emb1Rd5+0ppCPx/FiaCSTLL6+buF8W0rprqvB3r13cvi7pd
-        Z+UX2XReLHOdqJ/8AtgagG+uV4TZRze+673yIlvgFQvsl/ySXzL6WRmaYylF
-        3X0wyGP3jp+c3n/44PTk5NPT+/ee7RPe9luezUgDIiE1+QZ47P6jvYPx7v7B
-        vU8f7vV47P54b//TTz892Osx2P1s8vDBXpZvH8xmk+393Z3721m2d3/7PH9w
-        fzrJpnsPP83oHer0/y0M9iJvr6r67d2l/Dxbtnl9nk0Niy2L6UYeG3zde8nn
-        Mob3/y42e7Jzb3/v4YP7zx4+/PTeyS4hbr/lOY00IEJSk2+AzQ4e3b833t3b
-        OdiLaTJiwYcHD3Z37/f4bH9n8un5p+fT7Ww22dnez+5NtyfZvQf0z2SX2Owg
-        m+x8Su9Qr/9v4TP9uquMZJp+8gtQ1QDsMdnAu94rPosB2P+rOOzg2ZOne/sP
-        7p8+u//pycN7Dwhv+y3PZqQBkZCafAMcRopsn+zh/v29vQc9Ftsd7+483Nn7
-        tK/Isgf3QIp72/f2793f3j842N/O9mfT7Yf39smiZ9l0/z46pk7/38Jgg5pI
-        5okUz0YeG3zde8nnMob3/yo22/v0wb2Hz45PHzzdffrg/sFDQtx+y3MaaUCE
-        pCbfDJvtjR8cPHz4cLdvL++N7396f+fg/qc9Nnvw4ODg08neZHsyIxW2P5mQ
-        vZzs3tue7WUH+X0ypPufwnWkTv/fxmaqi/RPnaWffHH6hpAzEAeZrPOy94rP
-        Ygzt/1Us9uTJgycnD0/3jneePDl5undAiNtveT4jDYiI1OSbYbHd8cP7B7v3
-        9+/3WGx3vLdLztq9Bz0Wu79z78Esm+1v33/w4N72/sPdyfbBvf2HZCqn9/fo
-        i/O92f/LTKWyxd2yymZPsjJbTvE9z9HzJ4SYgTbIXsGL3gs+cxGk/1ex1lPi
-        mofPnh3fv7//dPfeQ0i9/ZbnMdKAiEdNvhnW2hkfPCDttdfXXrvj+/eJ6yJG
-        8tP7+/emnz7Mt3enZCn3H8x2t8m//3R7tnMw+3R37zzPHvy/jLX067vZZVaU
-        2aQoi/b6dU7TtLg+vqRfCDcDsMddQ+967yiDGWD/r2KwnVMyes8e7D54totf
-        EdXYb3k28WmnAZGQmnxTDPbpwQ5FEg8jDLZ/f+fTT/d2ewx2//69+/ceUiT5
-        cEq02qeetg8+fbC3vbu3O324k+XTHe6YOv1/C4MZFbRaT8pievbyeDYjAI3x
-        wl7qx4Qifcxwe3w2CMJ7SRkthPn/Kna79/D4CaUIdj7df3ry7MnJCSFvv+W5
-        jTQgglKTb4zd9h5QGmw/wm739h/sHtzvm8rppzvZLN/Ltg/OJ3tkKs8/3c52
-        DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
-        VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Etag:
-      - '"9ccbc2b08e013be7c37774f3f127c3d74c654066"'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Cache-Control:
-      - max-age=300
-      X-Github-Request-Id:
-      - 17EB2714:5095:EA5632:56337A77
-      Content-Length:
-      - '1902'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Via:
-      - 1.1 varnish
-      Connection:
-      - keep-alive
-      X-Served-By:
-      - cache-atl6221-ATL
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      Vary:
-      - Authorization,Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Fastly-Request-Id:
-      - d48f36d593112d4b2db8e51ca9c87794c43b09dd
-      Expires:
-      - Fri, 30 Oct 2015 14:16:03 GMT
-      Source-Age:
-      - '0'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        {
-          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "storageAccountName": {
-              "type": "string",
-              "metadata": {
-                "description": "Name of storage account"
-              }
-            },
-            "adminUsername": {
-              "type": "string",
-              "metadata": {
-                "description": "Admin username"
-              }
-            },
-            "adminPassword": {
-              "type": "securestring",
-              "metadata": {
-                "description": "Admin password"
-              }
-            },
-            "dnsNameforLBIP": {
-              "type": "string",
-              "metadata": {
-                "description": "DNS for Load Balancer IP"
-              }
-            },
-            "vmNamePrefix": {
-              "type": "string",
-              "defaultValue": "myVM",
-              "metadata": {
-                "description": "Prefix to use for VM names"
-              }
-            },
-            "imagePublisher": {
-              "type": "string",
-              "defaultValue": "MicrosoftWindowsServer",
-              "metadata": {
-                "description": "Image Publisher"
-              }
-            },
-            "imageOffer": {
-              "type": "string",
-              "defaultValue": "WindowsServer",
-              "metadata": {
-                "description": "Image Offer"
-              }
-            },
-            "imageSKU": {
-              "type": "string",
-              "defaultValue": "2012-R2-Datacenter",
-              "metadata": {
-                "description": "Image SKU"
-              }
-            },
-            "lbName": {
-              "type": "string",
-              "defaultValue": "myLB",
-              "metadata": {
-                "description": "Load Balancer name"
-              }
-            },
-            "nicNamePrefix": {
-              "type": "string",
-              "defaultValue": "nic",
-              "metadata": {
-                "description": "Network Interface name prefix"
-              }
-            },
-            "publicIPAddressName": {
-              "type": "string",
-              "defaultValue": "myPublicIP",
-              "metadata": {
-                "description": "Public IP Name"
-              }
-            },
-            "vnetName": {
-              "type": "string",
-              "defaultValue": "myVNET",
-              "metadata": {
-                "description": "VNET name"
-              }
-            },
-            "vmSize": {
-              "type": "string",
-              "defaultValue": "Standard_D1",
-              "metadata": {
-                "description": "Size of the VM"
-              }
-            }
-          },
-          "variables": {
-            "storageAccountType": "Standard_LRS",
-            "availabilitySetName": "myAvSet",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet-1",
-            "subnetPrefix": "10.0.0.0/24",
-            "publicIPAddressType": "Dynamic",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-            "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
-            "numberOfInstances": 2,
-            "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
-            "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-            "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]",
-            "lbProbeID": "[concat(variables('lbID'),'/probes/tcpProbe')]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Storage/storageAccounts",
-              "name": "[parameters('storageAccountName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "accountType": "[variables('storageAccountType')]"
-              }
-            },
-            {
-              "type": "Microsoft.Compute/availabilitySets",
-              "name": "[variables('availabilitySetName')]",
-              "apiVersion": "2015-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "properties": {}
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/publicIPAddresses",
-              "name": "[parameters('publicIPAddressName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                  "domainNameLabel": "[parameters('dnsNameforLBIP')]"
-                }
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/virtualNetworks",
-              "name": "[parameters('vnetName')]",
-              "location": "[resourceGroup().location]",
-              "properties": {
-                "addressSpace": {
-                  "addressPrefixes": [
-                    "[variables('addressPrefix')]"
-                  ]
-                },
-                "subnets": [
-                  {
-                    "name": "[variables('subnetName')]",
-                    "properties": {
-                      "addressPrefix": "[variables('subnetPrefix')]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "type": "Microsoft.Network/networkInterfaces",
-              "name": "[concat(parameters('nicNamePrefix'), copyindex())]",
-              "location": "[resourceGroup().location]",
-              "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
-              ],
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig1",
-                    "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                        "id": "[variables('subnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools": [
-                        {
-                          "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
-                        }
-                      ],
-                      "loadBalancerInboundNatRules": [
-                        {
-                          "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM', copyindex())]"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-05-01-preview",
-              "name": "[parameters('lbName')]",
-              "type": "Microsoft.Network/loadBalancers",
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
-              ],
-              "properties": {
-                "frontendIPConfigurations": [
-                  {
-                    "name": "LoadBalancerFrontEnd",
-                    "properties": {
-                      "publicIPAddress": {
-                        "id": "[variables('publicIPAddressID')]"
-                      }
-                    }
-                  }
-                ],
-                "backendAddressPools": [
-                  {
-                    "name": "BackendPool1"
-                  }
-                ],
-                "inboundNatRules": [
-                  {
-                    "name": "RDP-VM0",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50001,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  },
-                  {
-                    "name": "RDP-VM1",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 50002,
-                      "backendPort": 3389,
-                      "enableFloatingIP": false
-                    }
-                  }
-                ],
-                "loadBalancingRules": [
-                  {
-                    "name": "LBRule",
-                    "properties": {
-                      "frontendIPConfiguration": {
-                        "id": "[variables('frontEndIPConfigID')]"
-                      },
-                      "backendAddressPool": {
-                        "id": "[variables('lbPoolID')]"
-                      },
-                      "protocol": "tcp",
-                      "frontendPort": 80,
-                      "backendPort": 80,
-                      "enableFloatingIP": false,
-                      "idleTimeoutInMinutes": 5,
-                      "probe": {
-                        "id": "[variables('lbProbeID')]"
-                      }
-                    }
-                  }
-                ],
-                "probes": [
-                  {
-                    "name": "tcpProbe",
-                    "properties": {
-                      "protocol": "tcp",
-                      "port": 80,
-                      "intervalInSeconds": 5,
-                      "numberOfProbes": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "apiVersion": "2015-06-15",
-              "type": "Microsoft.Compute/virtualMachines",
-              "name": "[concat(parameters('vmNamePrefix'), copyindex())]",
-              "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-              },
-              "location": "[resourceGroup().location]",
-              "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNamePrefix'), copyindex())]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-              ],
-              "properties": {
-                "availabilitySet": {
-                  "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                  "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                  "computername": "[concat(parameters('vmNamePrefix'), copyIndex())]",
-                  "adminUsername": "[parameters('adminUsername')]",
-                  "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                  "imageReference": {
-                    "publisher": "[parameters('imagePublisher')]",
-                    "offer": "[parameters('imageOffer')]",
-                    "sku": "[parameters('imageSKU')]",
-                    "version": "latest"
-                  },
-                  "osDisk": {
-                    "name": "osdisk",
-                    "vhd": {
-                      "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                  }
-                },
-                "networkProfile": {
-                  "networkInterfaces": [
-                    {
-                      "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('nicNamePrefix'),copyindex()))]"
-                    }
-                  ]
-                },
-                "diagnosticsProfile": {
-                  "bootDiagnostics": {
-                     "enabled": "true",
-                     "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
-                  }
-                }
-              }
-            }
-          ]
-        }
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Request-Id:
-      - 151ed1f2-39d0-49c1-a980-efe6c275f39d
-      X-Ms-Correlation-Request-Id:
-      - 151ed1f2-39d0-49c1-a980-efe6c275f39d
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141103Z:151ed1f2-39d0-49c1-a980-efe6c275f39d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Content-Length:
-      - '1307'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41dxfFL8p+sK7z3buzfFVW14t82TZ3vyimddVU5+34u8VyVl01
-        r/P6Mq/3dnb3Xu09zdpsSs3yeps+uP9g92B3/97O/sO71SqvM0Hl4acHTx+e
-        fPrw2cnBs9PT04cfjT6y354B9UiDVY0mbZE3Hz36xfjrsmioebG8eN1mLQ37
-        o9fr6TTPZ/mMWrfFIm/abLGiz4HG9s7B9u7Bm92DR/t7j/Z2xnv7+w/vffrg
-        p6jpbC0dU8uXb/a+2H84/vTTe/T1w9f0ZVtn07fUB2P1YHo+O9jJZtt7+XS6
-        vT97+GD7IDuYbU+nD2aT/fP9B/fyjN6hftt1c1LNgNSXvxd90mb1Rd6+UtoC
-        /29+gpgis7z2p+ekWqzWbX73sqjbdVZ+kU3nxTJv7p6+enl3VmQXy6ppi+nr
-        vG1piM3d7ILmjdA1fby5XhGyH90Mrw/Lg/IiWwAK+pQOfskv+SWjnw0KfKMs
-        erB/b5858NnOs2dPD57RgOy3zAyRBjQF1OTDWfTew0f3iEUPHu7cf9hn0YMv
-        7o/3H+zf293tc+jeLPv0YOfTg+3pwYQ4NM/ubU/u7efbB3vnk08f7j/MdnYn
-        9A51+/9+DiWsDKjbMqL3iuO6/2/w2+7us/unDz/d2zl4cry7+wQaz37LUxtp
-        QASlJt8Av+0+2nk4vnd/Z+fg/qc9ftsb79zb29359H6P2+4fZOf53oOd7dns
-        3mx7f/f++fbDPQCeTO/v7x8czM73P6V3qFPHbSd1TqgxPj9HLPcib6+q+u3d
-        pfw8w7yc0/w0d/N69eD+AaFm4PX4bvBd7yXlPAX2/wnme3p6cvzg2e7Jp/tP
-        jvf2TvdpNPZbnulIAyItNflmmO/BeO/+/n1Crsd8u/fH9+59uv9g99Me9917
-        mD98uJNNt+/d39vZ3p/cJ12XP8y2J5/mDw+mk53s/P4OvUO9Ou77OdV1hnlU
-        aemf3luEmwE4yHmdl71XlO8ctP9PsN7DT+/tPn16/+Tp3pMHpwf74Cz7LU9z
-        pAERl5p8U6y3u/fpHumuGOvt7d67TxTpsd7Bvdnu5Hz30+3dPSLd/qe7+fZk
-        fy/b3nlwPsk/nT3Y/5R7pl7/X8Z6q/WkLKZnq+PZjN5vSOfBQDoeGmS73ove
-        S8p4gPT/CZa7t3e8t/t092Tv+P6nnz54cp+GYr/l6Y00IKJSk2+G5T4dE9iD
-        ezt9U7u7P/704NODB/fv9Vlu7+FudnDvYPvBvRl5dgf7RD9Sf9tkgSefnt9/
-        eD59+P8uz85wjprK1/l0XRfttb4LZnEcNMh20Ze9F/+/xnqnT5/ee/Bwf3f/
-        +PTZ/s4u7JP9lqc50oCIS02+Edbb2x8/uL+/9+D+wx7r3dsbHzx4sLvT57zd
-        6cOdGUUi27sPP93f3n9w8GD7YT7d2b6/e2/68OFutvvwwT16hzr9fwnnvW6r
-        miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
-        AAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 8fe471de-54b4-41f4-94a1-9ba83ac17eb8
-      X-Ms-Correlation-Request-Id:
-      - 8fe471de-54b4-41f4-94a1-9ba83ac17eb8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141103Z:8fe471de-54b4-41f4-94a1-9ba83ac17eb8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Content-Length:
-      - '1090'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
-        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d1/8Pq8+vzvLV2V1vciXbXP3i2JaV0113o6/Wyxn1VXzOq8v
-        83pvZ+fg1d7rl7vbezu79x/e372/t3N/9261yutMen+6++T+k/2dk4f3np08
-        eXp/56PRR/bbM2AbabCq0aQt8uajR78Yf10WDTUvlhev26ylkX70ej2d5vks
-        n1HrtljkTZstVvQ5sNje3dneuf9m9+Gje/uPdvfHD/bu7+/f3/0pajpbS8fU
-        8uWb/S/u05c7Bw8f3t9/TV+2dTZ9S30wVgez+3t75/lke3p/cm97f+/hp9uT
-        PKdhZp/mew8+Pb8/2dmld6jfdt2cVDMg9eXvRZ+0WX2Rt6+UnMD/G50TJsYs
-        r/0ZOakWq3Wb370s6nadlV9k03mxzJu7r7Myb84rgvDV67uzIrtYVk1bTF/n
-        bUvDbO5mFzS1hLLp5831ihD+6GbAfVgelBfZAlCCzqWnX/JLfsnoGybHN8Ki
-        +zv7T3c//fR07+G9/QefnhzQYOy3zAyRBjQP1OTDWXTv4aPdh+OHhNLOgz6L
-        Pvhi/+H4/v0HO59+utdj0Z17kwfnk0/3tx88uL+/vf/w4MH2wexevj3dn97f
-        37t3fp7dP6d3qN//b7AoYWbA3ZYTvVcibPf/WoZ78GRv9+DZwbMn+/f3H57e
-        O6Fh2G95aiMNiKrU5BtguN1H93bGe58++PTTe/d6DLc7vr9z/+HuPUxGwGzn
-        u7Ppgwf3zrenD/d3t/cfTPLtCSnE7b17u5Ppw/uz7OFORu9Qn47ZTuqcMGN0
-        fvgc9yJvr6r67d2l/Dxbtnl9nk2J5xrLIuvmALJsQPa4bhCG95LyXQfo/1s5
-        7+Dp05PdveP7T/d3P336YOcpDcR+y/McaUDUpSbfCOftHZDBvXd/Z7/PePfH
-        +wd7D/Ye7vZY795kL3uw/+n59myPwO1PCOBkundve+/T7Hwnm04fTu/BaaBO
-        Hev9XOk5wzGr9aQspmer49mMXm2I63zFdPaSsKPPGeQg1/VgeC8p13WA/r+V
-        6/b3yMF7cry7+3B//+GDJ2Aq+y1PcaQBUZeafDNcd49s6MGnOwf3e2y392C8
-        t7e7t3ev7wHee5Dt0Uhm2/ns0+n2/u7BdHuyQ9b200/384N8untv91MoD+r1
-        557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
-        /h+BjiSEdgwAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c683b1e4-999a-47b9-a620-e9bb394dbf38
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 809719d8-859f-49a5-b388-fd36e8fb23c7
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141104Z:809719d8-859f-49a5-b388-fd36e8fb23c7
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
-        d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/0oP88m5/ce
-        7G3f3997uL3/4NNs++De9Hz7wWTnwd7D2YPp+b3z3/cj7+X2esVjvbFr752y
-        mmYYON7Ls6Zd+1/SaFZ53RZ5Q19bmsoXl0VDrxXLi9dt1nK3r9fTaZ7Pcm88
-        1NSSai3k3n24/+mDB/nu9oODg53t/fuzbHvy8EG2PT0/OL+/N5nMPr13HgDI
-        ZjOC0bxeZVN046HhvnxZ5+fFO0ZTOcA8H+3ujPfGO+Odu7uffuR/9X33xy/x
-        uyNuWOZtD1LQLTUzfDWjWVqXrY8xnv/X8NZdwgDjuTuE6IdwnDzghiibyIOv
-        b8ks8oSTisZ2Dvf2I82L1Um1PC8u1jVzMpAIpk6eHl54ftjTRDOBn2fLNq/P
-        iZ+bu1O8R6/M7u/t3O2OhD6Y8ge7AevK43Otef5fOshV1bQXBGt7ll/u37tP
-        w/p/9zhf/D6vPn/PITZZmTfnFcFYNwcHNKD3GWH3I0834Qm+9/6wzfQz/kEf
-        /pL/Bx08EGYUBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 448fcf02-88a7-40f4-bbee-3fd4bf8a65e8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - dbc90927-5f71-4502-a3dc-51e11e810255
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141104Z:dbc90927-5f71-4502-a3dc-51e11e810255
-      Date:
-      - Fri, 30 Oct 2015 14:11:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
-        3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o+nD7OHB
-        p7O97YOc/tn/9MFse/Lw/oPt6afTh/gov39v5/f9yHu5vV7xcG/s23unrKYZ
-        ho738qxp1/6XNJxVXrdF3tDXlqzyxWXR0GvF8uJ1m7Xc7ev1dJrns3zmIFBT
-        S6y1EHz6cD8739nJtqcPd86393cPJtsPHx7sbJ9PdrN7Dx5+er7TAZDNZgSj
-        eb3KpujGQ8N9+bLOz4t3jKYygXk+2t0Z8393dz/9yP/q++6PX+J3R/ywzNse
-        pKBbamZYa5afZ+uy9THG8/8i7rpLOGBEd4dQ/RCekwf8EGUUefD1LdlFnnBa
-        0djO4t5+pDkND6N+nU/XddFeM+XorR4i1PSHPS8x1Kjd2U/o+7sBU+LxuVGe
-        j4rVSbU8Ly7WNcsqiBwwpzyR4eLdn5sBny3bvD4nkW3uLopfNJV3d/f3Pr3b
-        HQx9MOUP+qSIEeP/veOczvPzJq8v83r34NN7NKz/n47Tzefewf3/H49ztZ60
-        edPu39+hIf3/dIx5vbq/c5+G8//T8RGv7j3Ye0Dj+X/5AEl3bL+sq9l7js++
-        t00WplrOtu13NML3GXL3I889whN87/1hm+lnhnSWXNZRWlz/5IvTN854f4O0
-        ux1zdD2kHkK+HzTZ2ZnOpjv72ztktLb3M/JXHz4gPKZ7+ezTfLLz4OF55vtB
-        /9/wvXc/3d2bTvcOth/ufEqj2r93vp2df/pw+9O9/YNdcsd3s/u7AQD1w/5f
-        6nu/5ubbAcp4/l/CWnepf8KvuTuI54dwnDzghiibyIOvb8ks8oSTisZ2DqOe
-        d1fJ0BvB1MnTwwvPD32WaA7w02rI5u6ymP7/2LbT6HZpMO8zuu5HnqDiCb73
-        /rDN9DNDJUsZK7LNKp9uQzgcL/3QKdWV1hhOvmRmO9O93f2DB9ufHpwTKtmD
-        h9uT7Hx3e+f+g08f7u3fO/h0f9eXzP9v2IL9AyLnp9Nziu93Drb383sz0jf3
-        8u3dnfP709ne/u7uwV4AQDXDj2zB1+Suu4QCoXhLc/C+TCcPGCLKKfLg61vy
-        izzhvKKxncb/H5oDnqqvoTV7dPh//xDf1+x1P/KkFk/wvfeHbaaf8Q/68Jf8
-        P4bMBwG5FwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Request-Id:
-      - bd649a84-d955-4014-886c-cd571749402f
-      X-Ms-Correlation-Request-Id:
-      - bd649a84-d955-4014-886c-cd571749402f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141104Z:bd649a84-d955-4014-886c-cd571749402f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
-      X-Ms-Correlation-Request-Id:
-      - 052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141104Z:052e4c32-dfe3-4b5d-ace8-ff88b9b3ebe6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:03 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:06 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3c75317f-9736-4c88-aa78-34bddd913ff5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 6553f060-4c08-4864-a4b2-88a9fa599b75
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:6553f060-4c08-4864-a4b2-88a9fa599b75
-      Date:
-      - Fri, 30 Oct 2015 14:11:04 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
-        5x8til+U/WBd57sfjex3xQzf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2
-        /s700+2H55Pz7Z29g7392e5stn9w/26dN9W6nuaf19V61dy1wO+u6uqymOV1
-        c/eLYlpXTXXejl/k7VVVv717WdTtOiv1T+8tD6W8zS6A1Hfv/r4f3b+fHezO
-        Jve3Jw8ne9v7Dw4m2wf59Jz+fDjdO8j2zu/f3/l9P/Jebq9XPNYbu/beKatp
-        hoHjvTxr2rX/JY1mlddtkTf0taWpfHFZNPRasbx43WYtd/t6PZ3m+SyfOQjU
-        1JJqLeS+f3Dw6YPd7OH2p5Pp7vb+wSTbpk/2th/cn+4ePNzf39s9/zQAkM1m
-        BKN5vcqm6MZDw335ss7Pi3eMpnKAeT7a3RnvjnfGO3d3P/3I/+r77o9f4ndH
-        3LDM2x6koFtqZvhqlp9n67L1Mcbz/xreuksYYDx3hxD9EI6TB9wQZRN58PUt
-        mUWecFLR2M7h3n6kebE6qZbnxcW6Zk4GEsHUydPDC88Pe5poJvDzbNnm9Tnx
-        c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
-        9/6wzfQz/kEf/pL/B5s5aaAjBgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 31316f83-9a91-4ea0-be78-42c8d489507c
-      X-Ms-Correlation-Request-Id:
-      - 31316f83-9a91-4ea0-be78-42c8d489507c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:31316f83-9a91-4ea0-be78-42c8d489507c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:04 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - a0698cc7-54f9-43e5-9865-057e1ef2fc61
-      X-Ms-Correlation-Request-Id:
-      - a0698cc7-54f9-43e5-9865-057e1ef2fc61
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:a0698cc7-54f9-43e5-9865-057e1ef2fc61
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:04 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 182b63a6-da2b-4dc1-8441-91ea4efbc100
-      X-Ms-Correlation-Request-Id:
-      - 182b63a6-da2b-4dc1-8441-91ea4efbc100
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:182b63a6-da2b-4dc1-8441-91ea4efbc100
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:04 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 8a223801-30e6-44b8-9e4b-6e789e36c4b1
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - a92a8aed-fe78-4015-a6f3-658064962711
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:a92a8aed-fe78-4015-a6f3-658064962711
-      Date:
-      - Fri, 30 Oct 2015 14:11:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NG9h9P79/Z2pts7k5172/uf5g+3H57vnG/vP7iX
-        Z7MHnx6cZ5OPRt6L2WVWlNmkKIv2+nXeEgwPLH1fMNi7zXrSTOti1RbVsrm7
-        /+ne+V52frCdf/og397fmX5KvUzOt3f2Dvb2Z7uz2f7B/bt13lTrepp/Xlfr
-        VXP3ZJ6fb7+sq9ldGsRlMcvr5u4XxbSumuq8HZ9Ui9W6ze920GnuHv/k8dnz
-        4ydnz8/e/D6vT9/sfeSw+yX+OOZZPbvK6px6OC9KEC8cx+XidfEDfPzR6zZb
-        zqj173+8MwSsaas6uxiEVSzoy1f5eV7ny2nva2qwWk/KopnnNX330RQDxyCB
-        nk97PB9V5wTGNcvrS/qz26h5uzZNJtdV2fue3mloYtCmzNq8ab2BhUOjxlXz
-        tGjeUtsu1lXz5nqF4Xz0vFiu3/V6WWYL/tbOZK/FtM6p+y+ZS9DyWV0tzkCs
-        XsvLOfiqgwF9vq4L+vyjeduuHt29iwETt8zu7+7tjCdlNRlPqzofXxXLWXXV
-        jJd5e5cAebw1pj+DsXdHT11Ms+m8WF6gm1ckE9+tizYP3gnf+GiWtRkoBpH7
-        3vfdV34zoh11H2WWqXB2/WIz9T7KZoti+RUxgCHzpK6W2cW86bQrMTcn1fK8
-        uFjXmVI66JIazYomm5T5y6xprqp6drxu5/myLaam/XlWNrn/jj8Yer/JaSrb
-        jSMm4hPotzQSM2zz0dmShnueTaGkvveLP4IG+dlXIC+k77s9HJiJtumV2f29
-        nY9+yfeDQdDHlwVEhxiC9AIxAhH+9Xo6zfNZ7jjJvfORQYrGZtQznmACeMg/
-        RKV5WdTtOiu/yMDYNGL3Vv6uzZcYn//aGX1yMW+b8U9+8bTILpZVQ5zRkLZt
-        iQqNHTQN2/z6fTf+/7cMzUnFJr30Uasa7UbI3jtlZeXkozxr2rX/5arM8IU3
-        37Z/MFpXPd/SFIARZ+spzK82EkNgWuhMGD60veO9zQ7B+fT83myaT7fPJwez
-        7f2H5/e3H84OptuT3fv5bHp+/mBnfxpg0rHABMMDS9//kBmgg87/HxwCO8jv
-        ih17LXPt9YfHeQabm6lvsLezc7D9am/79cvdXhN6DToAzb4R90AR6vVjBOEl
-        aZQLmu3tp/llrxEZFsLhh+8j+Ej9f8BN8NENKXNrT0FJcJOvQMQTG/iTXxxf
-        kJdATdp6nQewqFm+hEdBnkS1IEjTr1Y0YNY6aOy39QdM7/3/yZVYmUmZ5Zf7
-        9+53vYmZs6YE3IzFNaAmk6pqPaPb/Z5aCJ1poExYDzweo4i+ek8RCBnX/RGg
-        TyCEEYjtSScSu1MX/593hnxB+v+fP+SPzon/DZr4m/KK5DumCon2L/l/AApi
-        H7C8EAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - f038adb2-bd05-41da-a920-0bd4380a68db
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 99d31ecb-5eaf-4fb8-b78e-1139ecb0a5c8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141105Z:99d31ecb-5eaf-4fb8-b78e-1139ecb0a5c8
-      Date:
-      - Fri, 30 Oct 2015 14:11:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NHB7qcPHj6Y7mx/OrmXb+9P93a3D/K9e9v7B7O9
-        h5/ODmb57t5HI+/F7DIrymxSlEV7/TpvCYYHlr4vGOzdZj1ppnWxaotq2dzd
-        /3TvfC87P9jOP31AvexMP91+eD45397ZO9jbn+3OZvsH9+/WeVOt62n+eV2t
-        V83dk2qxWrf5T37R3KVRXBazvG7uflFM66qpztuxfn23g09z9/gnj8+eHz85
-        e3725vd5ffpm9yOH3i/xBzLP6tlVVucv6+q8KEG9cCCXi9fFD/DxR6/bbDmj
-        1r//8f0hYE1b1dnFIKxiQV++ys/zOl9Oe19Tg9V6UhbNPK/pu4+m8/x8G4ME
-        ej7x8XxUnRMY1yyvL+nPbqPm7do0mVxXZe97eqehmUGbMmvzpvUGFg6NGlfN
-        06J5S227WFfNm+sVhvPR82K5ftfrZZkt+FugIYju9tpM65wQ+JIZBW2f1dXi
-        DOTqtbycg7U6ONDn67qgzz+at+3q0d27U+GLy0Wze+/h3nhSVpPxtKrz8VWx
-        nFVXzXiZt3cJVHPXw2pMHwQU6NKAuplm03mxvEBXr/Js9t26aPPgnfCNj2ZZ
-        m4FukLzvfd995TcjCg6xjI6jfnETDT/KZoti+RV9Z8g9qatldjFvOu1KzNFJ
-        tTwvLtZ1pvQOOqVGs6LJJmX+Mmuaq6qeHa/beb5si6lpf56VTe6/4w+H3m9y
-        mtB245hpAgj0W2/g5qOzJQ34PJtCW33vF38EVfJD0CQvpPO7PSR8Djn49N5H
-        v+T7wTgYFqSIuIJUBHED0f71ejrN81nu2Mm985HBi4ZnVDWeYA541D9MBXpZ
-        1O06K7/IwN7hoO/m79p8iSH6L57RJxfzthn/5BdPi+xiWTXEHw3p3pYI0dhx
-        08jNr993JPh/0eiceGxWVB+1quRuhO69U1ZWZD7Ks6Zd+1+uygxfePMeYNDV
-        2Le0DmDI2XoKk6yNeCR2QnQ6DD/a3vHeZidhOt3d3d3b2dv+NNvLtvfP7023
-        JweTbDufzj799Pzhwe79g2mASccoEwwPLH3/w+aCDj4/u07CILBv1Ek4yZak
-        eaZZwCl4nIPw1WS9bNevhQu6rdRD2N0f7+yP720/f/O614Reg+yj2Q/BSTh9
-        9bL3HdkS6vjnwjkgbP4/4BQQliElfuQMfKDGGHYG8np1f+f+zxMngBjr/4fG
-        n0blxCCueL4pYy/fmWm3kwt+2WxrP32w8+n+9OABheEPHxA5Jg+3s4efUny+
-        P70/259Mzme791zX9GLHthEMDyx9/8Mmegefn11buzME7Ee2lvR7rxfD8l+c
-        /USQ1cHzc2hsgc7/B6wt0Axp8SNz+4FKY9jcLopftPdg78HPE3sL1vr/ocHF
-        sJwkDKifn3OTO/uUDMHOg/3t2UFOBDk/P9+e5GR3D/bpi51PZzvZnpcOoBfn
-        2ftbqj3FD4/BEc83a6ksCX+yaIhwr9v1rKh83PE4q/Vd0cS9BmqwDsa726cQ
-        yVVdNPn2i167b9pqDeHjMY6yRjAheH5uzZfB6mfdivnfeExuno/KNQa/E0DA
-        Y0kIaGRo3vYISG26JDxdrNrrSDsMMkJA+ubrktBiFSFglyB4fCK+qJa9OaYW
-        AAcx/PwJNdoNv+4C7A1F6bjbaUdfdOnoKTLz/L+AjjF3qj9s6ug96Xgv/Nra
-        HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
-        WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
-        6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
-        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
-        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
-        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
-        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
-        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
-        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
-        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
-        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 988338cb-11fe-4142-84fd-b4c3c40ea704
-      X-Ms-Correlation-Request-Id:
-      - 988338cb-11fe-4142-84fd-b4c3c40ea704
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:988338cb-11fe-4142-84fd-b4c3c40ea704
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Request-Id:
-      - 8eeac86b-4827-4c8d-95c4-0925c865523f
-      X-Ms-Correlation-Request-Id:
-      - 8eeac86b-4827-4c8d-95c4-0925c865523f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:8eeac86b-4827-4c8d-95c4-0925c865523f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:06 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Request-Id:
-      - 7f911484-eba2-4e09-99ec-cc948f1373f2
-      X-Ms-Correlation-Request-Id:
-      - 7f911484-eba2-4e09-99ec-cc948f1373f2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:7f911484-eba2-4e09-99ec-cc948f1373f2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - bd11549c-de21-42e5-bbb2-c443050583bc
-      X-Ms-Correlation-Request-Id:
-      - bd11549c-de21-42e5-bbb2-c443050583bc
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:bd11549c-de21-42e5-bbb2-c443050583bc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:05 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - abf9b9a0-35e0-4f90-8c52-d199e4adf662
-      X-Ms-Correlation-Request-Id:
-      - abf9b9a0-35e0-4f90-8c52-d199e4adf662
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:abf9b9a0-35e0-4f90-8c52-d199e4adf662
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Fri, 30 Oct 2015 14:11:06 GMT
-      Content-Length:
-      - '133'
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - c3ae9e0e-0f5b-4fa9-9c62-23e080e353e7
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - e0418490-13f1-4af7-9df8-ba85d3b6f24e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141106Z:e0418490-13f1-4af7-9df8-ba85d3b6f24e
-      Date:
-      - Fri, 30 Oct 2015 14:11:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejVV2t
-        8rot8oa+tR/TF5eLsxl99NF0dr6TnT94uH1vZ3+2vT97cG/74XR6f/vg/v3d
-        ye7D2TTfefDRyHtxntWzq6zOX9bVeVGiUw8sfX+5eF38AB9/9CRriunvf7zz
-        kfv+l/iQmraqs4tBQMWCvnyVn+d1vpz2vqYGq/WkLJp5XtN3H31RTOuqqc7b
-        7xbLWXXVvM7rS/rG6w/PR9U5wUP7zc2at2s02tvZOdh+tbf9+uVurwm91hTV
-        Es3KrM2b1htmOFBqXDVPi+Ytte2OoWreXK8wOINQr59ltuDvX2dl3pxX9TT/
-        6nWv0bTOCYcvV61i9KyuFmegX6/l5RzT3kGDPl/XBX3+0bxtV4/u3l1e1xcP
-        dw/2x5OymoynVZ2PrwS/8TJv7xKQ5q6P0Jg+CcbfpQD1MM2m82J5gV5e5dns
-        u3XR5sE74RsfzbI2A9XAud/7vvvKb0b0G2KfabVYrdu8fnEj/T7KZoti+VWT
-        14bWk7paZhfzzmR8pCQ4qZbnxcW6zpTaQb/UjGTusgBv/OQXxxf5sqUmbb3O
-        A1jULF9mkzI/XrfVgiBNv1rRgFlM0dhv6w+Y3mtymu0WDQepQnN0VdVvPdKY
-        j86WRJLzbIqOvveLPyqIGT6626wnzbQumHuau/uf7p3vZecH2/mnD/Lt/Z3p
-        p9sPzyfn2zt7B3v7s93ZbP/g/t06b6o10fLzulqvmrsvfp9Xn9/lcc9ILO5a
-        YRy/kG7v9rq/29j5WDcHBx/9ku8HI5gV2cWyaogugxM8qar2qWvW/Z5aCIVp
-        iExSDzweo36+eg/GD9nV/RGgzmTA9BOzv25pTgH+9Xo6zfMZIWNaunc+MsTE
-        GFSD4wmG8xGmKv1ZnasTkZi7l0XdrrPyiwzySjPlS87d/F2bLzE6/80z+uRi
-        3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
-        tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - d4f41964-1306-4ab0-8875-07259b9f7c36
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
-      X-Ms-Correlation-Request-Id:
-      - 7d5bf832-e87b-4b6e-ba96-7d00c2c4ebf2
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141107Z:7d5bf832-e87b-4b6e-ba96-7d00c2c4ebf2
-      Date:
-      - Fri, 30 Oct 2015 14:11:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IhUc
-        00lZTdKiSc+r9XKWTtZtuqSXr/M2XVWrNREmn40DKG2xYBB7O7v3t3d3tu/t
-        vNndf7S7+2jn0092dh7t7HxkGv8S+eX7+PFLGAQwfQsMlSqWJh8tM4F6Ms/P
-        t4ksM9dnlJreu3g2ULRZT6d5Pss9iHgcRc+W51XnO0IzJKgPNh2CGKPMvUf7
-        Dx7dPxjv3b93//7ebodCRBfzK1NJ//4+w/0of9fmS3QKFHTkdtSWYl8U07pq
-        qvN2fEaNL+ZtM/7JL54W2cWyatpi2rzO25awbrRTv4M+YR349yLoEDHfn5Ab
-        iXhvZ2f/04OQiMJYUcyrq7xGz/ndWZ6VZTWlX/2ubo00SYsPQRoKIX/j5Jf8
-        PzujnY1iBAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/chef-prod520?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"043707df-d3a4-491d-974f-6cb82401deac"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 90a60cdf-aeec-4c17-8e2f-f2df66c3813b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - bb132c54-ceea-4868-b988-de89d19d5c02
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141107Z:bb132c54-ceea-4868-b988-de89d19d5c02
-      Date:
-      - Fri, 30 Oct 2015 14:11:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz7dXdTW7v7fz
-        0Yi/Kmb44m6znjTTuli1RbVs7u5/une+l50fbOefPsi393emn24/PJ+cb+/s
-        Heztz3Zns/2D+3frvKnW9TT/vK7Wq+buCWC/JNh3qYPLYpbXzd0vimldNdV5
-        O36Rt1dV/fbuUn6eLdu8Ps+meXM3glPeZhfA6rt3f9+PdvbvPdh5MDvfnt3L
-        9rf3H+7Oth8+2D/f/nQ6IVx2dmd5Nv19P9IX2+sVj/MW/eobZTXNMGa8lWdN
-        uzZfEEarvG4LavkoZSrKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljJroe7e
-        waeT8/s797az3d3p9v7e/Yfbk53z2fb53qf3dqcH+b29nV37crE6qZbnxcW6
-        ZsTQ/ffkq9TggcfOabGacnsLAc//u6b1bndM9EEM6a877/JgdnpTJg++usXE
-        yUONi0tqcvbyeDYjagDaR7s7473xznh/sGlpOOmLvJ1XTP2n1zRHxbT7ynpS
-        FlN6wwIPUKUWP+S56yBEc2ff+8jH7JeE4yD0aNYJ059j9C+Lul1npf7pv0UY
-        EIbN3Vl+nq3LNhyM+8P+qr98X8f50WzZvM7bllgmmCX5vL4kdOjj75nm9EW2
-        WpVFPnsafi9fG+p9lC+zSUkc86yqr7J6RtCp1XlWNrlpQUhjKK/z6bou2mum
-        BrVxCPyQKRzDx3tX6WoHqBPyRTadF0sI2s8G4t8+fbb98tWXT6OIn1SL1brN
-        DWsoJvRWF2X8oH9+yf8DYmP4yiYHAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"96715016-ce95-44ca-bfbf-68ec8f9dce3c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b0e3ba9c-c6cf-4cae-91f0-a1b336b545a4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 6c31bde4-b0c4-4e7e-bd60-8366defef287
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141107Z:6c31bde4-b0c4-4e7e-bd60-8366defef287
-      Date:
-      - Fri, 30 Oct 2015 14:11:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
-        vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
-        P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/evjpg937O7ufbk/zh/e3
-        9/en2fYEeHx6kE8Pzh/Opvm96e/7kb7YXq94hLfoVN8oq2mGAeOtPGvatfmC
-        RrDK67aglo9Spp98eFk01LxYXrxus5Y7e72eTvN8liv21Ix6ELKshbSznXuz
-        nd0Hs+1PJztEy4O98+2He9PJ9sPdSTa5t3Pv3sHOA/uyxbQ0uH2Rt3OiDQF6
-        ek1zWExt22JW5m+KRV6t27PlF8Vy3TK6+/b71Um1PC8u1jUDoq90JPiOId79
-        Yc36Un6eLdu8Ps+mNOtTvEevzO7v7dztYNrQB1P+YPcjwfiX4Af980v+HwRa
-        /S3MAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 9c95cd00-4512-4c4e-b306-0ac458702e58
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 4da92c20-4425-4565-9474-6eba7c437281
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141108Z:4da92c20-4425-4565-9474-6eba7c437281
-      Date:
-      - Fri, 30 Oct 2015 14:11:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbTz4JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKC+rJr2grrefppfum6jtPNex7OB
-        fs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoEMUace4/2Hzy6/+n44N7upzsP
-        7neIRKQxvzKh9O/vM9yPJlXVPi2yiyWRpZgCDx0zjXbZVGX+elrn+bKZV+2T
-        spp8VRfU5KN5266aR3fvTuf5+aquZvd393bGE/p+PK3qfHxVLGfVVTNe5u1d
-        dDBzHWyv6CfoP9s+n57fm03z6fb55GC2vf/w/P72w9nBdHuyez+fTc/PH+zs
-        T+/60zW+zRvjxiI8nixWTAbljfxdS18QgTFMnWUdLX1rGOSLYlpXTXXejs+o
-        8cW8bcY/+YVHotd529IMNQyZYOOHErPPRA78ezHPEOO8P9NsZpiH+3u79/YC
-        hhFaxTD/8jW6ze+SBOd1VhY/CPq5NcakBHwI0nC415fVVV7j7fzuLM/KsprS
-        r1+3Yx+CNJTp+42TX/L/AEeXYFayBQAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:09 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces/postgres-dev435?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"0bc0c07c-1d50-43c4-b8bb-cf9238056209"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 106c0a40-913a-4d6e-8f3c-311278228c13
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - dd92b4c7-e9b7-46dc-bb15-8e7ee83a76a4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141108Z:dd92b4c7-e9b7-46dc-bb15-8e7ee83a76a4
-      Date:
-      - Fri, 30 Oct 2015 14:11:07 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFU17UWdN9uz/HL/
-        3v2PRvxtMcN3d5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv0ugqnU9zT+vq/WquXsyz8+3X9bV7O6qri6LWV43d78o
-        pnXVVOft+EXeXlX127tL+Xm2bPP6PJvmzd04WnmbXQCx7979fT/amUx3pjsP
-        ptu7s/s72/v3pvvbk4PJZHt6/nDv3sHO/U/3dh7+vh/pi+31ikd7i671jbKa
-        Zhg23sqzpl2bL2gcq7xuC2r5KGVayoeXRUPNi+XF6zZrubPX6+k0z2f5TN6k
-        ZjQgIc5aCLyb5bv3JruT7YOD/Qfb+w8f0Bge7N/fvp9PpueTnXuTycMD+3Kx
-        OqmW58XFumbE0P335KvU4IHHzmyxmnL7XQMBz//rZvZud1j0QQzvrzv18mCC
-        erMmD766xdzJQ42LS2py9vJ4NqNBANpHuzvjvfHOWJnUPF7T0jDTF3k7r3gC
-        nl7TNBXT7ivrSVlM6Q0LPECVWvyQp6+DEE3fSzN9T/PLj3zkfkk4FMKQ5p6Q
-        /TkewWVRt+us1D/9twgDwrC5O8vPs3XZhoNxf9hf9Zfv6zg/mi2b13nbEtcE
-        EyWf15eEDn38PdOcvshWq7LIZ0/D7+VrQ72P8mU2KYlpnlX1VVbPCDq1Os/K
-        JjctCGkM5XU+XddFe83UoDYOgR8yhWP4RPnEjlHn5ItsOi+WELefDdy/ffps
-        ++WrL59GcT+pFqt1mxvuUEziWOMH/fNL/h9LzfwgOAcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fc547913-769d-43c0-930a-9e7e0dfe95a2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2c90a9db-ac06-4019-afc3-9f94574e9e33
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - e77e1d12-2b69-498f-b6e7-98e4b1e2b6bd
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141108Z:e77e1d12-2b69-498f-b6e7-98e4b1e2b6bd
-      Date:
-      - Fri, 30 Oct 2015 14:11:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GXVtBd13mw/zS8/
-        GvFXxQxf3G3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29
-        g7392e5stn9w/y7Bqdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vR+fT+/oOH
-        u/e2H3z6cLa9f2+6s/3w3k62/TB/kO/MzvOH97O93/cjfbG9XvE4b9GvvlFW
-        0wxjxlt51rRr8wUNYpXXbUEtH6VMRfnwsmioebG8eN1mLXf2ej2d5vksn8mb
-        1Ix6EMqshbr5w2xn/2CWb+/ms93t/Yfnn25nk73z7U9n+d6n+7NPZzs7+/Zl
-        i2lpcPsib+cVA3p6TTNZTG3bYlbmb4pFXq3bs+UXxXLdMrr79vvVSbU8Ly7W
-        NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
-        SP8S/KB/fsn/AwfrPqbVAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 4c234869-d8c6-4cd6-92a5-243ff671f97f
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - c498ab07-4546-4583-ab9a-7fba5423dd2c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141108Z:c498ab07-4546-4583-ab9a-7fba5423dd2c
-      Date:
-      - Fri, 30 Oct 2015 14:11:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbRz8MnOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCn8/y8yevLvN51vUZJ572NZwP5
-        mvV0muezfOYg4nHkO1ueV53vCNGQej7YdAhijDb3Hu3vPbp/f/zw4P7DT/cf
-        dmhElDG/Mp307+8z3I/yd21OU0DTQFB15HbUlmZfFNO6aqrzdnxGjS/mbTP+
-        yS+eFtnFsmraYtq8ztuWsG60U7+DPmEd+Pci6BAx35+QG4j46Xhn/2C/Q0Ph
-        rCji1VVeo+P87izPyrKa0q9+T7fGmSTDhyANhY6/cfJL/h/LOmKCTgQAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/chefserver1863?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ec36b00e-1d84-4807-8c45-a59d8f936e11"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5b3ce122-2723-4d92-b80b-9b30a2d2f46c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 51b53fd7-5adb-4c48-a88d-ccaeff3fdc2b
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141108Z:51b53fd7-5adb-4c48-a88d-ccaeff3fdc2b
-      Date:
-      - Fri, 30 Oct 2015 14:11:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aDrPz5u8vszr3YNP
-        73004i+LGb6626wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquXtSLVbrNv/JL5q7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vLuXn2bLN6/Nsmjd3o2jlbXYBxL579/f9KJ/e+3Sy
-        s5Nv784O9rf3D3YebB9M9+9vZ/cfzg7OH977NN/d/X0/0hfb6xUP9hY96xtl
-        Nc0wbLyVZ027Nl/QMFZ53RbU8lHKpJQPL4uGmhfLi9dt1nJnr9fTaZ7P8pm8
-        Sc0scdZC4Em+O9ub7U+2s3t70+396cHu9uR8Z7a9e+/Bp/cePsj2ZpPcvlys
-        TqrleXGxrhkxdP89+So1eOCxE1usptx+10DA8/+6mb3bHRZ9EMP76069PJig
-        3qzJg69uMXfyUOPikpqcvTyezYgggPbR7s4Y/90fbFoaZvoib+cVT8DTa5qm
-        Ytp5hWaF6EXfBxjSFz/sWbss6nadlfpn8BrhQDg2d2f5ebYu2498TH+J+8P+
-        qr98X0f60WzZvM7blogN4tmByufgCnz8PdOcvshWq7LIZ0/D7+XrX6LNPsqX
-        2aQkWj+r6qusnhF0anWelU1uWhDSGMvrfLqui/aa6UFtHAI/bBrHEKJ2Zz+h
-        7+8qae0YdVK+yKbzYgku/eHjrl8b/lBUApk2WOMH/fNL/h9nVwHSbgYAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 5a0bfe75-da61-47eb-b6b1-942b350f1807
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 0db692d4-5095-43fc-9293-32d1259d577c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141109Z:0db692d4-5095-43fc-9293-32d1259d577c
-      Date:
-      - Fri, 30 Oct 2015 14:11:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbRz8MnOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlBPX710vUVJ5r2FZwPZmvV0muez
-        fOYg4nFkO1ueV53vCMGQaj7YdAhijCb3Hu3vPbp/f/zw4P7DT/cfdmhDFDG/
-        Mn307+8z3I/yd21OpCfyE1QduR21pdUXxbSumuq8HZ9R44t524x/8ounRXax
-        rJq2mDav87YlrBvt1O+gT1gH/r0IOkTM9yfkBiJ+Ot7ZP9jv0FA4Kob4l6/R
-        a36XeDmvs7L4QdDNrREmcfAhSMPhXl9WV3mNt/O7szwry2pKv37djn0I0lBm
-        7zdOfsn/A0h+5h+8BAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/erp505?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"26a13215-44d2-4d13-b683-a83fea9e083f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 945576cc-31e2-46e9-b535-de53eb419d38
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 882cf0b9-fd89-4536-9767-3dacbeac06e8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141109Z:882cf0b9-fd89-4536-9767-3dacbeac06e8
-      Date:
-      - Fri, 30 Oct 2015 14:11:08 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9KK9X93fufzTiD4sZ
-        PrrbrCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n59s7ewd7+7Pd
-        2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd3P2imNZVU523
-        4xd5e1XVb+8u5efZss3r82yaN3cDdPI2uwBC3737+36092m2e29v9/72/v5s
-        b5v6vbc9+fTg3nZ2cO88zx7mO/Tz9/1IX2yvVzy4W/Sob5TVNMNw8VaeNe3a
-        fEHor/K6Lajlo5RJJx9eFg01L5YXr9us5c5er6fTPJ/lM3mTmlmirIWwNIRP
-        Zw9mB9v3H+bnRMnz2fbDaUZ/7kw+vT/7dDrJsx37crE6qZbnxcW6ZsTQ/ffk
-        q9TggcdOZLGacvtdAwHP/2tm9G53OPRBDN+vO+XyYGJ6syUPvrrFnMlDjYtL
-        anL28ng2I0IA2ke7O2P8dzDYtDRM9EXezism/NNrmp5i2n1lPSmLKb1hgQeo
-        Uosf9rR1MKJpO3318iMfqV8SDoEwo6kmJH+uMb8s6nadlfpn8BrhQDg2d2f5
-        ebYu23A47g/7q/7yfR3pR7Nl8zpvW+KXYIrk8/qS8KGPv2ea0xfZalUW+exp
-        +L18bej3Ub7MJiWxy7OqvsrqGUGnVudZ2eSmBSGNsbzOp+u6aK+ZHtTGIfDD
-        pnEMIZ9D7Nh0Mr7IpvNiCQH74eOsXxu+UFQCbPGD/vkl/w/8lQWOCQcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f5930798-c9a8-4431-9fee-a887d36f96c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2918e677-aea1-4b53-b21d-d9cdee65410f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14990'
-      X-Ms-Correlation-Request-Id:
-      - 78306692-d58f-4924-8009-517feb490caf
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141109Z:78306692-d58f-4924-8009-517feb490caf
-      Date:
-      - Fri, 30 Oct 2015 14:11:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96PTVy49G/Ekxw993
-        m/WkmdbFqi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vt
-        H9y/W+dNta6n+ed1tV41d0+qxWrd5j/5RXN3VVeXxSyvm7tfFNO6aqrzdvwi
-        b6+q+u3d1XpSFtOzl8ezGQFo8uauwyVvswtg8927v+9H5/cf3tt58PBge/ow
-        O9je37+3Syjk+XZ2cPBgdu/T84efTnd/34/0xfZ6xcO6RXf6RllNM4wVb+VZ
-        067NF4T7Kq/bglo+Splo8uFl0VDzYnnxus1a7uz1ejrN81k+kzepGfUgFFkL
-        Vc8f7O/t3fv0/vZkbw9j2NvfPjjIP93enzzY/fThw8mD6acP7MsW09Lg9kXe
-        zisG9PSaJq6Y2rbFrMzfFIu8Wrdnyy+KJdEd6O7b71cn1fK8uFjXDIi+0pHg
-        O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
-        MQDoSbwCAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - bf9d7311-bdc6-4a27-9b37-c81381e999d0
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - d252d076-ae32-49fd-88c9-c5b4385ba00e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141110Z:d252d076-ae32-49fd-88c9-c5b4385ba00e
-      Date:
-      - Fri, 30 Oct 2015 14:11:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pXuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbTz8JOdnUc7
-        Ox+Zxr9Efvk+fvwSBgGk3gIZJYAd/kfLTKB+cfYTe667KM281/BsoFuznk7z
-        fJbPHEQ8jm5ny/Oq8x1hGJLNB5sOQYwR5d6j/b1H9++PHx7cf/jpfpc4RBLz
-        KxNI//4+w/0of9fmRHuiP0HVkdtRO2IV07pqqvN2fEaNL+ZtM/7JL54W2cWy
-        atpi2rzO25awbrRTv4M+YR349yLoEDHfn5AbiPjpeGf/YL9DQ2GpKOLVVV6j
-        4/zuLM/KsprSr35Pt8aZRMKHIA2Fjr9x8kv+HyyRCM5HBAAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miq2727?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"86ae9cbe-172e-4618-a950-a33604937de9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e4431f1a-3b00-4615-bae4-68fe033a6fee
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 7785c11c-12b2-4083-baf2-780838116f1f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141110Z:7785c11c-12b2-4083-baf2-780838116f1f
-      Date:
-      - Fri, 30 Oct 2015 14:11:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8or0Hew8+GvGn
-        xQyf3W3Wk2ZaF6u2qJbN3f1P9873svOD7fzTB/n2/s700+2H55Pz7Z29g739
-        2e5stn9w/26dN9W6nuaf19V61dw9qRardZv/5BfN3VVdXRazvG7uflFM66qp
-        ztvxi7y9quq3d5fy82zZ5vV5Ns2buyE+eZtdAKPv3v19Pzr4NMsfTif59u6D
-        PULj092D7ezh/Z3t7N69T3f2H957MMsf/r4f6Yvt9YqHd4su9Y2ymmYYL97K
-        s6Zdmy8I/1VetwW1fJQy8eTDy6Kh5sXy4nWbtdzZ6/V0muezfCZvUjNLlbVQ
-        dn+aP7i3v39/e7ozvb+9n+fn29mnB+fbD7PZp3meTR/s7923Lxerk2p5Xlys
-        a0YM3X9PvkoNHnjsVBarKbffNRDw/L9nSu92x0MfxBD+unMuD2amN13y4Ktb
-        TJo81Li4pCZnL49nM6IEoH20uzPGfw8Hm5aGi77I23nFlH96TfNTTLuvrCdl
-        MaU3LPAAVWrxw563DkY0b1+c/cTeRz5WvyQcA6FGk01Y/lyjflnU7Tor9c/g
-        NcKBcGzuzvLzbF224XDcH/ZX/eX7OtKPZsvmdd62xDDBHMnn9SXhQx9/zzSn
-        L7LVqizy2dPwe/na0O+jfJlNSuKXZ1V9ldUzgk6tzrOyyU0LQhpjeZ1P13XR
-        XjM9qI1D4IdN4xhC1M6xiB2czsYX2XReLCFiP3yk9WvDGIoKtfDQxQ/655f8
-        P1R9PzgPBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"eb7757d9-4b50-4dd6-91b0-74f2ca2df862"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8e173e30-9806-45fa-bba0-63db1acc72ad
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - c9e2d1ad-b203-4319-92f0-01b3b5b9387f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141110Z:c9e2d1ad-b203-4319-92f0-01b3b5b9387f
-      Date:
-      - Fri, 30 Oct 2015 14:11:09 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96Iuzn9j7aMQfFTN8
-        cLdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2Z7uz
-        2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0UxraumOm/H
-        L/L2qqrf3l2tJ2UxPXt5PJsRgCanNg6ZvM0ugM537/6+H+WTBw/uP5g93N6f
-        3N/Z3p/NCIfdyc72g/3zvWm2Nzs/+HTv9/1IX2yvVzKwm/vTN8pqmmGweCvP
-        mnZtviDkV3ndFtTyUcpkkw8vi4aaF8uL123Wcmev19Npns/ymbxJzagHIcla
-        yLqTH+wf5A8n2/lkZ58Gsn9v++H9KQ1p/+H+ZOf804PpgQ6dXraYlga3L/J2
-        XjGgp9c0dcXUti1mZf6mWOTVuj1bflEsifBAd99+vzqplufFxbpmQPSVjgTf
-        McS7P7QZX8rPs2Wb1+fZlGZ8UfyivQd7D+52sGzogyl/sPuRYPtL8IP++SX/
-        D8aATOm/AgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 5563d63e-47e8-42e7-b437-11d88221a5ff
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - 35fbf16c-deef-4f3a-a11a-604b792ebc1f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141110Z:35fbf16c-deef-4f3a-a11a-604b792ebc1f
-      Date:
-      - Fri, 30 Oct 2015 14:11:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        93be7O4/2t19tLvzyc7Oo52dj0zjXyK/fB8/fgmDAFJvgYwSwA7/o2UmUL84
-        +4mTarFat/mu6zVKOu9tPBvI16yn0zyf5TMHEY8j39nyvOp8R4iG1PPBpkMQ
-        Y7S592h/79H9++ODvYefPnj4aYdGRBnzK9OJ/laQdnSWNrOszQivtz+iDP8g
-        qF3K7Llef35RBj++z3A/yt+1OYktiS5B1ZHbUVuKfVFM66qpztvxGTW+mLfN
-        +Ce/eFpkF8uqaYtp8zpvW8K60U79DvqEdeDfi6BDxHx/Qm4m4v79ezsPQiL2
-        WcliXl3lNXrO787yrCyrKf3qd3VrpEmd+hCkoRDyN05+yf8DdkdRoEgGAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/miqcompute1426?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"15e05a07-0ca2-435c-8eec-b61e5da24da7"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 57a94eb0-9449-440a-8678-081cf816b916
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 3152bd0b-b723-45e4-bc6e-4bb322917b7e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141112Z:3152bd0b-b723-45e4-bc6e-4bb322917b7e
-      Date:
-      - Fri, 30 Oct 2015 14:11:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aFH8omm1WK3bfHd/
-        79OPRvxlMcNXd5v1pJnWxaotqmVzd//TvfO97PxgO//0Qb69vzP9dPvh+eR8
-        e2fvYG9/tjub7R/cv1vnTbWup/nndbVeNXdPBPRPftHcXdXVZTHL6+buF8W0
-        rprqvB2/yNurqn57dyk/z5ZtXp9n07y5G0Urb7MLIPbdu7/vR7v385372c6D
-        7Z1ptre9f+/+dPsgz6fbk0938/uzjDDKHvy+H+mL7fWKB3uLnvWNsppmGDbe
-        yrOmXZsvaBirvG4LavkoZVLKh5dFQ82L5cXrNmu5s9fr6TTPZ/lM3qRmljhr
-        IfDew8ne7N7edPvBg3x/e/98mm9P9j79dPvBJDvIHpwffLq3u2NfLlYn1fK8
-        uFjXjBi6/558lRo88NiJLVZTbr9rIOD5f93M3u0Oiz6I4f11p14eTFBv1uTB
-        V7eYO3mocXFJTc5eHs9mRBBA+2h3Z4z/9gebloaZvsjbecUT8PSapqmYdl9Z
-        T8piSm9Y4AGq1OKHPX0djGj6vjj7CX139yMfuV8SDoUwpKknZH+uR3BZ1O06
-        K/XP4DXCgXBs7s7y82xdtuFw3B/2V/3l+zrSj2bL5nXetsQ3wVTJ5/Ul4UMf
-        f880py+y1aos8tnT8Hv52tDvo3yZTUpim2dVfZXVM4JOrc6zsslNC0IaY3md
-        T9d10V4zPaiNQ+CHTeMYQtSuxyl2jDopX2TTebGEwP3wcdevDX8oKtSijzV+
-        0D+/5P8B4BsgKTkHAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"df08f466-aab6-4d63-affe-688a6f41020f"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 579381fc-f197-44f0-99c5-ef1ad7894b5a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - 59208ef9-7024-4672-bcdb-b14f3570964e
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141112Z:59208ef9-7024-4672-bcdb-b14f3570964e
-      Date:
-      - Fri, 30 Oct 2015 14:11:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96IuznzipFqt1m+9+
-        NOJvihk+v9usJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn2zt7
-        B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrmrcH/yi+buqq4ui1leN3e/KKZ11VTn
-        7fhF3l5V9du7q/WkLKZnL49nMwLQ5NSmh1PeZhfA6rt3f9+PZuc7B+f7n366
-        nWWTT7f3Z5/e287Oz/PtTw8Osk/P93d39nbOf9+P9MX2eiXDvLlbfaOsphnG
-        jLfyrGnX5gsawyqv24JaPkqZiPLhZdFQ82J58brNWu7s9Xo6zfNZPpM3qRn1
-        IJRZC3Vnewfn09396fZsNtvZ3j8/p9Hs7t8nwt57kN97kH364N6OfdliWhrc
-        vsjbecWAnl7TRBZT27aYlfmbYpFX6/Zs+UWxJBoC3X37/eqkWp4XF+uaAdFX
-        OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
-        +EH//JL/B0wm3MTUAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 0bbc8040-6edf-4bc3-89a0-2e77d889e555
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 1c1f2103-1afb-418b-8cac-ebce78f9bc1f
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141112Z:1c1f2103-1afb-418b-8cac-ebce78f9bc1f
-      Date:
-      - Fri, 30 Oct 2015 14:11:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbS798nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
-        nzmIeBzlzpbnVec7QiAknA82HYIYI8u9R/sPHt3/dHxwb/fTnQf3O+Qhophf
-        mUT69/cZ7keTqmqfFtnFsmraYgo8dMw02mVTlfnraZ3ny2ZetU/KavJVXVCT
-        j+Ztu2oe3b3brPLpbtNWNU3t7nhCDcbTqs7HV8VyVl0142Xe3kUPM9fDNt65
-        XOxs59nugzzb29/OZtlse39/em87Ozh4uL2zs3/vfLK3e//h+R53sP2TX+yM
-        b9N63Fhcx5PFiimgDNGfXh0mffde0zo0pe8/nZun8uH+3u69kNNlKFHMq6u8
-        Rs/53VmelWU1pV/9rm6NNMmmD0EaCr/8xskv+X8AsQnz5tAEAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic0?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"ac03b5da-e835-4650-87ba-5953e106ba33"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 12f88f6d-0308-442c-9ae3-510657d5459f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 520edc30-c878-428d-bed2-d2ddc7725490
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141112Z:520edc30-c878-428d-bed2-d2ddc7725490
-      Date:
-      - Fri, 30 Oct 2015 14:11:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd35aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+1E23bk3uT/LtvOD
-        e/e39z+9v7N98GCSbd9/eP9evrvz6SS7d+/3/UhfbK9XPMRbdKpvlNU0w4jx
-        Vp417dp8QSNY5XVbUMtHKRNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s3RZ
-        C23vHzyc7u482Cc6zna39+9PJtsP9w4ebE+yB+effjrdf0j0tC8Xq5NqeV5c
-        rGtGDN1/T75KDR547HQWqym33zUQ8Py/aVLvdkdEH8RQ/rqzLg/mpjdh8uCr
-        W0ybPNS4uKQmZy+PZzOiBaB9tLszxn/3B5uWho++yNt5xbR/ek0zVEw7r9CE
-        EKno+wBD+uKHPWGXRd2us1L/1On6yRenb+4SCoRic/c1/9ze/cjH9JeEwymr
-        bPYkK7PlNK+fZNO3+XKmZHtZVSVoZ3lXns6wCcQPe+A+yjrs50/uTvrI39UB
-        4Y+QCEQG/8/vD9PkbDmp1svZi6x9tS6ZM/8/Qo8iRPzuq6cvt3/yi52NZHB/
-        2M/1F0Ohj2bL5nXetiSHoIUdvHxeXxIG9PH3THP6IlutyiKfPQ2/l68NL36U
-        L7NJSWL4rKqvsnpG0KnVeVY2uWmh3P5FNp0XS4i/6/qbo/eXX7z86s3pT37x
-        OkpvnQ4jeIqKUtyRlilG//yS/wduCFLLtQcAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 7110017e-7add-4c03-a8ec-da3716a44434
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - ce13a733-5bc9-47e7-a9fc-515647b5e98a
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141112Z:ce13a733-5bc9-47e7-a9fc-515647b5e98a
-      Date:
-      - Fri, 30 Oct 2015 14:11:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd3727s72/d23uzuP9rdfbS798nOzqOd
-        nY9M418iv3wfP34JgwBSb4GMEsAO/6NlJlCrBk1ch1GqeS/i2UC5Zj2d5vks
-        nzmIeBzlzpbnVec7QiAknA82HYIYI8u9R/sPHt1/MH6w8+mnB58edMhDRDG/
-        Mon07+8z3I8mVdU+LbKLZdW0xRR46JhptMumKvPX0zrPl828ap+U1eSruqAm
-        H83bdtU8unu3WeXT3aatapra3fGEGoynVZ2Pr4rlrLpqxsu8vYseZq6Hbbxz
-        udjd3pncz/ay/fPt3dmnD7b3d2f5dra7N92+tzvbebD76cO9T/eIsNR4+ye/
-        2B3fpvW4sbiOJ4sVU0AZoj+9Okz67r2mdWhK3386N0/lpw93P/30fjCVMpQo
-        5tVVXqPn/O4sz8qymtKvfle3Rppk04cgDYVffuPkl/w/IPkF8dAEAAA=
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces/spec-nic1?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"79a4e4b1-b793-46f8-a809-201f55afc502"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 241cad7d-b946-4cd0-be22-dbcf8e7c204b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - 2ef951e9-c736-4743-ac75-ff0f25ec948c
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141113Z:2ef951e9-c736-4743-ac75-ff0f25ec948c
-      Date:
-      - Fri, 30 Oct 2015 14:11:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qFnl0+1lMd39aMSf
-        FzN8erdZT5ppXazaolo2d/c/3Tvfy84PtvNPH+Tb+zvTT7cfnk/Ot3f2Dvb2
-        Z7uz2f7B/bt13lTrepp/XlfrVXP3pFqs1m3+k180d1d1dVnM8rq5+0Uxraum
-        Om/HL/L2qqrf3l3Kz7Nlm9fn2TRv7nYxytvsAjh99+7v+9GDh9l+vj/Z3Z48
-        eHhve/9TQik72Hm4vbeze37/fnY+vb+z9/t+pC+21yse4i061TfKapphxHgr
-        z5p2bb6gEazyui2o5aOUCSgfXhYNNS+WF6/brOXOXq+n0zyf5TN5k5pZuqyF
-        tg92Zvd37t/f297bO9/d3r//ab49me2dbz+c7J7v5vf2z8/zHftysTqplufF
-        xbpmxND99+Sr1OCBx05nsZpyeyWePP9vmtS73RHRBzGUv+6sy4O56U2YPPjq
-        FtMmDzUuLqnJ2cvj2YxoAWgf7e6M8d/+YNPS8NEXeTuvmPZPr2mGimnnFZoQ
-        IhV9H2BIX/ywJ+yyqNt1VuqfOl0/+eL0zV1CgVBs7r7mn9u7H/mY/pJwOGWV
-        zZ5kZbac5vWTbPo2X86UbC+rqgTtLO/K0xk2gfhhD9xHWYf9/MndSR/5uzog
-        /BESgcjg//n9YZqcLSfVejl7kbWv1iVz5v9H6FGEiN999fTl9k9+sZkM7g/7
-        uf5iKPTRbNm8ztuW5BC0sIOXz+tLwoA+/p5pTl9kq1VZ5LOn4ffyteHFj/Jl
-        NilJDJ9V9VVWzwg6tTrPyiY3LZTbv8im82IJ8Xddf3P0/vKLl1+9Of3JL15H
-        6a3TYQRPUVGKO9IyxeifX/L/AKug0K61BwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130894780390733291
-      X-Ms-Request-Id:
-      - 79fd8ad7-cc49-4776-8d50-f1156ff34795
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 62e08415-7e64-4380-9a40-c1ce070c5210
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141113Z:62e08415-7e64-4380-9a40-c1ce070c5210
-      Date:
-      - Fri, 30 Oct 2015 14:11:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
-        Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3fvbuzvb
-        93be7O4/2t19tHvvk52dRzs7H5nGv0R++T5+/BIGAaTeAhklgB3+R8tMoL7O
-        yrw5r+pp/tVr122Udt7reDbQr1lPp3k+y2cOIh5Hv7PledX5jjANyeeDTYcg
-        xohz79H+g0f3Px3fv79z72D/oEMkIo35lQmlf3+f4X40qar2aZFdLKumLabA
-        Q8dMo102VZm/ntZ5vmzmVfukrCZf1QU1+Wjetqvm0d27y+v64uHuwf54Qt+N
-        p1Wdj6+K5ay6asbLvL0L4DMHfLsxtN+ezs53svMHDwn//dn2/uzBve2H0+n9
-        7YP793cnuw9n03znwV1/qsa3eWPcWGTHk8WKSaB8kb9r6QsiLoaoM6wjpW8N
-        c3xRTOuqqc7b8Rk1vpi3zfgnv/DI8zpvW5qdhiETbPxQQvYZyIF/L8YZYpr3
-        Z5iNzPLp7h6R7tOAWYRWUcyrq7xGz/ndWZ6VZTWlX/2ubo006QAfgjQUQv7G
-        yS/5fwDm8y0Y/QQAAA==
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces/salesforceus88?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"10151287-e86a-4dca-869a-8ebd68e2834e"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 00c24975-c126-4d08-872a-cacb4716c6fa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
-      X-Ms-Correlation-Request-Id:
-      - 7078ce61-d257-4c8b-b243-1907d204cff4
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141113Z:7078ce61-d257-4c8b-b243-1907d204cff4
-      Date:
-      - Fri, 30 Oct 2015 14:11:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qMnKvDmv6mm+bg4O
-        Phrxl8UMX91t1pNmWhertqiWzd39T/fO97Lzg+380wf59v7O9NPth+eT8+2d
-        vYO9/dnubLZ/cP9unTfVmoB9XlfrVXP3xe/z6vO7q7q6LGZ53dz9opjWVVOd
-        t+MXeXtV1W/vLuXn2bLN6/Nsmjd3owjlbXYBlL579/f9aHdn9/7u3sGD7fzg
-        02x7fzbNtg8+fUj/5JPZpwf53sG9/fz3/UhfbK9XPMxb9KxvlNU0w4DxVp41
-        7dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1s2RZC2kn
-        2V4+vU9Iz+7dP6Ax7M+2s93d3e3pbn7vwb2dTycPJ3v25WJ1Ui3Pi4t1zYih
-        ++/JV6nBA4+d0mI15fa7BgKe/xfN6d3ugOiDGMZfd9LlwdT05ksefHWLWZOH
-        GheX1OTs5fFsRqQANEJnvDfeGX862LQ0bPRF3s4rJv3Ta5qgYtp9ZT0piym9
-        YYEHqFKLH97EdXChiXttJ+6r12cvP/Ix+yXhOAg9mnfC9GcN/ZN5fr79sq5m
-        G8dwWdTtOiv1T/8twoAwbO7O8vNsXbbhYNwf9lf95fs6zo9my+Z13rbEMsEs
-        yef1JaFDH3/PNKcvstWqLPLZ0/B7+dpQ76N8mU1K4phnVX2V1TOCTq3Os7LJ
-        TQtCGkN5nU/XddFeMzWojUPgm6NwtVit2/wnv2g2kjiGELU7+wl9f1dJa8eo
-        c/JFNp0XS8jazwLug8ytSBnGUCRC1jYI4wf980v+H9qMLAEjBwAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin12.5.0 x86_64) ruby/2.2.0p0
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NDYyMTM5MzIsIm5iZiI6MTQ0NjIxMzkzMiwiZXhwIjoxNDQ2MjE3ODMyLCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.Mak2gsEnDRObm428FG0OZmyVbU1NvG_8VgtOjHVkz3u-eDvjNZwIVTYB_sRA41zOfBCsGeJsEmihgtx_-wCGMqX6PyJkuVEHYAv1DutBMx4SlX2UaOVkRhvS-FCVAQP9_d1CZTInNeZhyy0C3cCgb1chqEUVaF-JbOEsaSzua9Z_uoTmfGzhSVYGlX7ZrZQnJvgF0P9VamyOAyUNVjMrfjK1wc_AZpX1YqOhN0xnNgeyJl_MvNjgAzbx7UO68oZBeOWyHSEBAhvsl6nAvDq1qypa-QRBnfuQg6QsG1gU3qdKyrHzXrsIccQb2E6Hl7SZYpdZ6o3PeGg7Uh_q0W5vCQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"978aa5e9-0713-4335-8460-f8eebc243dbd"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - eeb6541c-e67c-4c5a-a91e-1c87bd5765f6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 6eaa8fee-6696-4d04-be0e-892b23d9fcc8
-      X-Ms-Routing-Request-Id:
-      - EASTUS:20151030T141113Z:6eaa8fee-6696-4d04-be0e-892b23d9fcc8
-      Date:
-      - Fri, 30 Oct 2015 14:11:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96HVW5s15VU/zr16f
-        vfxoxF8WM3x1t1lPmmldrNqiWjZ39z/dO9/Lzg+2808f5Nv7O9NPtx+eT863
-        d/YO9vZnu7PZ/sH9u3XeVGsC9nldrVfN3Re/z6vP767q6rKY5XVz94tiWldN
-        dd6OX+TtVVW/vbtaT8pievbyeDajV5u8uRtFKG+zC6D03bu/70cPHxxk2f38
-        4fbOg9172/v37t3fPtj/dGf7/CDPJ9O9/Xuzyez3/UhfbK9XPMxb9KxvlNU0
-        w4DxVp417dp8QcNY5XVbUMtHKRNRPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1
-        ox6ELGsh7e6D2d5BPsu29zKi4H5+b7b98MFssj15mGWT/dn5vYPzc/uyxbQ0
-        uH2Rt/OKAT29poksprZtMSvzN8Uir9bt2fKLYrluGd19+/3qpFqeFxfrmgHR
-        VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
-        55f8P07bQ1vOAgAA
-    http_version: 
-  recorded_at: Fri, 30 Oct 2015 14:11:15 GMT
+        v2T00TyrZ1dZnb+sq/OipFFjmK+LH9BvHz3JmmL6+x/voF3TVnV24TcrFvT3
+        q/w8r/PllD9ZrSdl0czzmt6dzvPzbaAD4ESN6pwa2s/z+pL+Iqhv1/rZ5Loq
+        6QP6uCGy0Idl1uZNi66r5mnRvEUHVfPmekVdffS8WK7fUfNltsCfJwRgm1Cb
+        0UfTOqc3v2Tq0lfP6mpxBkzpq8s50f8Xf7SuC/pi3rarR3fvom8i4uz+7t7O
+        eFJWk/G0qvPxVbGcVVfNeJm3d+k1Ijm14y7G9CewmmbTebG8IEivaNa/Wxdt
+        jo9nWZsBXWKY732f/q4aesmQbCozU7/oo53NFsXyKyKMDmlSV8vsYt7QVyUG
+        e1Itz4uLdZ3JuH7xR7OiySZl/jJrmquqnh2v23m+bIupNjjPyian/pucCNIa
+        bGg41Pgt9WlQ0k/OloTWeTYFo3f5nt77xhjXjDjKuC8El7s9nHiWtumV2f09
+        4kaMZFZkF8uqoQH7BJ5UVfvUfYOP8iXIRPi39Toneggff2V5oLkdE3z0S6hT
+        anNZgD9p4l+3xGYE46sVTTn9jck3o6WOiYjfGNFuJe2XRd2us/KLDGxJJHOk
+        zt+1+RJY+6+d0ScX87YZ/+QXHsFITWAsDdH4G5z0D8OfJEBlwv+oFUVwIxxq
+        WlZGKD7Ks6Zd47M2o0Eya6/KjL4hQZA+wAqqizapMxrJbD0lpa7fiEIjHunI
+        DilTthnn0/N7s2k+3T6fHMy29x+e399+ODuYbk927+ez6fn5g539KYHtqGwA
+        +OHOQgeB97cZJBbLGX3/Nc2Gxei7InuvhbCkR9V+dD8XC7K3s3Ow/Wpv+/XL
+        XfqMvgG70+cbjYiCohd07l+SEFwQ2baf5pf0KSlOev0btyR+L9+gMfHBEoYb
+        7Ili1LMohLxot5/84viCbIlRmaJBycBUC2o7ZYUH5sa3hNTXszDfGFsT1Vkn
+        RNl62KKsDLlm+eX+vfuk8Aj5b8yo3IodoC4c0Wn6SXZo3kmG1tNpns8IPjUg
+        HHm81O83SbZbaYOOLg1Y9/+jZsUfAsmCSkfn0w8yLoM2YGd3b//B3r1Ptz/d
+        mT7Y3t/fy7Yf5g9m2zvTg0+zvd17O5MZtNc8G9auH+KRn2RL4rJpBtNmtOlX
+        k/WyXXeU6e7eeGd/fH/7+ZvX9Bl9g0mmzzcq045HvmbApH7odfqUNAS9fDtV
+        ekuHjN5r7vrd7O3sfrq7S/9/uPsNqlW/B8J2g1r9OXDTvzFRInJ/HSXqE+f+
+        Pkk34f6N6dBb8sH/97SoT7X/j2pRfwjE+ioMnU9/drTowe6nDx4+mO5sfzq5
+        R4Oc7u1uH+R7lIc5mO09/HR2MMt39whix5EFgG+MZF9+8fKrN6c/+cXrjTTr
+        YNBzpXdpjBuVPTGyutLknlgB8Vpu1veQHT9kMTpfPjeTJCofn2nUQx+DHenD
+        99H3ACAwYcJIl9G7t1P3kHKh2OWi2b33cG9AzulFyQNoN9+gjvegEob/P1Xx
+        MuSf/IJc3wjTDut4jzgHn94j3UPIMwRwCRGeuJQoTty6/tlXt7cTvI568Ufw
+        c69uP3gIxIbKmOGHH6RtaUp/KGmQ6ZQ8tL2dvW1yeLPt/fN7lAE5mGTb+XT2
+        6afnDw927x/8bKdBbjcBHQw+RHlz0/dV3rd31vfhrN/7IGf99NVL+oO0E73z
+        s6C0Cfw3qKwJGmH0IyXtI3E3r1f3d8hLANL8JriACE1cSBQmblz/v1U503T+
+        f1UpE+rEbsqA8scHKeFBrfnpg51P96cHD8jRfUiJg53Jw+3s4afkAe9P78/2
+        J5Pz2e49gtjRWQDwQ6ZQB4MP0Zo/yymOb0BrfnH2Ewg0SF/QSz8LahPwv0G9
+        CXCE048Up4/E3UXxi/Ye7D0gdUJY86sNIUGkJk4kGhNHrv/fqjkxof9fVZ3A
+        nThOeVD/+tlRnrNPSVvsPNjfnh3kNKrz8/PtSU4a9GCfvtj5dLZDqVeCOM9u
+        o5V4+et9tZId0E8WDQ3jdbueFRV1aTSUW4cS5XQw3t0+BYuu6qLJt1/QF7fU
+        UA6So6wSEWMkCaW3f3ZUlenmPTTWL/6oXBMeOxZbfEnq5m0E19PFqr2mjwH9
+        6+NpO+hj+aJagg74FrP++ZOPHu2CpxjF3R6K4NefVRQjqj+C4j3WWzeofTM1
+        9O4G7a+Y9PQ/CZW4kz+MVUHqzEkwvfeNqSkhwdeyD0rQ3f29T0l1ElIMARSh
+        aSHVQIxNKmL9/2IzoV/t/n/YWuhX4GFl3fDDD7Id9HpGIyWOg8QTZo4HyQiw
+        Fcmz3Qd5tre/nc2yGa3dTe9tZwcHD7d3dvbvnU/2du8/PIdK6DjAAPBDpl0H
+        A2ry+xz/JLne4Mt5dgsb95Sd9K9t49QEWX+7Y+Ts52LqaM1ub/vV3vZT0npT
+        Ui78FTUAj9LX72fsqgaqkf4mzUMvWsV8k51rVvl0Vwe8u0k3Swc7fc08aOKg
+        LjZpZ3S9/ZNf7BBmXdVMvxEh+FP6VnH5udXO3xgrCxHeXxszuSjAo+AQeH9j
+        S423YwLkNR3BaeZJZmjKSXbWnvL/xoh0O3nv6Dceh3KUYST3yQdpyUHduDO5
+        T9nc/fPt3dmnlJ7YneXb2e7edPve7mznwe6nD/c+3YPodTQTAPyQadXBgJr8
+        SDd+s7ox4lh/qG6EdWct+CPdSKx8s24kFgXeP9KNPa3G41COMozkPvnZ0Y3T
+        2flOdv7g4fa9nX3yG2cP7m0/nE7vbx/cv7872X04m1JqgiDOs2Ht8yRriunX
+        TIja0ahCsCrmJtWzcwDV8/olKEPfYFLp8/fTOa+zMm/OK5q2r5BlJami12+t
+        eZbX9cXD3YP9OL+J0vF7+AY1jw+WsGM942mf/7cFzd+UVL34fV59HpWnDUrH
+        UmrdHBx885pnMxPcTumYUVKfPwxiDaiNgFd/zgPxD8Ke+F4lofPpz44K3bn3
+        MJ9N9w627+cHOzS+nb3tyez+dHv//sNsf5bd39072CeIHecOAL4pan339PWb
+        ky+PX795+mSzweng4L15/F5u5msy4lYgvKa3VPavf+K5VehG0dNn5FDub3/3
+        Nf3Ye4Vkheh6l2mmj+gdcCV9/J6q3vT4NL+kT0mL0eu3U/UNifkVdTWtsqad
+        TZpPHx58Ghd31fleV9+kzvfAEpo/X3T+d4nyJ6D80yfv7XD+Ilr5A8Vm+eXu
+        Aa2MAP9vTPl32eL+w0/3Btji59IMWAG/STV0VGDAxj/n5uAbGQWJhgpL59Ov
+        ZxYw+ZvMwr1P73+6n2U72/fPpwfb+wcH+fbk4cP97QfZw51sej6ZTCdQcvNs
+        WOGqZ/21lO2Xq3z5vLooptSH0bEnJPVfwhCKZn0wfg/v+TkW36m5khABf9Vc
+        LugTUg/04u2VKV6ts/Jg52AgVhM9imbogczBp7u79P/9+w++QX1qwBOWG3Rp
+        iVH3NCllEqAcXmZNQzpnRqpzTtAKwxrnGSke6v5rak4i2UaZuaXMYIBE5qi4
+        DCtNvAWy3L//s6EwAZ1w2jD1P5e68uT0xZtXx8+jFBtQCTwi0OvnXEV+CPLE
+        6Mr63idfTysCAM0wFOP3f8n/Ax3aphKqQgAA
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 19:44:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://login.windows.net/a50f9983-d1a2-4a8d-be7d-123456789012/oauth2/token
+    uri: https://login.windows.net/(AZURE_TENANT_ID)/oauth2/token
     body:
       encoding: US-ASCII
-      string: grant_type=client_credentials&client_id=f895b5ef-3bb5-4366-8ce5-123456789012&client_secret=5YcZ1lwRmNPWgo82X%2F1l97Fe4VaBGi%2B123456789012%3D&resource=https%3A%2F%2Fmanagement.azure.com%2F
+      string: grant_type=client_credentials&client_id=(AZURE_CLIENT_ID)&client_secret=(AZURE_CLIENT_SECRET)&resource=https%3A%2F%2Fmanagement.azure.com%2F
     headers:
       Accept:
       - "*/*"
@@ -33,11 +33,11 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.5
       X-Ms-Request-Id:
-      - 04c009de-91fb-4e73-a679-0314e0505ff2
+      - 7597e572-739e-4b8f-b706-932a3e4dabef
       Client-Request-Id:
-      - 56a34328-dcf6-4844-a3bc-bff544fa4fca
+      - 6e481629-de94-49a6-8480-5304eea8e3a1
       X-Ms-Gateway-Service-Instanceid:
-      - ESTSFE_IN_21
+      - ESTSFE_IN_490
       X-Content-Type-Options:
       - nosniff
       Strict-Transport-Security:
@@ -51,14 +51,14 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       Date:
-      - Tue, 19 Jan 2016 13:48:57 GMT
+      - Wed, 03 Feb 2016 14:18:55 GMT
       Content-Length:
       - '1218'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","expires_on":"1453214937","not_before":"1453211037","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","expires_on":"1454512735","not_before":"1454508835","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A"}'
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:48:57 GMT
+  recorded_at: Wed, 03 Feb 2016 14:18:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2015-01-01
@@ -75,7 +75,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -98,15 +98,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 98618e90-115e-4b6a-855a-fe56e300f811
+      - 49f816c4-9e88-4715-8851-19feed3d9dc8
       X-Ms-Correlation-Request-Id:
-      - 98618e90-115e-4b6a-855a-fe56e300f811
+      - 49f816c4-9e88-4715-8851-19feed3d9dc8
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134858Z:98618e90-115e-4b6a-855a-fe56e300f811
+      - NORTHCENTRALUS:20160203T141857Z:49f816c4-9e88-4715-8851-19feed3d9dc8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:48:58 GMT
+      - Wed, 03 Feb 2016 14:18:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -118,7 +118,7 @@ http_interactions:
         fUEvNC19Qk1Pl9mkzGf4xOv6ZVUW0yJvPnr0iz8qq2nGn5XZNF/ky5bxerme
         UJPff29nd3975+H2zi5B+EXrqs34W3Tif/dLfsn3f8n/A2SfqJgiAQAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:48:58 GMT
+  recorded_at: Wed, 03 Feb 2016 14:18:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/providers?api-version=2015-01-01
@@ -135,7 +135,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -158,15 +158,15 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
+      - a3a51cfc-552e-4e07-b5f8-1e8ba8ddd62a
       X-Ms-Correlation-Request-Id:
-      - 6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
+      - a3a51cfc-552e-4e07-b5f8-1e8ba8ddd62a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134859Z:6c1fa4fd-9610-4ad8-9375-0cff4a4c37ec
+      - NORTHCENTRALUS:20160203T141857Z:a3a51cfc-552e-4e07-b5f8-1e8ba8ddd62a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:48:58 GMT
+      - Wed, 03 Feb 2016 14:18:57 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -193,232 +193,254 @@ http_interactions:
         Jox+SN1wR4NarFowcHrJxwWge9hltvXxdFqt++NWO6dWCD+M4WKLNGwf+YPQ
         JG6wkhttFxH5njIMkQDcY+nChLhxTHfr9XJSVT2+///H4ILU1f8PhkgIDYyl
         h9PX6ZC7jMvOk6ydwj/zEQLUHooTNDQTQC8EWIaEVZK73xzx+dMIUTveorSw
-        AIOmDFNnLJhp50AyGMwsfSpN0Dn9Yb8wAPiDEBUHRuFKG5luh4v5G5D1j4Gp
-        obCYNJiZGlZn/Acpffob81Rcklfpposmq0N8IsMAf3D3llDAWEahv/2I8rAd
-        fYI6Gob0/PqA7v6iddVmXXiCpCUnxiVj1d9+ND8gKxN2QD8Vy4svMk77+JQH
-        jN5cLLIVpYnRtD8FROqtl1ndLvP6DjXQzwYRIyndI8QIrU4fRPa4JL43pJL8
-        +5NqsVgvC4Hyss7P8zpfEgU+EPR6hfTsNwKcwQ9NzQ/eZKVJ1IIePhoA1UNM
-        X6GmPgrCuDQbbl56jM5f2L+Y8XxuZQj6u7xpuJGBBawuf+AN+oMh+Y2j9CBV
-        Tf+Dqs5VR2+gy0lGqVkC7Y8dgHrUeJXP+twawb6Ho5M1/gPjcrQRAPZP/pKb
-        YcTBb6x8AmrIH3iF/uhoHv45RPOeanAf2PfoU4O2aAVFzvzBDfWv6CwQVx7Q
-        LFBT+QNZDvmDJof+5+Yn+FDyIP5HNH80e53ZoEn72osBP4to0Sy+n8L5WcSF
-        GfaEfW8Xj9JrXw+twR7uymKn66I7dOVxw03M08I9wUdgxeA3Znjmua9ef+S4
-        0TVRbmZYYFnzgfQXypT9S4QG79s/0ID+6EhQXCbcpwrCoCWSoL2ZP/hN/StK
-        apo8+t8m6tKrF8uqaYvp67xtyb72yAtEPKoo4YQIBjv+Wj6ylGBM7V+d0fOX
-        /FYAgr8OoQoN0bX9Ay/TH/jMzAm/CBqaD3qEdB/YtvSp6UpoqHiZP7ih/nUD
-        eZnAAxZgBqnwiY/Xe9NBeZLzoqTvOuQ3GDIxMJbgt6G5ENSDj3ho/Ju0t1PD
-        X9i/GLASkaGAUuYDoT+a2D/wNv3RmV9HbW3sPuAmABqnKSmE4eyX0uhuvpyt
-        qiISewYjRtfBbz/fqXWX0vsXBb38I6q9D9WmBLdazCjv9CPabaQdYSjuCX2+
-        LjdK5wfDvqsTpX/+ELuynKF//xx2rQKtf/1cIuLLiH72TaJzG3/8gzqw4/1G
-        0c5nF/mymm206jcAZbADnkVet8U5Yvr8VX5BGQQZAfXlowGQPcSm7tUva1qd
-        6SF4UVaTrBxEjh14Ru0mwHe9T76xXogZLws0/pwBHK9Wmnh4WRfLabHKyrPl
-        V01ev8mX2RLq7Rvp9ZL0I+dS3Ih8up8tz6ta1ia+Xo/c58BUy1IwZXFW6xZm
-        wEcNkHrIiihCZHpUh8o3FsNqe/MBf0lsaX9jEwYrQr/Tb2KcPP5VGOFHwR/y
-        irVgDMv+JVYKfdk/0ID++DomyyAjTrvDw/wN0PYPwCEM071063WbXeTIBQqu
-        5jX60nw1MHe7e5g7DWVp3cX9IQLMf1CQEPyBFRmab5rtzqSxmntqZ26Dsvuh
-        oOPx0N2mrPoqnSmojMOExySYD/hLZgD97UecxF/93Ezd3boir5Ze/NEEyt8A
-        bf8AHMLw//0TeGM6LIocdUT/+zodfTD4y6Ju11n5BeXBi+WPGJDwMH8DtP0D
-        cAjDHz4D0v/cH4PcOCVisB0qelP4TSAT6zK6hPpNdGb+GBxsh2V/vudI+XfL
-        qKZj8zc6sn8ADqH0AVxM80L/u928iIYaVoUGHfpYf/vRtCjtzZDNa/Sl+eob
-        mpbeZHQ7pO9lCMFHiqr7jaeMR8Of9hsr1RgWSGM+kP7sLDII+5fMBt63f6AB
-        /dGZbUd7bew+4CbokT7l3y29DZLmb4C2fwAOof+zNBk0PIlGu/SPQiJl+XU0
-        J/3P/TGoRv0/fzawifW5qC7z1+tJM62LFfp6pV9//f5jvVgi0yy16+aDoDP8
-        jUH/i7y9quq39KKPBsD2EFNR1De6aAnrqXgwx4J7zQf8pRMrYsJQ8ro8Sh8x
-        jPCj4A95xQodw7J/idShL/sHGtAf/x8QQZo/fzKFIfkPw53mj03iQTmrfHa2
-        +tE8/azPE8/GhnmiSaL/Refpa/uhIR8Efwx2dkE5xavs+vV6taI5yWdPc2Q1
-        f1i904SLXvuGO6T/uT8Ge1+K1nqdT9c1Jbw+r6v1j0SD8DB/A7T9A3AIw29a
-        hcXmpdEJebWmtAA19+fjwyD/rEeV3OlG4/q6rWqiEb3o44YOe9jSAheaHk+n
-        1ZqWhekVH2GZEWVEnkhMqvmAv2SG0t9+xJn81W2mWSaT/zAza/6g/+1uT/IW
-        /bpP7B+DquaHqtM5qa98pszzgYn9sOPgj0EsOtx7F85HxLTIXDKDuemiP4QB
-        go+ErTDd9g+8TH/gM8P5/CK4yHzgGAzNgg9sW/qUf7dMZTo2f6Mj+wfgEEq3
-        4zjb3P3Gsth9wX5kZYr7tH8FchSdNJoN+t/7zcYtck2MBuMXIMuIhPjLnGCQ
-        9g+8TH/gMzMf/CKIbj5w84FmwQe2LX3Kv9s5MB2bv9GR/QNwCKX/X0yQZDeG
-        k07fdE/fOHwB+7M4AOngg8F+oHMQqkX+I9bLrGh6cfI3CL5YEGV+FuFXzdnP
-        dg8/xJiA+9/orp0tz2vSCfV62q7r/IvignCDsPtIA5feMKax94eyQ6J3VB2y
-        AoHOMx/wl6x/9DdWT6x8+FPRSoGiYhjhR8Ef8opVXQzL/iWaG33ZP9CA/ghU
-        nK+ntbH7gJtgEHFNyDO1e/+GKagWq/XtqJ15/g3ZsTh9eeT6W4eEEeIEH/Fw
-        wo+klSUaw7J/cS86ffwuSGE+EJKiif0Db9Mfjn76rfvAQqFPg2nYSF/md/qD
-        /re7vaopuM+viOhE8g4BNZFncur04o/o9wH0u5u/a/OlQPwRKT+MlOTS3eCh
-        AkOhhP72/3OSkgGj/8GA3Uw9cY6GvS8ZDI9Zf/sR8ZR4r6dZmRPP/bwnGYns
-        h4iwpeOPtKIMVqj4zZA0/PxHdP2m6KqLA2fLNq/PyTP9EWW/KcqGn/+I0h9O
-        aUetkHLfMPS7RB4Kf/ErvW0/BlyMWCirv/1oioaIeLl4XfzgR0xOFPu6FFw3
-        kQyUDIjHrb/9v5qARC+gSdj+HBBwtZ6URTMnePS2/RhwgRORjj7W335ExJCI
-        hPaPVOBtSMfEi+f1nmZtdlItl/kUPfkEBuweyafSlLr+IluS5Pe5FkMDxYbw
-        PAhRI8Q6XThoP2uQnfGkJPC67AeVH9wVL/u+IIpvWOx93164n+FZfJZNaS0G
-        nfi4AFwPu5lt3l9esVj1WB48Kl/obyxU0igQFYZgXwu4tyN6/GH4sggIerB/
-        AB79gc+MTPGLEA/5YICCuztEQWrNf+w89P8Abe0fD+gPS2jzIf2v/yHWKsIP
-        92XRo/chuu5+OJzsCGbka2fZInMhH9nJACndX52p4S/5rQAEfx1ClXlB1/YP
-        vEx/4DOZE33xhkkiitD/bkOUr5k8EwIE2MtHlgrA3P31/3KasGLxxP0GHROF
-        T3xM/+twJ39C/zMfDnZ+/ANaPPtgDFg+qCn/8c2LZgx7x07Xr2kkC0zH/zsx
-        JU4U89Tl8Z8rFBnJYdPzPHubHy+z8po0FlD2hwMsewPMptNqvezbXZYUFtxN
-        I/UQI7QGQN/FdAOx1zTh+bF++rPZYUMdkUv0c9DVXXLL2owSOH137IfT610K
-        YdrXWfOmeks55Z8FHBy8EPaHA3S+ILWI+IJfuwcL92tCZJibZY5Zm6D7PQNg
-        DxczhdTWx+SbmBkD+u55UedXWVm+WpeExDffkYMXwv5wgP+fZAFqI+lZv0+A
-        6mFBtu7mWEQniD7ueEf8xbCvQrbigCJPD2lCuYMAAYqTQYD/LPV6VrXfXk9+
-        FrvkTgdn5w35fs+zCQH28QK0HqY0Jz00O36iosd4w6v0fosMQH9neTO+KD6x
-        f+DFwWHe397zmZAG2cE3X9KyQbVckPf7/ym8qbs4H94KonGN6H9x19xB/BrQ
-        NwJ0CqoL2xCMPtbfmHSgE/1ufouSujdTQmI0sX/g7dvSm0cwIA7VdA1uefqE
-        IPuDBLTesOG4TbLG+hn0TjBkICWD60gwf2H/wkCkGf+mg+yN2qXc0Cz4wLal
-        T02od7ak4Jz+5u86f5k23Gnwh1BTO5A/gOwgaSn8O6CW9Af9Rv+LM1yHUFDx
-        PyLWELFonAMiBODS888rEjGRhuR1QX79q/yCvHohGr3s0xOgexSe8Vs98l6U
-        1SQrN6HmAlRk0gg1QqwDu61Wz/PLvBTMfnb6YD9JOtjkKX0jfSFekq5e5dNq
-        QcqRhJkB/Wz0dknsR/Bz06Ob17PleVUv+FcC8833fJFTeEg9v26qV/kvWoNH
-        fza6IQmlXvjNDwfPHQwIxjV9TjmO57dLc5TTZlVXP00LJmge4NVJM0KUjQbh
-        3zeKudFUgU6Qj6y6YshhC7zrGvBf/Dk3hV4yGARvoXv6jf2KL14/e8Mo0Afm
-        T/0++FPh8AcdvJw6RMvgA4vH4HTR/3a3s3I1B3T5CDPY+ehe/yNMLfkqxSXx
-        onFZOt9FPpzkbQeEQGUOGZ5rJEawSlb10zE/mnZuGXxg8fi6064T9LWn/Rub
-        9rJaz2b5qqyuSaH/SOZtt26u0TL4wOLx/8XJp9ENmJ0fTTW3DD6weAxONZPb
-        zMpGQ3x6SWOg9A514M8JYPVmyULozZLDbQOycXq535hyjmhCj+AVhhV+xO8q
-        GflrdGU+6DCPcAbesH+gO/pD+rK0x6fuL9NfGFOYv7it/BGdDRIxXkfiOegQ
-        lB1ljjZB1Q2+chQyzbNblNrUDQ0jLl3vA5YBWw4gqI6HnuVZS0uZgE7/2p4B
-        sIfLuWt7IybUOTDxGJlQoHd9eGQzLosZvff1ADJIf1TklOqoKDoqLuZsfPw+
-        AauHBUUeq2pJfILWPhqWeYhZoygRtel/jtrAz/5B/wPpCcVOf1f5pCW++yH1
-        RuFGXdDAv4nOYvCzMq/bOrbawcJF8FXO+beNssrNVPpZTn11ICKPJvYPvE1/
-        CExvQPp2+BHepN9YTwVfOG2HJsEHDAZI0KeBOhoiGRHKkYz+N0CydVs1UyJc
-        k7dtsbz4EeWUWDdSjpIfy7al37skuw3YXSznmz/km1gfDmzYhaHDBw7BgnTp
-        7Ffvs94mkG/sxgL/WmA/9f+g/8X7AB9T1iSfnb5bESe9/hE3R4lJ/4vTj9yO
-        i2XVtMX05yHpTA/ifTmA5m9gpn8MUfnBEGEXeVsX06f5ebEshJY/oqv5G5jp
-        H+9N17K6+BFRgZwBaP4GZvrHDURlsvo+q/PEf6/8+iczMgQEz6c7YPRm4hIN
-        ezMQoQzGKL/Jl5b4jLL9i5sp5XmooIL5gL+MkZJbhv0xWP5N5gzv2j/wJf3h
-        CK7fug8YIvqmT4MZGCKrb6l297Z3H3rxAVE6Sra7TT6t8x+R773JR4N9P6di
-        E3juIC4Jz6uLYkrv+d0Dag+hq6p+e15WV118dLYC0gZ/MFXC7+UVO6UgtvsL
-        lDbzye+CyOYDbsowuJn/G096MHvyB76mP4I58idSv3cfcBN0OjiViNAseZnm
-        9GEnl0QU71CQhhefUqVHQKLgD8Yo/F5esUTDiN1fGJKhGL+L0ZgPuCnD4Gb+
-        b/+vJyGB+nKQigF6t+o31sUiW2YX+ex4Vfysd3Aiqzb8/jfQFXcWl/Ivsvpt
-        3q5K+vzLmrJA5ABTjz5iANtDNbuo8zy6ssCIhRwJjsFvQ9iygmIcO70Qz8Zn
-        9AZIDCs+3hd5C31F8Py+AKLX+2VRt+us1De6KNhRWRmh376+7MmbAdm4TfhR
-        8AfDC0QTn9g/0Dn9EfCLL4na2H3ATYDThonavU+vyB/0P8dj/CGbF+9DnoYO
-        UVfrSVlMz14ez2b0TUOU/xFZvwGyLoVJz5ZtXp8Tz/+IrN8IWcsqmz3Jymw5
-        Jej02o9I+sEkVU59nU/XNS3TfF5X69WPSGtIq3/Q/xwVb01aImWbv8kmlNOm
-        l35E0A/m1dAD+JyyrFfZ9Y9o+43QFiT8EWV/Nig7HQ4egDCNhz4GavKbkMWS
-        kJvYv7iZ0s8ibz6QNwOCcZvwo+APhvf/NYJmqxX5rEzFH3EqDZbIRoT8Bgjr
-        SBiS84fRpVv5+7nt/f3WHb9RHE7m+fTt02XzgiLl48usKLNJUZJPRrBsI+r6
-        h4LLuqHUxw+RCpb+P8Q+83f0bdO8ItHKT4p6ui568y5awpdo+k3UgVUd3MT+
-        xc1Ub1ihNR/Im4Gi4DbhR8EfDO//a4rEp+zrvL4spvnLurosKKHVpfDPIhaz
-        ZfODatnj4o8uymqSlUPj393dvrdDr5g/6F/TiX4IdPbth5t6vntM7/yc9U0P
-        vfZz1f3Ji+MvTum9n6v+X755RW/9XPX+xe9NL/1cdf7m935Db/1c9f761U/S
-        Wz/k3km7nZ8XU0nZ16u6Oi8iYfeNeFC62nS5v713sLHLKcz1G+n3C+n3Bsv9
-        If0zBgM59KotCAfu5tvrCUbto4oOeshbSGgd4OhMxQbbETdS7jc2V7BN9Dv9
-        dju7x++qpeSv0ZX5oGPhxPrhDfsHuqM/pC9rj/Gp+StK9/3tnYegOxN4kEp3
-        l30i/4hsA2RjyYAsMO02CYQjkuLkPmCUMRT6tD9e/7f/n1CNKFTSct+bIq8J
-        1I/INEAmeikeKXhEURzcB4wiUKdP++Pzf/v/JJWYTlZZEZGccbCr8Fl5tmyK
-        iznHOD5NAa5HZaQBGRhaB1QG5jLqGxFUk2atmDFt97b31N6TG0/23v2xQ/+j
-        8dBoOvg0bVWThdUh0Hr8eXHRRS2KwyagJG5v32T1Rc408UHZUUZhdocw2AFR
-        RojfhR8FS5CYGBvn81W+qNr8eLUiiH5vANLrf1qV5UDq0ckGhkrfug+YU8HB
-        9GmHeQe5nn93n6ocCXvjE/sHmIb+EF4PwMlHyk8ROeIPwlcAzL3Bf9HnA8Q1
-        wkKkHSbTXS+5+COa3ZJmjS4erupiOS1WWfkjym2gXDadVutlX+V8bYBtvliV
-        lAg/W5CG/LpgGfCQypHuANrvGkB6yDTkG0/rYiX9h7hEUSBlCiNBTekPwof+
-        5ywGY7Wph7sU6r1XXulD+qKJF3VOrd4jSfx+XZo/4yvxAUOC1QN+9RmYv3TN
-        VEYMNxgBCOAxjPAjaRUyvf1LZAzg7R9oQH90BDku7e5TBYGX07PljPHnlvYv
-        g5T8bSn9QZRugsl1ZPZITqB/NvpqswsWNXrfdftNdQWv5mcH8ixfldX1gqbi
-        Zx2+k7Wfna6+HviNavI1hb2zdcnRm98bgPT6/+lq4llQesPHQaXO8DwLoohD
-        8JG0stLI0mP/gkgZVcDvQujMB9yUYXAz/i2QX/kDX9IfHWEOcEAT+o11S0+e
-        3Qf8LjCgT/l3FWQHzfwNBPSP6FR8SvNA/6OW9AdN8wH98fVmWulnEODhCG7B
-        R9LK0pXxs39hoIao/C7GaD7gpgyDm/FvQlh8Y//Al/TH/7epfF5WV7chcPCH
-        4Bh8JK9Y+jKe9i8M2BCX38VYzQfclGFwM/83ppsQG63sH/ia/uhQ3tFTv3cf
-        cBN0GqcaqYmAUEw9+rCzUsX0G9AheVZPgYRPXoDvEbzhlrq41qM8hkkDp48x
-        BvltI2ntyAw5+T39Xd4M5onbhx8JTQGW/nA0AyD6oENk8+YGHiTCHWzvPqTG
-        8sceJcTlD2LIB9v3drdfWpISQTv0IWU8favkQSpyQxZyqPev0eHX7InHGQNK
-        kxNXXhshMc70Bw/gBn6TyI1e8XsGwB4uJsp73WbtuouPnVBmBcw5fotiKbrl
-        3nZWrubgLvvRXv+jXf8jSiexJAUf0cT0PuJ3nbzR6DcOhYb7/5/B3L0s6nad
-        lV9k03lBy3EE5/83Q8uXs1VVkHdIEP5/M6hmPVlGEpD/nxpSmzW9kOP/WyPI
-        yG////gkLKplQVlyWkKid/7/MIy7q6xlZ+j/F4OZZE1OoTmcrf9fjCdbtsUi
-        K6+y+v/bQ5plbXZiQ/HjC8K9pwd4DOoMswfb85RpgPY3DjfgB9Pv9NvtvOfg
-        D3nFOucMy/4lfjb6sn+gAf3R8bF7Prj7gJtgEPQp/66OuMPD/A3Q+sf/N2aQ
-        stWR3KzMjc4YjxijNx/wl0x5/e1HU4iPfnhTuKpo0a34/7i3ykuH2TISjv9/
-        ahhX+YSWl2k+GP9nRZ1fZWV/Se//xWPiUQ0FvJwReMIBrD9wINsjhYWB1sHo
-        nRxi6PSt+4CFUQUzSiT729fSMvyu6i3+Gl2ZDzrqQ1QL3rB/oDv6Q/qyCgmf
-        ur9Mf6IztBv7F7eVP6LTTckSXVOkWegQ1CZJmKpfK1NCkHnaN3VDw3jftAlB
-        6oBlwJYDCGqPi55lk7qY0nt+94DaQ2haEntQr9TWR0do6aaVf+PP7FwI7c2M
-        UIOhIXjCsxn3X1QSWB8/AOlhTL3HSdjFlH/rYWkHxDwefCGsF3zEbZWFGZTP
-        0wHfyh9oT3/gM0cpgWv/7IiCk0992X3ATdAjfWrQEv7WLswf3FD/ik4DMQ/9
-        z6kiw1H0P3AUzUmHyo6wPyKy/sEN9a9vmMh3pzQwVjcRVwMYC6EYHf5NcDHo
-        8kfa7EcUp0/of3GKWzW/QcMLdZhOjA3/JqgYbPkjbfZzQ3Dq//8TBG/IIBEI
-        avgjEvMf3FD/+kZJfBfRJnI5PyK2/YMb6l9RYpN7Qv+LEzv64cYZwE/yvr6c
-        /DQi/ssfzcR7zAQRl/73NYiezRbFsgBClP/7EcXtH9xQ//pZpPiXxh3flN5i
-        ujF2/JugZrDnj7TZjyaAPqH/bZ4A+pgon03K/Cmhv8pnT3+k+ulv7sL8wQ31
-        r2+a+tOKfmHy/4ju9Dd3Yf7ghvrXN0v3YrEi7Kn9jyjNf3BD/etng9Kn7/Dv
-        j/Q7oSVE1i7MH9xQ//pm6U8o/4jmQljtwvzBDfWvb5bm57qcUK/LH6nzHwbB
-        Tbj6Op+ua8rCvBxYaQPuQjJGjH8TrAzi/JE2+xHt6RP63/vR/ou8pfWCH5He
-        /sEN9a9vlvTZekZZ3uXFj9id/uYuzB/cUP/6ZmkOj32xyJezfHZaEibF9GVV
-        9ReOgbpQjPHi3wQpgzd/pM1+RHr6hP63mfRG0/yI8fGpkli7MH9wQ/3rZ4v6
-        02q5RFKyWv6I/vQ3d2H+4Ib6188W/ZsfWVqlsHZh/uCG+tfPFvHx2xdZ8/ZH
-        2gdU1i7MH9xQ//ohTsDdHwVa3IX5gxvqXz9b02CU0HGZ162ZCAIUTAFjZUfK
-        fzEdBUEzBv4Io6Xfbj8N7jelPwMFecwHMgfo1f6B9vSHwLSI/RxPwftNwe0J
-        zxRiqkTJZ0ltvxCyxNqa35SyDPRrkRpN3F8/F4SnNVr6n+P9TbR27G48ztd5
-        ix8/Irj9gxvqXx9M8B+RmRAUWipM8wc31L8+mMzm49WPQld0Yf7ghvpXlMak
-        nOl/jsa3Vtq5pAp+RG/uwvzBDfWvb5be6ya76FtFYCoEYjT4N8HBoMkfabMf
-        UZo+of9tprQzkQsOR5/m58WSdDhA/4j8+gc31L9+dsn/I6LbP7ih/vXNEt3X
-        5j+iO/3NXZg/uKH+9bNO99mP1A13zl2YP7ih/vXNzoBTN221+ol1XkdiT+At
-        5GKk+DfByCDNH2mzH9GdPqH/vT/d7/4i+nn9Jn8HvH40A/wHN9S/vtkZyGaX
-        RVPVP+J2+wc31L++WVqrnsfC6in9ssjaH2mZ96A7pQHof47u3/8lTOxltsib
-        VTYFpb8opnXVVOft+HVb1RQrEVx/MgCqPz3S9Hg6rdbLdsOM6G9MdPt7uvW6
-        pbfv0Gc8HG7Jv1licVulN48S5DAfBDSXP/A2/SEkNzRjuPx2+FHwh7xiO/46
-        szRE+k+3d+/TK/IH/c+fB5qFDk2p/1pJGJLzmwEfjYO/GdDTeT59+4J46vgy
-        K8psUpSUlKbXv/meOnxHGfD6spj2hiXsw9MLxpDf9LM++9m577ACv6AsZyfb
-        fCBshyb2DwCjPwRKwGP8dvgR3qTfWDCCLxyDoUnwAYMBEvRpwKdR4pJupf8N
-        qNcBOqor/Z6Ru37285CyTNshbVrn2eJ4mZXXZMBAR38OACoyK3iFkt0/XU3w
-        QkD4YCggSIecOmKhkf1K6IcG9Ae/xe/z4DBeQ3T+IEJH/VrA4H36Q7rot+Xf
-        HE3xWfAB94FO6dOAyG6eNpqy3R0Q3eiKh/4fn/p/0P/cHzxR5o979IfVL/wh
-        fU3/w1TSRHamw5G/MxWggyOxwZ2Hj0HTbz+aCvmD/uf+YEKbP4Kp2Eh9Cm6q
-        NutOws8dYkRDJ6V3iUgXy4pc0+nQQhWILxOiv3nMYYjNX8tHll8wxe6vjbOk
-        jRmK+Yb/4OZhL8I/QMX+gZfpD3xmuIxfBIOYDxzvoFnwgW0b5xaiLv0vLmIE
-        wqPlexgf/e1HpLSkpLHF3UcZkB09/8XoB2MBKulXPkHtGzIyNKA/LIZmNPxB
-        SBc0NV/Ly+iU/hDA/bb8m6MCPgs+4D7QKX26cfaiVNuoFQ7oDyvu5sPbqAr6
-        jf6HueDZ8J2AhXUCmvVqRWOmN/zZAmLvMX8RqvHow4+CP0BvN4ECwP7JX3Iz
-        EDr4jadfpgyf2D/wCv3RoT3/xLSYycY75nc3e/g0+MC+NzRfOw+IstsvO7MC
-        zUzkJmJ3SKdUJh38Nu8HozL6gDyMQPhR8AeG6+glAOyf/CU3w8CC3/6/QD4m
-        YJxbKa21zsqmXc+Kil7zqQzgPbpnEj5Q069BcAxLfgN15LeggYAJyW7/4reV
-        VAwc9DAfCNHRxP6Bt+mPzgw4mnLjKDlJyOl/HR1Bn+xt731K5CRixqlyd1VX
-        P51P0evPX+owfXxmc/HRd/MJtfZpB5g9ajYFZfzuUmY7X0q/HXJ2cAamZqD8
-        OxNLRom/7R86ZCHjJsoy5LAF3nUN+C/+nJv6pA7eQvf0G+uIL14/e8Mo0Afm
-        T/0++FPh8AcdvDqz439g8aBP8SVBDWJz/gygvc8cqt6H0mX0K0ZejK572fzN
-        COhfUbYhdQTDS03lDygs+8dtrC/9sWf/2N/e3fX+8ADQH/S/PnvS/6ALiTmj
-        7NaUFSVFfsR0P2I6+o15xfzxs8h0xbJpsyUl4eiFH3EbunXMhZbBBxYP+hRf
-        EtQfcdv7cJuouB/x3I94TlnF/PGzyHOW235kWumDDl6Oz9Ay+MDiQZ/iS4L6
-        I8Z7H8brKLsfsR990MHLcRtaBh9YPOhTfElQf8R+t2O/1XpSFs2cEtxf0RLr
-        j7jNdOuYCy2DDywe9Cm+JKg/4rbbcRtxGq1EId2SXWZFmU1K0PpHHIduHYOh
-        ZfCBxYM+xZcE9UccdzuOkz9OKhpPVf5IvZluHW+hZfCBxYM+xZcE9UfMdjtm
-        s0qNBjp9+yNuM9065kLL4AOLB32KLwnqj7jtdtxGflv7GtHDcdMUF8t89qb6
-        NlnXF2Rd6eWvyXlmhv7fynlAj2aXMGRG4z/BHuYDYYMfcZ75gzkvxj0Sd8Id
-        A8M8KQiN5cWPVJbp1vEJWgYfWDzoU3xJUH/+Mc6sWmTF8surJfU8L1ZnM8Kx
-        OC/oL4LwIxZCt45j0DL4wOJBn+JLgvrzj4Uk5/UjDWQ+6ODluAUtgw8sHvQp
-        viSoP5/Yh+hTK4P8iFmkW8cbaBl8YPGgT/ElQf3/K7PwH9+ghz3Naxg1YrAf
-        rT/abh1noWXwgcWDPsWXBPX/nawWsoB+aP/4fw3/UUb+Mq+fZfXiR+xnunXc
-        hpbBBxYP+hRfEtT/d7IfNZU//t/DafDIqNmPeAzdOpZCy+ADiwd9ii8J6v87
-        eSyce/3Q/vH/LsaTUIAa/4j90K3jNrQMPrB40Kf4kqD+v5P9qKn88f8aTqvX
-        lKFY9LTc/xsGEcVXJGORt3Ux/f8k0k/z82JZCMr/n0KftZEO4v/DqP9/kf7O
-        4dVB/H8Y9f8v0p+ZqM6n1WKRL2eK8P/7kH8Prf//o7Fc5FWdXzCm/18ehjAZ
-        NV/QckE2mwHlcDw/cv1+3rl+MUbB0gAtCZwuL4u6WpIQ//8lRnCTik+DDywQ
-        +hRf8iveDPFngO995vrxPpRxRL9ilGUe3cvmb0ZA//rGZ9n88R56pcMZg5xx
-        d7Eu2+JVVeYvq6r8EaPwZ4Dvfeb68T6UcUS/YpSFFdzL5m9GQP/6/xSjXFX1
-        27z+EZdghvkzwPc+c/14H8o4ol8xysIH7mXzNyOgf/1/ikvEh+9yyP8Hh/D/
-        wTAkOphAvevY/v83ov+fzJanY3Vg/z8bzv9P5qnDg8WyabPl9P+VSdLbB5jv
-        M1Cdzp93A/5/N/9+2NB9abXjJlA/D0aps/vza7T/f+HlRbYkl3r27f7w6V1/
-        WD+KU/CZ68f7UMYR/YpRlkjEvWz+ZgT0r/83cE2UQWb5qqyuwRHPLTeEnPH/
-        BtRvz/CrurosgOnnZTXJyuPV6jWtohTT/GVdLKfFKivPll/RwsqbfJktwRr/
-        3x1q0ahWy51YL7NFnl1mRZlNSsjU/3dHNy2zpimmX1STosx1Dv+/zZqE6hcZ
-        1DEm6ng6rdb/v1HDvO7gXuQ/9fvgT4XDH3TwcoobLYMPLB70Kb4kqP+v0+TM
-        Jdv1lFp7fxveuDU73F1VV3lNWqt5RctyIIBwxo+4RLp1TIGWwQcWD/oUXxLU
-        /9dxCWsmyxXKKvLhJG8BxPskK1dzgnRr1plWy2U+FR75Eb9It4490DL4wOJB
-        n+JLgvr/On4RLfLhWsWxxvH0/y9LFDzd7kX+U78P/lQ4/EEHL8cMaBl8YPGg
-        T/ElQf3/LXfQpz6L+L//iF08vBx3oGXwgcWDPsWXBPXnC7sc/3+dRWSyaOJ4
-        zn/EIt+MRvmR5vDwclyAlsEHFg/6FF8S1P8/swX/8yPe8PByrICWwQcWD/oU
-        XxLU/1/zBsH4EU+gW8cCaBl8YPGgT/ElQf3/NU94zuiP+MN069gBLYMPLB70
-        Kb4kqP+f4w/mEKSym1U2BXu8yK9e5WUxHR+//IJe8pkHUPvspBxEbQOG6Y6J
-        vhd0g494ePwbE4t/kzftBHAT+xfDAM2ZsPQBv8e/RylASeUdGjE15D9Myrg3
-        7Nf5cnZRF7Px6YJS+tTcHyaA3XrgDqEhbHmU+huzKQ+RP5WxByRiGOFHwR/y
-        iiUQw7J/iRCiL/sHGtAfHYF2XK2N3QfcBIOIU5hyaOCpKFHXU1pJaJ7QKu/b
-        ZnxS5ln99AnB9ikJMD3azrI2m2QNfdkhbgfrgBBAfDOdhQD4xP6h1BAiBuDk
-        I0tJ7hJUMF3gTfc1/8XvxQjnf6rd85d+j1HiErvS/0BcIm2HSNOSYFJzAvYj
-        GjGNmEo+A76pSay/KKZ1NX6a57Q+OV3XRXtNoH1aAlCPukPirYNIt15mdbvM
-        ayjpmzAkEfl0e/c+YUj4dfoh0sRXHt4bUkmLGCfVYrFeFgLlZZ2f50QBIsUH
-        gl6vSCLzbwQ4/vt/AJDRaEYHkAEA
+        AIOmDFNnLJhp50AyGMwsfSpN0Dn9Yb8wAPiDEBUHRuFKG5luh4v5G5D1j6Gp
+        2aPZoJb8B8XI3h+s2/gPsgD0NyatuCQX080dzVxnJogmA8zCuFiqAX0Zkv72
+        o2lQYhOleRpi1HUEDYk7APUWgO7+onXVZl14grGlLQYpA9fffjRZvcliKg+o
+        sWJ58UXG2SF/GgCwNzGLbEXZZDTtzwfRfetlVrfLvL5DDfSzISwhv3uEGKHV
+        6YPmIC6j7w2ppDDgpFos1stCoLys8/O8zpdEgQ8EvV4hi/uNAGfwQ1PzgzdZ
+        afK5oIePBkD1ENNXqKmPgnAxzYablx7X8xf2L+ZCn3UZgv4ubxrWZGAB38sf
+        eIP+YEh+4yg9SInT/6DEc9XeG+hyklEGl0D7YwegHjVe5bM+t0aw7+HoBI//
+        wLgcbQSA/ZO/5GYYcfAba6KAGvIHXqE/OmqIfw7RvKcn3Af2PfrUoC0qQpEz
+        f3BD/Ss6C8SVBzQL1FT+QDJE/qDJof+5+Qk+lHSJ/xHNH81eZzZo0r72msHP
+        Ilo0i++ncH4WcWGGPWEX3YWt9NrXQ2uwh7uyJuq66A5dedxwE/O0cA8+sh+B
+        FYPfmOGZ5/jTfmPlZoYFljUfSH+hTNm/RGjwvv0DDeiPjgTFZcJ9qiAMWiIJ
+        2pv5g9/Uv6Kkpsmj/22iLr16sayatpi+ztuW7GuPvEDEo4oSTohgsOOv5SNL
+        CcbU/tUZPX/JbwUg+OsQqtAQXds/8DL9gc/MnPCLoKH5oEdI94FtS5+aroSG
+        ipf5gxvqXzeQlwk8YAFmkAqf+Hi9Nx2UTjkvSvquQ36DIRMDYwl+G5oLQT34
+        iIfGv0l7OzX8hf2LASsRGQooZT4Q+qOJ/QNv0x+d+XXU1sbuA24CoHGakkIY
+        TpIpje7my9mqKiIhajBidB389vOdWndpFeCioJd/RLX3odqU4FaLGaWnfkS7
+        jbQjDMU9oc/X5Ubp/GDYd3Wi9M8fYleWM/Tvn8OuVaD1r59LRHwZ0c++SXRu
+        449/UAd2vN8o2vnsIl9Ws41W/QagDHbAs8jrtjhHTJ+/yi8ogyAjoL58NACy
+        h9jUvfplTYs4PQQvymqSlYPIsQPPqN0E+K73yTfWCzHjZYHGnzOA49VKEw8v
+        62I5LVZZebb8qsnrN/kyW0K9fSO9XpJ+5FyKG5FP97PleVXLEsbX65H7HJhq
+        WTGmLM5q3cIM+KgBUg9ZEUWITI/qUPnGYlhtbz7gL4kt7W9swmBF6Hf6TYyT
+        x78KI/wo+ENesRaMYdm/xEqhL/sHGtAfX8dkGWTEaXd4mL8B2v4BOIRhupdu
+        vW6zixy5QMHVvEZfmq8G5i5IYdLyjPtDBJj/oCAh+AMLNzTfNNudSWM199TO
+        3AZl90NBx+Ohu01Z9VU6U1AZhwmPSTAf8JfMAPrbjziJv/q5mbq7dUVeLb34
+        owmUvwHa/gE4hOH/+yfwxnRYFDnqiP73dTr6YPCXRd2us/ILyoMXyx8xIOFh
+        /gZo+wfgEIY/fAak/7k/BrlxSsRgO1T0pvCbQCbWZXQ99ZvozPwxONgOy/58
+        z5Hy75ZRTcfmb3Rk/wAcQukDuJjmhf53u3kRDTWsCg069LH+9qNpUdqbIZvX
+        6Evz1Tc0Lb3J6HZI38sQgo8UVfcbTxmPhj/tN1aqMSyQxnwg/dlZZBD2L5kN
+        vG//QAP6ozPbjvba2H3ATdAjfcq/W3obJM3fAG3/ABxC/2dpMmh4Eo126R+F
+        RMry62hO+p/7Y1CN+n/+bGAT63NRXeav15NmWhcr9PVKv/76/cd6MYkAv6cv
+        qOdvJF6LdWhnldiiXTcfNByGvzHL8CJvr6r6Lb3oowGwPcRU9vWNLlrC6yqP
+        LCIQF/MBf+nkmLg+FPWuUNBHDCP8KPhDXrFSzrDsXyLm6Mv+gQb0x/8HZJ7m
+        z59MkQD+w4iD+WOTPFKSLJ+drf5/NE9EO5oW0JcIEJkn+vT/a/P0tR3fEH7w
+        x2BnF6TGrrLr1+vVisaZz57mSKP+sHonwRS99g13SP9zfwz2vhSt9TqfrmvS
+        2J/X1fpHokF4mL8B2v4BOIThNy0asXn5WQ82udONJvB1W9U0EnrRxw0d9rCl
+        dS80PZ5OqzWtFtMrPsJCN2UXJjdIbz7gL3na9bcf8Q9/dZtplsnkP8zMmj/o
+        f7vbk7xFv+4T+8egQvihal7O9SufKfN8oP8Ydhz8MYhFh3vvwkWIGACZS2Yw
+        N130hzBA8JGwFabb/oGX6Q98ZjifXwQXmQ8cg6FZ8IFtS5/y75apTMfmb3Rk
+        /wAcQul2HGebu99YFrsv2I+sTHGf9q9AjqKTRrNB/3u/2bhFCorRYPwCZBmR
+        EH+ZEwzS/oGX6Q98ZuaDXwTRzQduPtAs+MC2pU/5dzsHpmPzNzqyfwAOofT/
+        iwmSpMdwLuqb7ukbhy9gfxYHIB18MNgPdA5Ctch/xHqZFU0vmv0GwRcLoszP
+        IvyqOfvZ7uGH6Llz/xvdtbPleU06oV5P23Wdf1FcEG4Qdh9p4NIbxjT2/lDS
+        SPSOqkNWINB55gP+kvWP/sbqiZUPfypaKVBUDCP8KPhDXrGqi2HZv0Rzoy/7
+        BxrQH4GK8/W0NnYfcBMMIq4JeaZ2798wBdVitb4dtTPPvyE7Fqcvj1x/65Aw
+        QpzgIx5O+JG0skRjWPYv7kWnj98FKcwHQlI0sX/gbfrD0U+/dR9YKPRpMA1R
+        +hLn72/f29le1RR151f0Dn1oiG7+oP/t2hY8Dx2qag7O5N/pxR8R9Zsm6t38
+        XZsvpZsf0fdngb7kEd7g4AJtIY/+9v9zOpP9o//B/t1MPfGthp03GQyPWX/7
+        EfGUeK+nWZkTz/28J9nPhlxb4v5If8pgiYo/u3QOP/8RsX9Wia0LCGfLNq/P
+        yS/+Ebl/Vskdfv4j8v8skd+RMCRntEuC9jWh3yWaUZiOX+lt+zHgggxCbv3t
+        R/P2XpS9XLwufvAjcQBZv0myrptITk1GycTQ335E1fei6mo9KYtmTp3Q2/Zj
+        dAZEhSD6248oewvK0lh+pFaZnkSq9yNdLOsvY6LBRrvoTlkMarPMVs286keY
+        HwzZQqP0SfOWiD4w8e/ZEXcVT/Y+zdrspFou8ymmwEcH4HoITqUp9fZFtiTl
+        2ZfxjajRhB3cNGcO2s8aZOep0MrAunzPibxNV9N5Pn37gih+7GXIP7AX7md4
+        Fp9lU1qgQyc+LgDXw25mm/fX3CxWPV0A4ZUv9DfWNtIo0CEMwb4WiHVHJ/GH
+        4cuiOdCD/QPw6A98ZpQNvwi9IR8MUHB3hyhIrfmPnYf+H6Ct/eMB/WEJbT6k
+        //U/xAJW+OG+rIT1PkTX3Q9JLqlXnsdNM0LC//Vyp5G5kI/sZICU7q/O1PCX
+        /FYAgr8Oocq8oGv7B16mP/CZzIm+eMMkEUXof7chytdMiQoBAuzlI0sFYO7+
+        +n85TVixeOJ+g46Jwic+pv91uJM/of+ZDwc7P/4Brah+MAYsH9SU//jmRTOG
+        vWOn69c0kgWm4/+dmBIninnq8vjPFYqM5LDpeZ69zY+XWXlNGgso+8MBlr0B
+        ZtNptV727S5LCgvuppF6iBFaA6DvYrqB2Gua8PxYP/3Z7LChjsgl+jno6i65
+        ZW1GKbS+O/bD6fUuBXzt66x5U72lRYGfBRwcvBD2hwN0viC1iPiCX7sHC/dr
+        QmSYm2WOWZug+z0DYA8XM4XU1sfkm5gZA/rueVHnV1lZvlqXhMQ335GDF8L+
+        cID/n2QBaiMJcr9PgOphQbbu5lhEJ4g+7nhH/AX7Kr4zxL/ZNrdxaigqJT/5
+        HrWmP8jCHFAg7w2VBtpBm0DHiScoMRr/b8H1rGq/vZ78vw5RRnWQf95Qd8+z
+        Cb3sjwage+MjrukNroOfDsoNxP1mh8QtwtakEYy3jE/sH3gxPmYa5v3tPV9M
+        aJAdfPMlLS1VywX55/+fwpu6i/P8rSAaLqD/xYMHB/FrQN8I0KnQLmxDMPpY
+        f2PSgU70u/ktSureTAmJ0cT+gbdvS28ewYA4VNM1uOXpE4LsDxLQesOGaznJ
+        GusJ0TvBkIGUDK4j9/yF/QsDkWb8mw6yN2qXLUWz4APblj41wejZktIH9Dd/
+        1/nLtOFOgz+EmtqB/AFkB0lLAeoBtaQ/6Df6X5zhOoSCEfoRsYaIReMcECEA
+        l55/XpGIiTQkrwuKPF7lFxR3CNHoZZ+eAN2j8Izf6pH3oqwmWbkJNRdCk7kF
+        aoRYB3ZbrZ7nl3kpmP3s9MGenHSwyZf7RvpCRCddvcqn1YKUIwkzA/rZ6O2S
+        2I/g56ZHN69ny/OqXvCvBOab7/kipwCWen7dVK/yX7QGj/5sdEMSSr3wmx8O
+        njsYEIxr+pyyMM9vl4gpp82qrn6alnTQPMCrkwiFKBsNwr9vFHOjqQKdwB85
+        dcWQwxZ41zXgv/hzbgq9lB4LBsFb6J5+Y7/ii9fP3jAK9IH5U78P/tSR8Acd
+        vJw6RMvgA4vH4HTR/3a3s3I1B3T5CDPY+ehe/yNMLfkqxSXxonFZOt9FPpzk
+        bQeEQGUOGZ5rpG6wjlf1E0Y/mnZuGXxg8fj//LSX1Xo2y1dldU0K/Ucyb7t1
+        c42WwQcWj/8vTj6NbsDs/GiquWXwgcVjcKqZ3GZWNhri00saAyWFqAN/TgCr
+        N0sWQm+WHG4bkI3Ty/3GlHNEE3oErzCs8CN+V8nIX6Mr80GHeYQz8Ib9A93R
+        H9KXpT0+dX+Z/sKYwvzFbeWP6GyQiPFKF89Bh6DsKHO0Capu8JWjkGme3bLZ
+        pm5oGHHpeh+wDNhyAEF1PPQsz1pabAV0+tf2DIA9XM5d21tgsgtGpqb0B2EC
+        tDyuJnwIkA+cDMhlMSMg9MqHQmf4/njJXdXxUtxUXMzZLPkIAHAPJYpJVtWS
+        OAitfZwsWxEbD+DHGpteoz8UP/sH/Q+TQih2+rvKJy1x5A+pNwpE6oIG/k10
+        FoOflXnd1rGVGhY7gq8agH/bKMXcTPUCS7CvKEQZoIn9A2/THwLTG5C+HX6E
+        N+k31mDBF04PoknwAYMBEvRpoKiGSEaEciSj/w2QbN1WzZQI1+RtWywvfkQ5
+        JdaNlKO0yLJt6fcuyW4DdnfX+0O+ifXhwIZdGDp84BAsSJfofvU+a4UC+cZu
+        LPCvBZZWg9wf9L94H+Bjyqfks9N3K+Kk1z/i5igx6X9x+pFDcrGsmraY/jwk
+        nelB/DIH0PwNzPSPISo/GCLsIm/rYvo0Py+WhdDyR3Q1fwMz/eO96VpWFz8i
+        KpAzAM3fwEz/uIGoTFbfZ3U++u+VX/9kRoaA4Pl0B4zeTFyiYW8GIpTBGOU3
+        +dISn1G2f3EzpTwPFVQwH/CXMVJyy7A/Bsu/yZzhXfsHvqQ/HMH1W/cBQ0Tf
+        9GkwA0Nk9S0VBQu7D734gCgdJdvdJp/W+Y/I997ko8G+n1OxCTx3EJeE59VF
+        MaX3/O4BtYfQVVW/PS+rqy4+OlsBaYM/mCrh9/KKnVIQ2/0FSpv55HdBZPMB
+        N2UY3Mz/jSc9mD35A1/TH8Ec+ROp37sPuAk6HZxKRGiWvExz+hDhs/2QKd6h
+        IA0vPqVKj4BEwR+MUfi9vGKJhhG7vzAkQzF+F6MxH3BThsHN/N/+X09CAvXl
+        IBUD9G7Vb6yLRbbMLvLZ8ar4We/gRNZz+P1voCvuLC7lX2T127xdlfT5lzWl
+        hMgBph59xAC2h2p2Ued5dM2BEQs5EhyD34awZQXFOHZ6IZ6Nz+gNkBhWfLwv
+        8hb6iuD5fQFEr/fLom7XWalvdFGwo7IyQr99fdmTNwOycZvwo+APhheIJj6x
+        f6Bz+iPgF18StbH7gJsApw0TtXufXpE/6H+Ox/hDNi/ehzwNHaKu1pOymJ69
+        PJ7N6JuGKP8jsn4DZF0Kk54t27w+J57//wxZ/99N1rLKZk+yMltOCTq99iNO
+        /WCSKqe+zqfrmhZwPq+r9epHpP1GSEukbPM32YRy2vTSjwj6wQQNPYDPKct6
+        lV3/iLbfCG1Bwh9R9meDstPh4AEI03joY6AmvwlZLAm5if2Lmyn9LPLmA3kz
+        IBi3CT8K/mB4/18jaLZakc/KVPwRp9JgiWxEyG+AsI6EITl/GF26lb+f297f
+        b93xG8XhZJ5P3z5dNi8oUj6+zIoymxQl+WQEyzairn8ouKwbSn38EKlg6f9D
+        7DN/R982zSsSrfykqKfrojfvoiV8iabfRB1Y1cFN7F/cTPWGFVrzgbwZKApu
+        E34U/MHw/r+mSHzKvs7ry2Kav6yry4ISWl0K/yxiMVs2P6iWPS7+6KKsJlk5
+        NP7d3e17O/SK+YP+NZ3oh0Bn3364qee7x/TOz1nf9NBrP1fdn7w4/uKU3vu5
+        6v/lm1f01s9V71/83vTSz1Xnb37vN/TWz1Xvr1/9JL31Q+6dtNv5eTGVlH29
+        qqvzIhJ234gHpatNl/vbewcbu5zCXL+Rfr+Qfm+w3B/SP2MwkEOv2oJw4G6+
+        vZ5g1D6q6KCHvIWE1gGOzlRssB1xI+V+Y3MF20S/02+3s3v8rlpK/hpdmQ86
+        Fk6sH96wf6A7+kP6svYYn5q/onTf3955CLozgQepdHfZJ/KPyDZANpYMyALT
+        bpNAOCIpTu4DRhlDoU/74/V/+/8J1YhCJS33vSnymkD9iEwDZKKX4pGCRxTF
+        wX3AKAJ1+rQ/Pv+3/09SielklRURyRkHuwqflWfLpriYc4zj0xTgelRGGpCB
+        oXVAZWAuo74RQTVp1ooZ03Zve0/tPbnxZO/dHzv0PxoPjaaDT9NWNVlYHQKt
+        x58XF13UojhsAkri9vZNVl/kTBMflB1lFGZ3CIMdEGWE+F34UbAEiYmxcT4p
+        jvppyiZ++e68qmcE1e8RgHo4ZNNptV72R8izNzRCWrjvhFcbUHqVL6o2P16t
+        qAu/cwDroTOtypLw5746GDlxBfXpW/cBCw+Eij7tyNOgIPLv7lMVbZE4fGL/
+        ACXoDxG/AJx8pCweEW3+IHwFwNwb/Bd9HiWyk18i7TCZ7nr5zh/R7JY0a3Q9
+        c1UXy2mxysr/n1DuZ4dyTkeE3PW1Abb5YlVSbv5sQUq7R/pbgmXAQypHugNo
+        v2sAiSCzzPoKMNo5aXZYLGpKfxAm9D9fCRI+HdgUab5XWuv9oLMjbT4DJejV
+        b74X8+fPzhgaCpamdbESqD/rPdw1X/4w+vrZnf2wLxJx8SWo1XusULxfl+bP
+        z+tqvep2MWw2WKf7Sp6/dM3Ujhi5N0YigMcwwo+kVaje7F9ihwDe/oEG9EfH
+        2MUtovtUQeDl9Gw5Y/y5pf3LICV/fzOUboLJNV/+iO7U0v5lkJK/fzbpfsF0
+        t392Z+Bno2sH/2e/rza7gPX4IXXFmR/88pNZuf5Z6nSWr8rqekEMckv4FFoZ
+        +B/SmVPDP4R+EZ/eshuC9D6Q33cUBI7Ab3TJXpOzMluXnLzyewOQXv8/XU08
+        b53e8HFQ/WOkn1WSKIbgI2ll9RLrEfsXlItRivwu1I/5gJsyDG7GvwWaTP7A
+        l/RHR60FOKAJ/cZatqfZ3Af8LjCgT/l3VWkOmvkbCOgf0amgwJynwsz0Af3x
+        9WZa6WcQ4OEIbsFH0srSlfGzf2Gghqj8LsZoPuCmDIOb8W9CWHxj/8CX9Mf/
+        t6l8XlZXtyFw8IfgGHwkr1j6Mp72LwzYEJffxVjNB9yUYXAz/zemmxAbrewf
+        +Jr+6FDe0VO/dx9wE3QapxqpiYBQTD368PaZpNd5Vk+BhE9egO8RvOGWr/P6
+        suib6ygxNpLWjsyQk9/T3+XNYJ64ffiR0BRg6Q9HMwCiDzpENm9u4EEi3MH2
+        7kNqLH/s0Xqg/EEM+WD73u72S0tSImiHPqSMp2+VPLDHGxZhhnr/Gh1+zZ54
+        nDGgNDlx5bUREuNMf/AAbuA3yRLRK37PANjDxWSUXrdZu+7iYyeUWQFzjt+i
+        WLJuIfSycjUHd5mPKKXc+2iv/9Gu/xG5FyxcwUc0V72P+F0ngkSQjaMjCvz/
+        enx3L4u6XWflF9l0Xiz/fz/afDlbVQV5rwTh/8/jbNaTZWQt5//ro2yzphcG
+        /H9+UBlFCv//m6pFtSxopZKW8emd/5+O7O4qa9lJ+//r+CZZk1PoDb/w/69D
+        pPWQYpGVV1n9/7tRzrI2O7G5heMLGk5PzfCw1Ltnl7zn+tOY7W8cP8Gxp9/p
+        t9uFA8Ef8oqNNhiW/UsCB/Rl/0AD+qMTNPSCCvcBN8Eg6FP+XSMLh4f5G6D1
+        j//PTiqt/kVWQGS6dBKZCCCI+YC/5MnQ3340q/TRz+2srqqymBb//3O/s9WK
+        pm8ZSUz8v35kN4zsKp8cY3AypGdFnV9lZfn/8WHyQIcSBJxBecIBv08L4N+j
+        joWB1gFBnEyDGvSt+4AFW4U8Sjf729fSWPyu6kD+Gl2ZDzqqSNQU3rB/oDv6
+        Q/qyyg2fur9Mf6J/tBv7F7eVP6IcQMmlhzQfNA80Cx2C2qQSU/VrZZYIMk/7
+        pm5oGO+bZiJIHbAM2HIAQe1x0bNsUhdTes/vHlB7CE1LYg/qldr66Agt3bTy
+        b/yZnQuhvZkRajA0BE94NuP+i0oC6+MHID2Mqfc4CbuY8m89LO2AmMeDL4T1
+        go+4rbIwg/J5OuBb+QPt6Q985iglcO2fHVFw8qkvuw+4CXqkTw1awt/ahfmD
+        G+pf0Wkg5qH/OVVkOIr+B46iOelQ2RH2R0TWP7ih/vUNE/nulAbG6ibiowBj
+        IRSjw78JLgZd/kib/Yji9An9L05xq+Y3aHihDtOJseHfBBWDLX+kzX5EcPqE
+        /hcneEMGiUBQwx+RmP/ghvrXN0riu4hckVD6EbHtH9xQ/4oSm9wT+l+c2NEP
+        N84AfpL39eXkp5E9uPzRTLzHTBBx6X9fg+jTarFYLzVOfF4s+wsYwFqIxSjx
+        b4KPQZk/0mY/ojp9Qv/bTPVstiiWBRCiPO+PKG7/4Ib6188ixb80QdCmBCXT
+        jbHj3wQ1gz1/pM1+NAH0Cf1v8wTQx0T5bFLmTwn9VT57+iODS39zF+YPbqh/
+        fdPUn1b0C5P/R3Snv7kL8wc31L++WboXixVhT+1/RGn+gxvqXz8blD59h39/
+        pN8JLSGydmH+4Ib61zdLf0L5RzQXwmoX5g9uqH99szQ/13Wdel3+SJ3/MAhu
+        kgSv8+m6ptzXy4GFUeAuJGPE+DfByiDOH2mzH9GePqH/baZ9tp5Rgnd58SOa
+        09/chfmDG+pf3yzN4TYuFvlyls9OS8KkmL6sqv4yMlAXijFe/JsgZfDmj7TZ
+        /y9Iz8Q2o/zZIL1RNQOM/yPq0x/cUP/62aL+tFoukY+slj9SPPQ3d2H+4Ib6
+        188W/fHbF1nz9keaH1TWLswf3FD/+iFOwN0fOZzchfmDG+pfP1vT0KjLeVzm
+        dWsmggAFU8BY2ZHyX0xHQdCMgT/CaOm320+D+03pz0BBHvOBzAF6tX+gPf0h
+        MC1i/5+agtsTnikkiBhc+SOMin77OSE1mri/fi4ITyuE9D9H+E20duxuvP3X
+        eYsfPyK4/YMb6l8fTPAfkZkQFFoqTPMHN9S/PpjM5uPVj6IndGH+4Ib6V5TG
+        pJzpf47Gt1bauUSrP6I3d2H+4Ib61zdL73WTXfStIjAVAjEa/JvgYNDkj7TZ
+        jyhNn9D/NlPamchF3tbF9Gl+TgvbQvIfkV//4Ib6188u+X9EdPsHN9S/vlmi
+        +9r8R3Snv7kL8wc31L9+1uk++5G64c65C/MHN9S/vtkZcOqmrVY/sc7rSOwJ
+        vIVcjBT/JhgZpPkjbfYjutMn9L/3p/vdX0Q/r9/k74DXj2aA/+CG+tc3OwPZ
+        7LJoqvpH3G7/4Ib61zdLa9XzWNs7pV8WWfsjLfMedKc0AP3P0f37v4SJvcwW
+        ebPKpqD0F8W0rprqvB2/bquaYiWC608GQPWnR5oeT6fVetlumBH9jYluf0+3
+        Xrf09h36jIfDLfk3Syxuq/TmUYIc5oOA5vIH3qY/hOSGZgyX3w4/Cv6QV2zH
+        X2eWhkj/6fbufXpF/qD/+fNAs9ChKfVfKwlDcn4z4KNx8DcDejrPp29fEE8d
+        X2ZFmU2KkpLS9Po331OH7ygDXl8W096whH14esEY8pt+1mc/O/cdVuAXlOXs
+        ZJsPhO3QxP4BYPSHQAl4jN8OP8Kb9BsLRvCFYzA0CT5gMECCPg34NEpc0q30
+        vwH1OkBHdaXfM3LXz5SyP58oy7Qd0qZ1ni2Ol1l5TQYMdPTnAKAis4JXKNn9
+        09UELwSED4YCgnTIqSMWGtmvhH5oQH/wW/w+Dw7jNUTnDyJ01K8FDN6nP6SL
+        flv+zdEUnwUfcB/olD4NiOzmaaMp290B0Y2ueOj/8an/B/3P/cETZf64R39Y
+        /cIf0tf0P0wlTWRnOhz5O1MBOjgSG9x5+Bg0/fajqZA/6H/uDya0+SOYio3U
+        p+CmarPuJPzcIUY0dFJ6l4h0sazINZ0OLVSB+DIh+pvHHIbY/LV8ZPkFU+z+
+        2jhL2pihmG/4D24e9iL8A1TsH3iZ/sBnhsv4RTCI+cDxDpoFH9i2cW4h6tL/
+        4iJGIDxavofx0d9+REpLShpb3H2UAdnR81+MfjAWoEK/eQS1b8jI0ID+sBia
+        0fAHIV3Q1HwtL6NT+kMA99vyb44K+Cz4gPtAp/TpxtmLUm2jVjigP6y4mw9v
+        oyroN/of5oJnw3cCFtYJaNarFY2Z3vBnC4i9x/xFqMajDz8K/gC93QQKAPsn
+        f8nNQOjgN55+mTJ8Yv/AK/RHh/b8E9NiJhvvmN/d7OHT4AP73tB87Twgym6/
+        7MwKNDORm4jdIZ1SmXTw27wfjMroA/IwAuFHwR8YrqOXALB/8pfcDAMLfvv/
+        AvmYgHFupbTWOiubdj0rKnrNpzKA9+ieSfhATb8GwTEs+Q3Ukd+CBgImJLv9
+        i99WUjFw0MN8IERHE/sH3qY/OjPgaMqNo+QkIaf/dXQEfbK3vfcpkZOIGafK
+        3VVd/XQ+Ra8/f6nD9PGZzcVH380n1NqnHWD2qNkUlPG7S5ntfCn9dsgJ1MzI
+        NtKER+XTgb9mWjIM/i0gh/yBL+kPfj06Ryz00nXwdfDHZtL6H3AT4EmfAhG1
+        bA6e+Zsb2r++eP3sDSMu/fGfgN39UwfPHwjSlkL8PcbjJUj4M7zjfWYQoabu
+        Q4EV+SrKNqSOYHjpPfkDCsv+cRvrS3/s2T/2t3d3vT88APQH/a/PnvQ/6EJi
+        zii7NWVFSZEfMZ2DZ/7mhvYv5iJuz/3xn4Dd/VMHzx8I0pZC/D3GYxlGP8M7
+        3mcGEWrqPhRYka/+v8h0xbJpsyUl4eiFH3Eb/80N7V/MPtye++M/Abv7pw6e
+        PxCkLYX4e4zHcop+hne8zwwi1NR9KLAiX/1/kdtExf2I5yw88zc3tH8xE3F7
+        7o//BOzunzp4/kCQthTi7zEeyy/6Gd7xPjOIUFP3ocCKfPX/RZ6z3PYj00p/
+        GHjmb25o/2JO4vbcH/8J2N0/dfD8gSBtKcTfYzyWafQzvON9ZhChpu5DgRX5
+        6v+LjNdRdj9iP/rDwDN/c0P7F/MTt+f++E/A7v6pg+cPBGlLIf4e47Gso5/h
+        He8zgwg1dR8KrMhX/99iv9V6UhbNnBLcX9ES64+4zf7NDe1fzD7cnvvjPwG7
+        +6cOnj8QpC2F+HuMx3KKfoZ3vM8MItTUfSiwIl/9v5HbhrmNOI1WopBuyS6z
+        oswmJSjzw+Y4nnyZX0dR+ohng2j7I46jDwVW5Kv/r3HcmvTajziO8TXwzN/c
+        0P7FLMTtuT/+E7C7f+rg+QNB2lKIv8d4LLfoZ3jH+8wgQk3dhwIr8tX/tzhO
+        /jipaBhV+SODav/mhvYv5h5uz/3xn4Dd/VMHzx8I0pZC/D3GYxlFP8M73mcG
+        EWrqPhRYka/+v8VsVqkR9tO3P+I2+zc3tH8x+3B77o//BOzunzp4/kCQthTi
+        7zEeyyn6Gd7xPjOIUFP3ocCKfPX/LW6jSKF9jXj1uGmKi2U+e1N9m/y5F2Rd
+        6eUfcR7/zQ3tX8xK3J774z8Bu/unDp4/EKQthfh7jMdyjX6Gd7zPDCLU1H0o
+        sCJf/exyXox7JNOBAAAM86QgCi0vfqSy7N/c0P7FnMDtuT/+E7C7f+rg+QNB
+        2lKIv8d47KTrZ3jH+8wgQk3dhwIr8tXPFePMqkVWLL+8WlLP82J1NiPUivOC
+        /iIIP2Ih/psb2r+YJ7g998d/Anb3Tx08fyBIWwrx9xiPnX79DO94nxlEqKn7
+        UGBFvvq5YiHJsv5IAxkGMfDM39zQ/sX8wO25P/4TsLt/6uD5A0HaUoi/x3js
+        1OtneMf7zCBCTd2HAivy1Q+ffWg0tTLIj5hF/+aG9i+efW7P/fGfgN39UwfP
+        HwjSlkL8PcZjJ1o/wzveZwYRauo+FFiRr352mYX/+AY97Glew6gRg/1oxfv/
+        V6wWsoB+aP/4fw3/Ua70Mq+fZfXiR+xn/+aG9i/mJ27P/fGfgN39UwfPHwjS
+        lkL8PcZjWUc/wzveZwYRauo+FFiRrzaxH70nf/y/h9PgkVGzH/EY/80N7V/M
+        NNye++M/Abv7pw6ePxCkLYX4e4zH8od+hne8zwwi1NR9KLAiX23isXDu9UP7
+        x/+7GE9CAWr8I/bjv7mh/Yv5idtzf/wnYHf/1MHzB4K0pRB/j/FY1tHP8I73
+        mUGEmroPBVbkq03sR+/JH/+v4bR6TRmKRU/L/b9hEFF8RTIWeVsX0/9PIv00
+        Py+WhaC8Af3/96HP2kgH8f9h1P+/SH/n8Oog/j+M+v8X6c9MVOfTarHIlzNF
+        +P99yL+H1v//0Vgu8qrOLxjT/y8PQ5iMmi9ouSCbzYByOB7nm9AX4n5YV4Yd
+        IfsXe0pwqUxr/podI4bBv4m3h2/sH/iS/uDXPdeGPsI39NuPXD98KLAiX33j
+        HBdjFCwN0JLA6fKyqKslCfGPYoQfMYr54z1U022Z6+5iXbbFq6rMX1ZV+SNe
+        s39zQ/sXMw+35/74T8Du/qmD5w8EaUsh/h7jsXyin+Ed7zODCDV1HwqsyFf/
+        n+K1q6p+m9c/YjQ0sX9zQ/sXcw635/74T8Du/qmD5w8EaUsh/h7jsUyin+Ed
+        7zODCDV1HwqsyFf/n2I0CUa6TPb/wSH8fzCeig4mMDI6tv//jej/J7PlqWkd
+        2P/PhvP/k3nq8GCxbNpsOf1/Zbb39pHy+wxUp/Pn3YD/382/HzZ0X1rtuAnU
+        z4NR6uz+/Brt/194eZEtyU+efbs/fHrXH5bzxekLcbet686Ov/2LIwOEEKY1
+        f82BAMPg3yS6wTf2D3xJf/DrnitPH+Eb+u1HoQ4+FFiRr/7fwHhRHpvlq7K6
+        BlM9twwVMtf/G1C/vcys6uqyAKafl9UkK49Xq9e0olRM85d1sZwWq6w8W35F
+        i0xv8mW2BHf9f3eoRaOKMXeaYZkt8uwyK8psUoKb/787ummZNU0x/aKaFGWu
+        c/izyZqMCGP1szUiIv4XGTQ6Jup4Oq3W36QmFzXJeo7VFf8myhvf2D/wJf0h
+        etNpKvoI39BvP9Lk+FBgRb4akCLmku16Sq96fxveuDU73F1VV3lNWqt5RUuU
+        oKFIbyjJbhj0hWBqR800s38xUUF905q/ZhoyDP5NGAPf2D/wJf3Br3tUoI/w
+        Df32Iy7BhwIr8tUAl7CutVyhrCIfTvIWKHqfZOVqnr0H60yr5TKfCo/8iF/0
+        b25o/2IG4PbcH/8J2N0/dfD8gSBtKcTfYzx2rvUzvON9ZhChpu5DgRX5aoBf
+        RIt8uFZxrHE8/dFCyY+4I+QO+tRnEf/3H7ELNbF/c0P7F88/t+f++E/A7v6p
+        g+cPBGlLIf4e47FTrZ/hHe8zgwg1dR8KrMhXP1x2+RGLUBP7Nze0f/Gcc3vu
+        j/8E7O6fOnj+QJC2FOLvMR47vfoZ3vE+M4hQU/ehwIp89bPPIj9iC2pi/+aG
+        9i+eZ27P/fGfgN39UwfPHwjSlkL8PcZjp1Q/wzveZwYRauo+FFiRr3722YL/
+        +RFvUBP7Nze0f/Fkc3vuj/8E7O6fOnj+QJC2FOLvMR47r/oZ3vE+M4hQU/eh
+        wIp89UPgDYLxI57gv7mh/Ysnmdtzf/wnYHf/1MHzB4K0pRB/j/HY+dTP8I73
+        mUGEmroPBVbkqx8CT3iexo/4w/7NDe1fPOHcnvvjPwG7+6cOnj8QpC2F+HuM
+        x86tfoZ3vM8MItTUfSiwIl99Tf5gDkEqu1llU7DHi/zqVV4W0/Hxyy/oJZ95
+        ALXPTspB1DZgmC6i9L1QMvjIUZIpwL/Jm5Zc3MT+xTAwbUwt+oDf49+jFKCk
+        8g6NmBryHyZl3Bv263w5u6iL2fh0QSl9au4PE8BuPXCH0BC2PEr9jbmah8if
+        ytgDEjGM8KPgD3nFEohh2b8C2ZI/0ID++DqSEqUw5dDAU1Girqe0ktA8oYXi
+        t834pMyz+ukTgu1TEmB6tJ1lbTbJGvqyQ9wO1gEhgPhmOgsB8In9Q6khRAzA
+        yUeWktwlqGC6wJvua/6L34sRzv9Uu+cv/R6jxCV2pf+BuETaDpGmJcGk5gTs
+        RzRiGjGVfAZ8U5NYf1FM62r8NM9pfXK6rov2mkD7tASgHnWHxFsHkW69zOp2
+        mddQyjdhSCLy6fbufcKQ8Ov0Q6SJrzy8N6SSFjFOqsVivSwEyss6P8+JAkSK
+        DwS9XpFE5t8IcPz3/wCWiSCZQZsBAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:48:59 GMT
+  recorded_at: Wed, 03 Feb 2016 14:18:57 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourcegroups?api-version=2015-01-01
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourcegroups?api-version=2015-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -432,7 +454,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -451,19 +473,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14996'
       X-Ms-Request-Id:
-      - c94bd72c-2878-4954-a90f-79f9b764e65d
+      - d711155c-826f-4d27-bacb-295fec48c7e0
       X-Ms-Correlation-Request-Id:
-      - c94bd72c-2878-4954-a90f-79f9b764e65d
+      - d711155c-826f-4d27-bacb-295fec48c7e0
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134900Z:c94bd72c-2878-4954-a90f-79f9b764e65d
+      - NORTHCENTRALUS:20160203T141858Z:d711155c-826f-4d27-bacb-295fec48c7e0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:48:59 GMT
+      - Wed, 03 Feb 2016 14:18:58 GMT
       Content-Length:
-      - '411'
+      - '450'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -471,17 +493,17 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
         qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qafTT6aJktCPhH/kdlNc0AnD7Os6ZdN/TZqq5W
-        ed0WefPRo1+Mvy6LhpoUy4vXbdYCwuv1dJrns3z20S/5JaNvENdqsVq3+U9+
-        ASwMsv5n/6/C9ml+nq3Ldvt1W9XZRb59Shh99ZowUswHv/9/1SgWxS/KfrCu
-        c8JB8fY++X8lpruERAdVfPT/Slz3CIkOrvjo/1W4fnH2Ez/5BSioiNq//1+F
-        5Yvf59Xn1L/iqH/9vwrD7+ZNe1IRGk+fAA/FtPOph/EVffM1MP7+L/l/AJak
-        dX0nBgAA
+        ta6n+ed1tV41d6f5sq2z8qPRR8tsQaA/ch+U1TQDYPfhuqGPV3W1yuu2yJuP
+        Hv1i/HVZNNSqWF68brMWIF6vp9M8n+Wzj37JLxl9c6iezPPz7Zd1NSMkFFn/
+        Iw/dPGvan2Ncq8Vq3eY/+QWwMMj6n/2/Ctun+Xm2Ltvt121VZxf59ilh9NVr
+        wkgxH/z+/1WjWBS/aHuS1xd5vUtoKOrhhx6+/69gacIu+8G6zgkHh6/5xEP2
+        /xXEZbxAxQ6q+Oj/lbjuERIdXPHR/6tw/eLsJ37yC1BQEbV//78Kyxe/z6vP
+        qX/FUf/6fxWG382b9qQiNJ4+AR6KaedTD+Mr+uZrYPz9X/L/AEVohGaFBwAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:00 GMT
+  recorded_at: Wed, 03 Feb 2016 14:18:58 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -495,7 +517,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -516,20 +538,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b5ec7302-cf6f-4506-aae5-9262d3ed337e
+      - 998be6ba-723e-4c16-9f2b-f9ca7d75b27d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 573d9dd2-ae1d-44dc-bdf9-d99779c2d9fd
+      - 2e2cc9b8-bb21-4eb3-8ee3-22e5e0b7a4fe
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134901Z:573d9dd2-ae1d-44dc-bdf9-d99779c2d9fd
+      - NORTHCENTRALUS:20160203T141859Z:2e2cc9b8-bb21-4eb3-8ee3-22e5e0b7a4fe
       Date:
-      - Tue, 19 Jan 2016 13:49:00 GMT
+      - Wed, 03 Feb 2016 14:18:58 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -547,162 +569,197 @@ http_interactions:
         2di+NIz4Rd7OK56gp9c0lcU08hrNHBGV2vRQpi+/udmtFqt1m//kF83G6b0s
         6nadlfpn8BrhQHg2d2f5ebYu24+62P6S8IPgT++P73sU+Gi2bF7nbUszAuoG
         BJDv6kvCk776nv8afZmtVmWRz56GbVyTX+I1/yhfZpOS5uVZVV9l9Yx6o9bn
-        WdnkppHiZ96yiFj5m4LJiXCz+3ve1H+D0wP4EKKNs0P0x08rYM3dAbx8aXrw
-        ab77aZ7tb9/f+/Rge//8we72wae797d3H9779P70wezewcG5L03/X9G9ewef
-        Ts7v79zbznZ3p9v7e/cfbk92zmfb53uf3tudHuT39nYCNUM6NNRGBOT/67rX
-        n35SruH46IMhxD+EP+TBzEWnVB58fcuJlYdeMNoz0LZ7pG33NzZ/L2W7Wk/K
-        Ykpv2U56qFOrH/K8dpCiebXv9bVsf0yEJnEGYfz/gqH07Id9izAgLP+/aD4W
-        2VRnhlp9tLOzvfN0+97x9u7e9vH+9tNnPpdtMDV+KyIEyEP+0rou2mumMLUL
-        B/BDnrkYTt673nwFxCE5XGT1NaHa1utgkMoKX2TTebGE+P+cDE8dGMOYio33
-        lj8w86v+YgZqEbcmYVU17QXhsT3LL/fv3Xcs8MMaVmfWPJMwjJqv9Gf3zu9P
-        7pO+fzAlfb8/fZhvP/x0P9/emexnu7MHs/1Pp1Nf6f9/xSnYzfLde5PdyfbB
-        wf6D7f2HD/a3Jw/272/fzyfT88nOvcnk4UEAoGs0Ccj/152CDgeQGxAOkT4Y
-        wv1DWEQeTF50VuXB17ecW3noBWPonQ5Wv8BjbvN4zf//6Be8NFP7NL/0FJc8
-        Rl255yPClPiDkP5/wWhUA+uf/luEAWHZ/H/QNfj/m7kf4K9gzDqPakkJ6Z+t
-        cXz79Nn2y1dfPo2OY8iuD43A/Kq/mBFZ3K1iry/avGmdivjmBmSDteiAOhPj
-        6fMeRr6WfvBgZzfPPt3Znsx2yeBNJg+2H+az+9sP9mb37ue7ZPOmu76W/v+K
-        Ib/34NPz8wnZ8N2HBw+39/cPJtvZ/nRn++GDbPLg/v7BbCcL9DgZ5NDKEZBb
-        GfIudeX5f8usk60Oh6Wf9/D9EJ6QB7MVnUZ58PUtJ1MeesGYYrFfaK+We//B
-        xvb/bzbdt5vPDlJ2Prf1i5Wnm+QxGsk9HxGyxBeE98/qgG5nL1TP6p/+W4QB
-        YdkMW+/+wGimvaAx/FoVtDzeH76ZFgv+s27dhwP/p/vb+6c+L97SEwgH7n+j
-        9FU7Rg3CQX1jsz0Vu3m5oDghMt1DZlW415tbOzP6iyGcRdtTsL8/v6sN6Jtv
-        bjBgQhrGZtYl7sTPQLd2UfLVZ7Y33Xuw8/D+9uz+jOb505yiyfu0vJc/nOT3
-        JvnewfTTe776/P+KSc2nk3vns4cPtu/dv0cU3qewODvP72/vPNw//3Tv4c50
-        fxJEVB9gUjvklef/NfMeM6r8RQ/jD2ELeTBhmMneTMqDr285n/LQC8ZKOtVk
-        rOqnG9v//9Oq8sT9yKzSg6n2rEv4tappebw/fPsopvNn3awOm0rTSPEzb1lE
-        rIZpZuf0P8e2P+xpo5nBT0+1EDr0Pw8jX3Xc2/t0+unDbHd78ulsj5bYDva2
-        J/cfzrYn9Ntkb2cymU33fdXxs2FRCB3Myi82RKWPaIRR1YQvbqmUPrLkUyOz
-        u3dvB4py+3z/Hq0mZgeUgN2ZzLb39h7c+/TBbDqZHAS+/9c2MkRt+p8PCs//
-        Wxihb2LoQ/pfD98PYRN5MFvRaZQHX99yMuWhF4zFEDWL9mphdoO5k8dr/14W
-        hqaIqEdteijTlz/kafyRGv5aahim9/dfFtPdnR03wT/suaPpwU9PBONo+ZL2
-        YGfn4e7e/sH2bP/+ZHt/dy+nXEk22Z5M93f3d87v37u/k/uS9rOhkGlMUbHF
-        F7cU2I8swYz2PbhPGmT3fJuyP7Rmc39CCbN7Ow+2dz7dOdjN9iiDthcC6Kop
-        AnIr7bsofhGofPYyoLE8/69igL4i3oj6hzCJPJi+6LzKg69vObvy0AtGvfbU
-        8X4Qr8njtX8vdawetNdLD3dq9UOe2g5SNLX6yQqT18XPKCr3fESIEnsQzv8v
-        GMzPRyMznEI7ebJ9cM/nww0GyW8VDtz/RumrOStqEA7qG5vtr5lCg9JB+5Bz
-        7fToL4Z6FnercvE+lNq+I9o3NybHi0CxOyRl2Q2a1kfK16H3D3bu79+bYQFi
-        /9Pt/dmne9sPJ/f3CbWdezv3Z+f79x8GSZP/rxjaBzv7Ow/yfH872yNru79D
-        BoKWWWihKv/0fLabT6b3HoYAumaIgLyfod3zweH5f9HkbzCyfbQ/hD3kwcRF
-        Z1QefH3LeZWHXjAm0+kqNbG7P39N7L6npuQxysk9HxGaxBiE8f8LhqIaV//0
-        3yIMCMsNBjb8IPjT+8O3hGIkf9YN6LBRNI0UP/OWRcSqEAgii6mXHv5hTw1R
-        Hz9jysPHytcN+wcH9+7vk27Y25uSip3tn5P7TSmR3Sz/9NO9nXu7e5OJrxv+
-        v2I6Du7N9u5nO7Pt/ekuxWjnn+5uP9x9cG/7/NP9+wfZbDLZnwRpov9/m45P
-        v7bteF/+kAczF51SefD1LSdWHnrB2AJRoGivtuPewcb2/7+2HQ/6OrY/KMKT
-        WINQ/n/BWD7AePQHRpPsBSnh16qv5fH+8K2EGJD/LxiXywVk1feSftgTR3OD
-        n55yieDkK47ZfXLRyfPcnj44yGgdPLu3Tdn1B9uTg4OH04O9B/cfhgu5PxuG
-        hdDBzPxsr8Z8mtOq9P4BrVQf7JGtyTPKDB5M8+3z6flBlpHFmfhUIgBdZUxA
-        bmVr+iSX5/89zNC3M+abHs5fh1k6IAjHcDLpQ/fg61tOqTz0grEaomrRXq3M
-        j5ZkOrg6mTIP6PHzSx/7TvUPeeJobvCzL4I+Tr6I3ft0/97k3sGn29OHn1Ke
-        /WA62c6wbnx/b5Lf39m7d3Cw//8Xfbxz8HDv/OH5dPv+OeWO9pE7yg7u0SLN
-        g739B3uT/YeU8wgAdJUWAXkffeyRXJ7/9zDDoD7u4/whzCIP5iw6mfLg61tO
-        qTz0glGwPX38DTr9NEtEQGrTw5i+/CHP5I/08YfoY89I/7AnjuYGP/si6OPk
-        i9ju/r3z/QcPJ9v53t7B9v5DQuogf0hJ2Z17+59m98+zWf7AF7GfDX1MA4rK
-        K764paR+ZKmlyvfBjEaRz6a0+pRR9iWjwU0ms9n2wf39/Z3J5NPpvWmQcfhQ
-        5evRV57/98z8oPLt4/whnCEP5iw6mfLg61tOqTz0gtGmPeX7cGPz91K+msrw
-        OumhTq1+yFPaQcqb0m39anUb/UvoEnMQ5v8vGNIHGJbwg+BP7w/fAohx+P+Q
-        4fC8iR/2xBDt8bOvPnycfPVwL3t4fn7wcLa9ezC7v71/b+fT7YNP6c979/Js
-        Jzvf271/L8jI/mwYDkIHM/Oz7chPd6c7kwNa9c3vPaSFy4fnD7cfPvx0ur13
-        kN3PZ+e7kwe5tyROALoKl4C8jy3xSC7P/3uYYdCW9HH+EGaRB3MWnUx58PUt
-        p1QeesEYB9GoaK+2ZHdnY/v3MiY0TURBatNDmb78IU/lByjc/sCIHj+/PHnP
-        w/hhTxzNDX72ZdDHyZexB9nB7vnDyafbe/s5aalP701ISz3Y3c7zTx/u3X+Q
-        PZhNAn/t/8MKmcg63f2UlAi1nFKmm5LcDx/ez7bz+weT6Xn+aT6ZBYneD1XI
-        Hsnl+X8PMwwq5D7OH8Is8mDOopMpD76+5ZTKQy8YBdtXyLsb2/9IIdMDevy8
-        Ush7HlP8sCeO5gY/ezIY4OTLWHZw/iC7fz/fzj6lBcf9T/fvb08ePjjY/vR8
-        MtmZ3r937+D+p76M/X9YIR/s3D9/cD/f2d7bI128P5nRKuvO/u52treT3X94
-        fzr5dC9wED9QIfskl+f/PcwwpJAjOH8Is8iDOYtOpjz4+pZTKg+9YBRsXyHf
-        29j+RwqZHtDj55dC9pKoP+yJo7nBz74M+jj5MnZ/untvb38329598Gm2vf9g
-        52D74STPKTH8YHdKUrabZTu+jH1thSyCgG5/rhTybHqP9MmEMt87e+Tf5Xv7
-        25P8IN++9/DBzsP97NMse5gFALpai4C8j0L2SC7P/3uYYVAh93H+EGaRB3MW
-        nUx58PUtp1QeesEo2L5CDpJO8njtf6SQ6QE9fn4pZM9K/7AnjuYGP/sy6OPk
-        y9j5pwcHD/f2s+2MVuVIxqbZ9mRKYf2D2b3d873J9N7BTu7L2P+HFfK9/YN7
-        pI/vb892dnaI6jsPtw+mDx5ivPvT8+lBfnDuUYkAdLUWAXkfhRwAw/P/HmYY
-        VMh9nD+EWeTBnEUnUx58fcsplYdeMAq2r5A/3dj+RwqZHtDj55dC9jKRP+yJ
-        o7nBz74M+jj5MjbNJw9oYX9n+945OYv7Owf3tx8+uPdg+16W7U13DiYPP723
-        58vY/4cV8sPZ7CGN6NPtndm9ve392d697exgcrC9f/9gmt3bv3f/03vnAYCu
-        1iIg76OQPZLL8/8eZhhUyH2cP4RZ5MGcRSdTHnx9yymVh14wCravkIOkkzxe
-        +x8pZHpAj59fCtmz0j/siaO5wc++DPo4+TJ2/vD+/oySp9t7D3cf0sI5RfQP
-        H+wRUllOyzcP9/bund/zZez/wwp58nD3PuUl7m/vTvZpqNmDT7cP7s3Ot2eT
-        LJs+yIkQWbBG/6EK2SO5PP/vYYZBhdzH+UOYRR7MWXQy5cHXt5xSeegFo2D7
-        Crm3Khm0/5FCpgf0+PmlkB+42f1hTxzNDX72ZdDHyZexnXxvNj2f7W+f5+T5
-        7D/cfbB9cEDLNvcOyAuidfT83sOJL2M/GwqZBhQVWHxxS1H9yFLLaN98MpvM
-        iMSECK0/HezvbGf7Bw9pOerg03xvL5tMPg2Uz4dqX4++8vy/Z+YHtW8f5w/h
-        DHkwZ9HJlAdf33JK5aEXjDbtad+9wH7K47V/L+27Wk/KYkpv2V56uFOrH/Kc
-        dpDy5nRbv1rdRgETusQdhPn/C4b0AZYl/CD40/vDNwFiHf4/ZDm8+O6HPTFE
-        e/zs6w8fJ18/7E5ne7v5p7vb09nOdHt/uk+69tP797bvPdi7/2l+73z/0/PM
-        1w//X7Ecu/v3dib7NJrp9Pyc0ieTyfbkfvZg++H9fGf3wd75faJxAKCrXgnI
-        +1iOABie//fM/KDl6OP8IZwhD+YsOpny4OtbTqk89IKxBKI+0d5Yjt2N7f//
-        Zjk8y3HwdSxHZDqIXj9kNv2R5aDHItLVIl4g+sOeGKI9fvb1h4+Trx8eZjvn
-        e3t5tp1P6J/9vWy6ffDwIenah9Nsurebfbp7b9fXD/9fsRwPHuaf5jsTWtH7
-        dOc+jeY+kTijNdH7s8nB+QOKPvbu7wcAuuqVgLyP5fDoK8//e2Z+0HL0cf4Q
-        zpAHcxadTHnw9S2nVB56wViCvuXY29j+/8eW4+HPR8vRHxjN9c+rbNY9L8j+
-        YU8czQ1+9vRLgJOvP7Lz+w9m0+kuJdnvUcZ4b5ZtTw4eHGzPyP2cPqAcxr2d
-        fV9//H/Fsuzs3d/Zm+xl23v3ZrS4u0f/PJzln25/unNvZ+fe3uT+znmgWD/Q
-        svj0lef/PTM/ZFkiOH8IZ8iDOYtOpjz4+pZTKg+9YCyFqFe0N5bl3sb2//+1
-        LPd2fmRZ6MFc//yyLF4Q/sOeOJob/OzrFx8nX3/c+/TgHiWGZtuzhwcTygrt
-        UDZ8fz/fPt+Z5Lu7+w8nD+6f+/rj/yuWJZ8e7N1/QC72wYP7FLPcP7iHRNe9
-        7U+z3fxhlu1nDz8NFOuHWhaPvvL8v2fmBy1LH+cP4Qx5MGfRyZQHX99ySuWh
-        F4ylEPWK9sayBFGnPF77/x9blt0fWRZ6MNc/vyyLF6T/sCeO5gY/+/rFx8nX
-        H/cnO/d3s4yWWO89/HR7/1NabJ3sH5xvT/Z2dvZ3H36618mW/3/FsswePLy3
-        s3c+2Z7t7dO4Dg52tx8e5LQesPvp/vl0+uBBlk0CAF31S0Dex7J49JXn/z0z
-        P2hZ+jh/CGfIgzmLTqY8+PqWUyoPvWAshahXtDeW5f7G9v8/tix7P7Is9GCu
-        f35ZFi9I/2FPHM0Nfvb1i4+Trz+mu7sHu+e7O9sPZvf2SQNnD7ezh7QCSEmj
-        /d3d7N69/d0g5/H/Fctyb2/nwcGDfHc738vhcR8cbB+cTx9s73463Xm4OzuY
-        7M0CBfOhlsWjrzz/75n5QcvSx/lDOEMezFl0MuXB17ecUnnoBWMpRL2ivbEs
-        n25s//9jy3Lv/32W5ZZD+pFl+RDL4gXpP2xepLnBz75+8XHy9cfk4ODe3sE9
-        SnLs34dHv/dgezLbO9/Odw8+3Z882DufznJff/x/xbKcf7o3m83unW/vTg+I
-        xOfn97czWnvZ/vQ835tM8slkdz8PAHTVLwF5H8vi0Vee//fM/KBl6eP8IZwh
-        D+YsOpny4OtbTqk89IKxFKJe0d5Ylgcb2///2LLs/8iy0IO5/vllWbwg/Yc9
-        cTQ3+NnXLz5Ovv7Y/zSb7j84n26ff3pOnun+p9Ptg+nDh9u7lEx/cH86me3s
-        THz98f8Vy7J7f/fe5P49yoad0+rK/n2ic3bwab796d70U0qT7WUHeRYA6Kpf
-        AvI+lsWjrzz/75n5QcvSx/lDOEMezFl0MuXB17ecUnnoBWMpRL2ivbEsBxvb
-        ///Ystz/kWWhB3P988uyeEH6D3viaG7ws69ffJx8/ZGf5wf7B5Qmmtx/SCn1
-        2cN98u13s+298/x8MsvO7336MMim/3/Fsuwd5PvZvcm97cnuPVolmH1K2bC9
-        3YfbBw/vZbTIcm93lgXLDB9qWTz6yvP/npkftCx9nD+EM+TBnEUnUx58fcsp
-        lYdeMJZC1Cvaq2W5t7Ox/f+PLcunP7Is9GCuf35ZFs+V+mFPHM0Nfvb1i4+T
-        rz8+nR58en8nn23nO7Ndyqaf59uTyYNse3d3d//T3b2H9z59EOiP/89Ylmw3
-        23u4m2/vPdwhvfhwb0LrLPTb/cn5pw8PHhx8OnsQJIM+1LJ49JXn/z0zP2hZ
-        +jh/CGfIgzmLTqY8+PqWUyoPvWAshahXtDeWZXdj+/8fW5aDH1kWejDXP68s
-        y77nSv2wJ47mBj97+iXAydcf0+n+wf79bLb94AFlb/cfkPKd0NLs9uQ8y2YP
-        H366u3Nv5uuP/69Ylt1PKSw5OP90+/7BPdKLlAmjbNiDB9vZebY/3T3Pdh/u
-        BcmgD7QsPn3l+X/PzA9ZlgjOH8IZ8mDOopMpD76+5ZTKQy8YSyHqFe2NZQmi
-        Tnm89v//tSz7Oz9sy/KNDWnAstBbRFTi4R9ZFnosIl0t47lSP2xepLnBz75+
-        8XHy9cfu7F527x7p3fv55P72/qd5TgkjQurT/Wy2c76/+2C6M/X1x/9XLEt+
-        b3+2Bz97hxacaZVgh3I5+9nu9r39hw93p/f2du7t3wsAdNUvAXkfy+LRV57/
-        98z8oGXp4/whnCEP5iw6mfLg61tOqTz0grEUol7R3liWYAbl8dr//9iy7P7I
-        stCDuf75ZVk8V+qHPXE0N/jZ1y8+Tr7+eHhv72BKOng7f0Drgvu7lDXKPt15
-        sH1AqoQ+f7g7yfZ9/fH/FcvyYC/Psge7O9v3pgfn2/vnM1pi2aVVgvuTGdmU
-        808nuw+DZYYPtSwefeX5f8/MD1qWPs4fwhnyYM6ikykPvr7llMpDLxhLIeoV
-        7Y1lCfKZ8njt/39sWfZ+ZFnowVz//LIsHsP/sCeO5gY/+/rFx8nXH/mne7v5
-        g5297d0H9+9t79/7dLadzT7d2965t3NAjv29+w/O7/v64/8rlmW2N6VVgR3K
-        ge3vkmW5P81o/fnebPvTB5/u7+3Qsv5slgUAuuqXgLyPZfHoK8//e2Z+0LL0
-        cf4QzpAHcxadTHnw9S2nVB56wViKGatXtDeWJchnyuO1//+xZdn/kWWhB3P9
-        88uyeAz/w544mhv87OsXHydff+zkD7OH9x/mtAqxn23vT8/vU85jOtt++GB/
-        52E+m87u7z/09cf/VyxLNn0w2d29/+n2+aefTmlcDw+2ibafbs8e3s/OH+48
-        fDi9NwkAdNUvAXkfy+LRV57/98z8oGXp4/whnCEP5iw6mfLg61tOqTz0grEU
-        ol7R3liWIOqUx2v//2PLcv9HloUezPXPL8viMfwPe+JobvCzr198nHz98WBG
-        axAPHn66vYcc+v6EVAdl0+9tTx9m2cPJZC/79F7u64//r1iWnezebraT7W/f
-        p5V8Wn8mt3tykB1s72YPHt6fnD84z3cfBAC66peAvI9l8egrz/97Zn7QsvRx
-        /hDOkAdzFp1MefD1LadUHnrBWApRr2hvLEswg/J47f9/bFk+/ZFloQdzzZbl
-        541l8Rj+hz1xNDf42dcvPk6+/tjJp1m2s0Oe6cMZobI33aGsEaWOHmQ5LdVm
-        hNbknq8//r9iWe4TBvvTg53t+wf3drb3Z58SifOdyXZ+8HD3HgZ2EGbpP9Sy
-        ePSV5/89Mz9oWfo4fwhnyIM5i06mPPj6llMqD71gLIWoV7Q3luXhxvb/P7Ys
-        D35kWejBXP+8siz3vSzDNzdxU0wBzdnmiaO5wc+efglw8vXH9NPz+7ufksLY
-        nZASoazR/e2H+/fubT/YnU72adl2en964OuP/69Ylr0He58++HSSb08ePqSY
-        Ze/8HqVx7lEI8+lk52A6pVWC7JvMhvn0lef/PTM/ZFkiOH8IZ8iDOYtOpjz4
-        +pZTKg+9YCyFqFe0V8uyf29j+/83W5bbzWkHKW9Of2RZ6MFc//yyLJ4v+M1N
-        3O14keYGP/v6xcfJ1x+7D+99+jDbv7e9l5ODv79DTPtw7yGljmgBPN/bm+QH
-        54Fn+v8Vy0I68P5kB9T99D6ts9x/sLP9cLa/t51nB7v7k4d7e5QsCwB01S8B
-        eR/L4tFXnv/3zPygZenj/CGcIQ/mLDqZ8uDrW06pPPSCsRSiXtGeLAv+2/15
-        a1n+XxmzVIvVus1/8otm45h6psW9RjgQnj+yLfRYRLp65sDx7jc3dbfjRpob
-        /OxrGB8nX4McPJhO9/cm0+0sv0fe/f0ZrXXP9h5u35vu7s12H+4+OLj/wNcg
-        /1+xLTMyJ5/uPtzbnk3uPdzez7N72wf39w62HxzcO5/sZOezBw9DAF0FTEDe
-        x7Z49JXn/z0zP2hb+jh/CGfIgzmLTqY8+PqWUyoPvWBshShYtDe2JchoyuO1
-        //+xbTn4kW3hB7P9/y/bgh8E5Zf8P4xYKaY9+gAA
+        WdnkppHiZ96yiFj5m4LJiXCz+3ve1H+D0wP4EKKNs0P0x08rYM3dAbx8aTqY
+        3dvLPt2ZbO/mu7Pt/XsHpKPufbqzfX7vYH/v4b179+5/et+Xpv+v6N69g08n
+        5/d37m1nu7vT7f29+w+3Jzvns+3zvU/v7U4P8nt7O4GaIR0aaiMC8v913etP
+        PynXcHz0wRDiH8If8mDmolMqD76+5cTKQy8Y7Rlo2z3Stvsbm7+Xsl2tJ2Ux
+        pbdsJz3UqdUPeV47SNG82vf6WrY/JkKTOIMw/n/BUHr2w75FGBCW/180H4ts
+        qjNDrT7a2dneebp973h7d297b2d796HPZRtMjd+KCAHykL+0rov2milM7cIB
+        /JBnLoaT9643XwFxSA4XWX1NqLb1OhikssIX2XReLCH+PyfDUwfGMKZi473l
+        D8z8qr+YgVrErUmYltWaJrdo77nZ/2GNqDNhvjWIYeWreopW8r3p7n1S9bO9
+        7f37u7vbB7sPsu3s3t40n+TT2ac7B76q/9lwBQgdyNEvNsSlj2iUUVOCL25p
+        RD6yJFTv4ODBg72DPL+3fXDv04fbFIxNt7OD7NNtCtfy+w+I8OfT8wBA13oS
+        kFt5BzGiy/P/JoYgXyAcnvddD+8PYRl5MHPRKZUHX99yYuWhF4y5d5qYvAP8
+        t/cNugc0VURFatNDmb785qZTdBKCKibEwHyqytI/g9cIB8JzgzHtD40o4inq
+        8GvVd/J4f/hWUwzqz7qxHTagppHiZ96yiPQl8r6b4W9w8j5UFn2sfEk7IEn7
+        9N7e/vank2yyvb//cHd7Mjm4R1mPffLAd6f3d3YCP/xnQznTkKJiiy9uKbAf
+        WXqpJn4w2X1IOpdUxkNSHvuTB9DJ59PtT+89yHZ2Jrv3aeABgK6qIiDvp4k9
+        Csvz/6bZ36CJ+3h/CH/Ig5mLTqk8+PqWEysPvWA0a18T9wYQtH8vTdyJiahx
+        D3dq9UOe1w5Swbxu65er2yhjQph4hHD/2R2UMxibRvUjO/OBduaB499vcPJu
+        xZE0O/gZ0zQ+Vr4eebh3f2c6mx1sP9jLKG/24OH+djadPNh+QKmfe3t7+cHD
+        86mvR/6/YmeyvX1adPl0uv3w4B55/BNKCmaTnf3t2f79+/v397L9vR2PJASg
+        q4gJyPvZmQAcnv83zf4GO9PH+0P4Qx7MXHRK5cHXt5xYeegFYzdE2aK9sTO9
+        AQTt/39tZx78yM7wg/n+/5Kd+QA7s6qa9oJIvj3LL/fveT7WNziDt2JLmiL8
+        9NTNMGq+RplQ99mElhQOsnufEkbn5Lnms2z74Wzn4N70waef7s1mvkb5/4rF
+        2c3y3XuT3cn2wcH+g+39hw/2tycP9u9v388n0/PJzr3J5OFBAKCrkgnIrSzO
+        8EKOIHL3/zUc0Lc6w7h/CIvIg8mLzqo8+PqWcysPvWCMiGhetCejg0Uoj7nN
+        4zX//6PNeWmm9ml+eRuNTJgSfxDS/y8YTc/W2LcIA8KyGTY14QfBn94ffuwh
+        YcnPYcjit6LBYcjBOg61C5H6Ic9GDKdB/grGrPOoyzaE9M/WOL59+mz75asv
+        n0bHoZ6K4SrFZngE5lf9xYzI4m4Ve33R5k3rVMQ3N6ApJobGcquJ8fR5DyNf
+        S5Nh27u3u/9w+/yc8nn7+7Md0tL5/e2d+w/3JpPdT/MH+ae+lv7ZMOSEDqTk
+        Z3v96N6DT8/PJ2TWdx8eUDS5fzDZzvanO9sPH2STB/f3D2Y7WaDayUaHho+A
+        3Mq2dwkuz/9bGIHMdzgs/byH74ewiTyYreg0yoOvbzmZ8tALxjqLSUN7Neb7
+        32AESVNE1KM2PZTpy29sGm+naFVB6Z/+W4QBYdkMm73+wIgeP08iLOHpXW8l
+        9Ic9cTQ3+NmTvwAnX8Z28nuzyXQn336QP6BVlb3pve3JziTfzkju7j14kB1M
+        D859Gfv/sCreO7h/74CGtf3pdEYLHw8/vbf9cJdU8cGDT3dnD2e7u/cO8gBA
+        V2cRkPdQxT7J5fl/DzMMqeMIzh/CLPJgzqKTKQ++vuWUykMvGAXbU8j39za2
+        /5FCpgf0+PmlkL2Y+4c9cTQ3+NmXQR8nX8by6f59So3vbN/fe0AOY0ZpIVr4
+        nm7nO5PzB58+3D8/vxdkMH42FDINKCqw+OKWovqRpZZq33zycPZwn3xgKGHS
+        HZ/u0vL9wXR7+nBycL6z8+k5DS0A0FVRBOR9tK9HX3n+3zPzg9q3j/OHcIY8
+        mLPoZMqDr285pfLQC0ab9rXv/sb276V9O3kkatzDnVr9kOe0g5Q3p/9vXE65
+        1ZB+ZFk+wLLsef7SD3viaG7ws6dfApx8/TE72Jnt03/b03w62yZVPCPHbZcW
+        ZA8me7PpdLazd77r64//r1iW8wezg+xgj8Y1nZ3LuB4+yGfbD+5N751nD8/z
+        B5NPAwBd9UtA3sOy+PSV5/89Mz9kWSI4fwhnyIM5i06mPPj6llMqD71gLIWo
+        V7Qny4L/doMZlMdr//9fy7J37/+NlkXy2Fhx3zSmnmlxrxEOhOePbAs9FhHW
+        M9SY9Mzvj6l3rOvN3AfO3NfP4nZR8vVHtjfde7Dz8P727P5sf3v/05yWsu/v
+        7G7nDyf5vUm+dzD99J6vP/6/Ylny6eTe+ezhg+179+8RhfdpTT47RwKanO1P
+        9x7uTPcngcv+AZalQ155/l8z7zG7wl/0MP4QtpAHExadSXnw9S3nUx56wZgJ
+        0a1oT2YFAcv+/3fNyu1mtIOUm9H/N1oVjOhGQ9kzKvYtwoCw/JFNocciYjVM
+        Mzun/zm2/WFPG80MfnqqhdCh/3kY+arj3t6n008fZrvbk09ne9v75wd725P7
+        5JZO6LfJ3s5kMpvu+6rjZ8OiEDqYlZ/tZYndvXs7UJTb5/v3Diitc7CPpPps
+        e2/vwb1PH8ymk8lBsMr4tY0MUZv+54PC8/8WRuibGPqQ/tfD90PYRB7MVnQa
+        5cHXt5xMeegFYzFEzaK9WpjdYO7k8dq/l4WhKSLqUZseyvTlD3kaf6SGv5Ya
+        hun9/ZfFdHdnx03wD3vuaHrw0xPBOFq+pD28N/10cu/TPXKAH0y393d3HmxT
+        cuDT7Z3s3kPSW3v5zuyBL2k/GwqZxhQVW3xxS4H9yBLMaN+D+6RBds+3s0/J
+        M92/P9nZfniPBrfz6c7BbraX7U/3QgBdNUVAbqV9F8UvApXPXgY0luf/VQzQ
+        V8QbUf8QJpEH0xedV3nw9S1nVx56wajXnjreD+I1ebz276WO1YP2eunhTq1+
+        yFPbQYqmVj9ZYfK6+BlF5Z6PCFFiD8L5/wWD+ZGR+SAj463G/bBnjiYHPyMa
+        xkfK1x33D3bu79+bPdh+mO9/ur0/Iy3ycHJ/n1Dbubdzf3a+f/9hkCz4/4qB
+        ebCzv/Mgz/e3sz2yMvs792nVdoL12/zT89luPpneexgC6KpfAvJ+BmbPB4fn
+        /0WTv8G49NH+EPaQBxMXnVF58PUt51UeesGYCtGvaK+mpb96H7T//7Np2b+N
+        /iU0iTEI4/8XDOUDDEv4QfCn94dvAcQ4/H/KcHhp0R/21BD18TOmPHysfN2w
+        f3Bw7/4+6Ya9vSmp2Nn++fZkRqmA3Sz/9NO9nXu7e5OJrxv+v2I6Du7N9u5n
+        O7QiO92l2OT8093th7sP7m2ff7p//yCbTSb7kyA98v9v0/Hp17Yd78sf8mDm
+        olMqD76+5cTKQy8YWyAKFO3Vdtw72Nj+/9e240Ffx/YHRXgSaxDK/y8YywcY
+        j/7AaJJ/nkQl68l6STqT+7rvRwE/5OmjGcJPT8UMYuYrkdmMkvKTnXw7u5eR
+        Rt65P91+mE0ebH967+H5waefPnx4f+e+r0R+loxMVCMRF9F4b6WLPrI0UyNz
+        /9P9e59OJw9B3gkZmezB9mT/08n2vdnu5OHB/d2DT2dBCvtrG5liNeX3dn1o
+        eP7fxgB9OzOM+odwiDyYu+ikyoOvbzm18tALxmyIrkV7NTP3f/6ZGX9qb6OP
+        CVPiD0L6/wWj+floaBbZVCePWn20s7O983T73vH2Lq3ukcN2z2fEDUbJb0WE
+        Avle59N1XbTXPAPULhzAD3lmYzgN8mpAn3Aa/W+UW77IpvNiCS3xczLCk2qx
+        Wre54V3FZnhs5lf9xYzV4m7Nx+UCrj6S2NqEvvshjakza57hiCHlm4T7u/uT
+        nYd72XZ2cEBZq737tM6E8CPLJrTkDwR3g/Xp/684DbSyQ/m22cPtfEaew/6n
+        9zJacn+4u53t7+1kDx/kD+5N8wBA16QSkFs5DRECy/P/orkn9yAcnPuqh/WH
+        MIc8mLbofMqDr285q/LQC8b+O71r/IXA85PHa///R3/BTt22frfytJU8Rke5
+        5yPClxiEUP9/wZhU8+qf/luEAWH5/0evYdgTMI0UP/OWRaSnaTwf/4c9czQ5
+        +BnRMT5SvgrZ2/304XlOuNDi0s72/jTLth/uTPa3H+Q7+5/ufLo7u5/v+irk
+        /yv2ZXJv78F0d2+6fZ8syvZ+9ikFVZP7e9vTnfMH98/vTT+dfOqRhAB0VTAB
+        eS/7EkDD8/+iuR+2L32sP4Q55MG0RedTHnx9y1mVh14w9kKULNqTfcF/e4E/
+        L4/X/v/P9mX3/432RXz3n/yCsrMbBtUzMO41woHw/JGFocci0tU13jLxNzh1
+        t2JHmhv87CsZHydfhczun892ael9e/rgINve38/ubU/2dihDeHDwcHqwR0HA
+        p8Gq+8+GfSF0MDO/2BCWPqIxRlUUvrilcvrIElBNzqf5wfTT/YPJ9sHBHi22
+        5Rk54gfTfPt8en6QZbTkNvGpRAC6WpmAvI/JCYDh+X8PMwwanD7OH8Is8mDO
+        opMpD76+5ZTKQy8Y+yFKF+3J3iCe+QbDGZolIiC16WFMX/6QZ7KnkO1bhAFh
+        +SN9TI9FpCuIn7rZ/WFPHM0NfvZF0MfJF7F7tFgzuUfZgulDWqLZP5hOKFtw
+        sL99f2+S39/Zu3dwsB+I2P+H9fHOwcO984fnFAKc5/uUHdmFPr63s/3wwd7+
+        g73J/sP7s/MAQFdpEZD30cceyeX5fw8zDOrjPs4fwizyYM6ikykPvr7llMpD
+        LxgF29PH3+ByFM0SEZDa9DCmL3/IM/kjffwh+tgz0j/siaO5wc++CPo4+SK2
+        u3/vfP/Bw8l2vrd3sL1P67zbB/nD/e18597+p9n982yWP/BF7KP2Q/VxXx/T
+        gKLyii9uKakfWWqp8n0wo1Hksymtu2EpO6PBTSaz2fbB/f39ncnk0+m96V4A
+        oKuhCMj7KF+PvvL8v2fmB5VvH+cP4Qx5MGfRyZQHX99ySuWhF4w27Snfhxub
+        v5fy1VSG10kPdWr1Q57SDlLelP6/MfVyqyF9gGEJPwj+9P7wLYAYh/8PGQ7P
+        m/hhTwzRHj/76sPHyVcP97KH5+cHD2fbuwez+9v793Y+3T74lP68dy/PdrLz
+        vd379ya+evj/sCM/3Z3uTA7ukya895CWOR+eP9x++PDT6fbeQXY/n53vTh7k
+        +wGArsIlIO9jSzySy/P/HmYYtCV9nD+EWeTBnEUnUx58fcsplYdeMMZBNCra
+        qy3Z7a10B+3fy5jQNBEFqU0PZfryhzyVH6Bw+wMjevz88uQ9D+OHPXE0N/jZ
+        l0EfJ1/GHmQHu+cPJ59u7+3npKU+vTchLfVgdzvPP324d/9B9mA2Cfy1/w8r
+        ZCLrdJcWALep5ZQy3ZTkfvjwfrad3z+YTM/zT/PJLEj0fqhC9kguz/97mGFQ
+        Ifdx/hBmkQdzFp1MefD1LadUHnrBKNi+Qu4tDQftf6SQ6QE9fl4p5D2PKX7Y
+        E0dzg589GQxw8mUsOzh/kN2/n29nn9Ia0v6n+/e3Jw8fHGx/ej6Z7Ezv37t3
+        cP9TX8b+P6yQD3bunz+4n+9s7+2RLt6fzGjhbGd/dzvb28nuP7w/nXy6FziI
+        H6iQfZLL8/8eZhhSyBGcP4RZ5MGcRSdTHnx9yymVh14wCravkO9tbP8jhUwP
+        6PHzSyF7SdQf9sTR3OBnXwZ9nHwZuz/dvbe3v5tt7z74lJb3H+wcbD+c5Dkl
+        hh/sTknKdrNsx5ex/w8r5Nn0HumTCWW+d/bIv8v39rcn+UG+fe/hg52H+9mn
+        WfYwCwB0tRYBeR+F7JFcnv/3MMOgQu7j/CHMIg/mLDqZ8uDrW06pPPSCUbB9
+        hRwkneTx2v9IIdMDevz8Usielf5hTxzNDX72ZdDHyZex808PDh7u7WfbGa3K
+        kYxNs+3JlML6B7N7u+d7k+m9g53cl7H/Dyvke/sH90gf39+e7ezsENV3Hm4f
+        TB88xHj3p+fTg/zg3KMSAehqLQLyPgo5AIbn/z3MMKiQ+zh/CLPIgzmLTqY8
+        +PqWUyoPvWAUbF8hf7qx/Y8UMj0frX6+KWQvE/nDnjiaG/zsy6CPky9j03zy
+        gBb2d7bvnZOzuL9zcH/74YN7D7bvZdnedOdg8vDTe3u+jP1/WCE/nM0e0og+
+        3d6Z3dvb3p/t3dvODiYH2/v3D6bZvf179z+9dx4A6GotAvI+CtkjuTz/72GG
+        QYXcx/lDmEUezFl0MuXB17ecUnnoBaNg+wo5SDrJ47X/kUKmB/T4+aWQPSv9
+        w544mhv87Mugj5MvY+cP7+/PKHm6vfdw9yEtnFNE//DBHiGV5bR883Bv7975
+        PV/G/j+skCcPd+9TXuL+9u5kn4aaPfh0++De7Hx7Nsmy6YOcCJEFa/QfqpA9
+        ksvz/x5mGFTIfZw/hFnkwZxFJ1MefH3LKZWHXjAKtq+Qe6uSQfsfKWR6QI+f
+        Xwr5gZvdH/bE0dzgZ18GfZx8GZtks4O9+/f3KA8IGTuf3t8+yB5Ot/Pzyf7+
+        /U+nnz548NCXsf8vK+R8MpvMiOqEGy1JHezvbGf7Bw9pherg03xvL5tMPg30
+        0YcqZI/k8vy/hxkGFXIf5w9hFnkwZ9HJlAdf33JK5aEXjILtKeS9wKTK47X/
+        kUKmB/T4+aWQvbDphz1xNDf42ZdBHydfxnans73d/NPd7elsZ7q9P90nffXp
+        /Xvb9x7s3f80v3e+/+l55svYz4ZCpgFFBRZf3FJUP7LUUu27u39vh7TEwfZ0
+        en5OWYnJZHtyP3uw/fB+vrP7YO/8PtE4ANBVUQTkfbRvAAzP/3tmflD79nH+
+        EM6QB3MWnUx58PUtp1QeesFo07723d3Y/r2072o9KYspvWV76eFOrX7Ic9pB
+        ypvTbf1qdRsFTOgSdxDm/y8Y0gdYlvCD4E/vD98EiHX4/5Dl8OK7H/bEEO3x
+        s68/fJx8/fAw2znf28uz7XxC/+zvZdPtg4cPSdc+nGbTvd3s0917u75++P+K
+        5XjwMP8035nQQtmnO/dpNPeJxBktNd6fTQ7OH5AHv3d/PwDQVa8E5H0sh0df
+        ef7fM/ODlqOP84dwhjyYs+hkyoOvbzml8tALxhKI+kR7Yzn2Nrb//7HlePjz
+        0XL0B0Zz/fMqJrnnBao/7ImjucHPnn4JcPL1R3Z+/8FsOt2l3PU9ivv3Ztn2
+        5ODBwfaM3M/pg/2Hu/d29n398f8qy2KQIrQstdSy7Ozd39mb7GXbe/dmtGa6
+        R/88nOWfbn+6c29n597e5P7OeaBYo5bFfe3Ntjwb5lye//fM/JBlieD8IZwh
+        D0n7D8+y3NvY/v+/luXezo8sCz2Y659flsULwn/YE0dzg599/eLj5OuPe58e
+        3KPE0Gx79vBgQlmhnQfbB/v7+fb5ziTf3d1/OHlw/9zXH/9fsSz5lBLlD8jF
+        Pnhwn2KW+wf3kOi6t/1ptps/zLL97OGngWL9UMvi0Vee//fM/KBl6eP8IZwh
+        D+YsOpny4OtbTqk89IKxFKJe0d5YliDqlMdr//9jy7L7I8tCD+b655dl8YL0
+        H/bE0dzgZ1+/+Dj5+uP+ZOf+bpbtbO/fe/jp9v6ns53tyf7B+fZkb2dnf/fh
+        p3udbPn/VyzL7MHDezt755Pt2d4+jevgYHf74UFO6wG7n9KC7PTBgyybBAC6
+        6peAvI9l8egrz/97Zn7QsvRx/hDOkAdzFp1MefD1LadUHnrBWApRr2hvLMv9
+        je3/f2xZ9n5kWejBXP/8sixekP7DnjiaG/zs6xcfJ19/THd3D3bPd3e2H8zu
+        7ZMGzh5uZw9pBZCSRvu7u9m9e/u7Qc7j/yuW5d7ezoODB/nudr6Xw+M+ONg+
+        OJ8+2N79dLrzcHd2MNmbBQrmQy2LR195/t8z84OWpY/zh3CGPJiz6GTKg69v
+        OaXy0AvGUoh6RXtjWT7d2P7/x5bl3o8sCz2Y659flsUL0n/YE0dzg599/eLj
+        5OuPycHBvb2De5Tk2L8Pj37vwfZktne+ne8efLo/ebB3Pp3lvv74/4plOf90
+        bzab3Tvf3p0eEInPz+9vZ7T2sv3peb43meSTye5+HgDoql8C8j6WxaOvPP/v
+        mflBy9LH+UM4Qx7MWXQy5cHXt5xSeegFYylEvaK9sSwPNrb//7Fl2f+RZaEH
+        c/3zy7J4QfoPe+JobvCzr198nHz9sf9pNt1/cD7dPv/0nDzT/U+n2wfThw+3
+        dymZ/uD+dDLb2Zn4+uP/K5Zl9/7uvcn9e5QNO6fVlf37ROfs4NN8+9O96aeU
+        JtvLDvIsANBVvwTkfSyLR195PioYj7s/9zM/aFn6OH8IZ8iDOYtOpjz4+pZT
+        Kg+9YCyFqFe0N5blYGP7/x9blvs/siz0YK5/flkWL0j/YU8czQ1+9vWLj5Ov
+        P/Lz/GD/gNJEk/sPKaU+e7hPvv1utr13np9PZtn5vU8fBtn0/69Ylr2DfD+7
+        N7m3Pdm9R6sEs08pG7a3+3D74OG9jBZZ7u3OsmCZ4UMti0dfef7fM/ODlqWP
+        84dwhjyYs+hkyoOvbzml8tALxlKIekV7tSz3dja2//+xZfn0R5aFHsz1zy/L
+        4rlSP+yJo7nBz75+8XHy9cen04NP7+/ks+18Z7ZL2fTzfHsyeZBt7+7u7n+6
+        u/fw3qcPAv3x/xnLku1mew938+29hzukFx/uTWidhX67Pzn/9OHBg4NPZw+C
+        ZNCHWhaPvvL8v2fmBy1LH+cP4Qx5MGfRyZQHX99ySuWhF4ylEPWK9say7G5s
+        //9jy3LwI8tCD+b655Vl2fdcqR/2xNHc4GdPvwQ4+fpjOt0/2L+fzbYfPKDs
+        7f4DUr4TWprdnpxn2ezhw093d+7NfP3x/xXLsvsphSUH559u3z+4R3qRMmGU
+        DXvwYDs7z/anu+fZ7sO9IBn0gZbFp688/++Z+SHLEsH5QzhDHsxZdDLlwde3
+        nFJ56AVjKUS9or2xLEHUKY/X/v+/lmV/50eWhR7M9c8vy+K5Uj/siaO5wc++
+        fvFx8vXH7uxedu8e6d37+eT+9v6neU4JI0Lq0/1stnO+v/tgujP19cf/VyxL
+        fm9/tgc/e4cWnGmVYIdyOfvZ7va9/YcPd6f39nbu7d8LAHTVLwF5H8vi0Vee
+        //fM/KBl6eP8IZwhD+YsOpny4OtbTqk89IKxFKJe0d5YlmAG5fHa///Ysuz+
+        yLLQg7n++WVZPFfqhz1xNDf42dcvPk6+/nh4b+9gSjp4O39A64L7u5Q1yj7d
+        ebB9QKqEPn+4O8n2ff3x/xXL8mAvz7IHuzvb96YH59v75zNaYtmlVYL7kxnZ
+        lPNPJ7sPg2WGnmUhIO9jWTz6yvOhM4+xfDMzP2hZ+jh/CGfIgzmLTqY8+PqW
+        UyoPvWAshahXtDeWJchnyuO1//+xZdn7kWWhB3P988uyeAz/w544mhv87OsX
+        Hydff+Sf7u3mD3b2tncf3L+3vX/v09l2Nvt0b3vn3s4BOfb37j84v+/rj/+v
+        WJbZ3pRWBXYoB7a/S5bl/jSj9ed7s+1PH3y6v7dDy/qzWRYA6KpfAvI+lsWj
+        rzz/75n5QcvSx/lDOEMezFl0MuXB17ecUnnoBWMpZqxe0d5YliCfKY/X/v/H
+        lmX/R5aFHsz1zy/L4jH8D3viaG7ws69ffJx8/bGTP8we3n+Y0yrEfra9Pz2/
+        TzmP6Wz74YP9nYf5bDq7v//Q1x//X7Es2fTBZHf3/qfb559+OqVxPTzYJtp+
+        uj17eD87f7jz8OH03iQA0FW/BOR9LItHX3n+3zPzg5alj/OHcIY8mLPoZMqD
+        r285pfLQC8ZSiHpFe2NZgqhTHq/9/48ty/0fWRZ6MNc/vyyLx/A/7ImjucHP
+        vn7xcfL1x4MZrUE8ePjp9h5y6PsTUh2UTb+3PX2YZQ8nk73s03u5rz/+v2JZ
+        drJ7u9lOtr99n1byaf2Z3O7JQXawvZs9eHh/cv7gPN99EADoql8C8j6WxaOv
+        PP/vmflBy9LH+UM4Qx7MWXQy5cHXt5xSeegFYylEvaK9sSzBDMrjtf//sWX5
+        9EeWhR7M9c8vy+Ix/A974mhu8LOvX3ycfP2xk0+zbGeHPNOHM0Jlb7pDWSNK
+        HT3IclqqzQityT1ff/x/xbLcJwz2pwc72/cP7u1s788+JRLnO5Pt/ODh7j0M
+        7CDM0n+oZfHoK8//e2Z+0LL0cf4QzpAHcxadTHnw9S2nVB56wVgKUa9obyzL
+        w43t/39sWR78yLLQg7n+eWVZ7ntZhm9u4qaYApqzzRNHc4OfPf0S4OTrj+mn
+        5/d3PyWFsTshJUJZo/vbD/fv3dt+sDud7NOy7fT+9MDXH/9fsSx7D/Y+ffDp
+        JN+ePHxIMcve+T1K49yjEObTyc7BdEqrBNk3mQ3z6SvPz+3ME/XtzA9ZlgjO
+        H8IZ8mDOopMpD76+5ZTKQy8YSyHqFe3Vsuzf29j+/82W5XbS3EHKm9MfWRZ6
+        MNc/vyyL5wt+cxN3O16kucFPp90NL/o4+fpj9+G9Tx9m+/e293Jy8Pd3iGkf
+        7j2k1BEtgOd7e5P84DzwTP+/YllIB96f7IC6n96ndZb7D3a2H87297bz7GB3
+        f/Jwb4+SZQGArvolIO9jWTz6yvP/npkftCx9nD+EM+TBnEUnUx58fcsplYde
+        MJZC1Cvak2XBf7s/by3L/ytjlmqxWrf5T37RbBxTz7S41wgHwvNHtoUei0hX
+        zxw43v3mpu523Ehzg599DePj5GuQgwfT6f7eZLqd5ffIu78/o7Xu2d7D7XvT
+        3b3Z7sPdBwf3H/ga5P8rtmVG5uTT3Yd727PJvYfb+3l2b/vg/t7B9oODe+eT
+        nex89uBhCKCrgAnI+9gWj77y/L9n5gdtSx/nD+EMeTBn0cmUB1/fckrloReM
+        rRAFi/bGtgQZTXm89v8/ti0HP7It/GC2//9lW/CDoPyS/wcaLHSEdzABAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:01 GMT
+  recorded_at: Wed, 03 Feb 2016 14:18:59 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -716,7 +773,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -737,20 +794,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2d618e26-0a73-4aef-8e2e-eeee35d84998
+      - 05a8dd32-c5b9-49df-9ed6-f4e9db47da11
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 5ebb1de4-c862-42b8-95fc-b780ecb7c661
+      - ba4b6b55-1f25-437a-a7e2-33b7de6ab19f
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134902Z:5ebb1de4-c862-42b8-95fc-b780ecb7c661
+      - NORTHCENTRALUS:20160203T141901Z:ba4b6b55-1f25-437a-a7e2-33b7de6ab19f
       Date:
-      - Tue, 19 Jan 2016 13:49:02 GMT
+      - Wed, 03 Feb 2016 14:19:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -760,112 +817,162 @@ http_interactions:
         5x9N5/l5k9eXeb178Om9j0a2QTHD13eb9aSZ1sWqLaplc3f/073zvez8YDv/
         9EG+vb8z/XT74fnkfHtn72Bvf7Y7m+0f3L9b5021rqf553W1XjV3T6rFat3m
         P/lFc3dVV5fFLK+bu18U07pqqvN2/CJvr6r67d2l/Dxbtnl9nk3z5u4ganmb
-        XQC57979fT96mB/sfro/vbd9vpsRRoTddvbpwf3t3clu/mAynTw8n01+34+8
-        l9vrFQ/8Fhh4b5XVNAMJ8GaeNe3a/5KGtcrrtqA3HjkSyxeXRUOvFcuL123W
-        csev19Npns/ymYNATS3R1kL4Sb4725vtT7aze3vT7f3pwe725Hxntr1778Gn
-        9x4+yPZmkzwAUKxOquV5cbGuGVGgopMuj4cXHssAxWrK7+360PD8v44D7naH
-        SB8M4f4hLCIPJi86q/Lg61vOrTz0QnFJzc5eHs9mRCBA/Wh3Z4z/7m9sXhrm
-        +yJv5xVPytNrmr5iGnmNZovoSG16GNOXP+wZvSzqdp2V+mfwGuFAeDZ3Z/l5
-        ti7bj7rY/pLwg+BP74/vexT4aLZsXudtSxMC4gYEkO/ASfjqe/5r9GW2WpVF
-        PnsatnFNfonX/KN8mU1KmpdnVX2V1TPqjVqfZ2WT+61ocBjz63y6rov2mulG
-        7UKkftjzEUOK2p39hL6/601DMGadyC+y6bxYgtN/bsahXxu+UnQCPeGPwPyq
-        v5gRWdytDszr1f0dTwh/aAPqTIyn+noo+Rptci/fP9/ZvUeY7Gfb+/v028Pp
-        /sH2/V1Sc/fzh+ezbOprtP+vGL1Ps91PZw9mNJCH+TlR+HxG48roz53Jp/dn
-        n04nebYTAOhaBALy/3mjJzNPti0cGn0whPOHsIY8mLTobMqDr285p/LQC8Z6
-        9Yzdwcbm72XsVutJWUzpLdtJD3Vq9cOe0g5WNKWnr156ekkeo43c8xFhSOxA
-        yP6/YRSqY/XP4DXCgfD8ke3+oc5HDKkuZwVj1QlUI0nI/tzgr18bflJ0epib
-        X/UXMxKLs1Xdi+IX7T3Ye+C0wQ9tJJ2Z8FR2HydfJWcP9/azyfT+9vTePUJl
-        sv9gO9ud3d/eyffOpwcPZ9lsmvsq+f8r1np/mj+4t79P49qhwe3nZLIprjrf
-        fpjNPs3zbPpgf89zYAhA16QRkP/PW2uderLO4djogyGkP4Q35MGsRadTHnx9
-        y0mVh14w9ldsFtqruX64sfn/L801BUR7nm6Sx2gk93xEKBJDELb/bxiG6lf9
-        M3iNcCA8f2Svf6jzEUOK2oWsFQxWZ1AtJGH7czMA/dowlKJDLTqom1/1FzMU
-        i7RV36QipwJzd3/vU6cXfmgj6kxJqL3jqPk6eufewWz/Xjbd3tmZEkbT+wfb
-        BwcPp9sPH0736audg/0Hn/o6+v8r9nvv4WRvhuzygwf5PuVFaXCTvU8/3X4w
-        yQ6yB+cHn+7t/v8/2g45gKx2OET6YAj3D2EReTB50VmVB1/fcm7loReMXRZb
-        hvZqxvc3Nv//qxnXd/2soDxGW7nnI8KU2IOQ/n/DaFT56p/Ba4QD4fkja/5D
-        nY8YUtQuymHBmHUi1YoS0j8349CvDV8pOtQiPgLzq/5iRmRxt6rdqc+9g/v+
-        Gu0Pa2CdCYpq9g5qvuLey/fze/keWb7dHYphP81JZ3+6v7v9cH/34AEp2Um2
-        88BX3P9fse2TTw/27j28/+n2vXuTT7f3DyYH25N9Ivf0008Psvvn97Odez+f
-        bDs4gEx5OET6YAj3D2EReTB50VmVB1/fcm7loReMsRYDh/Zq2z3H1Txe8/+f
-        23Y/JpHHaCv3fESYEnsQ0v9vGI3qYP0zeI1wIDx/ZNt/qPMRQ4raRTnMEll/
-        MTSwI7CKcVlMPQ37czUoTxt2EPJV3D4lHu/tTB5s3/v0IS0a5vuEx87DT7cP
-        Hk7u792b7Z2fZw99Fff/FSuY7U5ms9n5zva9/Yd72/vZp7vbk2mWb+/u5NPp
-        5NPp/nR3EgDomggC8v95K4h5J1MXDow+GML4QxhDHkxZdC7lwde3nFF56AVj
-        zMQAoL3avm8wrqU5IupRmx7G9OUPex67RmJx/ZMvTt/cpf4Jx+bua/657Tvt
-        8hiF5B4Su2z2JCuz5TSvn2TTt/lypnR8WVUliBnwuDwRGhCoHzYVfNRBg+dP
-        7k76I7iro8IffYoQTbofhYYOT0Cks+WkWi9nL7L21bpkHv7/EoGKEPu7r56+
-        3P7JL3ZuRZfwg+B77w+ffOJC/By6F6aR4mfesohYHU160FN2P/SZInHFz1Ax
-        +wj5ejeffJo93NnLtvc+PdihfOLe+fZkRvnEvYPs4ODBg4c7B9mOr3f/P2OQ
-        8/3JvYcHs+3dB7sH2/t7D+6RQb7/YHtvf5dsyf39+7RqHADo2i0CEsiihxce
-        O9nD5k0QuftzPO9kf8OB0QdDGH8IY8iDKYvOpTz4+pYzKg+9YCysqGG0V4Mc
-        LPnL4zX/kUEm1H2lraZL6QgLBmIGPC5PhAYE6odNBR910IDszY8M8g0Eihvk
-        29El/CD43vvDJ58Y3f8vGGTK6rR50+7f98PSH/Z8kdDip6eeo2j5Onj3/P40
-        m0xn1D0SgtP7+fZBRor43sOd89mD++ezTycTXwf/f8U4f7p7b38nn+1sz+7f
-        o2Bv9nC2PTmf7G9n2cHu/r29vfMH94Joi4xsaMMISCCXHl547MQPmzpB5O7/
-        K2afLHI4PPpgCO8PYQ95MHHRGZUHX99yXuWhF4zNFcWM9mqiAxdLHq/5e5lo
-        IpefmaXGPdSp1Q97WjtYuWnt6VyjndzzEWFJbEEI/79hJF2vw3uNcCA8f5Qr
-        /qHORwwpeqPHXZbA+osZv8XeKsP6Aq/u+sbm52hQnhaMIOWruIf39u8dfHqw
-        v/1wukdh3PT+w+2De9nO9t5enu8+yCbZ3mzfV3H/X7GAu/fzg/3zB5PtvQef
-        3tvevzd9SOHpvQfbB5N79+5le/nezuQ8ANA1EQTkVhawT195/l809WTtwrHZ
-        b3pIfwhryINJi86mPPj6lnMqD71gzJmYALQn67dH1m//4cb2/18xf6DIwKSS
-        OiqLwPyZqdvWr1aeqpLHKCj3fERMSOxBlOvNB335zTHqPD/ffllXs4182rOD
-        9i3CgLDcYAb7A6PJXmT1NQ2grdc2XpFH9bU83h++vRNT+HNoJk0jxc+8ZRHp
-        6hnPYf0GJ+4DNYyPlK9BJp+e5/fuZ7Tm9OD+ZHt/d3ZvO/s0298+n03y3YfT
-        2e7kPFhz+v+Kcfn0wf7e9P55tj27t7dPa2nnD7azycHu9sMHs4cPpg8f3jvf
-        80hCALoKmIC8j3EJgOH5f9HUDxqXPtIfwhryYNKisykPvr7lnMpDLxhjIQoW
-        7dW4+EkD83jt//9sXHZ/ZFzowWT//DIue451v8GJux0z0uTgZ1/D+Ej5GiR/
-        cH86e7hHSyf3H0zJPX24R0p49nA7e3j/fpbt5wfk4fsa5P8rxoUU4M5sNru/
-        Pdt/iNzdg53tg/z80+29h/leNjvf+XT3/jcauXj0lef/RVM/aFz6SH8Ia8iD
-        SYvOpjz4+pZzKg+9YIyFKFi0N8alZx2D9v9/Ni57PzIu9GCy/79gXBbZVGeQ
-        Wn20s7O983T73vE2uQjHD7Z37vnsuMEQ+a3CgfvfKH2/yKbzYgnpCgf1zc32
-        Zg7Wr810KzqOf73ZtXOjvxjSWcQ7ytZTW9/ccKaC7+UiPhxl10Et6+PkK9GH
-        0wez3XvTve1PH3z6gIKcB+dkhwif3YPsIa0iZdnOdOor0f+v2Nf7n+7f+3Tn
-        03z73qefkn3dnz7YfkjJwu3Jwf69fLK3t7s3mwQAujaIgLyHffXIK8//eyZ+
-        yLr2Uf4QvpAHMxadSnnw9S0nVB56wRhLp57UuO4fbGz//2bjessp7WDlpvRH
-        tpUezLVnYsKvVVPL4/3hG0mxnz+HtvUZ2dZjnxv/P2Nbb2Dgzbb165nWZpVP
-        t5fF1MvXfHPjUYSHfAXl14iOjWHlq9G9ab43O5gebB/cf0BqdA/hyb2Mlljy
-        ezuz6e6nOw/CGOX/M+b14OF0d+cBpUV3ZrsUgE0m2w/3Dh5sT7IH559+Ot1/
-        SHQOAHSNEAG5lXktVlN+rxdJ/b9p8vsmdhjtD+EOeTBv0QmVB1/fclrloReM
-        0XR6iows/ru/sfl72ViaKCIhtelhTF/+sCdTNZP+qVP5ky9O39wlFAjN5u5r
-        /rm96ykreYyKcg+JXzZ7kpXZcprXT7Lp23w5U1K+rKoS9Ax4XZ4IGQjUD5sQ
-        PupKhudP7k76g7irA8MffaIQWbofhTYTT0Cns+WkWi9nL7L21bpkTv7/GI2K
-        cAB3Xz19uf2TX+zcijThB8H33h8+BcUh+Vl3Vm7ngKj0qF2nFiE639z8fPnF
-        y6/enP7kF6+j86PTZ4RZ0dEZCqfCUlV/MYO2iFuDwy+TUvc09zc4IME4ynA0
-        IMNwpHjwM2JqfKx8S5Ll9x/cv5fNtim8pYW2fUqIZrP9/e3Jw4NPP713b29G
-        i5W+Jfn/ip/xYGd2f+f+/b3tvb1z+BkU0E9me+fbDye757v5vf3z89xzvQhA
-        1xITkECveHjhsdM+bLAFkbv/b5h8civC0dEHQ2h/CHfIg3mLTqg8+PqW0yoP
-        vWAcB7EraK9+xv7G5j/yM/gh8XOGSM2xkhJWGfQMeF2eCBkI1A+bED7qSgay
-        oT/yM26mUdzPuB1pwg+C770/fAqKL/EjP8OfH50+I8yKjs5QOBWWqvqLGbRF
-        3BqcywXnQjzr9Q2ORxC+id9I7+CnZ2kiSPl2hHK+9x+cTwiXB58+3N6f3Mu2
-        s5x+29mf7OUPJ9NPPz2479uRnw0vg9ABZ/1iQ1n6iMYYtVP44pYW6iNLQXU8
-        dmf3d3em5zS23ZyyHLv3yPHYu/+AZuHhND+f7N/fPQ9sFjkQoWkmIIGi8fDC
-        s4EP5Pl/ETeQlxGOzX7TQ/pDuEUeTFp0NuXB17ecU3noBeNGiJVBe/I6sIRA
-        q3yb2v+/0e2wCXOmw8BUqqLSP/23CAPC8v+PafZhi2IaKX7mLYtIRxT9daVv
-        cOI+TAgDpHwh2z/Yn50fTKbb9/LsnISMAqSDLN/Zns0e5vv0/517k4kvZD8b
-        KpkGFJVYfHFLWf3Ikkv1b/Zp9ul0tptvP3h4/9Pt/Qfn97eznXNSwrt7FAru
-        39u7Pwling/Uvz595fl/0dQP6d8I0h/CGvJg0qKzKQ++vuWcykMvGH3a07/7
-        PQMStH8v/atLol4vPdyp1Q97UjtYeZP6ozVcejDZP7+My0PHut/gxN2OGWly
-        8LOvYXykfA0y29v/NL8/29ueTpA3Oqf1vof39u9tnz+Y7Tw42MsfPJjOfA3y
-        /xnjMrtPaa9Jtn3w6YSMy8E03354/3yyTWPN7+/v7ua7+5MAQFcBE5D3MS4e
-        feX5f9HUDxqXPtIfwhryYNKisykPvr7lnMpDLxhjIQoW7cm44L9v0rlXXe31
-        0sOdWv2wJ7WDlTep/280LrcbU8+6uNcIB8LzR+aFHotIR9Pc9xyqH/rU0eTg
-        Z0/HBEj5OuTB+ad79x5m97c/fUhrE/s5+RHZwX62/WByfzK59/DTyfn5Q1+H
-        /H/FvDzMSSd+Oru3vbt3jxzvbOfB9mRnZ2/73v7+pw+mn06z3d1v0rz49JXn
-        /0VTP2ReIkh/CGvIg0mLzqY8+PqWcyoPvWDMhahYtCfzwrFLEH7K47X//7F5
-        ub/z/0bzYqOQTUPqWRf7FmFAWH6IcQkGp/paHu8P30qIAbHGJSCPfOcMh/ca
-        fflzZFzuOdb95iZuKsx4udjMjDQ5+NnXMD5SgQa5R8nmBwcHlHPeJR9//9Pp
-        9iT/dG/7wf379w8eTPZ2s08DDfL/FeMyyx4+nE33c0rj3Nvd3t/LDrYP8t2M
-        suoP9vcm53v39x4Eju+HGhePvvL8v2jqB41LH+kPYQ15MGnR2ZQHX99yTuWh
-        F4yxEAWL9sa4BFMoj9f+/83G5ZaT2sHKm9QfGRd6MNk/vyKXTx3rfnMTd0tm
-        pMnBz76G8ZHyNUj26cE90hiEy4Sc+/17s3w7y/LJ9nT/3sP7+ezB/b2H93wN
-        8v8V47K/c36wv/Pw4fb5Q1rr3idFuT2ZTe/RIvjD3dn5/kG2ey9wez/UuHj0
-        lef/RVM/aFz6SH8Ia8iDSYvOpjz4+pZzKg+9YIyFKFi0N8Zlf2P7/z8bl09/
-        ZFzowWT//8u44AdB+SX/D8Q9sUVEjQAA
+        XQC57979fT/69OH0YPfBp9n2+f29c8Lo3nQ7+/T+ZHvn/PzB+exgMtnPZ7/v
+        R97L7fWKB34LDLy3ymqagQR4M8+adu1/ScNa5XVb0BuPHInli8uiodeK5cXr
+        Nmu549fr6TTPZ/nMQaCmlmhrIfwk353tzfYn29m9ven2Pg1ye3K+M9vevffg
+        03sPH2R7s0keAChWJ9XyvLhY14woUNFJl8fDC49lgGI15fd2fWh4/l/HAXe7
+        Q6QPhnD/EBaRB5MXnVV58PUt51YeeqG4pGZnL49nMyIQoH60uzPGf/c3Ni8N
+        832Rt/OKJ+XpNU1fMY28RrNFdKQ2PYzpyx/2jF4WdbvOSv0zeI1wIDybu7P8
+        PFuX7UddbH9J+EHwp/fH9z0KfDRbNq/ztqUJAXEDAsh34CR89T3/NfoyW63K
+        Ip89Ddu4Jr/Ea/5RvswmJc3Ls6q+yuoZ9Uatz7Oyyf1WNDiM+XU+XddFe810
+        o3YhUj/s+YghRe3OfkLf3/WmIRizTuQX2XReLMHpP1vj+PKLl1+9Of3JL15H
+        x6FoGr5SdAI94Y/A/Kq/mBFZ3K0OnJbVmiayaA+cRH2DgxKsbzk5vvqLoeVr
+        tvz8wc704acPtz/d3c0Im08n2w/z7MH2w8nswe5Bvnee5VNfs/1sGD9CB+Ly
+        iw116SMaZVRz4otb6syPLA3VHk7PD/J79L/tnfsHpMT3J9Ptg/x8un3+MM8f
+        7GX7WbbnUYkAdI0FAbmVPYwRXZ7/V3EE2b5wfN53PcQ/hGfkwdRF51QefH3L
+        mZWHXjDmrWcNw4mUx2v/89Mc9odGFFlk9TUNoa3Xefi1ajx5vD98uycm8efQ
+        XJpGip95yyLiRFIZ+1M3wT/0uaPZwU9fFiNY+YJ2MM0/fbiz++n2vQNCYT/7
+        9MH25ODBbPs833/4cO9e9ul5NvEF7WdDOdOIolKLL24prx9Zeqkmfnjw8NP9
+        7OF0+/75g3vb+w/yne1JnhGlSRFPzsnZ3r+/EwDoaioCcjtN3CewPP9vmvyI
+        HjZf9dD+EO6QB/MWnVB58PUtp1UeesGo1b4a7g0gaP9eani1npTFlN6yvfRw
+        p1Y/7GntYOVP67Z+t7qNJiaEiUMI9/83DOpHRubrGZm8Xt3f8QLxH/rE0dTg
+        p6dkeij5CmTv3vn+3sODve17e5O97f297N72we7BdPvBg4Ps4b1P853dyUNf
+        gfx/xbx8mu1+OnswO9i+/zAnxbhzPtt+OM3oz53Jp/dnn07J1nwz5mU4eSSI
+        3P05n/m+bRnG+UNYQx5MWnQ25cHXt5xTeegFYytEv6K92pZv0MNXRe110kOd
+        Wv2wp7SDFU3p6auXt1G4hCGxAyH7/4ZRfIgtCT8I/vT+8JW+2IOfQ1vht6LB
+        YcxBqozahUj9sOcjhlSXs4Kx6gRqooyQ/bnBX782/KTo9DA3v+ovZiQWZ6u6
+        F8Uv2nuw98Bpgx/aSDoz4ansPk6+Sv700+nsYfZwb/tg5/7+9v79yf1tWsS5
+        vz3LZlNS0Nn53sN7vkr+/4q13p/mD+7t79/fnu5M72/v52Sys08pQfcwm32a
+        59n0wf6e58AQgK5JIyD/n7fWOvVkncOx0QdDSH8Ib8iDWYtOpzz4+paTKg+9
+        YOyv2Cy0V3P9cGPz/1+aa1oU2fN0kzxGI7nnI0KRGIKw/X/DMFS/8p8/stf/
+        b7XXHdYKBqszqBaSsP25GYB+bRhK0aEWHdTNr/qLGYpF2qpvUpFTgbm7v+cl
+        ln5oI+pMSai946j5Onr3QXbv4H72cJu0M9m5h9n59uThbEa4Taaz3d3Jg3v3
+        c19H/3/Ffu89nOzN7u0hNszJ9pxP8+3J3qefbj+YZAfZg/ODT/d2//8fbYcc
+        QFY7HCJ9MIT7h7CIPJi86KzKg69vObfy0AvGLostQ3s14/sbm///1Yzru7ue
+        3pLHaCv3fESYEnsQ0v9vGI0qX/0zeI1wIDx/ZM1/qPMRQ4raRTksGLNOpFpR
+        QvrnZhz6teErRYdaxEdgftVfzIgs7la1O/W5d3D/nlMWP7SBdSYoqtk7qPmK
+        ey/fz+/le2T5dndIcX+aT7dphXN3++H+7sEDUrKTbOeBr7j/v2LbJ58e7N17
+        eJ+WGO9NPt3eP5gcbE/2idzTTz89yO6f38927v18su3gADLl4RDpgyHcP4RF
+        5MHkRWdVHnx9y7mVh14wxloMHNqrbfccV/N4zf9/btv9mEQeo63c8xFhSuxB
+        SP+/YTSqg/XP4DXCgfD8kW3/oc5HDClqF+UwS2T9xdDAjsAqxmUx9TTsz9Wg
+        PG3YQchXcfv7k/17O5MH2/c+fZhRJnef8Nh5+On2wcPJ/b17s73z8yxYNPz/
+        ihXMdiez2ex8Z/vePqVY97NPd7cn0yzf3t3Jp9PJp9P96e4kANA1EQTk//NW
+        EPNOpi4cGH0whPGHMIY8mLLoXMqDr285o/LQC8aYiQFAe7V932BcS3NE1KM2
+        PYzpyx/2PHaNxOL6J1+cvrlL/ROOzd3X/HPbd9rlMQrJPSR22exJVmbLaV4/
+        yaZv8+VM6fiyqkoQM+BxeSI0IFA/bCr4qIMGz5/cnfRHcFdHhT/6FCGadD8K
+        DR2egEhny0m1Xs5eZO2rdck8/P8lAhUh9ndfPX25/ZNf7NyKLuEHwffeHz75
+        xIX4OXQvTCPFz7xlEbE6mvSgp+x+6DNF4oqfoWL2EfL1bj75NHu4s5dt7316
+        sLO9P92jfOLs4XR77yA7OHjw4OHOQbbj693/zxjkfH9y7+HBbHv3we7B9v7e
+        g3tkkO8/2N7b3yVbcn//Pq0aBwC6douABLLo4YXHTvaweRNE7v4czzvZ33Bg
+        9MEQxh/CGPJgyqJzKQ++vuWMykMvGAsrahjt1SAHS/7yeM1/ZJAJdV9pq+lS
+        OsKCgZgBj8sToQGB+mFTwUcdNCB78yODfAOB4gb5dnQJPzDf06/BHz75YHT/
+        v2GQKavT5k27f98PS3/Y80VCi5+eeo6i5evg3fP704zW9ah7JASn9/Ptg4wU
+        8b2HO+ezB/fPZ59OJr4O/v+Kcf50997+Tj7b2Z7dv0fB3uzhbHtyPtnfzrKD
+        3f17e3vnD+4F0RYZ2dCGEZBALj288NiJHzZ1gsjd/1fMPlnkcHj0wRDeH8Ie
+        8mDiojMqD76+5bzKQy8YmyuKGe3VRAculjxe8/cy0UQuPzNLjXuoU6sf9rR2
+        sHLT2tO5Rju55yPCktiCEP5/w0i6Xof3GuFAeP4oV/xDnY8YUvRGj7ssgfUX
+        M36LvVWG9cWup1V/rgbkacAOQr5q23nw6X62s7O/vXt/d7K9f37vfPtgsvtg
+        +8Heg4d7ZCN2p7sHvmr72bB8hA6Y6xcbitJHNL6o6sQXt1SaH1nqqTGcTfLz
+        B6Sttz+d3qfU8cNdSh0fzO5tnz842Dt/+DC7t78XmAEyaqG1ICC3MoYhueX5
+        fwkXkMELx8Sf9pD9EA6RBxMVnUF58PUt51EeesFYM7EAaE/Gb4+M3/17G9u/
+        l/Wj+SHKUZseyvTlNzeH8/x8+2VdzTZOYc9S2LcIA8Jyg6HoD4zoscjqaxpA
+        W6+tRy+PajR5vD98iyDG4ufQkJhGip95yyLiiR80967v639zE/f1ha+HlC9k
+        +zu703v72f52vnP+cHv/009zWpX59P52/nDv4ae7O5OHn+7d84Xs/8NqePd+
+        frB//mCyvffg03vb+/emDylheO8BKZV79+5le/nezuQ8ANBVWQTklmq4S3J5
+        /l/EDTF1LN/0kP4QbpEHkxadTXnw9S3nVB56wajYnkref7ix/Y9UMj2gx88v
+        ley5V9/gxH2gEPpIBUJGUnb/3t697fv3H5CQzfb3aI38nNbNp3sH92bZ/oMH
+        9859Ifv/sEr+9MH+3vT+ebY9u7e3v71PbvJ2NjnY3X74YPbwwfThw3vn35hn
+        3CW5PP8v4oZBldxH+kO4RR5MWnQ25cHXt5xTeegFo2J7KtlPfprHa/8jlUwP
+        6PHzSyXvudn9BifuA4XQR8oXsukkO/8025sSBruUh8129razfVo0nWb79+5n
+        5/n9e/ce+EL2/2GVTMmKndlsdn97tv8QmfsHO9sH+fmn23sP871sdr7z6e79
+        b9RL9kguz/+LuGFQJfeR/hBukQeTFp1NefD1LedUHnrBqNi+Su7ZlKD9j1Qy
+        PaDHzy+V/Kmb3W9w4j5QCH2kfCHL7+cPd/cnn24/mB6c09JYdrBN4SeF9NmD
+        6e69T/cn9/IgO/j/YZV8nzTxvU93zrcn9zNy8c4f3ts+uPdgup3vH3w6u//p
+        3v3sXrAM96Eq2SN5muJ//y/ihkGV3Ef6Q7hFHkxadDblwde3nFN56AWjYvsq
+        +f7G9j9SyfSAHj+/VLKXzfoGJ+4DhdBHyhcy6uvT+/v5p9t5Rqs2+/ce3N/O
+        ppODbXIZp59O9nbPd3Y/9YXs/8Mq+eH+wwf3du/tbe9Md2lJb0oJ5cnOzs72
+        vf393Z3ZOaUudgIf8UNVskdyef5fxA2DKrmP9IdwizyYtOhsyoOvbzmn8tAL
+        RsUGKhn/9UxK0Pz/jRr5dlPZVcmL6598cfrmLvVPODZ3X/PP7d0fKWR6OoLo
+        CfU3N21TmbbLxeZpo0nBz54E+jj5AvZwN7+/s3vw6fb9gwNa7/r0/mT7IPt0
+        n/78NNs92Jud5+dTX8D+P6yO73+6Tw4yrUbd+/RTSlrsTx9sP6TVvu3Jwf69
+        fLK3t7s3mwQAuiqLgLyHOvYoLs//e3hhSBn3Uf4QVpEHMxadSnnw9S0nVB56
+        wSjXQBfDPd4/2Nj+/43K2Dq6TIeBiezqYvcWYUBY/sg9psci0pVDb2XhG5w4
+        EcGbrChNDn72RdBHyheyezs7D6fn93a2d/OMcNk/P98+eLBzbzt/cD/f33uw
+        T3IWLJ7/f1gfH+wf7E/vT2bb03v3KQN6L5tsT/Zns+179z/N9z6dfHqw+3A/
+        ANDVWgTkffSxR3J5/l/EDYMauY/0h3CLPJi06GzKg69vOafy0AtGxfZU8v3/
+        7/nHVrkyHQam8kcq+UNUsrey8A1O3AcKoY+UL2T3s9l098FBtr27T8s1+9OD
+        /e3s/H5Oi133swf3ZwcPaQndF7KfDZVMA4pKLL64pax+ZMml+vfhbHcvmz7M
+        t2f3p+TP7d+bbk8m+Wz7fHJvuvcpIuvdbzJj7NNXnv8XTf2g/u0j/SGsIQ8m
+        LTqb8uDrW86pPPSC0aeB/sV/u99gxni1npTFlN6yvfRwp1Y/7EntYOVN6rZ+
+        tbqNDiZ8iT0I9f83jKlnXdxrhAPh+SPzQo9FpKtpvDj2hz51NDn42dcxPlKB
+        Djmf7D/89P75djb7lLLEs4cT+m26t509nGTkA+/t3ju47+uQ/6+Yl/39/YeU
+        /863s/3dB6Qbz3e3Dz7d/XR7b2+yO7v3KY1rmgUAuiqYgLyPefHoK8//i6Z+
+        0Lz0kf4Q1pAHkxadTXnw9S3nVB56wZgLUbFor+YlcBDk8Zr//9m67P3/x7os
+        rj80tU/4/zwxLV5G4oc+b8RB+NnXLz5Svv6Y7Rzc+/TebH/7fOcBqeCHD6fb
+        D6efzrb37+9NJgf3yfe/f+7rj58N00LoYGp+tpNJOzu7k/tYZj3I94jsu+SE
+        Tz6dPdzevf9gb3f/3v69h9k3mtz3SC7P/4u4YdDa9JH+EG6RB5MWnU158PUt
+        51QeesGYD1G5aK/WJoxH5fHav5e5oXkiClKbHsr05Q97Lrsa2XuNcCA8f+Tv
+        02MR6QqjF+P+0KeOJgc/+2LoI+WL2cPz3Vm+++Cc5Grn4fb++T75xeckdXuz
+        3QfTh9n0fDad+GL2/2GlPNnf/3TnwYTWWfNzIvu9+w+3D+5TtiTPJzs7pJcf
+        TA7yAEBXcRGQ91HKHsnl+X8RNwwq5T7SH8It8mDSorMpD76+5ZzKQy8YJdtX
+        yv/fW3S93Vz+SCl/kFL2Fn5+6FNHk4OffTH0kfLF7NO9SbY73bu/PTsgNPYz
+        8n0mO+fZ9jTfm+T39u7fu3/w0Bez/w8r5Qezyd6n+9m97enBbkZp/3PKJ5zn
+        e9u72f6D80+zvfODTx8GALqKi4C8j1L2SC7P/4u4YVAp95H+EG6RB5MWnU15
+        8PUt51QeesEo2b5SDqZQHq/9j5QyP6DIzy+l7AVQP/Spo8nBz74Y+kj5Yrab
+        75I6ekgx/b190lSzB7PtLNubbN97QIuTO/dmB5/u7fli9v9hpZzlB5/Osk8/
+        3Z7eozz5/uRgd/thtp9vn3+6d//+7r2dew93g1Txhyplj+Ty/L+IGwaVch/p
+        D+EWeTBp0dmUB1/fck7loReMku0p5b2dje1/pJT5AUV+fillL4D6oU8dTQ5+
+        9sXQR8oXswnlUrPsIbk9++cUlZ7v3Nt++PD+dPv8fk6O0P5kcm8arEn9f1gp
+        T88n+YM8O98+Jypv7+9NSKNgBfN8undviqB8dxqopA9Vyh7J5fl/ETcMKuU+
+        0h/CLfJg0qKzKQ++vuWcykMvGCXbV8q7G9v/SCnzA4r8PFHKzSqfbi+LqWes
+        f+hzR7ODn54cxrDyBe3BwQ4tdz3Itu9/OiNddTDJtx/uTEnkHn766YPz2YPs
+        YT7zBe1nQy3TiKJSiy9uKa8fWXqpDqZIerq782Cf6Dsjx/j+ZLL9cO/gwfYk
+        o2TFp9P9h0TnAEBXTxGQW+ngYjXl93rq4P9Nk9/XwsNofwh3yIN5i06oPPha
+        p/WmaZWHXjBqtaeGe1nwoPn/f7QwT+VPvjh9c5dQIDSbu6/55/bubbRwWWWz
+        J1mZLad5/SSbvs2XMyXly6oqQc+A1+WJkIFA/bAJ4aOuZHj+5O6kP4i7OjD8
+        0ScKkaX7UWgv8AR0OltOqvVy9iJrX61L5uT/j9GoCAdw99XTl9s/+cXOrUgT
+        fhB87/3hU1CM8c+hofZbqfR8kU3nxRLqJUTnm5ufL794+dWb05/84nV0fnT6
+        jDArOjpD4VRYquovZtAWcWtw+GVS6p7m/gYHJBjfxHCkePAzYmp8rHxLkucP
+        9mZZNtl+8OAeWZKH59Pthw8e7m5T4vuAVnTvZff2d3xL8v8VP+PBzuz+zv37
+        e9t7e0jA3f80357M9s63H052z3fzexS95J7rRQC6lpiABHrFwwuPnfZhgy2I
+        3P1/w+STWxGOjj4YQvtDuEMezFt0QuXB17ecVnnoBeM4iF1Be/Uz9jc2/5Gf
+        wQ+JnzNEao6VlLDKoGfA6/JEyECgftiE8FFXMpAN/ZGfcTON4n7G7UgTfhB8
+        7/3hU1B8iR/5Gf786PQZYVZ0dIbCqbBU1V/MoC3i1uCsJ+sl2U8m1e7uPS9f
+        9w2OSxC/ie9I/+CnZ3E2IOfblb39yb296YN72/TWQ1oeyz/dzg528+3dyacH
+        kwefPswowPXtyv9nvI7Z+XRnn5b9Ds4PaM1qj1b8Hj7YpRzpPcp07E7PH57v
+        3gsAdO0yAQm0jIcXHssEw+ZbELn7/yIeIF8jHCR9MIT9hzCJPJi+6LzKg69v
+        Obvy0AvGmxBjg/bqfOwFa7jyeO3fy/tYrSdlMaW3bC893KnVD3t2O1h1Z9dT
+        YPIYteWejwhX4hFC+/8N41FNrH8GrxEOhOfPryS634oGD5q8zqfrumivma7U
+        LkTqhz1fMaSGedCSWX8xVLBjsPrzcsGLXV4I+HM1NE9xRpDy9eHOdHr/wfmE
+        cCHlR/rwXrad5fTbzv5kL384mX766UGw9vazYTQJHbDaz/ZK7e7s/i7ls2ls
+        uzktFezeo+h97/4DmoWH0/x8sn9/9zwI/MgehiaGgNzKjvZJLs//i7iBrGU4
+        NvtND+kP4RZ5MGnR2ZQHX99yTuWhF4w1FAuC9mQ998h67n6D1pPmiShIbXoo
+        05ff3FzO8/Ptl3U12ziVPRtj3yIMCMufXybGNFL8zFsWkY4o7vshwzc3cR8m
+        hAFSvpDtH+zPzg8m0+17eUarbxPKMh5k+c72bPYw36f/79ybTHwh+9lQyTSg
+        qMTii1vK6keWXKp/s0+zT6cz8rUfPLz/6fb+g/P729nOOSnh3T3Kp+7f26No
+        JgDQ1VEE5D30r09fef5fNPVD+jeC9IewhjyYtOhsyoOvbzmn8tALRp/29O9+
+        z4AE7d9L/3biBGrcw51a/bAntYOVN6nb+tXqNjqY8CX2INR/dsdkzcSmIYlx
+        +dk2LjQw1dfyeH/4VkIMyP+HjMtDx7rf4MTdjhmJhfCzr2F8pHwNMtvb/zS/
+        P9vbnk7uTbb3zx/sI49E6ZAHs50HB3v5gwfTma9B/j9jXGb3P713b5JtH3w6
+        IeNyMKUk2f3zyTaNNb+/v7ub7+5PAgBdBUxA3se4ePSV5/9FUz9oXPpIfwhr
+        yINJi86mPPj6lnMqD71gjIUoWLQn44L/vknnXnW110sPd2r1w57UDlbepP6/
+        0bjcbkw96+JeIxwIzx/FLvRYRDqa5r7nUP3Qp44mBz97OiZAytchD84/3bv3
+        MLu/TZl0WtvPyfvIDvaz7QeT+5PJvYefTs7PH/o65P8r5uVhTjrx09m97d29
+        e+R4ZzsPtic7O3vb9/b3P30w/XSa7e5+k+bFp688/y+a+iHzEkH6Q1hDHkxa
+        dDblwde3nFN56AVjLkTFoj2ZF45dgvBTHq/9/4/Ny/2d/zealx/FLq6Jj+w3
+        aFy8heNvbuKmwoyXi83MSJODn30N4yMVaJB7lGx+cHBAOedd8vH3P51u0/rt
+        3vaD+/fvHzyY7O1mnwYa5P8rxmWWPXw4m9Ky/mx2b3d7fy872D7IdzPKqj/Y
+        35uc793fexA4vh9qXDz6yvP/oqkfNC59pD+ENeTBpEVnUx58fcs5lYdeMMZC
+        FCzaG+MSTKE8Xvv/NxuXW05qBytvUn9kXOjBZP/8Mi6fOtb95ibulsxIk4Of
+        fQ3jI+VrkOzTg3ukMQiXCTn3+/dm+XaW5ZPt6f69h/fz2YP7ew/v+Rrk/yvG
+        ZX/n/GB/5+HD7fOHtNa9T4pyezKb3qNF8Ie7s/P9g2z3XuD2fqhx8egrz/+L
+        pn7QuPSR/hDWkAeTFp1NefD1LedUHnrBGAtRsGhvjMv+xvb/fzYun/7IuNCD
+        yf7/l3HBD4LyS/4f5l00rjbaAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:02 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -879,7 +986,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -898,17 +1005,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14994'
       X-Ms-Request-Id:
-      - 116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      - 125e86cb-2eb6-454c-8eb6-a6bb119b6320
       X-Ms-Correlation-Request-Id:
-      - 116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      - 125e86cb-2eb6-454c-8eb6-a6bb119b6320
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134903Z:116f0a63-4ceb-4f1c-83e0-46e1fe673875
+      - NORTHCENTRALUS:20160203T141901Z:125e86cb-2eb6-454c-8eb6-a6bb119b6320
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:02 GMT
+      - Wed, 03 Feb 2016 14:19:01 GMT
       Content-Length:
       - '133'
     body:
@@ -918,10 +1025,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:03 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -935,7 +1042,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -954,17 +1061,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - f36bfffe-686f-4031-8da0-f102c8c52ef9
+      - aa465654-d854-4936-8d39-da2a288b21d6
       X-Ms-Correlation-Request-Id:
-      - f36bfffe-686f-4031-8da0-f102c8c52ef9
+      - aa465654-d854-4936-8d39-da2a288b21d6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134904Z:f36bfffe-686f-4031-8da0-f102c8c52ef9
+      - NORTHCENTRALUS:20160203T141902Z:aa465654-d854-4936-8d39-da2a288b21d6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:03 GMT
+      - Wed, 03 Feb 2016 14:19:01 GMT
       Content-Length:
       - '133'
     body:
@@ -974,10 +1081,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:04 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -991,7 +1098,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1012,20 +1119,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 097237de-ae5e-46c6-a052-ae18f09babdf
+      - a76bbaed-e3ce-405b-8f50-01e8932305c4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 4dcad710-60b5-49f0-bb24-0d9d6880221c
+      - 912f009a-2c10-48a2-81ec-543274832ce9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134904Z:4dcad710-60b5-49f0-bb24-0d9d6880221c
+      - NORTHCENTRALUS:20160203T141902Z:912f009a-2c10-48a2-81ec-543274832ce9
       Date:
-      - Tue, 19 Jan 2016 13:49:03 GMT
+      - Wed, 03 Feb 2016 14:19:02 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1050,10 +1157,10 @@ http_interactions:
         +f8fbd0XZz/hKSV5jCpyz0eEIHED4fr/gkH8yNb5doXahUj9kGcjhhO1C9jK
         0lZ/4R9Eil/y/wDYpcgf7g0AAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:04 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure2/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1067,7 +1174,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1086,17 +1193,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - 5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      - ba50c0a8-6550-4283-b143-fff0be36e48e
       X-Ms-Correlation-Request-Id:
-      - 5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      - ba50c0a8-6550-4283-b143-fff0be36e48e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134905Z:5a7a623b-2d30-41e3-93e7-c870d9b5ce6e
+      - NORTHCENTRALUS:20160203T141903Z:ba50c0a8-6550-4283-b143-fff0be36e48e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:04 GMT
+      - Wed, 03 Feb 2016 14:19:02 GMT
       Content-Length:
       - '133'
     body:
@@ -1106,10 +1213,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:05 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/MIQVM1/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1123,7 +1230,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1144,20 +1251,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3fb3b155-4389-44d3-aa3c-28040b85648e
+      - fc3a3e8b-3162-4084-a81f-db3f14f04430
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - d242aea1-16f2-4d57-a608-328f4521d3af
+      - 589bcd9b-3101-4785-9622-bb9a4614d4bf
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134905Z:d242aea1-16f2-4d57-a608-328f4521d3af
+      - NORTHCENTRALUS:20160203T141903Z:589bcd9b-3101-4785-9622-bb9a4614d4bf
       Date:
-      - Tue, 19 Jan 2016 13:49:05 GMT
+      - Wed, 03 Feb 2016 14:19:03 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1177,10 +1284,10 @@ http_interactions:
         8f/0/vi+B+aj2bJ5nbctsWJvwuW7+pLGQV99z3+NvsxWq7LIZ0/DNq6Jj+xH
         +TKblMSQz6r6Kqtn1Bu1Ps/KxqKs+PEPgvJL/h9jtFhWaQYAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:06 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Network/networkInterfaces?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1194,7 +1301,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1215,20 +1322,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4e011c08-8d6d-4a76-b703-1cd42a78b16d
+      - 04ca378f-f4d3-4bcb-a504-569163510de2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 91175de5-5526-45aa-b198-ec2300e0a344
+      - 8de88c0d-b086-4dbb-a7ed-5f850be52380
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134906Z:91175de5-5526-45aa-b198-ec2300e0a344
+      - NORTHCENTRALUS:20160203T141904Z:8de88c0d-b086-4dbb-a7ed-5f850be52380
       Date:
-      - Tue, 19 Jan 2016 13:49:06 GMT
+      - Wed, 03 Feb 2016 14:19:03 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1238,27 +1345,27 @@ http_interactions:
         5x81WZk351U9zdfNwcFHI9ugmOHru8160kzrYtUW1bK5u//p3vledn6wnX/6
         IN/e35l+uv3wfHK+vbN3sLc/253N9g/u363zploTwM/rar1q7r74fV59fndV
         V5fFLK+bu18U07pqqvN2/CJvr6r67d2l/Dxbtnl9nk3z5u4gUnmbXQCt7979
-        fT/aeXhvOtmfnm8/yHZ3t/ezew+3Jw9397f396cH5w8nD+59Otn5fT/yXm6v
-        VzzkW2DgvVVW0wyDx5t51rRr/0sa1iqv24LeeOSIK19cFg29ViwvXrdZyx2/
-        Xk+neT7LZw4CNbXkWgvJJ9lePr3/MNue3bt/sL0/259t0wB3t6e7+b0H93Y+
-        nTyc7AUAitVJtTwvLtY1IwpUdLrl8fDCY6e+WE35vV0fGp7/F8393e7g6IMh
-        rD+EOeTBtEXnUx58fctZlYdeKC6p2dnL49mMSAOoH+3ujPfGO+NPNzYvDdt9
-        kbfziqfj6TVNXDGNvbaelMWU3rKd9FCnVj+8Se3gQ5P62k7qV6/PXn7Uxe6X
-        9MdEaBJvEMY/q0M5mefn2y/rarZxPJdF3a6zUv/03yIMCMvm7iw/z9Zl2x9Y
-        +EHwp/fH973xfzRbNq/ztiUW682kfFdfEpr01ff81+jLbLUqi3z2NGzjmvhU
-        /ihfZpOSOO1ZVV9l9Yx6o9bnWdnkfisaHIb8Op+u66K9ZqpRuxCpb242qsVq
-        3eY/+UWzcTpiSFG7s5/Q93e9aQjGrPP4RTadF0vI7s/SOAYFRBE0DKWIhOLh
-        I29+1V/MYCzaVpVfLtq8ae95OuWHMJrOfHg6PIKOr5wPPp3tfLr76f3thxn9
-        s3++M9t+OPl0un2wn+3u7z78dLb34J6vnP+/YrnJsOx+Onvw6fZevkPjOshm
-        25N7n+Zkgz59mO/vPXx4fu9BAKBr3AjIrSx3n77y/L9i0slCh6Oy3/TQ/RCm
-        kAfTFZ1HefD1LWdTHnrBmGAxXmivFnvv4cb2/z8z2WbStvWrlaeY5DHqyD0f
-        EabEGIT0z+ponP3dNCRVsvqn/xZhQFhusNr9gdE0L7L6mgbQ1us8/Fq1szze
-        H755Fsv9c2jVTSPFj38QlF/y/wDVYguvJw4AAA==
+        fT/a2bk/meTZZHv68CHhcrA73X64f5Bt7+YHu5P8093zBw8f/r4feS+31yse
+        8i0w8N4qq2mGwePNPGvatf8lDWuV121BbzxyxJUvLouGXiuWF6/brOWOX6+n
+        0zyf5TMHgZpacq2F5JNsL5/ef5htz+7dP9jen+3PtrPd3d3t6W5+78G9nU8n
+        Dyd7AYBidVItz4uLdc2IAhWdbnk8vPDYqS9WU35v14eG5/9Fc3+3Ozj6YAjr
+        D2EOeTBt0fmUB1/fclbloReKS2p29vJ4NiPSAOpHuzvjvfHO+NONzUvDdl/k
+        7bzi6Xh6TRNXTGOvrSdlMaW3bCc91KnVD29SO/jQpL62k/rV67OXH3Wx+yX9
+        MRGaxBuE8c/qUE7m+fn2y7qabRzPZVG366zUP/23CAPCsrk7y8+zddn2BxZ+
+        EPzp/fF9b/wfzZbN67xticV6Mynf1ZeEJn31Pf81+jJbrcoinz0N27gmPpU/
+        ypfZpCROe1bVV1k9o96o9XlWNrnfigaHIb/Op+u6aK+ZatQuROqbm41qsVq3
+        +U9+0WycjhhS1O7sJ/T9XW8agjHrPH6RTefFErL7szSOQQFRBA1DKSKhePjI
+        m1/1FzMYi7ZV5ZeLNm/ae55O+SGMpjMfng6PoOMr54NPZzuf7n56f/thRv/s
+        n+/Mth9OPp1uH+xnu/u7Dz+d7T245yvn/69Y7vOHk91PZw8+3d7Ld2hcB9ls
+        e3Lv03z7Qfbpw3x/7+HD83sPAgBd40ZAbmW5+/SV5/8Vk04WOhyV/aaH7ocw
+        hTyYrug8yoOvbzmb8tALxgSL8UJ7tdh7Dze2//+ZyTaTtq1frTzFJI9RR+75
+        iDAlxiCkf1ZH4+zvpiGpktU//bcIA8Jyg9XuD4ymeZHV1zSAtl7n4deqneXx
+        /vDNs1jun0OrbhopfvyDoPyS/wcDBglAJw4AAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:06 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -1272,7 +1379,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1295,20 +1402,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 8ba2a572-cab6-4378-b1d9-a52400f2caa0
+      - 8ec9824c-56af-46f4-a373-73c78a8923c6
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - f7ec23cf-a076-45f1-b7c0-a6c25b45a401
+      - 12c90380-5a69-4fc7-91d3-d40a46de34cc
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134907Z:f7ec23cf-a076-45f1-b7c0-a6c25b45a401
+      - NORTHCENTRALUS:20160203T141905Z:12c90380-5a69-4fc7-91d3-d40a46de34cc
       Date:
-      - Tue, 19 Jan 2016 13:49:07 GMT
+      - Wed, 03 Feb 2016 14:19:05 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1335,10 +1442,10 @@ http_interactions:
         BuP18rXHcu/hbqh0/bF8ozNz/HDDUL6Redk4llvMy/sMZnfTCp7phr762RnM
         NzsxG5Xy/7tmBj++/xsnv+T/AatCloxaIQAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:07 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1352,7 +1459,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1371,19 +1478,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14994'
       X-Ms-Request-Id:
-      - 74ebf8e4-23aa-442b-a1cc-70f132bfb55c
+      - 3053fa5e-1ca9-4ebf-acbd-a59ac7bed2a5
       X-Ms-Correlation-Request-Id:
-      - 74ebf8e4-23aa-442b-a1cc-70f132bfb55c
+      - 3053fa5e-1ca9-4ebf-acbd-a59ac7bed2a5
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134908Z:74ebf8e4-23aa-442b-a1cc-70f132bfb55c
+      - NORTHCENTRALUS:20160203T141905Z:3053fa5e-1ca9-4ebf-acbd-a59ac7bed2a5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:08 GMT
+      - Wed, 03 Feb 2016 14:19:05 GMT
       Content-Length:
-      - '1446'
+      - '2089'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1391,40 +1498,54 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
         qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLtrn7RTGtq6Y6b8cv8vaqqt+e
-        Ldu8Ps+m+fbezu79hw939/c/vXfw0eijZbYghD66/QurulrldVvkzUePfvFH
-        q6wmANSU/1p23n1B3+Hz9npFPz963dbF8oJgKBk+sshvv86n1XK2bd/86JeM
-        PiqraQbCbIKQZ027btCaSEndnxFZh1vfpUYfSu9qsVq3+U9+0dwlSlwWMxp6
-        n9x3L4u6XWel/hm8RjgQog3N13m2LlvgvqqLy6zNz14el2bQX+TtvNo4mKfX
-        NHfF9KNfQgAW1QwfnS2ndQ4OyEpqyPg1BIvee90SfGrxej2d5vksn9H3bbHI
-        mzZbrOhzTPL27s72zsM3uweP9j99tH9v/ODe/Yf79x/+FDWdrWvGilq+fHNv
-        vHvv0/2H9/Zf0zfTqq7zkr8E7T/am+1MHmSz+9sPJtn59v5ksrt9cH8n357e
-        P3h48PDB+cPdezv0GuMG2rEw0EDyZoVpj3AitTZz8IZIIW/4n9BLRFA0tezT
-        0EuGknjB8Mn3fwn9R8PJV/lyli+nzMXfo0+qdUvz80qh4kMV0R46d3t9ORmM
-        sPH3aXoUFGb+Q7nP9ETc46R9ik+B41VW52P5K68v8xq/Tq6rkmX4we7B7v17
-        B/f2iDYgOGGE79/vRZq3Qek3BMfvQ0yr80AsqxLyRTadF8vba4r+q6+LH1CL
-        4VeJ9ZezrJ79/sc7eDmbLYrlVzRMocHwe5O6WmYXc0a2aas6u8iPp9NqvWxv
-        QhbUI0LN7u/ucZeKrzLQTW8HQ+0y200vo+tt7lu61veJL9d10V4zG90EI0CA
-        yfUyaxoCQ0zs3gLEXN9Fu8usKLNJUVIvr/MbSXQcNt+LgHhJWuW8qhfPoCWf
-        VousWJ6A+pvA3tsA56vVjHTgLQHdB6Bw1kXVDL9i+ezzV6/x9qzILpZV0xbT
-        5nUA6CbaYA55CpV9BgG9L0bZbEb6pHlZ5+fFu00v7u6M98Y74527u5/iPdJb
-        xEc3oe3ZM3nhPfrZ28drq/WkLKZnq2PB86YOAz7tvHsTab6W8XxGfBW3nDsH
-        27sHb3YfPrr/6aN7++Odew8OHtz/tGc5dx98cf/h+OH9+/cPPv00Zj0fPnjw
-        YG9yb3872/+UbMLBvWw7e/Dw0+3Zp/cm55/eP588PH9ArzFyN1hP9TioNdGD
-        bQhoIm/4n9BLqp9Unw7bTjJkm9+861iVBK8l0r0PsI7cDr/KL8dHrQJCr/rA
-        8Xqvu1C6v1ZvqtHpVR82Xu/1ppTSN4Z7o746b5Ik4RVrAt7n3Y5UvNe72i8r
-        epoRNh3D79N/xOyhX/WL9YPmS2J/+uub94KsIERccMXf0U38JHqFjWM4Z4TY
-        LSB4L4lyYl1tQYKIP5wxqnDf7YrM3Z5ddRj3hjkExHtHR9mD+sMbqQr03Y60
-        8lxSezGSDuHeIAfe917RMQYAwcw/nPGZSVD9YDWpfcvDtDe4gZe9V3RwDhpm
-        7udCKgdQdW95SH8j4/x/zwxGrOJdYkVyQB3+tx1yBJYHpUsF7ebnas6NHtUx
-        6J/eWx7qPQJo6+7L3ivd0fI4f7gj69lX956H6ODYeq97L/2/YHRq/0IPwL3r
-        ITs4wigI78X+KH9octtB0Vl5ti3WqDtcbxqkg+C9pAMMQJKz9Eu+/0v+HzQA
-        b2cOFgAA
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLlj7NltWymGbl+KvJetmuX+f1
+        ZV7v7u3sP3/zentvZ/fT3V36/8Pdj0YfLbMFofTR+7yyqqtVXrdF3nz06Bd/
+        tMpqAtHmNf9VVtMMw8Hv7fUKoF+3dbG8oPd0+B/lWdOum49+CX1S1O06K7/I
+        pvNimb/IgMrwe2vGrGHM+m+/Ln5AjYbffpI1xfT3P97Bm9lsUSy/Ikgy+uGX
+        JnW1zC7mjGzTVnV2kR9PpxXhcROyU5oZItTsPtEQbyuyL/L2qqrf3vS2nVe8
+        upR3zpZE5PNs+l50ur/vQXidT9d10V4z87wPFMBgmr3MmoYgEfe6FwE019ep
+        3azILpZV0xbT5vUHUWwQ0FnQfRfM3Q+XKmCyDVTu0j+XxYx4++4XxbSumuq8
+        HSsyd0N+kLeovcWf8CC63zTqWX6ercsWL6zWk7KYnq2OZzNCqLnpze4EdV5/
+        w68Nv/70mpi/mH70S+jVRTXDR2fLaZ1DhWQlNaSxXBYNEZHee91mLVq8Xk+n
+        eT7LZ/R9Wyzyps0WK/ocCoJIur2z+2Zv99He/qPdnfG9h3s79x/c+ylqOlvX
+        qhU+evlm/4u9B+NPH+7e29v/9DV9Oa3qOi/5e8zsR/v3Pt3b39+fbj/4ND/Y
+        3v90drA9Ob/3cHuaz8737p3nkwcPD+g1Rg9TwwqVxpI3KxIOAuCm6qRarNaE
+        +OgjogjPMKgib/if0Esqn6pMGnrFqDI0Nzrr+79kdNObd/N3bb4E3YaBMJg4
+        yqog6FW/G7ze65i4C02tXhjuj3rrvNthlvd6V/tlwTfaZPh9+o8YIF/ly1m+
+        nLLRoKHIB82XxBL01zdvDi13eIKrpL2r+Du63fVFiTRmSHtC7RYwvJdEcAP5
+        JKAg5Dc1TqiaD1RQDt3eGAfe917REXYAZqviJwkTGhV9Rxrh/vbOp9u79z8C
+        A3xTI988wyrvd7si6U8FIWpg9kY+8L73io48AIiZ/bng5wFsfwij/abGBwb6
+        fyEfTzEi/a4smvb3yq/xVoS/6X+7NID8ssiv/l/G554d8t48o08u5m0z/skv
+        nnr+Vd62ZOUxSINHj5pDfbpuvLeVeAE+DtQNSIDDfi7kyej2nm0M6OqNskej
+        QQjeSxHS8Ih/uGNU+xXa8PceZxSK92J0rD80Kelg6Wx1ME4yzQ7hm0bqYHgv
+        RUZJQDHOat2SzJDH84slfHrfkLPDR/3X4LxLJ68UGWpkBMaNYkh2fZSpv6/1
+        nqcAPNrfQsQ7fQ1SOugNhL3x3ZAfg/c3vd2hdqdnmlCitr5895vkXdJ1NnXT
+        w8rSAUmY+w8f7u7vf3oP8Y/wUX8Ygy+QiAymbZRw9l1h6S63OSa1yG8Travl
+        bNu+SQS2gcAmCBofUGsiJXWP0G+49V1q9KH0Fl7+yS+ajcpCWV3/DF4jHAjR
+        hubLhex1cUmR8dnL49IM+ou8nVPeZsNgvunI+/727s72zsM3uweP9j99tH9v
+        /ODe/Yf79x/2Iu974917n+4/vLcfC7v3ZjuTB9ns/vaDSXa+vT+Z7G4f3N/J
+        t6f3Dx4ePHxwTgE7nCPGDbRjPUMD+WHFsPQfDYfdAhtH0ie30H6KjtEOri8n
+        gxE2/mFIOxzPbeB4ldX5WP5iZYNfJ9dVyTL8YPdg9/69g3t7RBsQnDDC9+/3
+        Is3boPQbguP3IabVeSCWVQlRY3BrTdF/9aaMLbH+cpbVs58XSVt0TZEE9S1d
+        6/vEl86U3QQjQIDJdYt8bXaZFWU2KUrqhezzTX0ch833IiBeklY5r+rFM2jJ
+        p9UiK5YnoP4msPc2wPlqNSMdeEtAlG7ozrqomuFXLJ99/uo13h5MPN9EG8wh
+        T6GyzyCg98UoE4/kZZ2fF+82vUhp173xznjn7u6neI/0FvHRTWh79kxeeI9+
+        9uCPdf3UmzoM+LTz7k2k+VrG8xnxVdxy7hxs7x682X346P6nj+7tj3fuPTh4
+        cP/TnuXcffDF/Yfjh/fv3z/4NJq0fvjgwYO9yb397Wz/U7IJB/ey7ezBw0+3
+        Z5/em5x/ev988vD8Ab3GyN1gPdXjoNZED7YhoIm84X9CL6l+Un06bDvJkG1+
+        865jVRI88dFvD6wjt8Ov8svxUauA0Ks+cLze6y6U7q/Vm2p0etWHjdd7vSml
+        9I3h3qivzpskSXjFmoD3ebcjFe/1rvbLip5mhE3H8Pv0HzF76Ff93OZfFH9H
+        N/GT6BU2juGcEWK3gOC9JMqJdbUFCSL+rI+RMVThvtsVmbs9u+ow7g1zCIj3
+        jo6yB/WHN1IV6G72leeS2ouRdAj3BjnwvveKjjEACGb+4YzPTILqB6tJ7Vse
+        pr3BDbzsvaKDc9Awcz8XUjmAqnvLQ/obGef/e2YwYhXvEiuSA+rwv+2QI7A8
+        KF0qaDc/V3Nu9KiOQf/03vJQ7xFAW3df9l7pjpbH+cMdWc++uvc8RAfH1nvd
+        e+n/BaNT+xd6AO5dD9nBEUZBeC/2R/lDk9sOis7Ks22xRt3hetMgHQTvJR1g
+        AJKcpV/y/V/y/wDl04zxyScAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:08 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1438,7 +1559,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1457,19 +1578,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - 5b09a402-fa51-4477-9683-8a72507b2b24
+      - 1ef8e0aa-87ad-44a9-94c8-cbcb246f6fff
       X-Ms-Correlation-Request-Id:
-      - 5b09a402-fa51-4477-9683-8a72507b2b24
+      - 1ef8e0aa-87ad-44a9-94c8-cbcb246f6fff
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134909Z:5b09a402-fa51-4477-9683-8a72507b2b24
+      - NORTHCENTRALUS:20160203T141906Z:1ef8e0aa-87ad-44a9-94c8-cbcb246f6fff
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:09 GMT
+      - Wed, 03 Feb 2016 14:19:06 GMT
       Content-Length:
-      - '1791'
+      - '2516'
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -1477,47 +1598,63 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
         qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
-        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL9vmbrPKp9vLvGnz2bb7fHtW
-        4Z+8zNv8o9FHy2xByHx0q7arulrldVvkzUePfvFHbb5YlVmbPy+Wb/H3ui4I
-        0LxtV82ju3fr7Gp8UbTz9WTd5PWU4BC88bRa3D3+wbrO72b4d/sXrYvp26bN
-        6nbbgGvuLjJCo767u7OzzV/ltf1y+4pAbhMFi1kGegkYQXj80021JCy1r5/M
-        64ZaEEq74x3899EvoRFkNY2XIPIIymrKUPB7e70CHV63dbG8ICjUB2bpo1NC
-        Jv3q9Ue/hN5eVDN8dLac1jnIk5XUkIhyWaAneu91SzhSi9fr6TQntGb0fVss
-        iKzZYkWf7+3s3t/eebi9t/tmb+fR7sGjewfjh/cOHu7v7f0UNZ2ta8Xno5dv
-        9sf3d3Y+ffBg9zV9M63qOicC0JdnYJrp/YPd8/z+ve0H5/sz4pL7k+3s02x/
-        +8HD6b39hzvT6c7snF5j3GY8WmI3THWzyqbA8ItiWldNdd6OlXmoteGqN0QK
-        ecP/hF7KLrOizCZFWbTXr/O2oXcMCdH+o5xotW4++v4vof9oNPkqX87y5ZT5
-        5Xv0SbVuqatXChQfqgz0sLnb7ar7we5H1MkvGen7d392Zch9sNeRCJCU+r+h
-        FU3DreXmomjaAcGZ/OAqL+5mnz7Yu7+ze7Bzf3863Xs43ZtmNJjs6u692U62
-        9zDb23k4ffjpdHd6P9/PPt15cP/Tyd50tjvJds+z6YP7B/e4i/OizHfH7buW
-        0NM+biEw03lRzp7rlL80X+GbG8WHusHLT5lILzKQbfgtpueSxGZYG9Hk/yzI
-        4/7u+P69vd37n+735PHh+N69h/f2Pv1ZFkcnHbcQSEcbNPdlcbkuS5LCTXJI
-        f/zij5qizb8CAw5PxjyrZ9tTIvUslRfT86pOSVG3PAnymUMbaLJQujGpbHVl
-        +P8tQr0bMNaQUHdb0WTeWqhJPAdk+rbGkDh1e2/7ctFsl1U2m2RltpySXSwn
-        9bqkVgxAcH1/M9i0VZ1d5MfTabVetreRzV19hSZs9FE2WxTLr2hcQrcNb+b1
-        ZV5zc/vey6xprqqa5tu9l09pMPo2tZstG+BETPf8ydlLv6E08Tog1LapOd66
-        XOCll3V+Xry78Z2f/AKvFAsa0sv1pCya+WatZln7u8VyVl01r3lkFsaX5+f0
-        14b346+9/r2+2vQSscDe9qu97adZS0qDJpffLCcY56b3eITPn6Dxspii9S2p
-        Qq3x0goUmZ69PJ7NSLx4Lm58lalI7+D9y2V+K6ba/skXp2/4hcXr4gf06XBz
-        0uvLWVbPfv+nxIH0xjdpCHYfPtp/SLZg/OnDvYc7Dx72DMH+F7vjvYe7e5/u
-        3I/Zgvzh3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22
-        4LVIGbUmwrNeg96XN/xP6CUVSJXhrjXwPTNSr/HeVFnSqz5svN7rraO3h7uj
-        zjqvXhZ1u87KLzJyB5YEfehNfjeO6Iu8JZXxll71YeP1Xm8d3qVGQ/1Rb9TC
-        f1cx1d7e502o6Ceqot/nPRIUdHUG2SZnbQO29B9xZWjYf7F+0HxJfEp//SwY
-        Ucu0d3uzcbdHajGzVhOEs0Wo3QKE95JoEFEUFiao8EMeZjC3MkTSrQ7PwcEF
-        L3ov+AMjSGCLn9N57LC9DJFVs8N5cJCdl71X/GEyNAz0hzy0YApkYERxh+Pg
-        sIIXvRf8QRGknwN27KkMGRaZ7h0Pz8GB9V73XvIHx/AwYz9izZ+doQUcJgMj
-        hnI4Dg4reNF7wR8UQfp/FWvuengODqz3uveSPziGhxn7OWFNddHudvwvHqqL
-        khzmveEOAPBe8QbrIGLAP6QhDk4IDxL0/9lRNT+k4enX3VwERd7Xx5f0i4dm
-        b2xD73rv6NAMsB+iHOrXRvEZj1tm7Se/2DhpA+96r+i4LDDM2I8k8GdniIMi
-        xIOExGwc4ODr3kveEAXeD3F4+nVPiv7/LoEbJ23gXe8VHZcFhoF9SDLWEsjM
-        fP+dDjJmICL97/cO4dt/x3Bq4NTIG/Bhhl/osba8RJwcxe3m1zai14tT5TUX
-        lg6/qtTQP/XF0Ol0Lw1oJn7JU0SUM//+L/l/AHxfERhYHgAA
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL1v6OFtWy2KaleOvJutlu36d
+        15d5vbu3s//8zevtvZ3dT3fon4e79/YffDT6aJktCKuP3u+lVV2t8rot8uaj
+        R7/4o1VWE5A2r/mvsppmGBN+b69XAP66rYvlBb2nNPgoz5p23Xz0S+iTom7X
+        WflFNp0Xy/xFBmSG31szbo3g1n/9dfEDajX8+us2W86yevb7H+/g5Wy2KJZf
+        ETShwfB7k7paZhdzRrhpqzq7yI+n04pwuQnhRfGLsh+s63z3/sHeA7yuCL/I
+        26uqfnvT626G8e5SXjpbEqnPs+n7UWv33oEH43U+XddFe82c9F5wAIQJ9zJr
+        GgJFvOzeBNRc36d2syK7WFZNW0yb1x9GtkFIZ0H/XTh3P1zILCp3iekvixlx
+        +d0vimldNdV5O1Zk7oZc4b1lBkCIEOlvGvcsP8/WZYsXVutJWUzPVsezGWHU
+        3PRmb44677/h94bff3pNQlBMP/ol9OqimuGjs+W0zqFSspIa8ugbIiO9R3LU
+        osXr9XSa57N8Rt+3xSJv2myxos9JU3y6vbO7vbf7Zmfn0e7Bo92d8cP9e5/u
+        7dz7KWo6W9eqIT56+Wb/i7398cH+/U/37t1/TV9Oq7rOS/4ec/vR/Xzyab67
+        d759/950Z3s//zTfntybzbZnB7ODyf7DT3fvf5rRa4weJoc1LI0lb1YkIgTA
+        TZZKE7UmivAcgyryhv8JvaRiqnqloVeMWkNzo7++/0tGN715N3/X5kvQbRgI
+        g4mjrHqCXvW7weu9jom90NRqh+H+qLfOux1mea93tV+WfaNRht+n/4gB8lW+
+        nOXLKRsQGop80HxJLEF//SzYR8senuwqbe/qABzh7gbCBMUZkp+wuwUU7yUR
+        3lBGARbU/KYGazVOdKy301MO494wBwB4r+gguxCzVfGThAuNi74kxXB/e+fT
+        7d37H4EPvqmx3zDR+vXdrmgG80GoGqi9wQ8A8F7RwYcQMb0/J5ytX3fx/aEM
+        +JsaouWj6AgH2NG9pdxngPZGOADAe0VH2IWYTTEm/bIsmvb3yq/xWoTP6X+7
+        26s6vyzyq//X8btnmLxXz+iTi3nbjH/yi6eey5W3LZl9DNNg0iPoUKeuG+9t
+        JV+IkIN1AxZgs58TuTK6vmcuQ9J6A+2RaRCE91KMOjzoH/Iw1aSFlv39hxoF
+        470YH+4PT1w6eDoLHg4VBtshfdNoHRTvpdhIARaDrdYtIUnu0C+W8Op949IO
+        Q/Vfg2cvnbxSdKiRkR03DiVWT44DpKnDr/eipw68GbiFvHc6G6R22B0T98a3
+        Q84MIWx6vUPybuc0rURzffvuN8rGpP1suqdZ5dNtInSbU1BkP9+eVfgnLykv
+        QxwjnPTRrdqSjHjJnTZfrCgcy58Xy7f4myhFgOZtu2oe3b1bZ1fji6Kd08Bp
+        1FOCQ/DG02px9xhG8y6bzu1ftC6mbyk4rNttA45MNYUEeX13d2dnm7/Ka/vl
+        9hWB3CYuL2YcQggYQXj80w2ZWMSJ3JezubvjHfxHE/Y1ElKnhEz61WsWkm8i
+        /CXT/xDh7x6Hv/cOxg/vHTzc39vrh7/j+zs7nz54sBuLfaf3D3bP8/v3th+c
+        78+IS+5PtrNPs/3tBw+n9/Yf7kynO7Nzeo1xg1JjecZU9wNJZR5qbbgKGkze
+        8D+hl7LLrCizSVGSSJAMQoEZEqL95liOPnkPJdPtqvvBD1WG3Ad7HYkASan/
+        G1rRNNxabi7IcRwQnMkPrvLibvbpg737O7sHO/f3p9O9h9O9aUaDya7u3pvt
+        ZHsPs72dh9OHn053p/fz/ezTnQf3P53sTWe7k2yX1OCD+wf3uIvzosx3x+27
+        ltDTPm4hMKS4y9lznfKX5it8c6P4UDd4+SkTSczd8FtMzyWJzbA2osn/WZDH
+        /d3x/Xt7lDna78njw/G9ew/v7X36syyOTjpuIZCONmjuy+JyXZYkhZvkkP74
+        xR81RZt/BQYcnox5Vs+2p0TqWSovpudVnZKipmwkTYJ85tAGmiyUbkwqW10Z
+        /n+LUO8GjDUk1N1WNJm3FmoSzwGZvq0xJE7d3tu+XDTbZZXNJlmZLadkF8tJ
+        vS6pFQMQXN/fDIaR7m1kc1dfoQmj+Pa2Tik1Ie+Hm9v3brNWsOQcNzHd8ydn
+        L/2G0sTrgFDbpuZ463KBl17W+Xnx7sZ3fvILvFIsaEgv4bo1881azbL2d4vl
+        rLoihxQjszC+PD+nvza8H3/t9e/11aaXiAX2tl/tbT/NWlIaNLn8ZjnBODe9
+        xyN8/gSNaR0PrW9JFWqNl9SZfanOLADc+CpTkd7B+5fkTN/qpZ98cfqGX1jc
+        ernuKXEgvfFNGoLdh4/2H5ItGH/6cO/hzoOHPUOw/8XueO/h7t6nO9Flifzh
+        3v39nYP97fs72cH2fv5gZzs7mGTb984/Pd+f7j3Y3TuY0muM3Q22QFNR1JoI
+        z3oNel/e8D+hl1QgVYa71sD3zEi9xntTZUmv+rDxeq+3jt4e7o4667zaCQIH
+        3+R344hqlEWv+rDxeq+3Du9So6H+qDdq4b+rmGpv7/MmVPQTVdE3vue9R4KC
+        rlzMOtgn/UdcGRr2/3ekvhypxcxaTRDOFqF2CxDeS6JBRFFYmKDCD3mYwdzK
+        EEm3OjwHBxe86L3gD4wggZ1+Tuexw/YyRFbNDufBQXZe9l7xh8nQMNAf8tCC
+        KZCBEcUdjoPDCl70XvAHRZB+DtixpzJkWGS6dzw8BwfWe917yR8cw8OM/Yg1
+        f3aGFnCYDIwYyuE4OKzgRe8Ff1AE6f9VrPk+iwPude8lf3AMDzP2c8Ka6qJ1
+        Vwt5qC5Kcpj3hjsAwHvFG6yDiAH/kIY4OCE8SND/Z0fV/JCGp193cxEUeV8f
+        X9IvHpq9sQ29672jQzPAfohyqF8bxWc8bpm1n/xi46QNvOu9ouOywDBjP5LA
+        n50hDooQDxISs3GAg697L3lDFHg/xOHp1z0p+v+7BG6ctIF3vVd0XBYYBvYh
+        yVhLIDPz/Xc6yJiBiPS/3zuEb/8dw6mBUyNvwIcZfqHH2vIScXIUt5tf24he
+        L06V11xYOvyqUkP/1BdDp9O9NKCZ+CVPEVHO/Pu/5P8B9vobFUcwAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:09 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:06 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1531,7 +1668,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1550,17 +1687,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14994'
       X-Ms-Request-Id:
-      - 7b317067-5cb6-4fdc-94d3-ba7065ba3265
+      - 0b8e4c4a-7f2c-4317-a9a9-d374dac98f5c
       X-Ms-Correlation-Request-Id:
-      - 7b317067-5cb6-4fdc-94d3-ba7065ba3265
+      - 0b8e4c4a-7f2c-4317-a9a9-d374dac98f5c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134909Z:7b317067-5cb6-4fdc-94d3-ba7065ba3265
+      - NORTHCENTRALUS:20160203T141907Z:0b8e4c4a-7f2c-4317-a9a9-d374dac98f5c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:09 GMT
+      - Wed, 03 Feb 2016 14:19:06 GMT
       Content-Length:
       - '133'
     body:
@@ -1570,10 +1707,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:09 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1587,7 +1724,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1606,17 +1743,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14993'
       X-Ms-Request-Id:
-      - d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
+      - a4612f14-9494-41dc-a33d-853398cf29cb
       X-Ms-Correlation-Request-Id:
-      - d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
+      - a4612f14-9494-41dc-a33d-853398cf29cb
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134910Z:d0a2f5fa-05f8-45d0-8a46-45cb3fa3f7a7
+      - NORTHCENTRALUS:20160203T141908Z:a4612f14-9494-41dc-a33d-853398cf29cb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:09 GMT
+      - Wed, 03 Feb 2016 14:19:07 GMT
       Content-Length:
       - '133'
     body:
@@ -1626,10 +1763,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:10 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1643,7 +1780,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1662,17 +1799,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14995'
       X-Ms-Request-Id:
-      - f33ea29e-0458-4a6c-bf44-9d52872de0c7
+      - 23aee124-4a65-4c75-96eb-2725524a50e9
       X-Ms-Correlation-Request-Id:
-      - f33ea29e-0458-4a6c-bf44-9d52872de0c7
+      - 23aee124-4a65-4c75-96eb-2725524a50e9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134910Z:f33ea29e-0458-4a6c-bf44-9d52872de0c7
+      - NORTHCENTRALUS:20160203T141909Z:23aee124-4a65-4c75-96eb-2725524a50e9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:10 GMT
+      - Wed, 03 Feb 2016 14:19:08 GMT
       Content-Length:
       - '1160'
     body:
@@ -1705,10 +1842,10 @@ http_interactions:
         a/CypZNXigQ1MmLtsB/SHkx/w1m3ah5ROJ5u6cAZJJoh+M3vhBwEDDa91KEX
         dXTDCzpC/dNjoNhLA+6Be0m9gV/yS77/S/4fRYxdRsYRAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:11 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure2/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1722,7 +1859,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1741,17 +1878,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14999'
+      - '14993'
       X-Ms-Request-Id:
-      - 15483e47-abd9-499d-be5b-a8042445bbc4
+      - ae3f42a2-8283-403f-a52a-40b917e236aa
       X-Ms-Correlation-Request-Id:
-      - 15483e47-abd9-499d-be5b-a8042445bbc4
+      - ae3f42a2-8283-403f-a52a-40b917e236aa
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134912Z:15483e47-abd9-499d-be5b-a8042445bbc4
+      - NORTHCENTRALUS:20160203T141909Z:ae3f42a2-8283-403f-a52a-40b917e236aa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:11 GMT
+      - Wed, 03 Feb 2016 14:19:09 GMT
       Content-Length:
       - '133'
     body:
@@ -1761,10 +1898,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:12 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/MIQVM1/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1778,7 +1915,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1797,17 +1934,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14995'
       X-Ms-Request-Id:
-      - fe27ee76-2e66-4db6-be9e-1583a6548b26
+      - f8fa53f6-b66d-4b8f-8299-f563e1d3175a
       X-Ms-Correlation-Request-Id:
-      - fe27ee76-2e66-4db6-be9e-1583a6548b26
+      - f8fa53f6-b66d-4b8f-8299-f563e1d3175a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134912Z:fe27ee76-2e66-4db6-be9e-1583a6548b26
+      - NORTHCENTRALUS:20160203T141910Z:f8fa53f6-b66d-4b8f-8299-f563e1d3175a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:11 GMT
+      - Wed, 03 Feb 2016 14:19:10 GMT
       Content-Length:
       - '133'
     body:
@@ -1817,10 +1954,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:12 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Resources/deployments?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1834,7 +1971,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1853,17 +1990,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Request-Id:
-      - 25dff459-31a3-4d3e-81e5-5764b2160e18
+      - a5918880-6806-4f87-86f8-481a7fed9f52
       X-Ms-Correlation-Request-Id:
-      - 25dff459-31a3-4d3e-81e5-5764b2160e18
+      - a5918880-6806-4f87-86f8-481a7fed9f52
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134913Z:25dff459-31a3-4d3e-81e5-5764b2160e18
+      - NORTHCENTRALUS:20160203T141911Z:a5918880-6806-4f87-86f8-481a7fed9f52
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:13 GMT
+      - Wed, 03 Feb 2016 14:19:10 GMT
       Content-Length:
       - '1084'
     body:
@@ -1895,10 +2032,10 @@ http_interactions:
         vtZ7EZ73uLoDcJCc3SnZ8G6HKPSujw6Yq//ugI1x9ok8hV/y/V/y/wDBjeVB
         IA8AAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:13 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1204LTS-20161116191/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1912,7 +2049,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1931,17 +2068,101 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14995'
       X-Ms-Request-Id:
-      - 21e72d48-46bc-4f6e-be71-b9d9fcf5f599
+      - 6ee6bce1-a460-44dc-8ff4-83e20a988e46
       X-Ms-Correlation-Request-Id:
-      - 21e72d48-46bc-4f6e-be71-b9d9fcf5f599
+      - 6ee6bce1-a460-44dc-8ff4-83e20a988e46
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134914Z:21e72d48-46bc-4f6e-be71-b9d9fcf5f599
+      - NORTHCENTRALUS:20160203T141912Z:6ee6bce1-a460-44dc-8ff4-83e20a988e46
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:14 GMT
+      - Wed, 03 Feb 2016 14:19:11 GMT
+      Content-Length:
+      - '1384'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0/m+fn2y7qa3Z3lq7K6XuTLlj7NltWymGbl+KvJetmuX+f1
+        ZV7v7u3sP3/zentvZ/fT3V36/8Pdu9UqrzPp/mDv9OGTgwc7uw/v7X66/+zh
+        R6OP7LdnQDfSYFWjSVvkzUePfjH+uiwaal4sL163WUtD/ej1ejrN81k+o9Zt
+        scibNlus6HMgQSPb3tl9s7f7aG//0c7B+OD+3v1PP733U9R0tpaOqeXLN7tf
+        3L8/vrd//96n9/de05dtnU3fUh+M1eTe/Vk+OSdaTQ6Iavs7D7Yfzg4ebt/b
+        z/J8/9P7BwcP0Df1266bk2oGpL78veiTNqsv8vaV0hP4f/OTwhSZ5XVz94ti
+        WldNdd6OT6rFat3mdy+Lul1n5RfZdF4s8+bumqeq4am6m79r8yVI6b95Rp9c
+        zNtm/JNfPC2yi2XVtMW0eZ23LRGjoSEZPN5cr2hAH7k3h/p03Xhvv8gWeDvA
+        x4G6AYlf8kt+yehng5IfzN7P7u2d3D/eefZgf/fJk4OdUxqw/ZYZKdKApo+a
+        fAPsvfdo9954f39v78HDBz323vtid2+892D3wf7+/R57P7h3P5/Ndibbn06y
+        e9v7u/vT7YNsP99++On+3oxGPMvuPaB3qF+aq/+vsDehZ2DellW9VyL8+f9e
+        tjs5+fTZ7oNPj/effPpw98nBHo3DfssTHGlAZKUm3wDb7Tza2R3v3Nu7t7ez
+        12O73fHDg4O9nU8f9nhu7+H5wfTTyXR7P997uL2fzXa3Jw8PJtvZ3vRg7+A8
+        v3c/m9A71CnRX3nupM4JNcbn54jxXuTtVVW/vbuUn2fLNq/Ps2mH9e7vE4oG
+        bo/5BmF4L0XYj4D+v5YB9+89eXj/2d6nuwf7OzufPjihkdhvebYjDYi81OTD
+        GXD34aP7B+MHDx8S4Pt9BrwHDvz04cNPexy4k++RJd/Lt7NP94gN9/OMODDf
+        357t3J/sfTqd3DvYR8/UK02BcuDPqdYzjLNaT8pierY6ns3o/abDfIQgfcpQ
+        B1mvB8F7KcJ6/+9lvAd7eyefkgO2s/dg79nxPSg2+y1PcqQBkZaafCOMt//p
+        +OGD+zu7+z2+2xvvfrq3s7N/r8925/t7u/d3Hm7fP9852N6f3CdjS023s/z8
+        03vZbLJ7P9+hd6hPIv8Ph+2mmBAiRJztXrdVnV3kdxv5eTydVjQ/8ha1n92n
+        OSL0DMwe0w28772iLNcBmK2KnyRMaFT0HZH+/vbOp9u79//fy4wPT/ZOd08O
+        Hj48efZg594+jID9lqc+0oDGS02+EWa8/2C8Q7AfHPSYEa7f3sN79w/6SnBv
+        Ots5P5882N6Z3ZsRyR7ubmf3HpIZnp3P8vMHD2bTCWSGOv2hcaObESZHhxuN
+        ClPr+TqfruuivdZ3A63lGKzHkxuheC8qZwZg/1/Lf09PPj24/+TZvWefPjh4
+        uvf0GY3DfsuTHWlAJKYm3wj/7d8f3//0we7Bg74V3hk/2Hm4f7DbdwOzPbxA
+        rDe7dw9GeGe6PTnfm21PH96fPLyfH9y7d46OqVOi/w+H/6CG/l+oDacYkX5X
+        Fk37e+XXeCuiJel/uzSA/LLIr8Ct3/8l/w/FchL+FhIAAA==
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:12 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/Microsoft.NetworkInterface-201599144638/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 39d23ba3-c96a-458d-974d-6e0dd51d87b3
+      X-Ms-Correlation-Request-Id:
+      - 39d23ba3-c96a-458d-974d-6e0dd51d87b3
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160203T141913Z:39d23ba3-c96a-458d-974d-6e0dd51d87b3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 03 Feb 2016 14:19:12 GMT
       Content-Length:
       - '502'
     body:
@@ -1960,10 +2181,10 @@ http_interactions:
         Toz33vbrfFotZ9v2O0LX9PHmekXIfnQLeN5LL7IFXtrQwS/5Jb/k+7/k/wEy
         PiqhoAIAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:14 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:13 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Resources/deployments/chef-software.chef-serverchefbyol-2015718153832/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -1977,7 +2198,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -1996,17 +2217,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Request-Id:
-      - 2324e1a6-9269-4264-bd12-263e916ddad4
+      - e058f479-60ed-4f3c-bbb2-5be50509133c
       X-Ms-Correlation-Request-Id:
-      - 2324e1a6-9269-4264-bd12-263e916ddad4
+      - e058f479-60ed-4f3c-bbb2-5be50509133c
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134914Z:2324e1a6-9269-4264-bd12-263e916ddad4
+      - NORTHCENTRALUS:20160203T141914Z:e058f479-60ed-4f3c-bbb2-5be50509133c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:14 GMT
+      - Wed, 03 Feb 2016 14:19:13 GMT
       Content-Length:
       - '1685'
     body:
@@ -2051,10 +2272,10 @@ http_interactions:
         Sx7MpqT/Pr33kN6hPv9fwnImQM0uKbmWTYqSjCSlSMjTCT9AGGcA91hvCIj3
         jvJeDyqx4Pd/yf8D6PZ1nMEVAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:15 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/Canonical.UbuntuServer1204LTS-2016020191347/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2068,7 +2289,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -2087,17 +2308,101 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14995'
       X-Ms-Request-Id:
-      - d7719ef0-0c72-4b32-b755-42116367a4e7
+      - d1817c0e-5dc7-428f-b08c-83f22a3a6ae7
       X-Ms-Correlation-Request-Id:
-      - d7719ef0-0c72-4b32-b755-42116367a4e7
+      - d1817c0e-5dc7-428f-b08c-83f22a3a6ae7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134915Z:d7719ef0-0c72-4b32-b755-42116367a4e7
+      - NORTHCENTRALUS:20160203T141914Z:d1817c0e-5dc7-428f-b08c-83f22a3a6ae7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:14 GMT
+      - Wed, 03 Feb 2016 14:19:14 GMT
+      Content-Length:
+      - '1369'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS9X/xRMfvo0Ud3m/WkmdbF
+        qi2qZXN3/9O9873s/GA7//RBvr2/M/10++H55Hx7Z+9gb3+2O5vtH9y/W+dN
+        ta6n+ed1tV41d0+qxWrd5j/5RXN3lq/K6nqRL1v6OFtWy2KaleOvJutlu36d
+        15d5vbu3s//8zevtvZ3dT3fon4e79/Yf3K1WeZ0JBrs7O0+efHrvyb29T588
+        O/70049GH9lvz4BxpMGqRpO2yJuPHv1i/HVZNNS8WF68brOWRvvR6/V0muez
+        fEat22KRN222WNHnhMGn2zu723u7b3Z2Hu0ePNp5OH5wf+/T+/uf/hQ1na2l
+        Y2r58s3eF3vjh/fvf7p379PX9F1bZ9O31IUgtb+/m9M/23vn9/ZAt9n2wf7u
+        3vbudLr3cO/hzvlBdkDvULftujmpZsDpy9+LPmmz+iJvXylFgf7PwrQwRWZ5
+        3dz9opjWVVOdt2P9+u5lUbfrrPwim86LZd7cXfNkNTJZd/N3bb4ELf1Xz+iT
+        i3nbjH/yi6dFdrGsmraYNq/ztiVyNDQog8mb6xUN6SP35lCnrhvv7RfZAm+H
+        CDlYN2DxS37JLxn9rBDzG+DxT58cPL3/8MnuwYPTk7290wc0aPsts1OkAc0h
+        NfkGePzTRzufjj/debD34GGExXfHe3t7uw92dnss/mA6fbhzMMu3z6f3drf3
+        97J725PZg4Pte5Pz3en+zs79fO8+vUO90mz9f4fFCUED9bbs6r0S49H/V7Pe
+        yZN79w7u7+/sPvn04MGTTzF8+y1Pc6QB0ZaafAOst/9o5/5478HB/r0HffW6
+        P9779ODTnU/v9zgvm306Ocj2d7Y/zXcebO+f7z3Yzib3723fzw/y/Vn2MN/P
+        ISHUKc2Bct5JnRNqjM/PFfu9yNurqn57dyk/z5ZtXp9n0y4D7t6DZTCgezw4
+        CMV7KcaFAPv/ZkZ8cHJ6ev/Z008/fbb34MHpAVSH/ZZnPdKAqExNvhlG3CE7
+        /5D4cLfHiLt7408PdnZ2Pn3Q48R7O9nBdP/B7vZk98H97f1PpwfbDz89390+
+        mNybzbIH9+7dP9+jd6hXmgflxJ9bHWjYZ7WelMX0bHU8mxGApsuEhCJ9zHAH
+        ObAHwnspxoH/r2a/JwcPnu0+efb06dNnO09PHz6jsdhveaojDYi+1OSbYr+H
+        u3sPd+8/iLHfwd79HTLQPfbbnTz49OH+vdn27j2Y4Hv7s+2H+7sE9tPZ7jQn
+        ombncIepV5qE/1exn2qv1/l0XRfttb4csovjpkEWjILxXvz/HBse3D/e3Tnd
+        PXj49NPjpw+fPqGx2G95yiMNiM7U5Btgw3uP9g/GD+/t7Tz89F6PDXfGB/v7
+        +w8/7XPh/dl5/vD+7vn25NMH59v7u/c+3T7Yzabb02z/009383v38/N79A51
+        SnPww+HCRfGLsh+s63w3yoSv26rOLvK7jfw8nk4rmiLvrfsHe3AgDNAe+w0A
+        8F5RxutCzFbFTxIuNC76kqh/f3vn0+3d+/+vZsn7O3sPnu49e3pv99mT04N9
+        DMN+K/Pfb0BUpybfFEs+eED+595+hCU/Jb472OvHJrPsYPfBw3x3+/50dkBU
+        +3Rn+2GWk4Xef7A/nd3/NLt/70csKRCzKcakX5ZF0/5e+TVei7Aq/W93e1Xn
+        l0V+BZb9/i/5fwCNMWgjPxIAAA==
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2014-04-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 07aaa2af-4ad5-41d7-8ac2-547e93817429
+      X-Ms-Correlation-Request-Id:
+      - 07aaa2af-4ad5-41d7-8ac2-547e93817429
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160203T141916Z:07aaa2af-4ad5-41d7-8ac2-547e93817429
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 03 Feb 2016 14:19:15 GMT
       Content-Length:
       - '501'
     body:
@@ -2116,7 +2421,7 @@ http_interactions:
         WbTXr3OarM4Hu4SkgfzmekUofnQzEO+dF9kC73Ra7H70S37JL/n+L/l/AJ6P
         IniEAgAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:15 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:16 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/100-starter-template-with-validation/azuredeploy.json
@@ -2146,19 +2451,19 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000
       X-Github-Request-Id:
-      - 17EB2C1C:2F28:56C3D06:569E3EDC
+      - 17EB2C1C:517D:21F4EEF:56B20C64
       Content-Length:
       - '9'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 19 Jan 2016 13:49:16 GMT
+      - Wed, 03 Feb 2016 14:19:16 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1835-DFW
+      - cache-dfw1826-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -2168,19 +2473,19 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - b8cbe8e00ea064cfbd6ccca8113f44d5597770b6
+      - ac1ef0efd7334502271eb0745841ab14ec06f261
       Expires:
-      - Tue, 19 Jan 2016 13:54:16 GMT
+      - Wed, 03 Feb 2016 14:24:16 GMT
       Source-Age:
       - '0'
     body:
       encoding: UTF-8
       string: Not Found
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:16 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment2-dont-delete/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2194,7 +2499,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -2213,17 +2518,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Request-Id:
-      - ba9c7d11-870d-4664-90f5-1188b8b8af7b
+      - 4c50716a-0777-4269-8216-0b290fb948a4
       X-Ms-Correlation-Request-Id:
-      - ba9c7d11-870d-4664-90f5-1188b8b8af7b
+      - 4c50716a-0777-4269-8216-0b290fb948a4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134917Z:ba9c7d11-870d-4664-90f5-1188b8b8af7b
+      - NORTHCENTRALUS:20160203T141917Z:4c50716a-0777-4269-8216-0b290fb948a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:16 GMT
+      - Wed, 03 Feb 2016 14:19:17 GMT
       Content-Length:
       - '493'
     body:
@@ -2241,7 +2546,7 @@ http_interactions:
         AaMvfy/6pM3qi7x9pQQE8j8Ls8D0mOV1c/eLYlpXTXXejk2XkTlaEnHyGc2M
         +dyfKcLZdPTmekUYf3QDTO+FF9kCL9yik1/yS37J93/J/wOGedAynAIAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:17 GMT
 - request:
     method: get
     uri: https://gist.githubusercontent.com/bzwei/a6725018054cc29c2ca5/raw/3d0a29a209c96c1c5e4a60756b2cd1ba1fac7583/gistfile1.txt
@@ -2277,19 +2582,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C1D:2F2B:91C56D7:569E3EDC
+      - 17EB2C1C:517D:21F5069:56B20C65
       Content-Length:
       - '1004'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 19 Jan 2016 13:49:17 GMT
+      - Wed, 03 Feb 2016 14:19:17 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1828-DFW
+      - cache-dfw1821-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -2299,9 +2604,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 8d76727f118a54d8239db40924b44b8a7eabec11
+      - 425efd38d013002000d4255f62d5c396530ccfce
       Expires:
-      - Tue, 19 Jan 2016 13:54:17 GMT
+      - Wed, 03 Feb 2016 14:24:17 GMT
       Source-Age:
       - '0'
     body:
@@ -2338,10 +2643,10 @@ http_interactions:
             }
 
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Resources/deployments/spec-deployment1-dont-delete/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2355,7 +2660,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -2374,17 +2679,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14992'
       X-Ms-Request-Id:
-      - b73aad4b-41b9-4505-8b22-6f8b237175e2
+      - 5ac8e0ba-c24c-46b5-85fc-0d78013e1b99
       X-Ms-Correlation-Request-Id:
-      - b73aad4b-41b9-4505-8b22-6f8b237175e2
+      - 5ac8e0ba-c24c-46b5-85fc-0d78013e1b99
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134917Z:b73aad4b-41b9-4505-8b22-6f8b237175e2
+      - NORTHCENTRALUS:20160203T141918Z:5ac8e0ba-c24c-46b5-85fc-0d78013e1b99
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:17 GMT
+      - Wed, 03 Feb 2016 14:19:18 GMT
       Content-Length:
       - '1505'
     body:
@@ -2425,7 +2730,7 @@ http_interactions:
         DkipTc93Z5TA2M8fTugd6vT/Lez2uq3q7CK/28jP4+m0WptZ2tUPN7r9AwC8
         VzxWcxCJ1b7/S/4fqSYfH5gVAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:17 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:18 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -2461,19 +2766,19 @@ http_interactions:
       Cache-Control:
       - max-age=300
       X-Github-Request-Id:
-      - 17EB2C14:2F28:56C4012:569E3EDE
+      - 17EB2C14:5176:BB1C38:56B20C66
       Content-Length:
       - '1903'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 19 Jan 2016 13:49:18 GMT
+      - Wed, 03 Feb 2016 14:19:18 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw1828-DFW
+      - cache-dfw1822-DFW
       X-Cache:
       - MISS
       X-Cache-Hits:
@@ -2483,9 +2788,9 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 222c41dac9fdadd7f0b9958585dec2b1a1b1a2c2
+      - 90be04009ab265ca9c2e90d4245783ab924e7673
       Expires:
-      - Tue, 19 Jan 2016 13:54:18 GMT
+      - Wed, 03 Feb 2016 14:24:18 GMT
       Source-Age:
       - '0'
     body:
@@ -2830,10 +3135,10 @@ http_interactions:
           ]
         }
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:18 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2012R2Datacenter-2015718143049/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2847,7 +3152,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -2866,17 +3171,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14993'
       X-Ms-Request-Id:
-      - b01227ff-dcf5-4282-9ce4-90f349207deb
+      - f8948c63-de87-4428-9738-a551fd899928
       X-Ms-Correlation-Request-Id:
-      - b01227ff-dcf5-4282-9ce4-90f349207deb
+      - f8948c63-de87-4428-9738-a551fd899928
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134918Z:b01227ff-dcf5-4282-9ce4-90f349207deb
+      - NORTHCENTRALUS:20160203T141919Z:f8948c63-de87-4428-9738-a551fd899928
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:18 GMT
+      - Wed, 03 Feb 2016 14:19:19 GMT
       Content-Length:
       - '1307'
     body:
@@ -2913,10 +3218,10 @@ http_interactions:
         miLNu438PJ5OqzVmz75FOv0B4WeA9rhvAID3ivJdCJE48Pu/5P8Bm4nndoYR
         AAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:18 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Resources/deployments/Microsoft.WindowsServer2008R2SP1-201595152051/operations?api-version=2014-04-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -2930,7 +3235,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -2949,17 +3254,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Request-Id:
-      - 28e09461-e80d-4022-b61b-1685c6f60a30
+      - 1f11dd62-df0f-467e-9fe9-6e70a05506da
       X-Ms-Correlation-Request-Id:
-      - 28e09461-e80d-4022-b61b-1685c6f60a30
+      - 1f11dd62-df0f-467e-9fe9-6e70a05506da
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134919Z:28e09461-e80d-4022-b61b-1685c6f60a30
+      - NORTHCENTRALUS:20160203T141919Z:1f11dd62-df0f-467e-9fe9-6e70a05506da
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:18 GMT
+      - Wed, 03 Feb 2016 14:19:18 GMT
       Content-Length:
       - '1090'
     body:
@@ -2991,10 +3296,10 @@ http_interactions:
         557tXrdVTT7W3UZ+Hk+n1RoztryuLx7uHuwTVgZUj90G3vVeUWazwIjNvv9L
         /h+BjiSEdgwAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:20 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3008,7 +3313,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3029,20 +3334,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 232d912e-0114-41ca-b1d2-f67b8a7746d5
+      - 05a964c2-81b2-40ae-bc76-38baef1fa8a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - a0aa73ad-2891-498e-9ce9-54996398018f
+      - 234419a5-a501-4809-aaef-625744aac77b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134921Z:a0aa73ad-2891-498e-9ce9-54996398018f
+      - NORTHCENTRALUS:20160203T141920Z:234419a5-a501-4809-aaef-625744aac77b
       Date:
-      - Tue, 19 Jan 2016 13:49:21 GMT
+      - Wed, 03 Feb 2016 14:19:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3051,32 +3356,34 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
         5x+dzPPz7Zd1NftoZL8rZvjmbrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3
         d6afbj88n5xv7+wd7O3Pdmez/YP7d+u8qdb1NP+8rtar5q4FfndVV5fFLK+b
-        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/3o/qf5fnaw
-        d7796cPs3vb+/dnudra3s799kO+dTw6mD/YmWfb7fuS93F6veKw3du29U1bT
-        DAPHe3nWtGv/SxrNKq/bIm/oa0tT+eKyaOi1Ynnxus1a7vb1ejrN81nujYea
-        WlKthdy7D/c/ffAg391+cHCwg1Fl25OHD7Lt6fnB+f29yWT26b3zAEA2mxGM
-        5vUqm6IbDw335cs6Py/eMZrKAeb5aHdnvDfeGe/c3f30I/+r77s/fonfHXHD
-        Mm97kIJuqZnhq1l+nq3L1scYz/9reOsuYYDx3B1C9EM4Th5wQ5RN5MHXt2QW
-        ecJJRWM7h3v7kebF6qRanhcX65o5GUgEUydPDy88P+xpopnAz7Nlm9fnxM/N
-        3Sneo1dm9/d27nZHQh9M+YPdgHXl8bnWPP8vHeSqatoLgrU9yy/3792nYf2/
-        e5wvfp9Xn7/nEJuszJvzimCsm4MDGtD/u0f4dWeyzZv2918W030aUGeEi+IX
-        4duzl3v/3x7i5QLD2I1wqfnm/xfj+3RwfKGdlOf/e+N7MDi+B/+/GF9Ex5hv
-        /n8xvoeD43v4/5LxVYvVus1/8guyb19jgDFzb775f8kAP2gC93YHx/f/cRuo
-        o9gbHN//Lwzg3r3B8d37//b4mtk5/a8/OvqQ/vf/7bHpDA06L3v/v3Be9gad
-        l73/Xzgve4POy97/L5yXvUHnZe//F87L3qDzsvf/Fuflg8Z3b9B3uff/C9/l
-        3qDvcu//F77LvUHf5d7/L3yXe4O+y73/j/suOopI+sV88/+L8Q36L/f+X+K/
-        fI0MoQ5g0HW59/8L1+X/9+MbdF3u/f/CddkfNO37/78w7fuDpn3//xemfX/Q
-        tO///8K073dNH2Fhvvn/xfgGTd/+/0tM3weOb9A+7P9/3D5gDLw0Fhnh/7/W
-        xvYH0xP7/29JT3xYbn5/0Mjv/7/FyH/YAO8PWvn7/y+x8lMZ4OXiaw5wMAK8
-        //+SCHAKEaShfT0RvD9oJu7/v8RMfOgERrSo+eb/HQP8ujoUY4Cd2N2JCKE1
-        FPTt/zuG+XX5tL74/TGS/hD1i/+vjw5jiA0On/+/ZGxfVwJlEJFAQr/4f8fw
-        vrYJlFHsRqTPfPP/jwFGIl3zzf8/BjjIobtRFu1+9P3wg+B77w/bTD/jH/Th
-        L/l/AADf3cB6LgAA
+        u18U07pqqvN2/CJvr6r67d3Lom7XWal/em95KOVtdgGkvnv39/3oYOfBXnb/
+        /OH27F422d6f7J9vHzyYPdieTbOHs/zg/vnOvU9/34+8l9vrFY/1xq69d8pq
+        mmHgeC/Pmnbtf0mjWeV1W+QNfW1pKl9cFg29ViwvXrdZy92+Xk+neT7LvfFQ
+        U0uqtZB79+H+pw8e5LvbDw4Odrb378+y7cnDB9n29Pzg/P7eZDL79N55ACCb
+        zQhG83qVTdGNh4b78mWdnxfvGE3lAPN8tLsz3hvvjHfu7n76kf/V990fv8Tv
+        jrhhmbc9SEG31Mzw1Sw/z9Zl62OM5/81vHWXMMB47g4h+iEcJw+4Icom8uDr
+        WzKLPOGkorGdw739SPNidVItz4uLdc2cDCSCqZOnhxeeH/Y00Uzg59myzetz
+        4ufm7hTv0Suz+3s7d7sjoQ+m/MFuwLry+Fxrnv+XDnJVNe0Fwdqe5Zf79+7T
+        sP7fPc4Xv8+rz99ziE1W5s15RTDWzcEBDej/3SP8ujPZ5k37+y+L6T4NqDPC
+        RfGL8O3Zy73/bw/xcoFh7Ea41Hzz/4vxfTo4vtBOyvP/vfE9GBzfg/9fjC+i
+        Y8w3/78Y38PB8T38f8n4qsVq3eY/+QXZt68xwJi5N9/8v2SAHzSBe7uD4/v/
+        uA3UUewNju//FwZw797g+O79f3t8zeyc/tcfHX1I//v/9th0hgadl73/Xzgv
+        e4POy97/L5yXvUHnZe//F87L3qDzsvf/C+dlb9B52ft/i/PyQeO7N+i73Pv/
+        he9yb9B3uff/C9/l3qDvcu//F77LvUHf5d7/x30XHUUk/WK++f/F+Ab9l3v/
+        L/FfvkaGUAcw6Lrc+/+F6/L/+/ENui73/n/huuwPmvb9/1+Y9v1B077//wvT
+        vj9o2vf/f2Ha97umj7Aw3/z/YnyDpm///yWm7wPHN2gf9v8/bh8wBl4ai4zw
+        /19rY/uD6Yn9/7ekJz4sN78/aOT3/99i5D9sgPcHrfz9/5dY+akM8HLxNQc4
+        GAHe/39JBDiFCNLQvp4I3h80E/f/X2ImPnQCI1rUfPP/jgF+XR2KMcBO7O5E
+        hNAaCvr2/x3D/Lp8Wl/8/hhJf4j6xf/XR4cxxAaHz/9fMravK4EyiEggoV/8
+        v2N4X9sEyih2I9Jnvvn/xwAjka755v8fAxzk0N3/t7AotMvXMBE6iogPY775
+        f8n4vv4E7kbieHz6/5KBfdjERZwz883/S8b39SeOhxFxzsw3/78Y4N6gcdj7
+        f4tx+JocKj40eZf9Adqv/r89wvVkvWzXTV5f5vX9iJYpVlP+IGoEux99P/wg
+        +N77wzbTz/gHffhL/h801E1snjQAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:21 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3090,7 +3397,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3111,20 +3418,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a389b09e-c00a-416f-aba3-d8b3e27a921f
+      - e41d2fa0-37bb-496f-848c-cb2fac4d5393
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 462a29e4-7bda-4840-a3b5-44b5b8aa9f9f
+      - 172c0b26-1e7c-4f7a-a607-92bca39a9bf4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134921Z:462a29e4-7bda-4840-a3b5-44b5b8aa9f9f
+      - NORTHCENTRALUS:20160203T141921Z:172c0b26-1e7c-4f7a-a607-92bca39a9bf4
       Date:
-      - Tue, 19 Jan 2016 13:49:21 GMT
+      - Wed, 03 Feb 2016 14:19:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3133,32 +3440,36 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXWbnOP3qUfg9/pSl/iOejZbbA
         5x+dVIvVus1/8ovmo5H9spjhq7vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf
         3t+Zfrr98Hxyvr2zd7C3P9udzfYP7t+t86Za19P887par5q7DvrdVV1dFrO8
-        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o3vZg+nu
-        g2yPMNidbe/v7dzfPtj99NPtB/v7O/lsZ3Jvb3fv9/3Ie7m9XvFwb+zbe6es
-        phmGjvfyrGnX/pc0nFVet0Xe0NeWrPLFZdHQa8Xy4nWbtdzt6/V0muezfOYg
-        UFNLrLUQfPpwPzvf2cm2pw93zrf3dw8m2w8fHuxsn092s3sPHn56TmMLAGSz
-        GcFoXq+yKbrx0HBfvqzz8+Ido6lMYJ6PdnfG/N/d3U8/8r/6vvvjl/jdET8s
-        87YHKeiWmhnWmuXn2bpsfYzx/L+Iu+4SDhjR3SFUP4Tn5AE/RBlFHnx9S3aR
-        J5xWNLazuLcfaU7Dw6hf59N1XbTXTDl6q4cINf1hz0sMNWp39hP6/m7AlHh8
-        bpTno2J1Ui3Pi4t1zbIKIgfMKU9kuHj352bAZ8s2r89JZJu7i+IXTeXd3f29
-        T+92B0MfTPmDPilixPh/7zin8/y8yevLvN49+PQeDev/p+N087l3cP//x+Nc
-        rSdt3rT793doSP8/HWNer+7v3Kfh/P90fMSrew/2HtB4/l8+QNId2y/ravae
-        47PvbZOFqZazbfsdjfD/3UMmG/iTX+y+53gvFyySuzSYzujMN//vGNzXZlgd
-        xsPBAT78f8cAYey2aWjvy7AyivsRiTTf/P9ifAeD4zuIja/7kRec4Am+9/6w
-        zfQzQydLGxumLK5/8sXpG+c6f3OEuiWnd+OTHkJ+FDLZ2ZnOpjv72zvkMm7v
-        ZxQtPnxAeEz38tmn+WTnwcPzzI9C/r8R+e5+urs3ne4dbD/c+ZRGtX/vfDs7
-        //Th9qd7+we7FAzvZvd3AwAaBf2/NPJ9zc23A5Tx/L+Ete5S/4Rfc3cQzw/h
-        OHnADVE2kQdf35JZ5AknFY3tHEbj3q6OoTeCqZOnhxeeH/os0Rzgp6cql8X0
-        /8eeNY0u4qVsHF33I09Q8QTfe3/YZvqZoZKljBXZZpVPtyEcjpd+6JTqSmsM
-        J18ys53p3u7+wYPtTw/OCZXswcPtSXa+u71z/8GnD/f27x18ur/rS+b/N2zB
-        /gGR89Pp+fbk4c7B9n5+b0b65l6+vbtzfn8629vf3T3YCwCoZviRLfia3HWX
-        UCAUb2kO3pfp5AFDRDlFHnx9S36RJ5xXNLbT+P9Dc8BT9TW0Zo8O/+8f4vua
-        ve5HntTiCb73/rDN9DP+QR/+kv8Hh2yljTcbAAA=
+        bu5+UUzrqqnO2/GLvL2q6rd3L4u6XWel/um/5iGVt9kF0Pru3d/3o73Z7NPZ
+        9Pz+9vk0393ePz/ItyefZvn2p5Odh9N7O/cO9vcOft+PvJfb6xUP98a+vXfK
+        apph6Hgvz5p27X9Jw1nldVvkDX1tySpfXBYNvVYsL163Wcvdvl5Pp3k+y2cO
+        AjW1xFoLwacP97PznZ1se/pw53x7f/dgsv3w4cHO9vlkN7v34OGn5zsdANls
+        RjCa16tsim48NNyXL+v8vHjHaCoTmOej3Z0x/3d399OP/K++7/74JX53xA/L
+        vO1BCrqlZoa1Zvl5ti5bH2M8/y/irruEA0Z0dwjVD+E5ecAPUUaRB1/fkl3k
+        CacVje0s7u1HmtPwMOrX+XRdF+01U47e6iFCTX/Y8xJDjdqd/YS+vxswJR6f
+        G+X5qFidVMvz4mJds6yCyAFzyhMZLt79uRnw2bLN63MS2ebuovhFU3l3d3/v
+        07vdwdAHU/6gT4oYMf7fO87pPD9v8voyr3cPPr1Hw/r/6TjdfO4d3P//8ThX
+        60mbN+3+/R0a0v9Px5jXq/s792k4/z8dH/Hq3oO9BzSe/5cPkHTH9su6mr3n
+        +Ox722RhquVs235HI/x/95DJBv7kF7vvOd7LBYvkLg2mMzrzzf87Bve1GVaH
+        8XBwgA//3zFAGLttGtr7MqyM4n5EIs03/78Y38Hg+A7+3zG+r82g9QWGsReR
+        QPPN/0sGiAmEZvx644v4Neab/5eM7wMncH9wgPv//xhgxKsx3/z/Y4CRUMp8
+        8/+PAUaMhPnm/x8DjFgJ883/Swb4NZWo2LrdnYiVsF/9f3uE07Jaz4pl0UYM
+        hfvu/ydjjKhS993/S8b4dUVxquOIaFP71f9Lhvih0xjRp+67/5eM8WtPoxlI
+        RKe67/4/Psj1ZL2kFRrJMe7eiwx1Y4zf/chbAsETfO/9YZvpZ4Zilkp2MWRx
+        /ZMvTt+4BP0PnWTdVZAeQuFax/m9+7vZ7vZudn5P1jqyvb2D7XuzT3f39nbP
+        83vTfX+t4/8b62u7hPx0SsN4uPPp/vb+/r3z7ez804fbn+7tH+zSkttudn83
+        AKBrLf8vXV97zc23A5Tx/L+Ete5S/4Rfc3cQzw/hOHnADVE2kQdf35JZ5Akn
+        FY3tHFLs12/eVTL0RjB18vTwwvOzPUu9WaI5wE9PZy6L6f+P8/c0uoiP/f+X
+        0UkwtBtJhppv/n8xwL29oQHu7cUG2P3IU7V4gu+9P2wz/cwQyhLHKt1mlU+3
+        od6cNvihE6urb2M4+bo125nu7e4fPNj+9OCcUMkePNyeZOe72zv3H3z6cG//
+        3sGn+7u+bv3/hjXfPyByfjo935483DnY3s/vzbYfPriXb+/unN+fzvb2d3cP
+        9gIAqtt/ZM2/JnfdJRQIxVsa9PdlOnnAEFFOkQdf35Jf5AnnFY3tNP7/0KDz
+        VP3/2+6ZIb6v49L9yJNaPMH33h+2mX7GP+jDX/L/ANAbT5ZfKQAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3172,7 +3483,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3191,17 +3502,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Request-Id:
-      - bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
+      - e6c315b0-c31a-413e-9283-a3fd28e749c2
       X-Ms-Correlation-Request-Id:
-      - bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
+      - e6c315b0-c31a-413e-9283-a3fd28e749c2
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134922Z:bd9fd4dc-f186-4e8a-afb2-2fc446830c8f
+      - NORTHCENTRALUS:20160203T141921Z:e6c315b0-c31a-413e-9283-a3fd28e749c2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:21 GMT
+      - Wed, 03 Feb 2016 14:19:21 GMT
       Content-Length:
       - '133'
     body:
@@ -3211,10 +3522,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3228,7 +3539,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3247,17 +3558,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14992'
       X-Ms-Request-Id:
-      - 51f5f3c8-545f-4ed1-808c-60383f9c1f3e
+      - 809e67bf-019c-4bd1-915e-6752790a73fa
       X-Ms-Correlation-Request-Id:
-      - 51f5f3c8-545f-4ed1-808c-60383f9c1f3e
+      - 809e67bf-019c-4bd1-915e-6752790a73fa
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134922Z:51f5f3c8-545f-4ed1-808c-60383f9c1f3e
+      - NORTHCENTRALUS:20160203T141922Z:809e67bf-019c-4bd1-915e-6752790a73fa
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:22 GMT
+      - Wed, 03 Feb 2016 14:19:21 GMT
       Content-Length:
       - '133'
     body:
@@ -3267,10 +3578,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:22 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3284,7 +3595,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3305,20 +3616,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9c06368b-92bb-41cb-8f72-4b6f0309a97b
+      - 4d32ab73-0b63-40b6-877d-68fb7fab023a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - ea886f8b-3533-47f6-9e92-35dfa812c022
+      - 71edf86d-fb4b-411e-9289-7b716a5a4394
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134923Z:ea886f8b-3533-47f6-9e92-35dfa812c022
+      - NORTHCENTRALUS:20160203T141922Z:71edf86d-fb4b-411e-9289-7b716a5a4394
       Date:
-      - Tue, 19 Jan 2016 13:49:23 GMT
+      - Wed, 03 Feb 2016 14:19:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3337,10 +3648,10 @@ http_interactions:
         c3M3r1cP7h/c7Y6BPpjyB7sB08rj86t5/l86PHrv4NNPaTTvM7zuR56o4gm+
         9/6wzfQz/kEf/pL/B5s5aaAjBgAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:23 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure2/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3354,7 +3665,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3373,17 +3684,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Request-Id:
-      - e72e467d-3c26-41a4-bf7b-ec5c01110acc
+      - 03854ee0-9a1f-4a71-8a93-e0ff658fd8b9
       X-Ms-Correlation-Request-Id:
-      - e72e467d-3c26-41a4-bf7b-ec5c01110acc
+      - 03854ee0-9a1f-4a71-8a93-e0ff658fd8b9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134923Z:e72e467d-3c26-41a4-bf7b-ec5c01110acc
+      - NORTHCENTRALUS:20160203T141923Z:03854ee0-9a1f-4a71-8a93-e0ff658fd8b9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:22 GMT
+      - Wed, 03 Feb 2016 14:19:22 GMT
       Content-Length:
       - '133'
     body:
@@ -3393,10 +3704,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:23 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/MIQVM1/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3410,7 +3721,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3429,17 +3740,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Request-Id:
-      - 2cabca80-1dea-431f-975b-806a6a84a2ca
+      - 7ec80b23-0dba-410a-9039-39c86dfb39ac
       X-Ms-Correlation-Request-Id:
-      - 2cabca80-1dea-431f-975b-806a6a84a2ca
+      - 7ec80b23-0dba-410a-9039-39c86dfb39ac
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134924Z:2cabca80-1dea-431f-975b-806a6a84a2ca
+      - NORTHCENTRALUS:20160203T141923Z:7ec80b23-0dba-410a-9039-39c86dfb39ac
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:24 GMT
+      - Wed, 03 Feb 2016 14:19:22 GMT
       Content-Length:
       - '133'
     body:
@@ -3449,10 +3760,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:24 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Network/virtualNetworks?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3466,7 +3777,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3485,17 +3796,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14991'
       X-Ms-Request-Id:
-      - cbbd9e2e-7d01-4295-b975-f15de1cbfb80
+      - d1753442-ab9e-4c2b-a9eb-7525be28d665
       X-Ms-Correlation-Request-Id:
-      - cbbd9e2e-7d01-4295-b975-f15de1cbfb80
+      - d1753442-ab9e-4c2b-a9eb-7525be28d665
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134924Z:cbbd9e2e-7d01-4295-b975-f15de1cbfb80
+      - NORTHCENTRALUS:20160203T141923Z:d1753442-ab9e-4c2b-a9eb-7525be28d665
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:24 GMT
+      - Wed, 03 Feb 2016 14:19:23 GMT
       Content-Length:
       - '133'
     body:
@@ -3505,10 +3816,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:24 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3522,7 +3833,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3545,20 +3856,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 5c147a65-fae3-4698-a9d8-7f34d5ecb177
+      - f52e8593-b392-4041-bee7-0e212f43f088
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - a8fe69a2-a61d-430c-bf5e-6ad3f827e96f
+      - 50b8fd4f-bae8-4bfd-910d-ebb5a960e2a9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134925Z:a8fe69a2-a61d-430c-bf5e-6ad3f827e96f
+      - NORTHCENTRALUS:20160203T141924Z:50b8fd4f-bae8-4bfd-910d-ebb5a960e2a9
       Date:
-      - Tue, 19 Jan 2016 13:49:25 GMT
+      - Wed, 03 Feb 2016 14:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3579,22 +3890,26 @@ http_interactions:
         XWdK6aBLajQrmmxS5i+zprmq6tnxup3ny7aYmvbnWdnk/jv+YOj9JqepbDeO
         mIhPoN/SSMywzUdnSxrueTaFhvreLw4U1i/+JaOPoE5+9rXJC8Hlbg8nZqpt
         emV2f2/no1/y/WBQsyK7WFYNUWpwPidV1T51zbrfU4t8CdrTKNO2XuceeDxG
-        t3zlGL25HaeHPOr+CAZAMC4L6ALi8NctCSM6eb2eTvN8RiiZlu6djwxVMRI1
-        NniCQX2EOfshmoDLom7XWflFBkmlKXNv5e/afInx+a+d0ScX87YZ/+QX3syQ
-        7WiJCo0dNA3b/Pp9N/7/twzNifkmRftRqyr6RsjeO2VlBf+jPGvatf9lmxGJ
-        iIk9lliVGdp6LGBRAp92TdAtzR14c7aewr/QRmLsTAudHIOH7R3vWQXiPqYv
-        jMdzPj2/N5vm0+3zycFse//h+f3th7OD6fZk934+m56fP9jZnwaYdFwMguGB
-        pe9/yDzRQednw+MhXbCcUesfltNjB/ld0WCvZa69/vA472dzM/V/9nZ2DrZf
-        7W2/frnba0KvQS2g2TfiAilCvX6MILwkJXNBs739NL/sNSLjSTj88P0gH6n/
-        D7hCProhZW7tDSkJbvKHiHhiFn/yi+ML8oSoScw2i+Umb6laEKTpVysaMGsd
-        NPbb+gOm975Jdwm652df9Qy7RyszKbP8cv/e/f9XeEi3EoGQcd0fAfoEQhiB
-        2J50IrE7dfH/ef/IF6T//7lI/uic+N+gib8pR0m+Y6qQaP+S/wc0uTP1nREA
-        AA==
+        t3zlGL25HaeHPOr+CAZAMC4L6ALi8NctCSM6+WpFPEwfWAjulY8MUTEQtTV4
+        gjF9hCn7IVqAy6Ju11n5RQZBpRlzb+Xv2nyJ4fmvndEnF/O2Gf/kF97EkOnA
+        mBs7aBq2+fX7bvz/bxmak/JNevajVjX0jZC9d8rKyv1Heda0a//LNiMSEQ97
+        LLEqM7T1WMCiBDbtWqBbWjuw5mw9hXuhjcTWmRY6OQYP2zves/rDfUxfGIfn
+        fHp+bzbNp9vnk4PZ9v7D8/vbD2cH0+3J7v18Nj0/f7CzPw0w6XgYBMMDS9//
+        kHmig87PhsNDqmA5o9Y/LJ/HDvK7osBey1x7/eFxzs/mZur+7O3sHGy/2tt+
+        /XK314Reg1pAs2/EA1KEev0YQXhJSuaCZnv7aX7Za0S2k3D44btBPlL/H/CE
+        fHRDytzaGVIS3OQOEfHEKv7kF8cX5AhRk5hpFsNNzlK1IEhTNpusddDYb+sP
+        mN77Jr0l6J6ffdUz7B2tzKTM8sv9e/f/X+Eg3UoEQsZ1fwToEwhhBGJ70onE
+        7tTF6/V0muczQsi0dO/8f8I/8gXp/38ukj86J/43aOJvylGS7ww/2FkHI212
+        SnZ29/Yf7N37dPvTnemD7f39vWz7Yf5gtr0zPfg029u9tzOZBVbsPYz5DzV7
+        cZItSVqmWeDy4XHG+6vJetmuN9vu3b3xzv74/vbzN697Teg18CuafSO2e3P2
+        Ys3YkmmhbnuNSI8TBt+Q5b5lXEeQmrs+Vns7u5/u7tL/H+7+f8CK+5iHVLq1
+        Ff//XEoDGvFnXyEOG2mf5vf3/19ho2/J7CFjuj+CARCM/x9aaX/S/v9npf3R
+        OfG+Qet+w1YaP0i2f8n/A4sSuJ1CGQAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:25 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3608,7 +3923,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3631,20 +3946,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 4dabecda-4faa-46f6-80b0-c96efabdc433
+      - 66c79d28-beba-4dea-9488-c7f5ff26bf27
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - e0287391-7dcd-4032-a469-2a953458f72c
+      - a5dddda7-5a34-4b17-ae68-45c562487b8b
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134925Z:e0287391-7dcd-4032-a469-2a953458f72c
+      - NORTHCENTRALUS:20160203T141925Z:a5dddda7-5a34-4b17-ae68-45c562487b8b
       Date:
-      - Tue, 19 Jan 2016 13:49:25 GMT
+      - Wed, 03 Feb 2016 14:19:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -3682,41 +3997,20 @@ http_interactions:
         HDxDPsd7OVhGkEJEbu1nKUFu8rTIJIgX8ZNfHF+Qj0VN2nqdB7CoWb6EP0Z+
         WLUgSNOvVkRetiJo7Lf1x0vvfZOOGKFqrdcv/iWjj2DSfwgWfaNjpvO2u7/3
         6c8f/0y/2v1/l5v2TY/OyZPVdPFvvyGnzX3ZZuTOkhyoTjEcYvkArGUlwX1M
-        Xxg/Lsvv3dvNdve375+ff7q9f2+XXLj79Ofegwf57nn2ILu/m7kO6cV59v5+
-        3D3Lww5HPDf5cd+A91NfkPZp8/t796ez+5PtfPfe/vb+7j6Ncv/+/e3d3U+z
-        /WxncjB9mLH274IhnUTy6KzSsIPEPic16aBK33h2qYFhomUmmpbZfVodGjBL
-        zTWhvIgwIXdNfEoBzQUJ6fa0WrbuLyHX+Hx6fm82zafb55OD2fb+w/P72w9n
-        B7T8tHs/n03Pzx/s7E95sCGm/sTgGbK0X2M8i4zsTl78orsyG79/tnPw8MG9
-        6c72/QNaFtt/mE23Hz7Y298+mN0//zS/f2+2+/BWGHqG+P29wiErc3vTK6MJ
-        OeHnsdWFvfkmzA0YapvGPYvq42Ejq9PxwcYV4/i5tJs6DoeQ4aTeF9+QPZHv
-        DAUsB4J0m43Hw3uTe9OD82z7weTg/vb+p/sz0jR5tr1zThn5yb2Hu5P7B65r
-        enGevb/x+LpJANGG3Y/5i/czHrt7e9MdGuk5qaq97CHpq5397ckDGuy9/MFk
-        en9672E+2WF91QVEwkUc9yPz4T1fYzwd87G79/tPs9nOw/uzyfZBNtnb3p/c
-        y7azvVm2ff7pwxmt/pzPHu4+uA2O/68wILudcPhHJuRnW/PeZENoRv5/YkVo
-        JA4lw06Rr36uLcm9B/fye/sP723vHOyck4Oek2jfm55vf5o9IGfw4Ww/m+64
-        runFefb/QUuyd757/unB/sO97YdZvkvD3Hu4PXm4d3/7/Jyy6Nn+7r0sy1lv
-        deGQiBHT/ciQeM/XGE/HkOz9/gc7+wcP7z34dPsB2Yzt/f2HB9uT/X3Cc+fB
-        w3ufZucPd6f7t0Hx/xV2xJNnPD8yIx+sepXOlEOOqt6bzMj/b6yIx1ldjeZ9
-        83NtQ/Js90GeURohm2UQ5um97ezg4OH2zs7+vfPJ3u79h+ceuvRidpkVZTYp
-        yqK9psVhguGBpe9/2MTv4ENNfp/jn3x9+kZJgseQBc/XsYFPd4eA3WAD2ay8
-        /5Kq2sXXeU3Lnj7x8fTWVAea6crq3s7u3varve2npDynpIAiLeltiBda/1DW
-        VqsGKz29r0mTUe+3sdawLT0E6HPPtpFpa1b5dFcnaHfAthGk5q7gI7FoCDMc
-        O/Xwc2yyMKTtn/wicOqoWc9m0a80qfxxp6kO/kdm633VzbDZ4klZFuRqdwzX
-        rMguluTeFdPBCZ5UVfvUNet+Ty2ExDRGpqkHHo/RP1+9L+OHPOv+CPBnMoAJ
-        iONJFxKnUx//rza8GHkoH1bpRL76uTa9O5P72V62f769O/v0AcU1s3w7292b
-        bt/bne082P304d6ne4Hu+5Hp9YEpgw/B+pHp9R4rBWLqel+TNqbef85M7+7/
-        d0yvtzCN5/9HpteOythZjzL4CB85q/f/LtO7+yPTi7n4Yer+jonkkYfyYZVO
-        5Kufa9M7mTzI7+8/2N/e2d2hlOLD2d52dn6wu72zv5/f37u3SynHzHVNL86z
-        9zZdxzuKHx6DIx7DOkOwvgE9fzUnniHj8vvPPs3u04Jbtj19cE4cMKWEXbb/
-        kLKLn5J3cb43ycnrYO3bhXR7k8CWlpp0sKVvPKNwy1zj/29zp7Dt1PZy9/d/
-        cG/3wWyPlkXv36dF3/3ZvYfEevfub88opT3Z2ckeTD+9dxskf47t4aL4RdkP
-        1nVOo93d8bxqPH2r+KMkavaeWph4a5u6m0WV8LBFpAG3vz8sIs1JxyYyIFCR
-        uIaUFHELTcz/q20KBoP2GIzDyvBU/Ntv1rLgB/HEL/l/AE0zpyj9SAAA
+        Xxg/Ls92H+TZ3v52Nstm2/v703vb2cHBw+2dnf1755O93fsPzwNt/f/+1MkX
+        v8/xT1LKxIqNIwuer+OHPh1Mv/zs+KHq0Q0kRrqO6EAzdUf3dnb3tl/tbT8l
+        IzclrR1pSW9D+aD1D8UhrRqYx97XpP6pd+cAfKgv2qzy6a5O0O4m+y/47ESs
+        fzh26sGz/O/vhg6Ztdvbegxp+ye/2Akp0jf09CtNKn/caaqD//+RrYe++SGo
+        m2HbzpNCmc6drlmfudSDNwzXgJpMqqr1MhTd76mFkJjGyDT1wOMx+uer92X8
+        kGfdHwH+TAYwAXE86ULidOpjo1uCufhh6v6O1eSRh/JhlU7kq2/IGst3hgp2
+        /kC+zaZ3Z3I/28v2z7d3Z5/SqsXuLN/Odvem2/d2ZzsPdj99uPfpXqD7fmR6
+        fWDK4EOwfmR6vcdKgZi63tekjan3nzPTG0tghGOnHv7fYXo9bx7Pj0zvD0Hd
+        3Gx6d39kejEXP0zd3zGRPPJQPqzSiXz1zZpe/CBm/iX/D76SelPYLwAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:26 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3730,7 +4024,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3749,17 +4043,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14994'
       X-Ms-Request-Id:
-      - 5a1149d2-01b4-4738-a7a2-4848a302beae
+      - eece5cd1-a8d4-4ae7-82ed-0b47e494b747
       X-Ms-Correlation-Request-Id:
-      - 5a1149d2-01b4-4738-a7a2-4848a302beae
+      - eece5cd1-a8d4-4ae7-82ed-0b47e494b747
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134926Z:5a1149d2-01b4-4738-a7a2-4848a302beae
+      - NORTHCENTRALUS:20160203T141926Z:eece5cd1-a8d4-4ae7-82ed-0b47e494b747
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:25 GMT
+      - Wed, 03 Feb 2016 14:19:25 GMT
       Content-Length:
       - '133'
     body:
@@ -3769,10 +4063,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:26 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3786,7 +4080,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3805,17 +4099,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14992'
       X-Ms-Request-Id:
-      - 1b9522b9-7b3c-47e1-a320-006c70a6247a
+      - 2a18849e-859f-4b62-983f-ce36ab8635b7
       X-Ms-Correlation-Request-Id:
-      - 1b9522b9-7b3c-47e1-a320-006c70a6247a
+      - 2a18849e-859f-4b62-983f-ce36ab8635b7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134927Z:1b9522b9-7b3c-47e1-a320-006c70a6247a
+      - NORTHCENTRALUS:20160203T141926Z:2a18849e-859f-4b62-983f-ce36ab8635b7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:26 GMT
+      - Wed, 03 Feb 2016 14:19:25 GMT
       Content-Length:
       - '133'
     body:
@@ -3825,10 +4119,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3842,7 +4136,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3861,17 +4155,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14994'
       X-Ms-Request-Id:
-      - ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
+      - 4ac4e4e3-8cfa-40f4-b7f5-5bfaac974ce4
       X-Ms-Correlation-Request-Id:
-      - ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
+      - 4ac4e4e3-8cfa-40f4-b7f5-5bfaac974ce4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134927Z:ef0d4d8a-988c-400e-8a08-2ca96d4b4c22
+      - NORTHCENTRALUS:20160203T141927Z:4ac4e4e3-8cfa-40f4-b7f5-5bfaac974ce4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:27 GMT
+      - Wed, 03 Feb 2016 14:19:26 GMT
       Content-Length:
       - '133'
     body:
@@ -3881,10 +4175,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure2/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3898,7 +4192,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3917,17 +4211,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Request-Id:
-      - 88cee134-206f-4f86-8875-10f536517521
+      - 839a3ec6-ed63-4395-9674-53020d9d74f6
       X-Ms-Correlation-Request-Id:
-      - 88cee134-206f-4f86-8875-10f536517521
+      - 839a3ec6-ed63-4395-9674-53020d9d74f6
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134927Z:88cee134-206f-4f86-8875-10f536517521
+      - NORTHCENTRALUS:20160203T141927Z:839a3ec6-ed63-4395-9674-53020d9d74f6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:27 GMT
+      - Wed, 03 Feb 2016 14:19:27 GMT
       Content-Length:
       - '133'
     body:
@@ -3937,10 +4231,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:27 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/MIQVM1/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -3954,7 +4248,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -3973,17 +4267,17 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14992'
       X-Ms-Request-Id:
-      - e892447b-6efd-4ad1-8629-778838f1e4df
+      - 851aa19d-ee0b-49ae-978d-8d5be3b691f1
       X-Ms-Correlation-Request-Id:
-      - e892447b-6efd-4ad1-8629-778838f1e4df
+      - 851aa19d-ee0b-49ae-978d-8d5be3b691f1
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134928Z:e892447b-6efd-4ad1-8629-778838f1e4df
+      - NORTHCENTRALUS:20160203T141928Z:851aa19d-ee0b-49ae-978d-8d5be3b691f1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:28 GMT
+      - Wed, 03 Feb 2016 14:19:27 GMT
       Content-Length:
       - '133'
     body:
@@ -3993,10 +4287,10 @@ http_interactions:
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZuc4/evS97/+S/wdC6kBEDAAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:28 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4010,7 +4304,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4033,20 +4327,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 3fcde00a-cd3c-405f-aba1-152abd1ce38d
+      - 03f548c3-0a06-4244-90c2-4c06daa20f4f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14998'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - aabadf99-3e97-43db-aafa-e790813b75fc
+      - c259ded7-0afc-4069-8dc2-ca8985697ad9
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134928Z:aabadf99-3e97-43db-aafa-e790813b75fc
+      - NORTHCENTRALUS:20160203T141928Z:c259ded7-0afc-4069-8dc2-ca8985697ad9
       Date:
-      - Tue, 19 Jan 2016 13:49:28 GMT
+      - Wed, 03 Feb 2016 14:19:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4071,10 +4365,10 @@ http_interactions:
         3jbjn/zCm5HXedsSDRo7ZBq0+fX7bvT/7xiYE/UbNO5HrSrsG+F775TVlGSc
         tcVHeda0a0MUJgiJ8S/5fwAzqwV3yAcAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:28 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Chef-Prod?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4088,7 +4382,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4107,24 +4401,24 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"553ae346-9be8-4094-9df9-b03bcf792e31"
+      - W/"fe024cfd-0787-4b99-a338-bd44e8bbd8b0"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b7c2c518-abbd-4bf2-ad7e-0e873c03b05e
+      - 55c1248d-8de7-42f6-a2f0-f574f157546e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 10a10d3b-31cc-454c-8995-ed9fe5a3eaee
+      - e8cd247c-e6ab-43bc-9705-d1fb406e8740
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134929Z:10a10d3b-31cc-454c-8995-ed9fe5a3eaee
+      - NORTHCENTRALUS:20160203T141929Z:e8cd247c-e6ab-43bc-9705-d1fb406e8740
       Date:
-      - Tue, 19 Jan 2016 13:49:29 GMT
+      - Wed, 03 Feb 2016 14:19:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4133,18 +4427,18 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj96GSen2+/rKvZRyP+
         vJjh07vNetJM62LVFtWyubv/6d75XnZ+sJ1/+iDf3t+Zfrr98Hxyvr2zd7C3
         P9udzfYP7t+t86Za19P887par5q7FvDdVV1dFrO8bu5+UUzrqqnO2/GLvL2q
-        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/un//Xpbf26feJ/kB4fFw
-        f/vh7Pzh9mTn3mR6/uDhXn5v9/f9SF9sr1c8wlt0qm+U1TTDgPFWnjXt2nxB
-        I1jldVtQy0cp008+vCwaal4sL163WcudvV5Pp3k+yxV7akY9CFnWQtrZzr3Z
-        zu6D2fankx2i5cHe+fbDvelk++HuJJvc27l372DngX25WCmOeHN/Z7y7tzve
-        3X843nNN7GBKg/4XeTsn8tEbT69pmoupbVvMyvxNscirdXu2/KJYrlse0b79
-        fnVSLc+Li3XNgOgrHSy+Y4h3f1iMsZSfZ8s2r8+zKTHGFO/RK7P7ezt3O5g2
-        9MGUP9j9SDD+JfhB//yS/webJePn7wIAAA==
+        6rd3V+tJWUzPXh7PZvR+k3vvKUJ5m10Ape/e/X0/Os939van57PtnQcHD7b3
+        Jw8fbmf37h1sT2b7+/nBZDI7mOz8vh/pi+31ikd4i071jbKaZhgw3sqzpl2b
+        L2gEq7xuC2r5KGX6yYeXRUPNi+XF6zZrubPX6+k0z2e5Yk/NqAchy1pIO9u5
+        N9vZfTDb/nSyQ7Q82Dvffrg3nWw/3J1kk3s7NJydB/blYqU44s39nfHu7oPx
+        vfvj3U9dEzuY0qD/Rd7OiXz0xtNrmuZiatsWszJ/Uyzyat2eLb8oluuWR7Rv
+        v1+dVMvz4mJdMyD6SgeL7xji3R8WYyzl59myzevzbEqMMcV79Mrs/t7O3Q6m
+        DX0w5Q92PxKMfwl+0D+/5P8BnwoekO8CAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:29 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Chef-Prod/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4158,7 +4452,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4181,20 +4475,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 4a67d016-b0e5-418b-b14f-d2cd59a7cfca
+      - f49bdaeb-3af4-4ed8-8165-cbc5c6226d51
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - b45d873b-b6aa-43e4-b04f-175ab5cdb8db
+      - d47fb90a-fdb6-4fbd-927b-4b210bcb580e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134931Z:b45d873b-b6aa-43e4-b04f-175ab5cdb8db
+      - NORTHCENTRALUS:20160203T141930Z:d47fb90a-fdb6-4fbd-927b-4b210bcb580e
       Date:
-      - Tue, 19 Jan 2016 13:49:30 GMT
+      - Wed, 03 Feb 2016 14:19:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4204,21 +4498,21 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7u5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1ZJ6fbxMFZq7PKOG8d/FsIF6z
-        nk7zfJZ7EPE44p0tz6vOd4RmSDsfbDoEsUeZvTd7u4/u7zy692D88N7B/u7+
-        /Q6FiC7mV6aS/v19hvvRpKrap0V2sayatpgCDx0zjXbZVGX+elrn+bKZV+2T
-        spp8VRfU5KN5266aR3fvTomSKyLk/d29nfGEvh9PqzofXxXLWXXVjJd5excd
-        zFwH2+aV7XsPp/fv7e1Mt3cmO/e29z/NH24/PN85395/cI8Y6MGnB+fZ5K6d
-        qvFtmo8bi+x4slgZ0n3U5HWRlScyoOfVxf8XRsIo6xyMy+qC51M5PH/X0iiJ
-        UzBfyq46bfStYfMvimldNdV5Oz6jxhfzthn/5BfeXL/O25ZYrWHIBBs/lCv6
-        0uDAv5cUDEnA+3N/lPP3Hu18+mh3Z3z/04PdnYNPA84XWkUxr67yGj3nd+v1
-        Eh163dwaYdJk5m1pJAT8jZNf8v8A/BfbJ/oFAAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NHew092dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6Ms/Pt4kCM9dnlHDeu3g2EK9Z
+        T6d5Pss9iHgc8c6W51XnO0IzpJ0PNh2C2KPM3pu9nUf3Pn10f29878HO/b37
+        XQoRXcyvTCX9+/sM96NJVbVPi+xiWTVtMQUeOmYa7bKpyvz1tM7zZTOv2idl
+        NfmqLqjJR/O2XTWP7t6dEiVXRMj7u3s74wl9P55WdT6+Kpaz6qoZL/P2LjqY
+        uQ62zSvb9x5O79/b25lu70x27m3vf5o/3H54vnO+vf/gHjHQg08PzrPJXTtV
+        49s0HzcW2fFksTKk+6jJ6yIrT2RAz6uL/y+MhFHWORiX1QXPp3J4/q6lURKn
+        YL6UXXXa6FvD5l8U07pqqvN2fEaNL+ZtM/7JL7y5fp23LbFaw5AJNn4oV/Sl
+        wYEfloI1dBz9ZehOjQcEoM/8rB/xrjSRgUa7ra7yGu/ld+v1Ep17YG/dHakh
+        87Y0ktH/xskv+X8AVcVcIbcFAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:31 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/Postgres-Dev?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4232,7 +4526,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4255,20 +4549,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f9330761-0298-4fa4-aa73-9787673c1e3e
+      - 3141f84b-d831-4131-ba03-e84244580d2a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - ff05904e-09a0-42a6-a372-96c35e33fd37
+      - 4c7a3ca6-45c2-4dae-bec7-fb0cca33dc0e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134932Z:ff05904e-09a0-42a6-a372-96c35e33fd37
+      - NORTHCENTRALUS:20160203T141931Z:4c7a3ca6-45c2-4dae-bec7-fb0cca33dc0e
       Date:
-      - Tue, 19 Jan 2016 13:49:31 GMT
+      - Wed, 03 Feb 2016 14:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4285,10 +4579,10 @@ http_interactions:
         NQOir3Qk+I4h3v1hTfxSfp4t27w+z6Y08Ssz8bP8cv/e/bsdZBv6YMof7H4k
         SP8S/KB/fsn/AwfrPqbVAgAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:32 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/Postgres-Dev/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4302,7 +4596,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4325,20 +4619,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 7a1e7e14-62d7-4ea8-9412-f913565ac513
+      - 3d8d303d-0496-4550-8d7d-8429b930e483
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 0452b15f-dff4-4f61-aeb4-d1aa1acdfdb4
+      - a4ee0f0c-b747-42f1-9252-5e1509ae665a
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134932Z:0452b15f-dff4-4f61-aeb4-d1aa1acdfdb4
+      - NORTHCENTRALUS:20160203T141932Z:a4ee0f0c-b747-42f1-9252-5e1509ae665a
       Date:
-      - Tue, 19 Jan 2016 13:49:32 GMT
+      - Wed, 03 Feb 2016 14:19:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4348,21 +4642,21 @@ http_interactions:
         pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN79z7Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqy6ppL6jr7af5pes2SjvvdTwb
-        6Nesp9M8n+UzBxGPo9/Z8rzqfEeYhuTzwaZDED3i3N/e3SX6vNnZf7R/QGQZ
-        79779P7e3sMOkYg05lcmlP79fYb70aSq2qdFdrEkshRT4KFjptEum6rMX0/r
-        PF8286p9UlaTr+qCmnw0b9tV8+ju3ek8P1/V1ez+7t7OeELfj6dVnY+viuWs
-        umrGy7y9iw5mroPtFf0E/Wfb59Pze7NpPt0+nxzMtvcfnt/ffjg7mG5Pdu/n
-        s+n5+YOd/eldf7rGt3lj3FiEx5PFismgvJG/a+kLIjCGqbOso6VvDYN8UUzr
-        qqnO2/EZNb6Yt834J7/wSPQ6b1uaoYYhE2z8UGL2mciBfy/mGWKc92eazQxz
-        cG///t6nAcMIrWKYf/ka3eZ3SYLzOiuLHwT93BpjUgI+BGk43OvL6iqv8XZ+
-        d5ZnZVlN6dev27EPQRrK9P3GyS/5fwCGLAvDsgUAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG93U92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4H6smraC+p6+2l+6bqN0s57Hc8G
+        +jXr6TTPZ/nMQcTj6He2PK863xGmIfl8sOkQxJA4u9t7D9/sfPpo596jvU/H
+        n+4f7O/t7nWIRKQxvzKh9O/vM9yPJlXVPi2yiyWRpZgCDx0zjXbZVGX+elrn
+        +bKZV+2Tspp8VRfU5KN5266aR3fvTuf5+aquZvd393bGE/p+PK3qfHxVLGfV
+        VTNe5u1ddDBzHWyv6CfoP9s+n57fm03z6fb55GC2vf/w/P72w9nBdHuyez+f
+        Tc/PH+zsT+/60zW+zRvjxiI8nixWTAbljfxdS18QgTFMnWUdLX1rGOSLYlpX
+        TXXejs+o8cW8bcY/+YVHotd529IMNQyZYOOHErPPRA78ezHPEOO8P9NsZJgH
+        uzsP9/f3A4YRWsUw//I1us3vkgTndVYWPwj6uTXGpAR8CNJwuNeX1VVe4+38
+        7izPyrKa0q9ft2MfgjSU6fuNk1/y/wA7T9+RsgUAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:32 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/ubuntuserver?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4376,7 +4670,77 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Etag:
+      - W/"6ead573e-2b3c-42b7-af42-0bc2adfefcdf"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a87c1ef8-2165-4a98-b592-14d5853bf4b2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - b012388e-9085-4d88-b3c7-e8726d85b582
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160203T141932Z:b012388e-9085-4d88-b3c7-e8726d85b582
+      Date:
+      - Wed, 03 Feb 2016 14:19:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aD1ZL9t1k9eXef3R
+        iL8qZvjibrOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3d6afbj88n5xv7+wd
+        7O3Pdmez/YP7d+u8qdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
+        U5234xd5e1XVb++u1pOymJ69PJ7N6P0mb+5GcMrb7AJYfffu7/vRp3k2u//g
+        Xr69N7k33d7fmzzYzs7397Z3JtO9bHaen09n57/vR/pie73icd6iX32jrKYZ
+        xoy38qwhRPQLGsQqr9uCWj5KmYry4WXRUPNiefG6zVru7PV6Os3zWT6TN6kZ
+        9SCUWQt1zyf39vfPp9l2tvfpg+39+/jtXnZ/ezrJH+T3852H53sP7cvFSnHE
+        m/s7493dB+N7n4739g5sEzuY0qD/Rd7OK+7r6TVNdjG1bYtZmb8pFnm1bs+W
+        XxTLdcsj2rffr06q5Xlxsa4ZEH2lg8V3DPHuD4s3lvLzbNnm9Xk27fDG/f27
+        HVwb+mDKH+x+JDj/Evygf37J/wOLmvUT9wIAAA==
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Compute/virtualMachines/ubuntuserver/instanceView?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4399,41 +4763,46 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 7230c493-1cd3-40aa-b63c-b306b135063a
+      - 619f837e-7bd8-4a14-a365-363c336804ae
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - eed1204e-852b-4cb8-9ee6-22ae5c1cb3f9
+      - 4f4be45e-7e0c-4c9a-9fba-c3bda7879c92
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134932Z:eed1204e-852b-4cb8-9ee6-22ae5c1cb3f9
+      - NORTHCENTRALUS:20160203T141933Z:4f4be45e-7e0c-4c9a-9fba-c3bda7879c92
       Date:
-      - Tue, 19 Jan 2016 13:49:32 GMT
+      - Wed, 03 Feb 2016 14:19:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
         kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
-        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
-        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
-        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7+5/s7Dza
-        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
-        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcgerS5v727S+R5s7P/aJ/Ic3+8
-        8+D+g/2d3Q6NiDLmV6aT/v19hvtR/q7NaQpoGgiqjtyO2tLsi2JaV0113o7P
-        qPHFvG3GP/nF0yK7WFZNW0yb13nbEtaNdup30CesA/9eBB0i5vsTciMRd/f2
-        7h98ei8gorBWFPPqKq/Rc353lmdlWU3pV7+rWyNNouFDkIZCyN84+SX/D/av
-        A9VPBAAA
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
+        6YuPvnv8vFiu3/HH23vjnfHu/kcjbd20Wbtu8obafU8+Sg0kPB9Nq1lO3330
+        sq4uCwAslhev6Z38brOeTvN8ls8MLDwflfllXuKFs+V5FXwzK5pVmV3j5TW6
+        ++hVns2ugyaLvGmyC+7v83XetIxxWjRpvV6i4zRbztKMul21+GuZX6XTanle
+        XKzrrCXcmnEAri0WDGtvZ/fT7Z297Z17b3b3H+0+fLR3/5OdnUc7Ox+Zxr9E
+        fvm+vv1R/q7Nlxjtt6nHkihJYKLkaa9X3MUXxbSumuq8HX/5+s3JqXm9GTPl
+        nxbZxbJq2mIa4kcvawfebO2NaYqCdjJH9J3XM338nlNDbwxODn03MD2ujdLI
+        /vJ9/PglDAQvv8VLSiOL50fLTKZgPVkvCW5eX+a161hHFnKf9zqen+1h+mDT
+        IYg9Ttp9s7f7aG/v0e798YO9g/v7Ow87HEWkMb8yofRv4bCPJlXVOqYAHjpm
+        Gu2yqcr89bTOiYXmVfukrCZf1QU1+Wjetqvm0d2703l+vqqr2f3dvZ3xhL4f
+        T6s6H18Vy1l11YyXeXsXHcxcB9uW/oT63v6DvXufbn+6M32wvb+/l20/zB/M
+        tnemB59me7v3diaz3bu2OU3X+DZvjBuL8HiyWBnyfUQgiqw8kUE9ry7+vzIa
+        RlvnYlxWFzyvyuxWOWDelG11+uhbw/FOI5xR44t524x/8gtvzl/nLZRYY0hF
+        r0IfhK/eVpnwqzeqkv/PiJtnB06X2aTMvZauIQsUnoiA9UdqR/l+Ixwa3fuP
+        bEiJ7D/a2R3fv//g3t79B4ESEXaLYl5d5TV6zu+qZfS6uTXCP/mFsaumQ/wg
+        Yv6S/weQ5A0HWwgAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:33 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/chefserver1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4447,7 +4816,78 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
+      X-Ms-Request-Id:
+      - a42fdda8-905f-4715-8d64-144a31d23516
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 68725354-9131-4348-bba2-ba8ecdb08d3d
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160203T141933Z:68725354-9131-4348-bba2-ba8ecdb08d3d
+      Date:
+      - Wed, 03 Feb 2016 14:19:33 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UerMmvPq3rx1WqWtfnTapEVy48e
+        pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
+        103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
+        R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG9e5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgJ1Os/Pm7y+zOtd12uUdN7beDaQ
+        r1lPp3k+y2cOIh5HvrPledX5jhANqeeDTYcghrTZ3d57+Gbn00c79x7tfTp+
+        +OnOwYMH9zs0IsqYX5lO+vf3Ge5H+bs2pymgaSCoOnI7akuzL4ppXTXVeTs+
+        o8YX87YZ/+QXT4vsYlk1bTFtXudtS1g32qnfQZ+wDvx7EXSImO9PyA1EfDDe
+        2SES3v80IKKwVhTz6iqv0XN+d5ZnZVlN6Ve/q1sjTaLhQ5CGQsjfOPkl/w8w
+        0HhVTwQAAA==
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:34 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/ERP?api-version=2015-06-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4470,20 +4910,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 93cd86c7-c0fa-4805-aa88-1b3b2ce4af60
+      - 89647ebf-f698-4079-a03e-7dc4c6b003b7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 7e82b55a-f986-4d2a-845b-080d0b3ead07
+      - 010ba124-15cc-4593-a52a-c5796a081da5
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134933Z:7e82b55a-f986-4d2a-845b-080d0b3ead07
+      - NORTHCENTRALUS:20160203T141934Z:010ba124-15cc-4593-a52a-c5796a081da5
       Date:
-      - Tue, 19 Jan 2016 13:49:32 GMT
+      - Wed, 03 Feb 2016 14:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4500,10 +4940,10 @@ http_interactions:
         O4Z494c24Uv5ebZs8/o8m9KE5/Xq/s79ux0kG/pgyh/sfiTI/hL8oH9+yf8D
         MQDoSbwCAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:34 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/ERP/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4517,7 +4957,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4540,20 +4980,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - c8596422-0bda-4fea-b657-2a58f088639b
+      - 57bdf3ad-93e5-4845-8e39-676de08c6107
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 0283db3a-8c1a-4e8f-9703-01756e9cec70
+      - 534f029e-04b3-434c-90dc-238b2da6c6c7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134934Z:0283db3a-8c1a-4e8f-9703-01756e9cec70
+      - NORTHCENTRALUS:20160203T141934Z:534f029e-04b3-434c-90dc-238b2da6c6c7
       Date:
-      - Tue, 19 Jan 2016 13:49:34 GMT
+      - Wed, 03 Feb 2016 14:19:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4563,18 +5003,18 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN79z/Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATq6auXrrcoyby38GwgW7OeTvN8
-        ls8cRDyObGfL86rzHSEYUs0Hmw5B9Ghyf3t3l8jyZmf/0T6R5f5459OdnYMH
-        XdoQRcyvTB/9+/sM96P8XZsT6Yn8BFVHbkdtafVFMa2rpjpvx2fU+GLeNuOf
-        /OJpkV0sq6Ytps3rvG0J60Y79TvoE9aBfy+CDhHz/Qm5kYi7e3v3Dz69FxBR
-        WCqG+Zev0W1+l5g5r7Oy+EHQz60xJnnwIUjD4V5fVld5jbfzu7M8K8tqSr9+
-        3Y59CNJQpu83Tn7J/wOV12NkvQQAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG9/U92dh7t
+        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4F6+uql6y1KMu8tPBvI1qyn0zyf
+        5TMHEY8j29nyvOp8RwiGVPPBpkMQQ5rsbu89fLPz6aOde4/2Ph0/2N15uL/f
+        pQ1RxPzK9NG/v89wP8rftTmRnshPUHXkdtSWVl8U07pqqvN2fEaNL+ZtM/7J
+        L54W2cWyatpi2rzO25awbrRTv4M+YR349yLoEDHfn5Abifhw//69nQf3AyIK
+        S8Uw//I1us3vEjPndVYWPwj6uTXGJA8+BGk43OvL6iqv8XZ+d5ZnZVlN6dev
+        27EPQRrK9P3GyS/5fwBvtuD7vQQAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:34 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQ2?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4588,7 +5028,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4611,20 +5051,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 28b498da-bc37-4592-80a0-9fec42fc2d39
+      - c2bc8177-16c6-4f0c-80ae-a32c9f237645
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - f6783db7-2fc1-4f1e-8d9f-ea76a0354424
+      - e5f16462-cd53-4860-a03b-c0e75f65a9f4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134935Z:f6783db7-2fc1-4f1e-8d9f-ea76a0354424
+      - NORTHCENTRALUS:20160203T141935Z:e5f16462-cd53-4860-a03b-c0e75f65a9f4
       Date:
-      - Tue, 19 Jan 2016 13:49:34 GMT
+      - Wed, 03 Feb 2016 14:19:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4641,10 +5081,10 @@ http_interactions:
         BN8xxLs/tBlfys+zZZvX59mUZnxR/KK9B3sP7nawbOiDKX+w+5Fg+0vwg/75
         Jf8PB5XUGL8CAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:35 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQ2/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4658,7 +5098,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4681,20 +5121,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - a94e90b7-3648-4995-a780-810c8953ac97
+      - 90cc2e00-f6f0-4db1-99f9-94512cb90314
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 736ddabe-7952-449b-adb5-699820dbaef9
+      - cb94f3b6-ba97-4c78-86bf-1789a34a3f06
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134935Z:736ddabe-7952-449b-adb5-699820dbaef9
+      - NORTHCENTRALUS:20160203T141936Z:cb94f3b6-ba97-4c78-86bf-1789a34a3f06
       Date:
-      - Tue, 19 Jan 2016 13:49:34 GMT
+      - Wed, 03 Feb 2016 14:19:35 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4704,17 +5144,17 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aN7Dz7Z2Xm0
-        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zATqF2c/see6i9LMew3PBro16+k0
-        z2f5zEHE4+h2tjyvOt8RhiHZfLDpEMQeUe692b3/aPfTR/fujXc/fXBv716H
-        NkQR8yvTR//+PoP9KH/X5kR6Ij8B1YHbQTtaFdO6aqrzdnxGjS/mbTP+yS+e
-        FtnFsmraYtq8ztuWkG60U7+DPl0d+Pei5xAt35+OG2m4t/fwYPcgJKKwVBTz
-        6iqv0XN+d5ZnZVlN6Ve/q1sjTSLhQ5CGQsjfOPkl/w/qXwxFRwQAAA==
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG9+5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgL1i7Of2HPdRWnmvYZnA92a9XSa
+        57N85iDicXQ7W55Xne8Iw5BsPth0CGJIlN3tvYdvdj59tHPv0d6n40/3D/b3
+        dvc6xCGSmF+ZQPr39xnuR/m7NifaE/0Jqo7cjtoRq5jWVVOdt+Mzanwxb5vx
+        T37xtMgullXTFtPmdd62hHWjnfod9AnrwL8XQYeI+f6E3EjEB7s7D/f39wMi
+        Ck9FMa+u8ho953dneVaW1ZR+9bu6NdIkEz4EaSiE/I2TX/L/AD+InHxIBAAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:35 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/MIQCompute1?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4728,7 +5168,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4751,20 +5191,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 64e2b270-d446-4a04-a6ef-bf7a43f7f0c5
+      - 0738d6cc-cc02-4cd6-b142-8a664549c55a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - aa3c99a4-c72a-4c49-8be1-ba3946c5a2ab
+      - 972e1827-cdad-4138-a712-0a8d6fc87bee
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134939Z:aa3c99a4-c72a-4c49-8be1-ba3946c5a2ab
+      - NORTHCENTRALUS:20160203T141936Z:972e1827-cdad-4138-a712-0a8d6fc87bee
       Date:
-      - Tue, 19 Jan 2016 13:49:39 GMT
+      - Wed, 03 Feb 2016 14:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4781,10 +5221,10 @@ http_interactions:
         OhJ8xxDv/tAmfik/z5ZtXp9nU5r4RfGLpvLu7v7ep3c7yDb0wZQ/2P1IkP4l
         +EH//JL/B0wm3MTUAgAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:39 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/MIQCompute1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4798,7 +5238,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4821,20 +5261,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - beae932a-635c-4dcc-9095-aa0dc44f003a
+      - 0db9626d-6835-4152-9366-bcd8cce9af17
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - ffb4eae6-ade4-440c-8ea9-2a110e9d220e
+      - 7fbecf88-1d42-4e02-bb83-05f016ab7f8e
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134941Z:ffb4eae6-ade4-440c-8ea9-2a110e9d220e
+      - NORTHCENTRALUS:20160203T141937Z:7fbecf88-1d42-4e02-bb83-05f016ab7f8e
       Date:
-      - Tue, 19 Jan 2016 13:49:40 GMT
+      - Wed, 03 Feb 2016 14:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4843,19 +5283,19 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
         6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
         Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d3a3
-        dx++2b33aP/ho/29T3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfrF
-        2U+cVIvVus13Xa9R0nlv49lAvmY9neb5LJ85iHgc+c6W51XnO0I0pJ4PNh2C
-        6NHm/vbuLpHnzc4+EebR/QfjB7uffrq3c9ChEVHG/Mp0or8VpB2dpc0sazPC
-        6+3/7yhzb2/v4e79b4Aye67Xn1+UwY/vM9yP8ndtTmJLoktQdeR21JZiXxTT
-        umqq83Z8Ro0v5m0z/skvnhbZxbJq2mLavM7blrButFO/gz5hHfj3IugQMd+f
-        kJuJ+HD/wf0HuwER+6xkMa+u8ho953dneVaW1ZR+9bu6NdKkTn0I0lAI+Rsn
-        v+T/AfMpzztIBgAA
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d/a2
+        d+692d1/tPvw0b1PP9nZebSz85Fp/Evkl+/jxy9hEEDqLZBRAtjhf7TMBOoX
+        Zz9xUi1W6zbfdb1GSee9jWcD+Zr1dJrns3zmIOJx5Dtbnled7wjRkHo+2HQI
+        Ykib3e29h292Pn20c+/R3qfjT/cP9vd29zo0IsqYX5lO9LeCtKOztJllbUZ4
+        vf0RZfgHQe1SZs/1+vOLMvjxfYb7Uf6uzUlsSXQJqo7cjtpS7ItiWldNdd6O
+        z6jxxbxtxj/5xdMiu1hWTVtMm9d52xLWjXbqd9AnrAP/XgQdIub7E3IjER/s
+        7jzc398PiNhnJYt5dZXX6Dm/O8uzsqym9Kvf1a2RJnXqQ5CGQsjfOPkl/w+U
+        Vz8oSAYAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:41 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/chef-prod/providers/Microsoft.Network/publicIPAddresses/rgtest-publicIp?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -4869,77 +5309,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"0b530b36-edee-4b17-ae72-076b1003db6b"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2ba89c0e-1427-4df6-8515-9d24739bd768
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - db19d6a1-a7c2-4b4d-884c-507ecab08569
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134941Z:db19d6a1-a7c2-4b4d-884c-507ecab08569
-      Date:
-      - Tue, 19 Jan 2016 13:49:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bdXq0nZTE9
-        W3004m+LGb6726wnzbQuVm1RLZu7+5/une9l5wfb+acP8u39nemn2w/PJ+fb
-        O3sHe/uz3dls/+D+3TpvqnU9zT+vq/WquTud5+fbq7qa3aV/LotZXjd3vyim
-        ddVU5+34Rd5eVfXbu9r7y+PZjN5v8uZuHK28zS6A2Hfv/r4f7Uzu39uZ3Pt0
-        O5/lhM1k98F2lj/Y29558Olkd2fn3mzy6eT3/UhfbK9XPNpbdK1vlNU0w7Dx
-        Vp417dp8QeNY5XVbUMtHKdNSPrwsGmpeLC9et1nLnb1eT6c5YTeTN6kZ9SDE
-        WQuB9yb3Zweze7vbn+4ePNjef5Dtb2cPJve279+f7D/Mz+9lDx5M7MvFSnHE
-        m/s74wefjncfHtD/bQs7ltJg/0Xezivu6uk1zXgxtW2LWZm/KRZ5tW7Pll8U
-        yzXRm9rt2+9XJ9XyvLhY1wyIvtKx4juGePeHxR1L+Xm2bPP6PJta7rjbwdF8
-        /pEg+kvwg/75Jf8PV4k/s/ECAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -4962,376 +5332,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - b91b770c-4c21-4a09-8181-35151c0ff2c2
+      - 316bacef-e015-4670-a164-81c2b78bd360
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - aa996769-586b-491f-b703-c8579c301dd0
+      - 4f2a482f-6055-4661-8669-c730571f4824
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134942Z:aa996769-586b-491f-b703-c8579c301dd0
+      - NORTHCENTRALUS:20160203T141937Z:4f2a482f-6055-4661-8669-c730571f4824
       Date:
-      - Tue, 19 Jan 2016 13:49:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
-        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
-        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
-        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr36Sc7O492dj4yjX+J/PJ9
-        ffuj/F2bLzHab1OPJZGQwETJ016vuIsvimldNdV5Oz7+wbrOx0+L7GJZNW0x
-        bcZnWfba+ztEkd7XPryZ2h3vjXfGO0FLmSj61uuePn7P+aE3BmeIvrt5jqiR
-        N0svy/VFsUzzZTYp81m6tcwW+aP0PYgxSi9l2I9SHfSdsZ0VOy/2l+/jxy9h
-        dIDrW+Co82LJ8hGQoM8/qi9a4qH8/t796ez+ZDvfvbe/vb+7/3D7YP/+/e3d
-        3U+z/WxncjB9mI0v5x6VlNShTHgd4PnZprsPNh2C2OPvgze7nxJzP9r9dPwp
-        ffbpvfsdPifimV+ZlPq38H1k3HbM7zfeobG+/zgHxrh/79H9nfG9T3f293Yf
-        BGMU5ohiXl3lNXrO76o68bq5NcI/+YVRRqZD/CBi/pL/B2vfg5qJBQAA
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Network/publicIPAddresses/rgtest12-publicIp?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"d7ca7f34-1756-44df-998b-2e300446ce97"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a7f7dea2-32f5-4c25-9c5b-fde31a94e542
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - 0dfb6f5c-da57-4290-acc7-248558b6e5b7
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134943Z:0dfb6f5c-da57-4290-acc7-248558b6e5b7
-      Date:
-      - Tue, 19 Jan 2016 13:49:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bd3dterSdl
-        MT1bfTTi74sZvr3brCfNtC5WbVEtm7v7n+6d72XnB9v5pw/y7f2d6afbD88n
-        59s7ewd7+7Pd2Wz/4P7dOm+qdT3NP6+r9aq5e1ItVus2/8kvmrururosZnnd
-        3P2imNZVU5234xd5e1XVb+9q9y+PZzMC0OTN3SHM8ja7AG7fvfv7fjR7MM0e
-        nN/b3959cP/T7f392fn2w4cHk+29/N7Ozv7+p9P84YPf9yN9sb1e8ZBv0bm+
-        UVbTDCPHW3nWtGvzBY1klddtQS0fpUxQ+fCyaKh5sbx43WYtd/Z6PZ3m+Syf
-        yZvUjHoQ+qyFxtPpTjbdmd7b3r9P9Nz/dOfe9sFsRv/cm2AQD2Z5NrEvFyvF
-        EW/u74wffDq+92C8t3/PtrBjKQ32X+TtvOKunl7TtBdT27aYlfmbYpFX6/Zs
-        +UWxpHkC4H37/eqkWp4XF+uaAdFXOlZ8xxDv/tAYZCk/z5ZtXp9nU49B7nbQ
-        dN98JNj+Evygf37J/wPK70Rq+wIAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:43 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest12/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
-      X-Ms-Request-Id:
-      - 24692753-636c-4434-aa94-25a82e72fcfd
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 8af5c793-1390-41d1-84b4-63cf609148fd
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134944Z:8af5c793-1390-41d1-84b4-63cf609148fd
-      Date:
-      - Tue, 19 Jan 2016 13:49:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
-        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
-        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
-        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr34JOdnUc7Ox+Zxr9Efvm+
-        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
-        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
-        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
-        OsD1LXDUebFk+QhI0Ocf1Rct8dDu3t50597k3vl0e38ve7i9/3Bnf3vyYH+2
-        fS9/MJnen957mE92xpdzj05K7FAqvC7w/GxT3gebDkHscfjBm729R/d3Hu3u
-        jnce7hzsf9phdKKe+ZVpqX8L40eGbYf8fsMdGur7D3NoiAePdvfGnz64v7fz
-        6UEwRuGOKObVVV6j5/yu6hOvm1sj/JNfGG1kOsQPIuYv+X8AYF7KcooFAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/computevms/providers/Microsoft.Network/publicIPAddresses/rgtest2-publicIp?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"9dbc62b2-d8bb-4610-add3-3b22922b2c83"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 466f76ac-da66-4840-aef3-146c44fbe881
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 6fa629e9-1deb-4c08-a3b6-055a00bbc399
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134945Z:6fa629e9-1deb-4c08-a3b6-055a00bbc399
-      Date:
-      - Tue, 19 Jan 2016 13:49:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9qL5o86bd216tJ2Ux
-        PVt9NOKvixm+vNusJ820LlZtUS2bu/uf7p3vZecH2/mnD/Lt/Z3pp9sPzyfn
-        2zt7B3v7s93ZbP/g/t06b6p1Pc0/r6v1qrk7rRardZtfLpq7q7q6LGZ53dz9
-        opjWVVOdt+MXeXtV1W/vavcvj2czAtDkzd0BxPI2uwBq3737+370cDaZfro3
-        2dueHUwm2/uf7u5sZ7PZve17k729h3v0xfTg3u/7kb7YXq94wLfoW98oq2mG
-        geOtPGvatfmCBrLK67aglo9SJqd8eFk01LxYXrxus5Y7e72eTvN8ls/kTWpG
-        PQh51kLi/Wx67/7+w4fbO9PZ/vb+7N7e9iR/eH978vDhp/nB/t7Bwezcvlys
-        FEe8uXvvwXh3l/6/8+l498G+bWSHU5oBfJG384p7e3pN815MbdtiVuZvikVe
-        rduz5RfFkmYKsPft96uTanleXKxrBkRf6XDxHUO8+0NjkaX8PFu2eX2eTR2L
-        3O1gab/4SHD9JfhB//yS/wd0EkRB+gIAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:45 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/rgtest2/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
-      X-Ms-Request-Id:
-      - f313851c-ea89-4471-ba50-db56f93ee9fc
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 61fe9673-3f3a-4bd2-ae91-2a719cda4fe9
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134946Z:61fe9673-3f3a-4bd2-ae91-2a719cda4fe9
-      Date:
-      - Tue, 19 Jan 2016 13:49:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
-        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
-        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
-        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrr38JOdnUc7Ox+Zxr9Efvm+
-        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
-        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
-        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
-        OsD1LXDUebFk+QhI0Ocf1Rct8dDe+e75pwf7D/e2H2b57vb+7t7D7cnDvfvb
-        5+cHeZ7t797Lsnx8OffIpLQOhcLrAc/PNuF9sOkQxB6DH7zZ/fTR/f1Huw/H
-        u/d3d/Y/PegwOlHP/Mq01L+F8SPjtmN+v/EOjfX9xzk0xgeP9h6MP/304c7e
-        /qfBGIU7ophXV3mNnvO7qk+8bm6N8E9+YbSR6RA/iJi/5P8BLSBqRooFAAA=
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM0/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
-      X-Ms-Request-Id:
-      - 26fa3118-ef29-4340-992e-9650a3a4edd3
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
-      X-Ms-Correlation-Request-Id:
-      - 093f1cbc-45aa-4b3d-9d25-338485664e07
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134947Z:093f1cbc-45aa-4b3d-9d25-338485664e07
-      Date:
-      - Tue, 19 Jan 2016 13:49:47 GMT
+      - Wed, 03 Feb 2016 14:19:36 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5341,19 +5355,19 @@ http_interactions:
         pbuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aP9g092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
-        +cxBxOMod7Y8rzrfEQIh4Xyw6RBEjyz3t3d3iTJvdvaJJo/2Px3v7H36cPde
-        hzpEE/MrU0j//j6D/WhSVe3TIrtYVk1bTIGGDpkGu2yqMn89rfN82cyr9klZ
-        Tb6qC2ry0bxtV82ju3ebVT7dbdqqppndHU+owXha1fn4qljOqqtmvMzbu+hh
-        5nrYxjuXi53tPNt9kGd7+9vZLJtt7+9P721nBwcPt3d29u+dT/Z27z883+MO
-        tn/yi53xbVqPG4vreLJYMQWUH/qzq8Ok795rVodm9P1nc/NMHjzc//TeXjCV
-        MpQo5tVVXqPn/O4sz8qymtKvfle3RppE04cgDYVffuPkl/w/Lg2IFs8EAAA=
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG9Tz/Z2Xm0
+        s/ORafxL5Jfv48cvYRBA6i2QUQLY4X+0zARq1aCJ6zBKNe9FPBso16yn0zyf
+        5TMHEY+j3NnyvOp8RwiEhPPBpkMQQ7Lsbu89fLPz6aOdg0f3dscHO59+eu/T
+        LnmIKOZXJpH+/X2G+9GkqtqnRXaxrJq2mAIPHTONdtlUZf56Wuf5splX7ZOy
+        mnxVF9Tko3nbrppHd+82q3y627RVTVO7O55Qg/G0qvPxVbGcVVfNeJm3d9HD
+        zPWwjXcuFzvbebb7IM/29rezWTbb3t+f3tvODg4ebu/s7N87n+zt3n94vscd
+        bP/kFzvj27QeNxbX8WSxYgooQ/SnV4dJ373XtA5N6ftP5+ap/PTh7t7OvWAq
+        ZShRzKurvEbP+d1ZnpVlNaVf/a5ujTTJpg9BGgq//MbJL/l/AJ25V+bQBAAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:47 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/spec-VM1/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5367,7 +5381,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -5390,20 +5404,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - 5ac2d856-4d34-407d-83ae-357fcca12395
+      - cda0ace2-0510-4bf5-96f7-3d959ef8659f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 7f20999e-0edd-47f1-868f-459483d94186
+      - 403cb09e-0bca-44ad-be27-6385fe29a552
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134947Z:7f20999e-0edd-47f1-868f-459483d94186
+      - NORTHCENTRALUS:20160203T141938Z:403cb09e-0bca-44ad-be27-6385fe29a552
       Date:
-      - Tue, 19 Jan 2016 13:49:46 GMT
+      - Wed, 03 Feb 2016 14:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5413,19 +5427,20 @@ http_interactions:
         pTuj4Ntn2bpsu19eLo4v8mVLHzAo98lP5nVTVGj50VfLt8vqavkRv0EtmjZr
         103e0Hffk49S8zaej6bVLKfvPnpZV5cFgBTLi9f0Tn73q2V2mRVlNilzAw3P
         R2V+mZd45btZjdbBl7OioSFcA8IafX70omrTV3k2uw6aLfKmyS6445/8IuUx
-        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3d2t3cfvtm992j/4aP9g092dh7t
-        7HxkGv8S+eX7+PFLGASQegtklAB2+B8tM4FaNWjiOoxSzXsRzwbKNevpNM9n
-        +cxBxOMod7Y8rzrfEQIh4Xyw6RBEjyz3t3d3iTJvdvaJJo/2Px3v7d//dGen
-        Sx4iivmVSaR/f5/hfjSpqvZpkV0sq6YtpsBDx0yjXTZVmb+e1nm+bOZV+6Ss
-        Jl/VBTX5aN62q+bR3bvNKp/uNm1V09TujifUYDyt6nx8VSxn1VUzXubtXfQw
-        cz1s453LBWE+uZ/tZfvn27uzTx9s7+/O8u1sd2+6fW93tvNg99OHe5/uEWGp
-        8fZPfrE7vk3rcWNxHU8WK6aAMkR/enWY9N17TevQlL7/dG6eyod79+8d3Aum
-        UoYSxby6ymv0nN+d5VlZVlP61e/q1kiTbPoQpKHwy2+c/JL/B3Aw2gnQBAAA
+        pEWTrpd13qyqZVNc5uPghbZYcOu9nd1Pt3f2tnfuvdndf7T78NG9B5/s7Dza
+        2fnINP4l8sv38eOXMAgg9RbIKAHs8D9aZgK1atDEdRilmvcing2Ua9bTaZ7P
+        8pmDiMdR7mx5XnW+IwRCwvlg0yGIIVl2t/cevtn59NHOwaO9g/HDh/u7uw8P
+        OuQhophfmUT69/cZ7keTqmqfFtnFsmraYgo8dMw02mVTlfnraZ3ny2ZetU/K
+        avJVXVCTj+Ztu2oe3b3brPLpbtNWNU3t7nhCDcbTqs7HV8VyVl0142Xe3kUP
+        M9fDNt65XOxu70zuZ3vZ/vn27uzTB9v7u7N8O9vdm27f253tPNj99OHep3tE
+        WGq8/ZNf7I5v03rcWFzHk8WKKaAM0Z9eHSZ9917TOjSl7z+dG6by4Xjn4MHB
+        7s5+MJUylCjm1VVeo+f87izPyrKa0q9+V7dGmmTThyANhV9+4+SX/D+wK3A0
+        0AQAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:47 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Network/publicIPAddresses/publicIp100?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5439,149 +5454,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Etag:
-      - W/"33d6207d-2ebd-4c2d-88c4-13306af1a1b9"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f17d8438-f80c-4177-a057-f90c9e4497a4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14997'
-      X-Ms-Correlation-Request-Id:
-      - 271f6cbd-d436-4c13-b157-23fea58a0b9f
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134948Z:271f6cbd-d436-4c13-b157-23fea58a0b9f
-      Date:
-      - Tue, 19 Jan 2016 13:49:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UfLbJF/9Cj9aLWelMX0bLW7s/PR
-        iL8pZvj8brOeNNO6WLVFtWzu7n+6d76XnR9s558+yLf3d6afbj88n5xv7+wd
-        7O3Pdmez/YP7d+u8qdb1NP+8rtar5u7JPD/ffllXs7ururosZnnd3P2imNZV
-        U5234xd5e1XVb+8qAi+PZzN6v8kb84mHUt5mF0Dqu3d/34/u3Zt9urfzYLa9
-        l09m2/vTvdn2wcF0f3v33r2dT7Pz3Wx38vD3/UhfbK9XPMpbdKtvlNU0w5Dx
-        Vp417dp8QWNY5XVbUMtHKdNQPrwsGmpeLC9et1nLnb1eT6d5Pstn8iY1ox6E
-        MGsh7s6nBzv5DjDP9ve293fvz7Yfzu4Rce9P7j/Idw7uP7jvXi5WiiPe3N8Z
-        7+7ujw8ejj99YFvYsZQG+y/ydl5xV0+vaaaLqW1bzMr8TbHIq3V7tvyiWK5b
-        HtC+/X51Ui3Pi4t1zYDoKx0rvmOId39YnLGUn2fLNq/PsylxBuHa/v7LYkqc
-        cbeDaHN3UfwifH/2kr79SHD+JfhB//yS/wee5ic69AIAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Compute/virtualMachines/testprov100/instanceView?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
-      X-Ms-Request-Id:
-      - 09d59db5-ad0a-43fe-a030-2bbccb633bf5
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
-      X-Ms-Correlation-Request-Id:
-      - 2e41d2a1-0a2a-4343-a5dc-13cca3f55191
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134948Z:2e41d2a1-0a2a-4343-a5dc-13cca3f55191
-      Date:
-      - Tue, 19 Jan 2016 13:49:47 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
-        6YuP9sYPxru7Dw/GD+7d/2ikzZo2a9dN3lCD78lHqQGB56NpNcvpu49e1tVl
-        AUjF8uI1vZPfbdbTaZ7P8pmBheejMr/MS7xwtjyvgm9mRbMqs2u8vEZ3H73K
-        s9l10GSRN012wf19vs6blkeQFk1ar5foOM2WszSjblct/lrmV+m0Wp4XF+s6
-        awm3ZhyAa4sFw9rb2f10e2d3e/fhm917j/YfPrp3/5OdnUc7Ox+Zxr9Efvm+
-        vv1R/q7Nlxjtt6nHkkhIYKLkaa9X3MUXxbSumuq8HR//YF3n46dFdrGsmraY
-        NuOzLHvt/R2iSO9rH95M7Y73xjvjnaClTBR963VPH7/n/NAbgzNE3908R9TI
-        m6WX5fqiWKb5MpuU+SzdWmaL/FH6HsQYpZcy7EepDvrO2M6KnRf7y/fx45cw
-        OsD1LXDUebFk+QhI0OcfXc2JDAT+9599mt2/lz/ItqcPzvPt/en5bDvbfzjd
-        Pv9079O9871JvjvLx5dzj1BK7VAsvD7w/GyT3gebDkHssfjBm91PH+09fLR/
-        b7yz/2Dv/qe7HVYn+plfmZr6t7B+ZNx2zO833qGxvv84B8Z4b+fR/v54/+D+
-        w3sPwzEKf0Qxr67yGj3nd1WjeN3cGuGf/MLoI9MhfhAxf8n/A2uYcFGMBQAA
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Network/publicIPAddresses/SalesforceUSIP?api-version=2015-06-15
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -5604,20 +5477,20 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 42067839-ad65-4db9-9eff-99c1aad7b8c9
+      - 78c73beb-0f6b-4a8f-bde1-ec0a62ce76e8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - eeeb1fb0-7667-408a-b585-062d68f4dab7
+      - 33a3ba54-1cad-43a7-875e-07a6bdf14305
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134949Z:eeeb1fb0-7667-408a-b585-062d68f4dab7
+      - NORTHCENTRALUS:20160203T141938Z:33a3ba54-1cad-43a7-875e-07a6bdf14305
       Date:
-      - Tue, 19 Jan 2016 13:49:48 GMT
+      - Wed, 03 Feb 2016 14:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5634,10 +5507,10 @@ http_interactions:
         VzoSfMcQ7/4QZn0pP8+WbV6fZ1Oa9cbO+ro5OLjbQbOhD6b8we5Hgu4vwQ/6
         55f8P07bQ1vOAgAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:49 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Compute/virtualMachines/SalesforceUS/instanceView?api-version=2015-06-15
     body:
       encoding: US-ASCII
       string: ''
@@ -5651,7 +5524,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -5674,20 +5547,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 45ff7764-6885-4368-831c-f6db88005bb1_130971079586697714
+      - 45ff7764-6885-4368-831c-f6db88005bb1_130984778045211970
       X-Ms-Request-Id:
-      - d0d19ece-0219-4150-91e8-0376d2e1ae9c
+      - a956446d-2e37-4f63-b6c6-4489b40b585b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - b89c5080-b431-423e-b203-90e7df35cd33
+      - 1b35bcea-8201-45a6-af72-0033367b3b69
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134950Z:b89c5080-b431-423e-b203-90e7df35cd33
+      - NORTHCENTRALUS:20160203T141939Z:1b35bcea-8201-45a6-af72-0033367b3b69
       Date:
-      - Tue, 19 Jan 2016 13:49:50 GMT
+      - Wed, 03 Feb 2016 14:19:38 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5696,21 +5569,21 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xb5yk6UeXi+OLfNl+9Cjlv90nP5nXTVEt
         6YuPvlq+XVZXy49G2qJps3bd5A199z35KDVv4/loWs1y+u6jl3V1WQBIsbx4
         Te/kd79aZpdZUWaTMjfQ8HxU5pd5iVe+m9VoHXw5K5pVmV0Dwhp9fvSiatNX
-        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d3a3
-        dx++2b33aP/ho/u7n+zsPNrZ+cg0/iXyy/fx45cwCCD1FsgoAezwP1pmAvV1
-        VubNeVVP869eu26jtPNex7OBfs16Os3zWT5zEPE4+p0tz6vOd4RpSD4fbDoE
-        0SPO/e3dXaLPm539R/sPHt1/ON7Ze7B7f/dBh0hEGvMrE0r//j7D/WhSVe3T
-        IrtYVk1bTIGHjplGu2yqMn89rfN82cyr9klZTb6qC2ry0bxtV82ju3eX1/XF
-        w92D/fGEvhtPqzofXxXLWXXVjJd5exfAZw74dmNovz2dne9k5w8ebt/b2Z9t
-        788e3Nt+OJ3e3z64f393svtwNs13Htz1p2p8mzfGjUV2PFmsmATKF/m7lr4g
-        4mKIOsM6UvrWMMcXxbSumuq8HZ9R44t524x/8guPPK/ztqXZaRgywcYPJWSf
-        gRz492KcIaZ5f4bZyCy7ezsPdx7uB8witIpiXl3lNXrO787yrCyrKf3qd3Vr
-        pEkH+BCkoRDyN05+yf8DUzAquv0EAAA=
+        eTa7Dpot8qbJLrjjn/wi5TGkRZOul3XerKplU1zm4+CFtlhw672d3U+3d/a2
+        d+692d1/tPvw0b2DT3Z2Hu3sfGQa/xL55fv48UsYBJB6C2SUAHb4Hy0zgfo6
+        K/PmvKqn+VevXbdR2nmv49lAv2Y9neb5LJ85iHgc/c6W51XnO8I0JJ8PNh2C
+        GBJnd3vv4ZudTx/t3Ht0f3+8/+nuzsO9LpGINOZXJpT+/X2G+9GkqtqnRXax
+        rJq2mAIPHTONdtlUZf56Wuf5splX7ZOymnxVF9Tko3nbrppHd+8ur+uLh7sH
+        ++MJfTeeVnU+viqWs+qqGS/z9i6Azxzw7cbQfns6O9/Jzh883L63sz/b3p89
+        uLf9cDq9v31w//7uZPfhbJrvPLjrT9X4Nm+MG4vseLJYMQmUL/J3LX1BxMUQ
+        dYZ1pPStYY4vimldNdV5Oz6jxhfzthn/5BceeV7nbUuz0zBkgo0fSsg+Aznw
+        78U4Q0zz/gyzkVnu7937dPfeXsAsQqso5tVVXqPn/O4sz8qymtKvfle3Rpp0
+        gA9BGgohf+Pkl/w/UOWFmP0EAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:50 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -5724,7 +5597,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -5745,19 +5618,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
+      - 6600f3ce-1e1a-4f96-9a42-0e6e59f96fe1
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
+      - 6600f3ce-1e1a-4f96-9a42-0e6e59f96fe1
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134951Z:abaea8ec-926e-4ccc-8ccb-1a9184c6f96b
+      - NORTHCENTRALUS:20160203T141939Z:6600f3ce-1e1a-4f96-9a42-0e6e59f96fe1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:51 GMT
+      - Wed, 03 Feb 2016 14:19:39 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5774,10 +5647,10 @@ http_interactions:
         9H2TTyuQ2X/7u7l5u6E31s2X5y+lB/ouu8yKEqh43742MILvCbE2uwDl8ZvM
         6Y289NEv+f4vSf4fxlUpaegCAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:51 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:39 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts/chefprod5120/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Chef-Prod/providers/Microsoft.Storage/storageAccounts/chefprod5120/listKeys?api-version=2015-05-01-preview
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -5791,7 +5664,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
       Content-Length:
       - '0'
   response:
@@ -5814,19 +5687,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e930cd4e-6abb-4958-910f-4ddb6fc613d1
+      - c3a4aa3c-5a6a-481d-9f28-40a739f20187
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - e930cd4e-6abb-4958-910f-4ddb6fc613d1
+      - c3a4aa3c-5a6a-481d-9f28-40a739f20187
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T134952Z:e930cd4e-6abb-4958-910f-4ddb6fc613d1
+      - NORTHCENTRALUS:20160203T141940Z:c3a4aa3c-5a6a-481d-9f28-40a739f20187
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:49:51 GMT
+      - Wed, 03 Feb 2016 14:19:40 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5839,7 +5712,7 @@ http_interactions:
         Xv/U6ezdu/b3Xk0e/qJqXv7UT7av6x9cXM1/etLunX1n9nufn3y1u/ypqy8+
         P6Yefkny/wD0cfTdxgAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:52 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:41 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/?comp=list
@@ -5854,11 +5727,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:52 GMT
+      - Wed, 03 Feb 2016 14:19:41 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Wn/jS/g08ttfgc0WTrNy8M5EF7x2P2maxNQ0MKg56JE=
+      - SharedKey chefprod5120:iIREBIw33gURFiOHmHffPCJWHsdpyUudRgW25om75C0=
   response:
     status:
       code: 200
@@ -5871,11 +5744,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ced96114-0001-0084-39c0-5207e8000000
+      - 70e7cdcf-0001-002f-6b8d-5ed0fa000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:52 GMT
+      - Wed, 03 Feb 2016 14:19:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5894,27 +5767,32 @@ http_interactions:
         ZXAgMjAxNSAxNTo1ODoyMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4
         OEQyQkRFNjdCOTkwNzA1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
         L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
-        ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5t
-        YW5hZ2VpcTwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24s
-        IDA3IERlYyAyMDE1IDE2OjA5OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
-        Zz4iMHg4RDJGRjIwQjg2OUJEQkEiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2Nr
-        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0
-        ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1By
-        b3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5zeXN0ZW08
-        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyNSBTZXAg
-        MjAxNSAxOToxODo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQy
-        QzVERTI4NTE3RDk1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xl
-        YXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48
-        L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT52aGRz
-        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTggQXVn
-        IDIwMTUgMTk6Mzk6MTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhE
-        MkE4MDRCMzBFNURCRSI8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVh
-        c2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFz
-        ZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGll
-        cz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0Vu
-        dW1lcmF0aW9uUmVzdWx0cz4=
+        ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5i
+        b290ZGlhZ25vc3RpY3MtdWJ1bnR1c2VyLTAxMjQ3MjM2LTYwYzctNDQyYS05
+        ZTdkLTBjODZhMjEzMGJkMTwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
+        ZmllZD5Nb24sIDAxIEZlYiAyMDE2IDIxOjIwOjA0IEdNVDwvTGFzdC1Nb2Rp
+        ZmllZD48RXRhZz4iMHg4RDMyQjRENzNGMzZDOTYiPC9FdGFnPjxMZWFzZVN0
+        YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxh
+        YmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29u
+        dGFpbmVyPjxOYW1lPm1hbmFnZWlxPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
+        LU1vZGlmaWVkPk1vbiwgMDcgRGVjIDIwMTUgMTY6MDk6MDEgR01UPC9MYXN0
+        LU1vZGlmaWVkPjxFdGFnPiIweDhEMkZGMjBCODY5QkRCQSI8L0V0YWc+PExl
+        YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
+        dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVy
+        PjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPkZyaSwgMjUgU2VwIDIwMTUgMTk6MTg6NTYgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMkM1REUyODUxN0Q5NSI8L0V0YWc+
+        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
+        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFp
+        bmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5UdWUsIDE4IEF1ZyAyMDE1IDE5OjM5OjE1IEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDJBODA0QjMwRTVEQkUiPC9FdGFn
+        PjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwv
+        TGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250
+        YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:52 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:42 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-chefprod-39c5320c-0b03-46e9-9f0f-473ead768fab?comp=list&restype=container
@@ -5929,11 +5807,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:52 GMT
+      - Wed, 03 Feb 2016 14:19:42 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:vXmg5R9ZEAdJtGGP/DN4pkdXNYOFyIgEC8G5deIM2pI=
+      - SharedKey chefprod5120:HJX5UhR5dNbtFulbPr818kxYiCoTWm5zg2B/7GVbAXQ=
   response:
     status:
       code: 200
@@ -5946,11 +5824,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7300f5e7-0001-000c-22c0-52bf31000000
+      - 3ebd583e-0001-0041-498d-5e79d3000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:50 GMT
+      - Wed, 03 Feb 2016 14:19:41 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -5961,8 +5839,8 @@ http_interactions:
         OS05ZjBmLTQ3M2VhZDc2OGZhYiI+PEJsb2JzPjxCbG9iPjxOYW1lPkNoZWYt
         UHJvZC4zOWM1MzIwYy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc2Ny
         ZWVuc2hvdC5ibXA8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
-        VHVlLCAxOSBKYW4gMjAxNiAxMzo0OTowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+
-        PEV0YWc+MHg4RDMyMEQ3NEE0MkY4MTU8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        V2VkLCAwMyBGZWIgMjAxNiAxNDoxOTowMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDMyQ0E0RjdBNUY3RkU8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
         PjYxNDkxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5pbWFnZS9i
         bXA8L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
         LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1IC8+PENhY2hlLUNvbnRyb2wgLz48
@@ -5972,9 +5850,9 @@ http_interactions:
         U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
         b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPkNoZWYtUHJvZC4zOWM1MzIw
         Yy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc2VyaWFsY29uc29sZS5s
-        b2c8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxNSBK
-        YW4gMjAxNiAyMzoyMDo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDMxRTAyODEwQUQ0MDI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjE4MjI3Mjwv
+        b2c8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwMiBG
+        ZWIgMjAxNiAyMzoxMDo1OCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMyQzI2MUMxQ0M3OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjIwOTkyMDwv
         Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZSAvPjxDb250ZW50LUVuY29k
         aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDUgLz48Q2Fj
         aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
@@ -5984,7 +5862,7 @@ http_interactions:
         ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1h
         cmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:53 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:42 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-postgresd-fcf3dcec-fb8d-49f5-9d8c-b15edcff704c?comp=list&restype=container
@@ -5999,11 +5877,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:53 GMT
+      - Wed, 03 Feb 2016 14:19:42 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:KIZkOAYamkyUfWn88ZF7NJpOUI6zMYi6d5rQf0VkZ6M=
+      - SharedKey chefprod5120:CR6ASyV1gDyZakgw9SOrPxcTgqqt8dYfKzBzwfqchSs=
   response:
     status:
       code: 200
@@ -6016,11 +5894,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d46d0cd2-0001-0070-77c0-522204000000
+      - 079a047a-0001-007c-798d-5eccf5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:53 GMT
+      - Wed, 03 Feb 2016 14:19:42 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6031,7 +5909,77 @@ http_interactions:
         ZjUtOWQ4Yy1iMTVlZGNmZjcwNGMiPjxCbG9icyAvPjxOZXh0TWFya2VyIC8+
         PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:53 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:43 GMT
+- request:
+    method: get
+    uri: https://chefprod5120.blob.core.windows.net/bootdiagnostics-ubuntuser-01247236-60c7-442a-9e7d-0c86a2130bd1?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:43 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:McnVL8ElAx8kWdq5sGgZqv+lmxvERr2S4lKSPaCQuLo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0a986837-0001-0014-598d-5e92a4000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Wed, 03 Feb 2016 14:19:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jaGVm
+        cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
+        ZT0iYm9vdGRpYWdub3N0aWNzLXVidW50dXNlci0wMTI0NzIzNi02MGM3LTQ0
+        MmEtOWU3ZC0wYzg2YTIxMzBiZDEiPjxCbG9icz48QmxvYj48TmFtZT51YnVu
+        dHVzZXJ2ZXIuMDEyNDcyMzYtNjBjNy00NDJhLTllN2QtMGM4NmEyMTMwYmQx
+        LnNjcmVlbnNob3QuYm1wPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPldlZCwgMDMgRmViIDIwMTYgMTQ6MTg6NDUgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzMkNBNEVENEUzNkU4PC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD42MTQ5MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+aW1h
+        Z2UvYm1wPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAvPjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT51YnVudHVzZXJ2ZXIu
+        MDEyNDcyMzYtNjBjNy00NDJhLTllN2QtMGM4NmEyMTMwYmQxLnNlcmlhbGNv
+        bnNvbGUubG9nPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1v
+        biwgMDEgRmViIDIwMTYgMjE6MjQ6NDMgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMkI0RTFBNjM1RTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD45
+        MjE2PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlIC8+PENvbnRlbnQt
+        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENSAv
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4wPC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxO
+        ZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:44 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -6046,11 +5994,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:53 GMT
+      - Wed, 03 Feb 2016 14:19:44 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:3SwJfXwmrsTXN0I6GEf9R50j0CBD96FeDwu92KD//Fc=
+      - SharedKey chefprod5120:HqYjvv3HdtLNq0gUDHfdBBlYSihgeEY+xWabseoGKiY=
   response:
     status:
       code: 200
@@ -6063,11 +6011,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3a5d73ba-0001-0049-5bc0-5262a0000000
+      - d1395e0e-0001-002b-038d-5e2578000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:53 GMT
+      - Wed, 03 Feb 2016 14:19:43 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -6076,288 +6024,31 @@ http_interactions:
         cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
         ZT0ibWFuYWdlaXEiPjxCbG9icz48QmxvYj48TmFtZT5yZ3Rlc3QuYWUzMzFh
         MTQtNWZmNi00MzE5LTg1MTQtMjc3ZTFmYTdhNTFhLnN0YXR1czwvTmFtZT48
-        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDEz
-        OjQ5OjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRDc2NzlE
-        MUIzNjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDE1
+        OjUzOjA4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRThBMDM4
+        QkQ3MjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0
         aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
         dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
-        Z2UgLz48Q29udGVudC1NRDU+TDJVK0tHVFVPalFnT0lCa0gwOVJ0UT09PC9D
+        Z2UgLz48Q29udGVudC1NRDU+TUtjc1kwWjltWEVNZld4a0x6ZmhkUT09PC9D
         b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
         aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
         dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
         bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
         ZT5yZ3Rlc3QxMi45M2IzYzhmYS03Yjg1LTQ2NGQtOWRlYS0wZjY3MGIzOTFi
         NTguc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
-        ZSwgMTkgSmFuIDIwMTYgMTM6NDk6NTMgR01UPC9MYXN0LU1vZGlmaWVkPjxF
-        dGFnPjB4OEQzMjBENzY4NkQ2QUJDPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        ZSwgMTkgSmFuIDIwMTYgMTU6NTM6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMjBFODlGRDA1QUVFPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
         MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
         b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
-        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5hMFY3VUFMbnRB
-        aVlHYy9EVHBDYUNRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5UNTh6SFgxc3NO
+        RWhvSHBRS05aclBnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
         PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
         bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
         ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
         PC9CbG9iPjxCbG9iPjxOYW1lPnJndGVzdDEyX2NhZDA5NWRiLThhYjItNGIz
         YS1hMmRhLWY2OWQwYjlmZDkxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
-        c3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0OTo0OCBHTVQ8L0xh
-        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEQ3NjVFNTQ5Rjc8L0V0YWc+PENv
-        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
-        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
-        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
-        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
-        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
-        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
-        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
-        c2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFz
-        ZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNl
-        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rl
-        c3QyLjM3M2UzNDkzLTA4MGYtNDFlYi04M2NmLTZhN2QxOTlkNGFjMC5zdGF0
-        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOSBK
-        YW4gMjAxNiAxMzo0OTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDMyMEQ3NjA5MTQ2M0Q8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29u
-        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
-        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
-        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkRJOVQxcHBMZTRsSHVHK2VT
-        SW5GZ1E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
-        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
-        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
-        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
-        PEJsb2I+PE5hbWU+cmd0ZXN0Ml84MDQ4OTM3Ni03OWZkLTQ0OTgtYjQ0NS05
-        MDc5MzZhZjkxYzQudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
-        aWVkPlR1ZSwgMTkgSmFuIDIwMTYgMTM6NDk6NTAgR01UPC9MYXN0LU1vZGlm
-        aWVkPjxFdGFnPjB4OEQzMjBENzY2QzJCOTNCPC9FdGFnPjxDb250ZW50LUxl
-        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
-        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
-        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
-        LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxD
-        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
-        bG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
-        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFz
-        ZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9u
-        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0X2EwODk3
-        M2MwLTU4M2MtNDlhYy05NzI0LThkNWY2ZTUzZDE5Yy52aGQ8L05hbWU+PFBy
-        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0
-        OTo1MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEQ3NjhFMzg5
-        Mjg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVu
-        dC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJl
-        YW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
-        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hs
-        dlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1E
-        aXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gt
-        bXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9C
-        bG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
-        c2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5m
-        aW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
-        Yj48TmFtZT5zZGZzZGYuNTIzOTk1MTQtNDBkZC00ZDgyLWI3MWEtMTIxZjQ1
-        NWRkZGRlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
-        ZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE1OjM5IEdNVDwvTGFzdC1Nb2RpZmll
-        ZD48RXRhZz4weDhEMzAwRTY0NTJBOTBCNDwvRXRhZz48Q29udGVudC1MZW5n
-        dGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
-        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
-        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+c1orZ1V2
-        dHluSzRMUC9YVE9CL3dPdz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
-        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxv
-        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
-        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
-        aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZGZzZGZfZmQwNDZiYTUtMmU1Yy00
-        NDhiLWFkNzktNjViNzI2ODEyMTE5LnZoZDwvTmFtZT48UHJvcGVydGllcz48
-        TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE4OjE0IEdNVDwv
-        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTZBMTgxNENDMzwvRXRhZz48
-        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNl
-        cXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxM
-        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
-        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
-        b2I+PE5hbWU+dGVzdHByb3YxLjEwYjM5MjM1LTY4MjAtNDg2YS05ODA3LTI2
-        MmU2NGZkMjJjYi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
-        aWZpZWQ+TW9uLCAwNyBEZWMgMjAxNSAxNzoxOToxNiBHTVQ8L0xhc3QtTW9k
-        aWZpZWQ+PEV0YWc+MHg4RDJGRjJBODkwNTk0REI8L0V0YWc+PENvbnRlbnQt
-        TGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
-        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
-        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkNH
-        MGtLYUk4eGpuVW92K09SaS83Rmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
-        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9j
-        a0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
-        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
-        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3YxLjc3Mzg5NGU4
-        LWM0M2YtNDc2Ni04NDk4LTMwMDM3Yzk0NzNlNS5zdGF0dXM8L05hbWU+PFBy
-        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAwNyBEZWMgMjAxNSAxNzo1
-        OTozMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJGRjMwMjg3RTIw
-        NTA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+
-        PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRl
-        bnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdl
-        IC8+PENvbnRlbnQtTUQ1Pmp0V3lLTDVPNXVNQ3FHYzI4YjVKcnc9PTwvQ29u
-        dGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlv
-        biAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
-        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
-        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
-        dGVzdHByb3YxMDAuYmI3ZTU0NzQtMDEwMS00OWQyLWFmODEtMDQ0ZTUyMzFm
-        MWZhLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5U
-        dWUsIDE5IEphbiAyMDE2IDEzOjQ5OjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMzIwRDc2NkYyQTQ4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+
-        NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
-        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
-        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+MWtNUkU2SWlN
-        UklTV0V4eWQvT1Q4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
-        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
-        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
-        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjFfMTdkMjcwZGUtOWM3Yy00
-        YTQwLWFmYmEtMzAxNDUzNjBlODUyLnZoZDwvTmFtZT48UHJvcGVydGllcz48
-        TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI4OjU4IEdNVDwv
-        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUVGNzVFMjk4RTwvRXRhZz48
-        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNl
-        cXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxM
-        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
-        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
-        b2I+PE5hbWU+dGVzdHByb3YxXzI3MGQ1ZDAzLWNmMjYtNDJiMC1hNGYxLWJl
-        YjEwNzc0ODMzMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+TW9uLCAwNyBEZWMgMjAxNSAxODowMTozNyBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDJGRjMwNzM4NjU1NUM8L0V0YWc+PENvbnRlbnQtTGVu
-        Z3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
-        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
-        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
-        TUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENh
-        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
-        b2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
-        ZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+
-        dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwv
-        TGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRl
-        c3Rwcm92MV8yODFhZmEwMS04NjQ1LTRjMzMtOWY5YS0wOGIxN2QwZWMxZWQu
-        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkg
-        RGVjIDIwMTUgMTI6NDA6MDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzMDA5NURGNzYxQTI0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
-        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
-        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
-        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
-        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
-        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
-        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
-        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
-        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjFfNzMx
-        N2QyZmMtNTVlYS00ZDM5LWFmMzUtZDkyNWIwMGE3YzYzLnZoZDwvTmFtZT48
-        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDEz
-        OjQ5OjQ1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRDc2NDFB
-        NjUzMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250
-        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
-        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBz
-        SGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
-        LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+Mjwv
-        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8
-        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
-        ZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5p
-        bmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
-        bG9iPjxOYW1lPnRlc3Rwcm92MV9jMTMxMDAxZS00MWU5LTQ4NDEtYTJlMC0z
-        ZTBlMmEwM2E0MzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
-        aWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjg6NTMgR01UPC9MYXN0LU1vZGlm
-        aWVkPjxFdGFnPjB4OEQzMDAxRUY0MDZBM0RBPC9FdGFnPjxDb250ZW50LUxl
-        bmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
-        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
-        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
-        LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxD
-        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1i
-        bG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
-        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50
-        ZXN0cHJvdjFfY2YxNjI2OTctZWY2NS00MDE4LWI5YzItYjk5YmNlYmM1ZjBl
-        LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA3
-        IERlYyAyMDE1IDE3OjIwOjM2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
-        eDhEMkZGMkFCOEI2RENGRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3
-        MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
-        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
-        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lG
-        eStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
-        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5j
-        ZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5
-        cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
-        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
-        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3YyLmFl
-        YWM1YzI1LWJiYjctNDRmZC05OTI5LTg2OGFmODljODhiMS5zdGF0dXM8L05h
-        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAx
-        NSAyMjoyNzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFF
-        QzI4NkNENjI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1M
-        ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
-        L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
-        bmd1YWdlIC8+PENvbnRlbnQtTUQ1PmEyR0ZpMzR4SGhWaVdIeWhPOGdlUHc9
-        PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
-        b3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFz
-        ZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZh
-        aWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+
-        PE5hbWU+dGVzdHByb3YzLjA2ZTkxZWNlLTZmOTQtNDc5YS05ODMxLTkyZTU4
-        ZDNhMGVjNy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyNzoyMCBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDMwMDFFQkM5RTlCMUI8L0V0YWc+PENvbnRlbnQtTGVu
-        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
-        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
-        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkFrS3ox
-        M3Z3RUVReE0zSUh0WFlvQXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
-        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
-        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
-        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3Y0Ljg3MDdkOTkxLWU2
-        MTQtNGE3My04Y2RjLTljNmQ0NWJmNGQwNy5zdGF0dXM8L05hbWU+PFByb3Bl
-        cnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyOTow
-        MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRjhCOUNFMDU8
-        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENv
-        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
-        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
-        PENvbnRlbnQtTUQ1PjhqdHNidy9Iayt6YXZtaXcvRERnOFE9PTwvQ29udGVu
-        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
-        PjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
-        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
-        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
-        ZXN0MTEuMDMwNWUyZjctZDZjZC00NzA1LWI3NmItOTRiYjJkMDdmODI0LnN0
-        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4
-        IERlYyAyMDE1IDIyOjI3OjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
-        eDhEMzAwMUVDNTU1QkQ4QTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
-        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
-        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+QlR2T2o1NDQ4SmtGNmNx
-        ZGZHMkdPQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
-        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
-        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
-        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
-        Yj48QmxvYj48TmFtZT52bXRlc3QxMV8zM2VmZmZkNS0wMzNmLTQ4NWEtYTAw
-        Ni04NzAxMWU2N2E3MWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjk6MDUgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzMDAxRUZCMDkwMjYzPC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
-        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
-        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
-        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
-        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
-        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
-        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
-        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
-        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
-        ZT52bXRlc3QxMi5mMGY4Y2JhNS1jNGNkLTRhNDMtODNjNS03Mjg1ZGExYjMx
-        Yzkuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
-        ZSwgMDggRGVjIDIwMTUgMjI6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxF
-        dGFnPjB4OEQzMDAxRUMyRDc2MTM2PC9FdGFnPjxDb250ZW50LUxlbmd0aD41
-        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
-        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
-        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5iUHZMaXBDSjdq
-        NGYyLytMK0JsTHhnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
-        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
-        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
-        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
-        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDEyX2QxN2FlZmFjLWZlZWMtNGM1
-        Yy1iYWY1LTM5NWRmYjRiODQ2NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
-        c3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyOTowOSBHTVQ8L0xh
-        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRkRBMDhDRjM8L0V0YWc+PENv
+        c3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxNTo1NDoyOSBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEU4RDA5NzhCQUI8L0V0YWc+PENv
         bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
         bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
         VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
@@ -6367,21 +6058,21 @@ http_interactions:
         ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
         c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
         YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
-        PjxOYW1lPnZtdGVzdDEzLmVkNWIzYTVkLTc3ODYtNDJjNC1iZjBmLTExNWRl
-        YmU0MTE4My5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyODo1MCBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDMwMDFFRjIxQTUzNDI8L0V0YWc+PENvbnRlbnQtTGVu
+        PjxOYW1lPnJndGVzdDE1LmM5OGUxNzllLTBmNjMtNDJkMi1hZmQ3LWRjYjQ2
+        MjYzYjBmMy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAxOSBKYW4gMjAxNiAxNzowNDoyNCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMyMEYyOTRGMDQ0QTY8L0V0YWc+PENvbnRlbnQtTGVu
         Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
         dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
-        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pm9Fd2s1
-        TnJrakIxR2MwSExnaktMaEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkE0QURC
+        QldWbmRKQXgwK2NGMkZHeFE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
         b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
         b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
         dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
-        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MTNfZDI1NTI0ZjYtOGZj
-        ZC00NjgwLWI0YmYtNWM4NzhmZTg1MmZjLnZoZDwvTmFtZT48UHJvcGVydGll
-        cz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjM0OjA2IEdN
-        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUZBRThDQkM3QTwvRXRh
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0MTVfNjIxYjA5YzEtOThl
+        YS00NDhiLThmMDUtY2VkNDlhNzVjYjQ4LnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDE3OjA2OjMyIEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRjJFMTdEQ0IyQzwvRXRh
         Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
         aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
         dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
@@ -6391,21 +6082,21 @@ http_interactions:
         LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
         PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
         dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
-        PEJsb2I+PE5hbWU+dm10ZXN0MTUuZTA3OGYyZWItZWY3Yy00MzAyLWIxOWMt
-        ZWNhOTc4NjA0MTM3LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
-        b2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDEyOjU1OjIyIEdNVDwvTGFzdC1N
-        b2RpZmllZD48RXRhZz4weDhEMzAwOTdGRkU0NDFDNzwvRXRhZz48Q29udGVu
+        PEJsb2I+PE5hbWU+cmd0ZXN0MTYuNDg0ZGY4NjktMjE1My00YzIyLWJmZTkt
+        YTA2MGM0ZDVhOTljLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDE3OjA0OjIwIEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzIwRjI5MkI0MjM5NjwvRXRhZz48Q29udGVu
         dC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
         cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
         LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
-        WTRUbmw4Qjl2OXZWZnB5OElEdHJTZz09PC9Db250ZW50LU1ENT48Q2FjaGUt
+        cjBqOVZkTmFJT2crUm9DT3pYUytVZz09PC9Db250ZW50LU1ENT48Q2FjaGUt
         Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
         b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
         ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
-        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QxNV81YThkNGQz
-        NS0wMmQ3LTQ3MzEtOWIwYy0zMzgyMDMyMzE3NmEudmhkPC9OYW1lPjxQcm9w
-        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMTI6NTY6
-        MjIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDA5ODIzOTE1MTEx
+        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rlc3QxNl9hNGVjOTY2
+        ZC1iMTkxLTQ4OTItOGE4Ni1lNWEzNTBkYmY4NzAudmhkPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTkgSmFuIDIwMTYgMTc6MDU6
+        NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjBGMkNDOEFBQzY1
         PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQt
         TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
         PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
@@ -6415,322 +6106,105 @@ http_interactions:
         LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxv
         YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
         c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
-        QmxvYj48QmxvYj48TmFtZT52bXRlc3QxNi5iYWUzNDZlYi1hM2MwLTQ0NDYt
-        OTU4MC1jZTI0NzdlMzc5MDQuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMTU6Mjc6NDcgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBBRDRCMDcwNjU3PC9FdGFnPjxD
-        b250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
-        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
-        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
-        LU1ENT5sQkhac1RBYWQ3a2JCVkxzVzl1R1lBPT08L0NvbnRlbnQtTUQ1PjxD
-        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5
-        cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
-        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
-        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE2X2Rk
-        YWM2YTM0LTRmYmYtNGIxOC05MmY1LWVjNTk1MDRkNjRmYS52aGQ8L05hbWU+
-        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAx
-        NToyOTo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEFEOTc5
-        MDFDMjM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
-        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
-        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
-        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
-        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
-        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
-        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
-        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
-        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
-        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE3LjdmMjVhOTk5LTJmYjYt
-        NDBjNS05NGY4LTlkYjVlYTAwOGU3Yi5zdGF0dXM8L05hbWU+PFByb3BlcnRp
-        ZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAxNToyNzo0OSBH
-        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEFENEM1REVGNjg8L0V0
-        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
-        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
-        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
-        bnRlbnQtTUQ1PnBVd2xtQTA1TnA2NTVISXB3VHBkY0E9PTwvQ29udGVudC1N
-        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
-        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
-        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
-        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
-        MTdfMTZkNWQxYzktZTEwZS00ZmU0LTg1MGEtM2YxMDYxMmVhM2U5LnZoZDwv
-        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAy
-        MDE1IDE1OjI5OjUyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAw
-        QUQ5NTVENEE2NTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
-        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
-        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
-        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
-        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
-        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
-        ZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
-        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
-        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
-        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MTkuMTcxNzg3YjUt
-        NTI2OS00NTViLWFmMzQtOTU2MzU5MjIzMThhLnN0YXR1czwvTmFtZT48UHJv
-        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDE1OjQ2
-        OjE3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwQUZFMDNCNUQ4
-        QTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+ekZIZ1hsSE02NnZoTk84WlhMbVUvUT09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
-        bXRlc3QxOV81ZTE4Y2U1YS05NGIzLTQ1ZWItOGUxNS0yYTRkNzFlZjBhMTku
-        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkg
-        RGVjIDIwMTUgMTU6NDc6NTkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzMDBCMDFENDkwRjE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
-        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
-        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
-        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
-        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
-        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
-        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
-        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
-        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyMS4xNmEx
-        NWQ5ZS1hMjI2LTRiOTYtYjNhNS01ZWFhZDEyNzZjODYuc3RhdHVzPC9OYW1l
-        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUg
-        MjE6MDA6MTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBEQkJE
-        QTcyNTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
-        Z3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9D
-        b250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5n
-        dWFnZSAvPjxDb250ZW50LU1ENT5YcTFHZTNXaWJrNnBpdlR6dlgrMGVBPT08
-        L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9z
-        aXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VT
-        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
-        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
-        YW1lPnZtdGVzdDIxX2VlZDBkNGUzLWIxZTktNDZmNS05YzMxLTNhNjllMjEz
-        ZjgwOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2Vk
-        LCAwOSBEZWMgMjAxNSAyMTowMjo1MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0
-        YWc+MHg4RDMwMERDMTk4RTI5Q0M8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEz
-        NjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
-        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
-        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pnlm
-        ckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
-        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
-        dWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
-        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
-        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
-        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDIy
-        LjY5MTU4OTJjLTRmYjEtNDkxYi04MThhLWFjY2M2YTQ1NDQ3OS5zdGF0dXM8
-        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMg
-        MjAxNSAyMTowMDoyMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMw
-        MERCQkZCOTlCQjc8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVu
-        dC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJl
-        YW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
-        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnNkUEFTS21JMmRYRGJZcjkxd2Rw
-        RkE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1E
-        aXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxM
-        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
-        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
-        b2I+PE5hbWU+dm10ZXN0MjJfMGMzMTUzYzMtOWNlMC00ODE2LTljMjMtZjc5
-        NThkNWYyNTUyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
-        ZD5XZWQsIDA5IERlYyAyMDE1IDIxOjAyOjIyIEdNVDwvTGFzdC1Nb2RpZmll
-        ZD48RXRhZz4weDhEMzAwREMwODU1N0Q1MTwvRXRhZz48Q29udGVudC1MZW5n
-        dGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
-        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
-        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
-        RDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2Fj
-        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
-        Yi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
-        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
-        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
-        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
-        ZXN0MjMuYmFkMzZkYTgtMjgzNi00NzVlLTlkMzAtMGFlNGNiYTk4N2M1LnN0
-        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5
-        IERlYyAyMDE1IDIxOjAwOjE2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
-        eDhEMzAwREJCREEyQjgzMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
-        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
-        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
-        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WHExR2UzV2liazZwaXZU
-        enZYKzBlQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
-        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
-        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
-        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
-        Yj48QmxvYj48TmFtZT52bXRlc3QyM19lNDFjMTQ4Ny0wMDg3LTQ5ZDYtOTQ0
-        NS1lZTBlYTI5N2QyNzgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
-        ZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjE6MDI6MDcgR01UPC9MYXN0LU1v
-        ZGlmaWVkPjxFdGFnPjB4OEQzMDBEQkZGQkQ1OTZGPC9FdGFnPjxDb250ZW50
-        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
-        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
-        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
-        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
-        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
-        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
-        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
-        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
-        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
-        ZT52bXRlc3QyNS5iMjY3ZmYwNS1jODEzLTQ1MmUtODc2YS04YmNiYjdiMTE0
-        OTEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldl
-        ZCwgMDkgRGVjIDIwMTUgMjI6MTU6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxF
-        dGFnPjB4OEQzMDBFNjNFRUEyOTUxPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
-        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
-        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
-        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5CWEVEQzA5VkRD
-        NWdFSzFpbWVWdmdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
-        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
-        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
-        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
-        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI1XzY3N2ViMTE1LTdjZDYtNDU2
-        Yy1iYzc5LWNkNGU3MmE5MDYyMC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
-        c3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMjoxNzo1OCBHTVQ8L0xh
-        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEU2OTg2Q0VCRDg8L0V0YWc+PENv
-        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
-        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
-        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
-        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
-        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
-        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
-        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
-        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
-        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
-        PjxOYW1lPnZtdGVzdDI2LjJlZDg2YTQ1LWZlMTQtNDAyMi05ZDk1LWFmNWFi
-        ODk4NTliMy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMjoxNToyNCBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDMwMEU2M0M5MUYzRkQ8L0V0YWc+PENvbnRlbnQtTGVu
-        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
-        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
-        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlFSdits
-        d25XNERGeWUxNDc0M1RSNEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
-        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
-        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
-        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
-        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjZfODExMjZlMTgtODdi
-        YS00ZmNiLWI3YzEtOWZlZmRkMDM0MDY1LnZoZDwvTmFtZT48UHJvcGVydGll
-        cz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE4OjA1IEdN
-        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTY5QzY5MUJDMjwvRXRh
-        Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
-        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
-        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
-        Z2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9D
-        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
-        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
-        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
-        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
-        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
-        PEJsb2I+PE5hbWU+dm10ZXN0MjcuMmYxZjA2ZDItOTM2Mi00YTY5LWJjMTIt
-        YmE4OGNmMGQwZTdkLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
-        b2RpZmllZD5GcmksIDExIERlYyAyMDE1IDIxOjM5OjE0IEdNVDwvTGFzdC1N
-        b2RpZmllZD48RXRhZz4weDhEMzAyNzM4M0RBOTBENjwvRXRhZz48Q29udGVu
-        dC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
-        cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
-        LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
-        bkhRSGhjRkJmSTZYb3hMb2VPUjhLUT09PC9Db250ZW50LU1ENT48Q2FjaGUt
-        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
-        b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
-        ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
-        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyNy5hMTRmMmMz
-        Ni0xNmNmLTRiODAtYjY0MC04MmMxNjcyYzAyYjcuc3RhdHVzPC9OYW1lPjxQ
-        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjI6
-        MTU6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBFNjNEOEY0
-        ODQxPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3Ro
-        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
-        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
-        ZSAvPjxDb250ZW50LU1ENT5TdVNaY1ZQSmZzd2FudjhqN1o4RFVBPT08L0Nv
-        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
-        b24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
-        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
-        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
-        PnZtdGVzdDI3XzFiNzJmZTdmLTM4MGMtNDliNy05NTU1LWEyZTI1NjVhN2Vk
-        YS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAw
-        OSBEZWMgMjAxNSAyMjoxODowMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
-        MHg4RDMwMEU2OUExNTUzNDE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2
-        NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
-        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
-        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJ
-        RnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
-        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVu
-        Y2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JU
-        eXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
-        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
-        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI3Xzk3
-        ZWUyZjViLTdiZmUtNDJjYi1hYmI1LTIzM2Q3YzdiYWUzOS52aGQ8L05hbWU+
-        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxMSBEZWMgMjAxNSAy
-        MTo0MToyMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMjczQ0VB
-        Q0U2RTI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
-        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
-        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
-        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
-        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
-        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
-        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
-        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
-        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
-        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI4Ljg3MWEzMjIyLWMwZjYt
-        NGQ4YS04OWM2LTdhNzkyNDRkOGJhNi5zdGF0dXM8L05hbWU+PFByb3BlcnRp
-        ZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNDowNiBH
-        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ1RURGRjVFNUY8L0V0
-        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
-        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
-        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
-        bnRlbnQtTUQ1Pkc3MDMrMTJkQUVGVExUcjJZVFRpMWc9PTwvQ29udGVudC1N
-        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
-        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
-        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
-        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
-        MjhfYmU5YjFmY2UtNWEwNy00ZWI0LTg3ZTktNjQyY2E4NTg1M2UxLnZoZDwv
-        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEphbiAy
-        MDE2IDIwOjE2OjMyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzE2
-        RDY0NEFCRERFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
-        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
-        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
-        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
-        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
-        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
-        ZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
-        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
-        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
-        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjkuYzk3OTZmMzMt
-        NzRjNS00ZWE5LWJkNTMtZDJhYTNhMjBhMjQyLnN0YXR1czwvTmFtZT48UHJv
-        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEphbiAyMDE2IDIwOjEz
-        OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzE2RDVFODEwOUVB
-        RjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
-        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
-        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
-        Lz48Q29udGVudC1NRDU+T2RUbFpjYkpyZTAwYTgzbHNtUHl6Zz09PC9Db250
-        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
-        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
-        bXRlc3QyOV8wMTZmOTk5NC1jMDkwLTQwM2ItYjMxZi0zOThlMjg0ZTlmOTUu
-        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYg
-        SmFuIDIwMTYgMjA6MTY6MTMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzMTZENjM5OURDMzc3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
-        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
-        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
-        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
-        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
-        LW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
-        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
-        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
-        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QzLjhmMWQ0
-        YTY3LTEyYWUtNDliYi1hZmY1LWVmNTdjZGYyNjI0Ny5zdGF0dXM8L05hbWU+
-        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAy
-        MjoyOTo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFGMTBE
-        Mzc0REI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5n
-        dGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0Nv
-        bnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1
-        YWdlIC8+PENvbnRlbnQtTUQ1PnFGeXBPNGFvUFpSQWFZQTBycHVDV0E9PTwv
-        Q29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3Np
-        dGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0
+        QmxvYj48QmxvYj48TmFtZT5yZ3Rlc3QyLjM3M2UzNDkzLTA4MGYtNDFlYi04
+        M2NmLTZhN2QxOTlkNGFjMC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxNTo1MzowMyBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMEU4OUQyRUJEQzU8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1Pk5vam8rTWZPcll5dTFEWjhCSkhCR1E9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlw
+        ZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0MjAuNjll
+        ZjBiZDYtYTYyMS00OGY0LTlkMDctNjczYWVmYzlhZTJiLnN0YXR1czwvTmFt
+        ZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2
+        IDE5OjI2OjAyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIxMDY1
+        RTY4NEU0QzwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxl
+        bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
+        Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
+        Z3VhZ2UgLz48Q29udGVudC1NRDU+N3dFbnVpT0NBYTlBa3B3MDc2OGZIUT09
+        PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
+        c2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNl
+        U3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFp
+        bGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48
+        TmFtZT5yZ3Rlc3QyMF83NjM5NTdhOS03NzRlLTRmZjMtOGRmMy03NDFlNmQz
+        NjQ0NGQudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
+        ZSwgMTkgSmFuIDIwMTYgMTk6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMjEwNjkyQzQ1RTJDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4x
+        MzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBw
+        bGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQt
+        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55
+        ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1D
+        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxC
+        bG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9j
+        a2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNl
+        U3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rlc3Qy
+        MS5mMTIwM2U1OS05YWI0LTQwZmQtYTc1ZC1iNDhhYmUyNjRiMTIuc3RhdHVz
+        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTkgSmFu
+        IDIwMTYgMTk6MjY6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQz
+        MjEwNjYxNUFGNDZFPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRl
+        bnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3Ry
+        ZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVu
+        dC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5DOTFCZDhXcGFSTW9zR21ua2x3
+        RENBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQt
+        RGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48
+        TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
+        bG9iPjxOYW1lPnJndGVzdDIxXzUwNGE2N2E5LWI4N2UtNDhkNC1hODIxLWVk
+        NjZiZjE4YjcyNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAxOSBKYW4gMjAxNiAxOToyNzozOSBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMyMTA2OTdGNTIxNDk8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
+        b2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+
+        dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwv
+        TGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJn
+        dGVzdDIyLjJiMDcyNWE5LTU5YjgtNDM0OS05MTA4LWE1ZWY1OWYyZDE3NS5z
+        dGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAx
+        OSBKYW4gMjAxNiAxOToyNjoxNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
+        MHg4RDMyMTA2NjYyMjkxQ0U8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwv
+        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
+        dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
+        b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnVRY0UrS0RmVk1XYU11
+        V2s1RHdmcWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
+        dGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JU
+        eXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNl
+        U3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Js
+        b2I+PEJsb2I+PE5hbWU+cmd0ZXN0MjJfZWVlMmRhYTYtODIxYi00ZWU0LTg5
+        MWYtMzk5MzIxZWIyODBmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDE5OjI4OjI1IEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzIxMDZCM0E2QjVENzwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVu
+        dC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBl
+        PjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29u
+        dGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1E
+        NT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgt
+        bXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0
         YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxh
         YmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5h
-        bWU+dm10ZXN0MzIuNzkzNzMyMDQtNzMyMy00MThiLWEzYjctZGRmYzVmYjIz
-        ZWI5LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5X
-        ZWQsIDA2IEphbiAyMDE2IDIwOjE0OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMzE2RDVFREQyQTc3QTwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        bWU+cmd0ZXN0MjMuNzhhYTIzYjctNjJkYi00YzkzLThhM2MtYmM5MTEzOGJk
+        NTU1LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5U
+        dWUsIDE5IEphbiAyMDE2IDE5OjI2OjIwIEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMzIxMDY2OEY1QTBGNDwvRXRhZz48Q29udGVudC1MZW5ndGg+
         NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
-        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODdsVkNkZkRk
-        eWFxRk1UU2cyL1NaUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Z1VUMnE3L2Nq
+        RlFkbnE1ZTd1ejlodz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
         QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
         TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QzMl9iZGI0OThiYy0wZGZhLTRh
-        ZTAtYWEyYi0xNzUwMDA1NmRmZTMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
-        YXN0LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTY6MjIgR01UPC9M
-        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENjNGMzlBNTc3PC9FdGFnPjxD
+        PjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rlc3QyM19jNTA3NmZmNy00YWM5LTRh
+        YzQtODA1Ni02M2VkZTYxMjE3NTAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPlR1ZSwgMTkgSmFuIDIwMTYgMTk6Mjc6NDAgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjEwNjk4QzU5N0RGPC9FdGFnPjxD
         b250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxD
         b250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50
         LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAv
@@ -6740,190 +6214,119 @@ http_interactions:
         dWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExl
         YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
         dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
-        Yj48TmFtZT52bXRlc3QzXzYzNWY0ZDc5LTNhYjctNDIyYi1hZDg2LTY0NDMz
-        Y2QxMWRjZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
-        VHVlLCAwOCBEZWMgMjAxNSAyMjozMTo0MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+
-        PEV0YWc+MHg4RDMwMDFGNTkzRTc5REI8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
-        PjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
+        Yj48TmFtZT5yZ3Rlc3QyNS5iYzUwYzc1MC1lMTE1LTRkOTItOGU2My1iMmRi
+        ZWUzNmI4YzIuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
+        aWVkPlR1ZSwgMTkgSmFuIDIwMTYgMjA6MTc6MTcgR01UPC9MYXN0LU1vZGlm
+        aWVkPjxFdGFnPjB4OEQzMjEwRDg2REUyMTM4PC9FdGFnPjxDb250ZW50LUxl
+        bmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGlj
+        YXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5j
+        b2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5lZldt
+        MXZhR01CT1ladG5TWE11VTZBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250
+        cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tC
+        bG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3Bl
+        cnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJndGVzdDI1XzQ0NmE5ZmVjLWI4
+        OWQtNDIwMi05YjAxLWRlMzhhNTNmYmJmNy52aGQ8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAyMDoxOToyNCBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMTBERDJFMUQ5ODc8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5n
+        dGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0Nv
+        bnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1
+        YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwv
+        Q29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3Np
+        dGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjxCbG9iPjxOYW1lPnJndGVzdDI2LjdjMDk1NzFhLTU1MTAtNDk0ZS05NWEw
+        LWZiYmZiY2Y0NDNjYy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
+        TW9kaWZpZWQ+V2VkLCAyMCBKYW4gMjAxNiAyMDo1NToyNSBHTVQ8L0xhc3Qt
+        TW9kaWZpZWQ+PEV0YWc+MHg4RDMyMURDMDUyMkM2QkM8L0V0YWc+PENvbnRl
+        bnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
         cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
         dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
-        PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hl
-        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
-        c2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
-        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
-        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
-        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVz
-        dDQwLjAxY2U1ZWZmLWQ0NDgtNDY3NS04MzQxLWY3OTM0NGIxNWRkOC5zdGF0
-        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBK
-        YW4gMjAxNiAyMDoxNDo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
-        RDMxNkQ2MDJCMjgxODA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29u
-        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
-        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
-        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmNveTVieDhnZW12QTA1eDk3
-        Z2d0ZVE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
-        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
-        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
-        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
-        PEJsb2I+PE5hbWU+dm10ZXN0NDBfMTgyZjQxMDQtMDRjMi00N2VjLWI1MTct
-        MTczMmMyODZmYjkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
-        ZmllZD5XZWQsIDA2IEphbiAyMDE2IDIwOjE2OjQ0IEdNVDwvTGFzdC1Nb2Rp
-        ZmllZD48RXRhZz4weDhEMzE2RDY0QzRDMDUzNDwvRXRhZz48Q29udGVudC1M
-        ZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
+        PjkzOW1YbVRna2VKcnBPY001ay9HTWc9PTwvQ29udGVudC1NRDU+PENhY2hl
+        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5C
+        bG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwv
+        UHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0MjZfZDhkZmUw
+        ODktYTE1OS00MDRjLWI1MTItZTUwOGU5NmY1YThkLnZoZDwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEphbiAyMDE2IDIwOjU4
+        OjA1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIxREM2NEQ3QzQw
+        NjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50
+        LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVh
+        bTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQt
+        TGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2
+        UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURp
+        c3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Js
+        b2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExl
+        YXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48
+        L0Jsb2I+PEJsb2I+PE5hbWU+cmd0ZXN0MjcuOWZlOGQ1MjEtYjhmZi00NTNi
+        LWI5MjQtNmFmZmFmOGVhYWU5LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEphbiAyMDE2IDE5OjIzOjEyIEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIxQ0YyMzQwQ0E2RjwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
         eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
         b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
-        dC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48
-        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMt
-        YmxvYi1zZXF1ZW5jZS1udW1iZXI+NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51
-        bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
-        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
-        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
-        dm10ZXN0NDEuMjYzYmY4MWUtYWU5OC00ZjE2LTk0NGUtNzA0MTkzMjdiNjhi
-        LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQs
-        IDA2IEphbiAyMDE2IDIwOjE0OjA0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
-        Zz4weDhEMzE2RDVFQ0MwRTA2NjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5
-        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
-        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
-        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eFVJMUNoRFlSZDg4
-        dW9hVmtyVDBFUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
-        b250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxv
-        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
-        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
-        QmxvYj48QmxvYj48TmFtZT52bXRlc3Q0MV8xYTcyMjFhMS03YzRjLTRmYjYt
-        ODI5OS1mN2Q5NWM0NGZjZTYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0
-        LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTU6NDggR01UPC9MYXN0
-        LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENjJBREY1MzcxPC9FdGFnPjxDb250
-        ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250
+        dC1NRDU+Vld6L1BMazhhK3ZjOTZ4OTYzaHJ1Zz09PC9Db250ZW50LU1ENT48
+        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JU
+        eXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2Vk
+        PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3Rh
+        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rlc3QyN19i
+        Y2I0MzA5MS1mYjViLTQzZGEtYWM0YS00ZWNlZGUwZTZmNGMudmhkPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgSmFuIDIwMTYg
+        MTk6MjY6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjFDRjkx
+        NkJFOEUyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBW
+        cHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4y
+        PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQmxvYj48QmxvYj48TmFtZT5yZ3Rlc3QyOC40NzFiMjBkOS1hYTQy
+        LTRhNmMtOGFjZS04Yzg3YTAzYTcxOGMuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0
+        aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgSmFuIDIwMTYgMTg6NTA6MjUg
+        R01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjFDQThGM0I3QUQ2PC9F
+        dGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250
         ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5
         cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxD
-        b250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQt
+        b250ZW50LU1ENT5kQzVqNXJ5WFBERHdIV2tyeTdLTUh3PT08L0NvbnRlbnQt
         TUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
-        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVu
-        Y2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNl
-        U3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFp
-        bGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48
-        TmFtZT52bXRlc3Q0Mi4wNjhiMjZiNS01MmRhLTRiMmYtYjljNC03NGM4OWZj
-        NjMzZmEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVk
-        PldlZCwgMDYgSmFuIDIwMTYgMjA6MTQ6NTUgR01UPC9MYXN0LU1vZGlmaWVk
-        PjxFdGFnPjB4OEQzMTZENjBBRTZENzRGPC9FdGFnPjxDb250ZW50LUxlbmd0
-        aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
-        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
-        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5xR1ErS1ZZ
-        VW1OOC81anErMTIwc0J3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
-        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9i
-        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
-        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
-        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQyXzRmZDk5YWExLTY0MGYt
-        NDc2Mi1iYmI0LWQwNDZlMDAwMmQ3NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+
-        PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNjozOSBHTVQ8
-        L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ2NDhGRDMzQzE8L0V0YWc+
-        PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+
-        PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRl
-        bnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdl
-        IC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29u
-        dGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlv
-        biAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1z
-        ZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48
-        TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
-        PmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
-        bG9iPjxOYW1lPnZtdGVzdDQ1LjFjYzY4NmZjLTRhYmEtNDdhNC1iMzdjLTAx
-        NDdlNDM1ZjMyZi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
-        aWZpZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowODowNyBHTVQ8L0xhc3QtTW9k
-        aWZpZWQ+PEV0YWc+MHg4RDMxQUE5QzY4NkM3REY8L0V0YWc+PENvbnRlbnQt
-        TGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
-        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
-        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlU
-        aTQvaUhHNWloWHlwRHY0Sm5CK0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
-        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9j
-        a0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
-        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
-        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NDVfZDQ2YTM2MjQt
-        ZDA5Yi00NjM1LThiMTktMDg3MzkzNGM5ODcxLnZoZDwvTmFtZT48UHJvcGVy
-        dGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA5OjM0
-        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlGQTg0NkU2Mjwv
+        QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
+        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJndGVz
+        dDI4X2NhYzgwNzFkLWIzMjMtNDBiYi04NzYxLTc0ZGJlZTYxMTczYy52aGQ8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBKYW4g
+        MjAxNiAyMDo1NTozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMy
+        MURDMDg1QkVFM0Y8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMx
+        MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9v
+        Y3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAv
+        PjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdq
+        M1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48
+        Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
+        Z2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJndGVzdDJfODA0ODkzNzYt
+        NzlmZC00NDk4LWI0NDUtOTA3OTM2YWY5MWM0LnZoZDwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDE5IEphbiAyMDE2IDE1OjU0OjUy
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIwRThERTdERUIxRTwv
         RXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxl
         bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
         Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
         Z3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09
         PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
-        c2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NDwveC1tcy1i
+        c2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1i
         bG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JU
         eXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNl
         U3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Js
-        b2I+PEJsb2I+PE5hbWU+dm10ZXN0NDYuY2JlODcwOTEtZDk1NS00MzRmLTll
-        MzctMTE4NTk4ODdmMWY4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA4OjAxIEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlDMzZDOUNCODwvRXRhZz48Q29u
-        dGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
-        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
-        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
-        RDU+Ny9mKy8zdlVGMUU1R1crUkdlZ2FSZz09PC9Db250ZW50LU1ENT48Q2Fj
-        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBl
-        PkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
-        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
-        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0Nl9iOTU4
-        Yjg0ZS01YjE2LTRmMjYtODZhOS00MDQxNzZhYzc5MTUudmhkPC9OYW1lPjxQ
-        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6
-        MDk6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFBQTA4Qzk2
-        NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRl
-        bnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3Ry
-        ZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVu
-        dC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNI
-        bHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQt
-        RGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94
-        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwv
-        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
-        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
-        PjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0Ny5jMmViN2ZiZS0xYWQxLTQ0
-        NDEtYWM4NS05ODA0N2NmZWFiYWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVz
-        PjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6MDc6NDUgR01U
-        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFBOUI5OTJFREI1PC9FdGFn
-        PjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
-        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
-        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
-        ZW50LU1ENT5COXk3NmUzUmVWMXZLT09iL0VzK1lnPT08L0NvbnRlbnQtTUQ1
-        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48Qmxv
-        YlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
-        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
-        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQ3
-        XzU1YzQ3NmM4LTMyNDYtNDZjNC1hMTQxLWY3M2NiMWI4NTJjMS52aGQ8L05h
-        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBKYW4gMjAx
-        NiAxNzoxMDoyMSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxQUFB
-        MTZCRUIxRDI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwv
-        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
-        dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
-        b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2
-        MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
-        dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
-        PjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VC
-        bG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3Rh
-        dHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3Bl
-        cnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDUuOTU5ZmFjMzItNzlk
-        Ni00OGQzLThkZGQtNzAzNzRlNWNkYzhlLnN0YXR1czwvTmFtZT48UHJvcGVy
-        dGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI5OjE1
-        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUYwMTBBRDgxRDwv
-        RXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29u
-        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
-        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
-        Q29udGVudC1NRDU+bUtWclI1OTFYbDJLMG9qSXE2S3ZPdz09PC9Db250ZW50
-        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
-        PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVu
-        bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xl
-        YXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRl
-        c3Q1NS5iMmM3NWNlYS0zYzNlLTRiNGEtYWI3Yi1jNzMyZGM1YzZiOTkuc3Rh
-        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEg
-        SmFuIDIwMTYgMTc6MDg6MDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
-        OEQzMUFBOUM0QjY4Q0FEPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0Nv
-        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
-        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
-        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5MYjJ0MzJFM1IwcXJ4aDF5
-        VHl4bUdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
-        bnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlw
-        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
-        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
-        PjxCbG9iPjxOYW1lPnZtdGVzdDU1X2Q4MmMxYzEzLWYyMGMtNGI1My1hZGY5
-        LWVmOTZjNWI1MDRmMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
-        aWZpZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowOToyOCBHTVQ8L0xhc3QtTW9k
-        aWZpZWQ+PEV0YWc+MHg4RDMxQUE5RjZCODJCOTY8L0V0YWc+PENvbnRlbnQt
+        b2I+PEJsb2I+PE5hbWU+cmd0ZXN0X2EwODk3M2MwLTU4M2MtNDlhYy05NzI0
+        LThkNWY2ZTUzZDE5Yy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+VHVlLCAxOSBKYW4gMjAxNiAxNTo1NDo1MCBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDMyMEU4REQ3RTczOTA8L0V0YWc+PENvbnRlbnQt
         TGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
         VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
         Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
@@ -6933,46 +6336,877 @@ http_interactions:
         dW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
         dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
         ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
-        PnZtdGVzdDVfMGQ2NGZkNzAtYTM4NS00OWQxLWE0OTktZTQyNTA2MDYxMzA0
-        LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4
-        IERlYyAyMDE1IDIyOjMwOjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
-        eDhEMzAwMUYzNzY5NTZERDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3
-        MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
-        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
-        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lG
-        eStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
-        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5j
-        ZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5
-        cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        PnNkZnNkZi41MjM5OTUxNC00MGRkLTRkODItYjcxYS0xMjFmNDU1ZGRkZGUu
+        c3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwg
+        MDkgRGVjIDIwMTUgMjI6MTU6MzkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFn
+        PjB4OEQzMDBFNjQ1MkE5MEI0PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8
+        L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0
+        ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
+        Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5zWitnVXZ0eW5LNExQ
+        L1hUT0Ivd093PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENv
+        bnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9i
+        VHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
+        ZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjxCbG9iPjxOYW1lPnNkZnNkZl9mZDA0NmJhNS0yZTVjLTQ0OGItYWQ3
+        OS02NWI3MjY4MTIxMTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjI6MTg6MTQgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMDBFNkExODE0Q0MzPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT50ZXN0cHJvdjEuMTBiMzkyMzUtNjgyMC00ODZhLTk4MDctMjYyZTY0ZmQy
+        MmNiLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5N
+        b24sIDA3IERlYyAyMDE1IDE3OjE5OjE2IEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMkZGMkE4OTA1OTREQjwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Q0cwa0thSTh4
+        am5Vb3YrT1JpLzdGZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjEuNzczODk0ZTgtYzQzZi00
+        NzY2LTg0OTgtMzAwMzdjOTQ3M2U1LnN0YXR1czwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5Nb24sIDA3IERlYyAyMDE1IDE3OjU5OjMxIEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMkZGMzAyODdFMjA1MDwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVu
+        dC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBl
+        PjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29u
+        dGVudC1NRDU+anRXeUtMNU81dU1DcUdjMjhiNUpydz09PC9Db250ZW50LU1E
+        NT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJs
+        b2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9j
+        a2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNl
+        U3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJv
+        djEwMC5iYjdlNTQ3NC0wMTAxLTQ5ZDItYWY4MS0wNDRlNTIzMWYxZmEuc3Rh
+        dHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTkg
+        SmFuIDIwMTYgMTU6NTM6MTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMjBFOEE1NkE5MUYyPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT51V3FYT0p0ejV0SGF6Rkkv
+        UXU3aTVnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjxCbG9iPjxOYW1lPnRlc3Rwcm92MTAxLjY0NDBlNTRkLTliYzUtNDhiYi1i
+        MGM0LTg1MzI4MjM2ODA3Ni5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+RnJpLCAyMiBKYW4gMjAxNiAwNjo1MTozMSBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMkY4NzVEQkE5OUI8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1PmZ5Sk04ZVZoSjF2ZmtUeDB4SkRENlE9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlw
+        ZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
         TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
-        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0Ny4xYzAx
-        YWY2Yy1jNDdlLTQ3M2ItOThiMi00ZWE4MzcxODNkMTYuc3RhdHVzPC9OYW1l
-        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUg
-        MjI6Mjk6MzIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRjBC
-        Qjc0QzI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdHByb3YxXzE3
+        ZDI3MGRlLTljN2MtNGE0MC1hZmJhLTMwMTQ1MzYwZTg1Mi52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAy
+        MjoyODo1OCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRjc1
+        RTI5OEU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
+        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3Rwcm92MV8yNzBkNWQwMy1jZjI2
+        LTQyYjAtYTRmMS1iZWIxMDc3NDgzMzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPk1vbiwgMDcgRGVjIDIwMTUgMTg6MDE6MzcgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQyRkYzMDczODY1NTVDPC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
+        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
+        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
+        QmxvYj48TmFtZT50ZXN0cHJvdjFfMjgxYWZhMDEtODY0NS00YzMzLTlmOWEt
+        MDhiMTdkMGVjMWVkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
+        ZmllZD5XZWQsIDA5IERlYyAyMDE1IDEyOjQwOjA4IEdNVDwvTGFzdC1Nb2Rp
+        ZmllZD48RXRhZz4weDhEMzAwOTVERjc2MUEyNDwvRXRhZz48Q29udGVudC1M
+        ZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
+        eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
+        b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
+        dC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48
+        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMt
+        YmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51
+        bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        dGVzdHByb3YxXzNjYmQxMjY5LTA5MDAtNDQxNi1hNWU1LWU0NzQ2ODI3YjE1
+        Yy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAy
+        NiBKYW4gMjAxNiAxOTo1NDo0MyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+
+        MHg4RDMyNjhBODhFRjZBMkQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2
+        NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJ
+        RnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVu
+        Y2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JU
+        eXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3Rwcm92MV83
+        MzE3ZDJmYy01NWVhLTRkMzktYWYzNS1kOTI1YjAwYTdjNjMudmhkPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTkgSmFuIDIwMTYg
+        MTU6NTY6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjBFOTEx
+        NTE1MTg2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0Nv
+        bnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQt
+        c3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29u
+        dGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBW
+        cHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRl
+        bnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4y
+        PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0cHJvdjFfYzEzMTAwMWUtNDFl
+        OS00ODQxLWEyZTAtM2UwZTJhMDNhNDMyLnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI4OjUzIEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUVGNDA2QTNEQTwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dGVzdHByb3YxX2NmMTYyNjk3LWVmNjUtNDAxOC1iOWMy
+        LWI5OWJjZWJjNWYwZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9k
+        aWZpZWQ+TW9uLCAwNyBEZWMgMjAxNSAxNzoyMDozNiBHTVQ8L0xhc3QtTW9k
+        aWZpZWQ+PEV0YWc+MHg4RDJGRjJBQjhCNkRDRkY8L0V0YWc+PENvbnRlbnQt
+        TGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQt
+        VHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48
+        Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRl
+        bnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+
+        PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
+        dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
+        ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
+        PnRlc3Rwcm92Mi5hZWFjNWMyNS1iYmI3LTQ0ZmQtOTkyOS04NjhhZjg5Yzg4
+        YjEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1
+        ZSwgMDggRGVjIDIwMTUgMjI6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMDAxRUMyODZDRDYyPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5hMkdGaTM0eEho
+        VmlXSHloTzhnZVB3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3Rwcm92My4wNmU5MWVjZS02Zjk0LTQ3
+        OWEtOTgzMS05MmU1OGQzYTBlYzcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjc6MjAgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRUJDOUU5QjFCPC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT5Ba0t6MTN2d0VFUXhNM0lIdFhZb0F3PT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48Qmxv
+        YlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3Rwcm92
+        NC44NzA3ZDk5MS1lNjE0LTRhNzMtOGNkYy05YzZkNDViZjRkMDcuc3RhdHVz
+        PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVj
+        IDIwMTUgMjI6Mjk6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQz
+        MDAxRUY4QjlDRTA1PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRl
+        bnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3Ry
+        ZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVu
+        dC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT44anRzYncvSGsremF2bWl3L0RE
+        ZzhRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQt
+        RGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48
+        TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxC
+        bG9iPjxOYW1lPnZtdGVzdDEwMC4zZjhhNmY0OC0yMTZlLTQ2NzctOWM2Ny1m
+        ODIzNzJlY2I3ZTYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPldlZCwgMjAgSmFuIDIwMTYgMjA6NTU6MzcgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMjFEQzBDQjVEMUU1PC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBw
+        bGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQt
+        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5n
+        S1BSNHAwLzU4U3diQkcvQ3U5Zk13PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1D
+        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+Qmxv
+        Y2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDEwMF84MTI4YTlj
+        ZS1iMTkxLTQyMzgtODBjNi1jNjFlMDRjMDY1YTcudmhkPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgSmFuIDIwMTYgMjA6NTc6
+        MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMjFEQzUwMUVGMTEw
+        PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQt
+        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
+        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
+        YW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZR
+        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
+        cG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT52bXRlc3QxMS4wMzA1ZTJmNy1kNmNkLTQ3MDUt
+        Yjc2Yi05NGJiMmQwN2Y4MjQuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6Mjc6MzQgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRUM1NTVCRDhBPC9FdGFnPjxD
+        b250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5CVHZPajU0NDhKa0Y2Y3FkZkcyR09BPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5
+        cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDExXzMz
+        ZWZmZmQ1LTAzM2YtNDg1YS1hMDA2LTg3MDExZTY3YTcxYy52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAy
+        MjoyOTowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFRkIw
+        OTAyNjM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
+        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDEyLmYwZjhjYmE1LWM0Y2Qt
+        NGE0My04M2M1LTcyODVkYTFiMzFjOS5zdGF0dXM8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyNzozMCBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMDFFQzJENzYxMzY8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1PmJQdkxpcENKN2o0ZjIvK0wrQmxMeGc9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
+        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
+        MTJfZDE3YWVmYWMtZmVlYy00YzVjLWJhZjUtMzk1ZGZiNGI4NDY1LnZoZDwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAy
+        MDE1IDIyOjI5OjA5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAw
+        MUVGREEwOENGMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
+        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MTMuZWQ1YjNhNWQt
+        Nzc4Ni00MmM0LWJmMGYtMTE1ZGViZTQxMTgzLnN0YXR1czwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI4
+        OjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUVGMjFBNTM0
+        MjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+b0V3azVOcmtqQjFHYzBITGdqS0xoQT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
+        bXRlc3QxM19kMjU1MjRmNi04ZmNkLTQ2ODAtYjRiZi01Yzg3OGZlODUyZmMu
+        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDgg
+        RGVjIDIwMTUgMjI6MzQ6MDYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMDAxRkFFOENCQzdBPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
+        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
+        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QxNS5lMDc4
+        ZjJlYi1lZjdjLTQzMDItYjE5Yy1lY2E5Nzg2MDQxMzcuc3RhdHVzPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUg
+        MTI6NTU6MjIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDA5N0ZG
+        RTQ0MUM3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
         Z3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9D
         b250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5n
-        dWFnZSAvPjxDb250ZW50LU1ENT5pekd4c2FPY2plTTNvQnZuT2lSNm1nPT08
+        dWFnZSAvPjxDb250ZW50LU1ENT5ZNFRubDhCOXY5dlZmcHk4SUR0clNnPT08
         L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9z
         aXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VT
         dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
         YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
-        YW1lPnZtdGVzdDdfODhjODlhZmMtMTZmNy00NmJmLWEyOTAtMGZjYmZmN2Jh
-        YTEwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUs
-        IDA4IERlYyAyMDE1IDIyOjMxOjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
-        Zz4weDhEMzAwMUY0QzQxQkZGNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2
-        MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxp
-        Y2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVu
-        Y29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZy
-        Q0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29u
-        dHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1
-        ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48Qmxv
-        YlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tl
-        ZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0
-        YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAv
-        PjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+        YW1lPnZtdGVzdDE1XzVhOGQ0ZDM1LTAyZDctNDczMS05YjBjLTMzODIwMzIz
+        MTc2YS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2Vk
+        LCAwOSBEZWMgMjAxNSAxMjo1NjoyMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0
+        YWc+MHg4RDMwMDk4MjM5MTUxMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEz
+        NjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBs
+        aWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1F
+        bmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pnlm
+        ckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNv
+        bnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJs
+        b2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE2
+        LmJhZTM0NmViLWEzYzAtNDQ0Ni05NTgwLWNlMjQ3N2UzNzkwNC5zdGF0dXM8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMg
+        MjAxNSAxNToyNzo0NyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMw
+        MEFENEIwNzA2NTc8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVu
+        dC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJl
+        YW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50
+        LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmxCSFpzVEFhZDdrYkJWTHNXOXVH
+        WUE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1E
+        aXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxM
+        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
+        b2I+PE5hbWU+dm10ZXN0MTZfZGRhYzZhMzQtNGZiZi00YjE4LTkyZjUtZWM1
+        OTUwNGQ2NGZhLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
+        ZD5XZWQsIDA5IERlYyAyMDE1IDE1OjI5OjU2IEdNVDwvTGFzdC1Nb2RpZmll
+        ZD48RXRhZz4weDhEMzAwQUQ5NzkwMUMyMzwvRXRhZz48Q29udGVudC1MZW5n
+        dGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
+        ZXN0MTcuN2YyNWE5OTktMmZiNi00MGM1LTk0ZjgtOWRiNWVhMDA4ZTdiLnN0
+        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5
+        IERlYyAyMDE1IDE1OjI3OjQ5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMzAwQUQ0QzVERUY2ODwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
+        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
+        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cFV3bG1BMDVOcDY1NUhJ
+        cHdUcGRjQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
+        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
+        Yj48QmxvYj48TmFtZT52bXRlc3QxN18xNmQ1ZDFjOS1lMTBlLTRmZTQtODUw
+        YS0zZjEwNjEyZWEzZTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMTU6Mjk6NTIgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMDBBRDk1NUQ0QTY1PC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT52bXRlc3QxOS4xNzE3ODdiNS01MjY5LTQ1NWItYWYzNC05NTYzNTkyMjMx
+        OGEuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldl
+        ZCwgMDkgRGVjIDIwMTUgMTU6NDY6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMDBBRkUwM0I1RDhBPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT56RkhnWGxITTY2
+        dmhOTzhaWExtVS9RPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDE5XzVlMThjZTVhLTk0YjMtNDVl
+        Yi04ZTE1LTJhNGQ3MWVmMGExOS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAxNTo0Nzo1OSBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEIwMUQ0OTBGMTU8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDIxLjE2YTE1ZDllLWEyMjYtNGI5Ni1iM2E1LTVlYWFk
+        MTI3NmM4Ni5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMTowMDoxNiBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMwMERCQkRBNzI1MkU8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlhxMUdl
+        M1dpYms2cGl2VHp2WCswZUE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjFfZWVkMGQ0ZTMtYjFl
+        OS00NmY1LTljMzEtM2E2OWUyMTNmODA4LnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIxOjAyOjUxIEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwREMxOThFMjlDQzwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0MjIuNjkxNTg5MmMtNGZiMS00OTFiLTgxOGEt
+        YWNjYzZhNDU0NDc5LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIxOjAwOjIwIEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzAwREJCRkI5OUJCNzwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
+        cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
+        LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
+        c2RQQVNLbUkyZFhEYllyOTF3ZHBGQT09PC9Db250ZW50LU1ENT48Q2FjaGUt
+        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
+        b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
+        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyMl8wYzMxNTNj
+        My05Y2UwLTQ4MTYtOWMyMy1mNzk1OGQ1ZjI1NTIudmhkPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjE6MDI6
+        MjIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBEQzA4NTU3RDUx
+        PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQt
+        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
+        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
+        YW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZR
+        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
+        cG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT52bXRlc3QyMy5iYWQzNmRhOC0yODM2LTQ3NWUt
+        OWQzMC0wYWU0Y2JhOTg3YzUuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPldlZCwgMDkgRGVjIDIwMTUgMjE6MDA6MTYgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDBEQkJEQTJCODMxPC9FdGFnPjxD
+        b250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5
+        cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENv
+        bnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50
+        LU1ENT5YcTFHZTNXaWJrNnBpdlR6dlgrMGVBPT08L0NvbnRlbnQtTUQ1PjxD
+        YWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5
+        cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8
+        L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0
+        ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDIzX2U0
+        MWMxNDg3LTAwODctNDlkNi05NDQ1LWVlMGVhMjk3ZDI3OC52aGQ8L05hbWU+
+        PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAy
+        MTowMjowNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMERCRkZC
+        RDU5NkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZw
+        c0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8
+        L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9i
+        PC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI1LmIyNjdmZjA1LWM4MTMt
+        NDUyZS04NzZhLThiY2JiN2IxMTQ5MS5zdGF0dXM8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwOSBEZWMgMjAxNSAyMjoxNToyOCBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMwMEU2M0VFQTI5NTE8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRl
+        bnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlw
+        ZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1PkJYRURDMDlWREM1Z0VLMWltZVZ2Z0E9PTwvQ29udGVudC1N
+        RDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxC
+        bG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
+        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
+        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
+        MjVfNjc3ZWIxMTUtN2NkNi00NTZjLWJjNzktY2Q0ZTcyYTkwNjIwLnZoZDwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAy
+        MDE1IDIyOjE3OjU4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAw
+        RTY5ODZDRUJEODwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2oz
+        VjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VT
+        dGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJv
+        cGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjYuMmVkODZhNDUt
+        ZmUxNC00MDIyLTlkOTUtYWY1YWI4OTg1OWIzLnN0YXR1czwvTmFtZT48UHJv
+        cGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE1
+        OjI0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTYzQzkxRjNG
+        RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+UVJ2K2x3blc0REZ5ZTE0NzQzVFI0QT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
+        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
+        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52
+        bXRlc3QyNl84MTEyNmUxOC04N2JhLTRmY2ItYjdjMS05ZmVmZGQwMzQwNjUu
+        dmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDkg
+        RGVjIDIwMTUgMjI6MTg6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4
+        OEQzMDBFNjlDNjkxQkMyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjcz
+        MDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRp
+        b24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rp
+        bmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5
+        K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9s
+        IC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNl
+        LW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlw
+        ZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QyNy4yZjFm
+        MDZkMi05MzYyLTRhNjktYmMxMi1iYTg4Y2YwZDBlN2Quc3RhdHVzPC9OYW1l
+        PjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTEgRGVjIDIwMTUg
+        MjE6Mzk6MTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDI3Mzgz
+        REE5MEQ2PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVu
+        Z3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9D
+        b250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5n
+        dWFnZSAvPjxDb250ZW50LU1ENT5uSFFIaGNGQmZJNlhveExvZU9SOEtRPT08
+        L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9z
+        aXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VT
+        dGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWls
+        YWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxO
+        YW1lPnZtdGVzdDI3LmExNGYyYzM2LTE2Y2YtNGI4MC1iNjQwLTgyYzE2NzJj
+        MDJiNy5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        V2VkLCAwOSBEZWMgMjAxNSAyMjoxNToyNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDMwMEU2M0Q4RjQ4NDE8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        PjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlv
+        bi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGlu
+        ZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlN1U1pjVlBK
+        ZnN3YW52OGo3WjhEVUE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wg
+        Lz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8
+        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
+        cz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0MjdfMWI3MmZlN2YtMzgwYy00
+        OWI3LTk1NTUtYTJlMjU2NWE3ZWRhLnZoZDwvTmFtZT48UHJvcGVydGllcz48
+        TGFzdC1Nb2RpZmllZD5XZWQsIDA5IERlYyAyMDE1IDIyOjE4OjAxIEdNVDwv
+        TGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwRTY5QTE1NTM0MTwvRXRhZz48
+        Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48
+        Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVu
+        dC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2Ug
+        Lz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250
+        ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9u
+        IC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNl
+        cXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxM
+        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
+        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJs
+        b2I+PE5hbWU+dm10ZXN0MjdfOTdlZTJmNWItN2JmZS00MmNiLWFiYjUtMjMz
+        ZDdjN2JhZTM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
+        ZD5GcmksIDExIERlYyAyMDE1IDIxOjQxOjIwIEdNVDwvTGFzdC1Nb2RpZmll
+        ZD48RXRhZz4weDhEMzAyNzNDRUFDRTZFMjwvRXRhZz48Q29udGVudC1MZW5n
+        dGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJl
+        cj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
+        ZXN0MjguODcxYTMyMjItYzBmNi00ZDhhLTg5YzYtN2E3OTI0NGQ4YmE2LnN0
+        YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2
+        IEphbiAyMDE2IDIwOjE0OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4w
+        eDhEMzE2RDVFREZGNUU1RjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9D
+        b250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0
+        LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENv
+        bnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RzcwMysxMmRBRUZUTFRy
+        MllUVGkxZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250
+        ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5
+        cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VT
+        dGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxv
+        Yj48QmxvYj48TmFtZT52bXRlc3QyOF9iZTliMWZjZS01YTA3LTRlYjQtODdl
+        OS02NDJjYTg1ODUzZTEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1v
+        ZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTY6MzIgR01UPC9MYXN0LU1v
+        ZGlmaWVkPjxFdGFnPjB4OEQzMTZENjQ0QUJEREVGPC9FdGFnPjxDb250ZW50
+        LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1t
+        cy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2Ut
+        bnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT52bXRlc3QyOS5jOTc5NmYzMy03NGM1LTRlYTktYmQ1My1kMmFhM2EyMGEy
+        NDIuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldl
+        ZCwgMDYgSmFuIDIwMTYgMjA6MTM6NTYgR01UPC9MYXN0LU1vZGlmaWVkPjxF
+        dGFnPjB4OEQzMTZENUU4MTA5RUFGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41
+        MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24v
+        b2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2Rpbmcg
+        Lz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PZFRsWmNiSnJl
+        MDBhODNsc21QeXpnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+
+        PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9C
+        bG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxM
+        ZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+
+        PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDI5XzAxNmY5OTk0LWMwOTAtNDAz
+        Yi1iMzFmLTM5OGUyODRlOWY5NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNjoxMyBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ2Mzk5REMzNzc8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        Pjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDMuOGYxZDRhNjctMTJhZS00OWJiLWFmZjUtZWY1N2Nk
+        ZjI2MjQ3LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmll
+        ZD5UdWUsIDA4IERlYyAyMDE1IDIyOjI5OjQxIEdNVDwvTGFzdC1Nb2RpZmll
+        ZD48RXRhZz4weDhEMzAwMUYxMEQzNzREQjwvRXRhZz48Q29udGVudC1MZW5n
+        dGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0
+        aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29k
+        aW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cUZ5cE80
+        YW9QWlJBYVlBMHJwdUNXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJv
+        bCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxv
+        YjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1
+        cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0
+        aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3QzMi43OTM3MzIwNC03MzIz
+        LTQxOGItYTNiNy1kZGZjNWZiMjNlYjkuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0
+        aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTQ6MDYg
+        R01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENUVERDJBNzdBPC9F
+        dGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250
+        ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5
+        cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxD
+        b250ZW50LU1ENT44N2xWQ2RmRGR5YXFGTVRTZzIvU1pRPT08L0NvbnRlbnQt
+        TUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48
+        QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
+        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVz
+        dDMyX2JkYjQ5OGJjLTBkZmEtNGFlMC1hYTJiLTE3NTAwMDU2ZGZlMy52aGQ8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4g
+        MjAxNiAyMDoxNjoyMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMx
+        NkQ2M0YzOUE1Nzc8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMx
+        MjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9v
+        Y3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAv
+        PjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdq
+        M1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48
+        Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVt
+        YmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBh
+        Z2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNl
+        U3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1By
+        b3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDNfNjM1ZjRkNzkt
+        M2FiNy00MjJiLWFkODYtNjQ0MzNjZDExZGNkLnZoZDwvTmFtZT48UHJvcGVy
+        dGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA4IERlYyAyMDE1IDIyOjMxOjQz
+        IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzAwMUY1OTNFNzlEQjwv
+        RXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxl
+        bmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwv
+        Q29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFu
+        Z3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09
+        PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bv
+        c2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1i
+        bG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JU
+        eXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNl
+        U3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Js
+        b2I+PEJsb2I+PE5hbWU+dm10ZXN0NDAuMDFjZTVlZmYtZDQ0OC00Njc1LTgz
+        NDEtZjc5MzQ0YjE1ZGQ4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFz
+        dC1Nb2RpZmllZD5XZWQsIDA2IEphbiAyMDE2IDIwOjE0OjQxIEdNVDwvTGFz
+        dC1Nb2RpZmllZD48RXRhZz4weDhEMzE2RDYwMkIyODE4MDwvRXRhZz48Q29u
+        dGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+Y295NWJ4OGdlbXZBMDV4OTdnZ3RlUT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBl
+        PkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9M
+        ZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+
+        PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0MF8xODJm
+        NDEwNC0wNGMyLTQ3ZWMtYjUxNy0xNzMyYzI4NmZiOTEudmhkPC9OYW1lPjxQ
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6
+        MTY6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENjRDNEMw
+        NTM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRl
+        bnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3Ry
+        ZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVu
+        dC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNI
+        bHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQt
+        RGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94
+        LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwv
+        QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
+        TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
+        PjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0MS4yNjNiZjgxZS1hZTk4LTRm
+        MTYtOTQ0ZS03MDQxOTMyN2I2OGIuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPldlZCwgMDYgSmFuIDIwMTYgMjA6MTQ6MDQgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMTZENUVDQzBFMDY2PC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50
+        LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+
+        PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250
+        ZW50LU1ENT54VUkxQ2hEWVJkODh1b2FWa3JUMEVRPT08L0NvbnRlbnQtTUQ1
+        PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48Qmxv
+        YlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2Nr
+        ZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VT
+        dGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQx
+        XzFhNzIyMWExLTdjNGMtNGZiNi04Mjk5LWY3ZDk1YzQ0ZmNlNi52aGQ8L05h
+        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAx
+        NiAyMDoxNTo0OCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ2
+        MkFERjUzNzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwv
+        Q29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3Rl
+        dC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxD
+        b250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PnlmckNJRnkrWWdqM1Y2
+        MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29u
+        dGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVy
+        PjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VC
+        bG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3Bl
+        cnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVzdDQyLjA2OGIyNmI1LTUy
+        ZGEtNGIyZi1iOWM0LTc0Yzg5ZmM2MzNmYS5zdGF0dXM8L05hbWU+PFByb3Bl
+        cnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwNiBKYW4gMjAxNiAyMDoxNDo1
+        NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxNkQ2MEFFNkQ3NEY8
+        L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENv
+        bnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQt
+        VHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+
+        PENvbnRlbnQtTUQ1PnFHUStLVllVbU44LzVqcSsxMjBzQnc9PTwvQ29udGVu
+        dC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAv
+        PjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51
+        bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9M
+        ZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10
+        ZXN0NDJfNGZkOTlhYTEtNjQwZi00NzYyLWJiYjQtZDA0NmUwMDAyZDc1LnZo
+        ZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA2IEph
+        biAyMDE2IDIwOjE2OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
+        MzE2RDY0OEZEMzNDMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5
+        MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZ
+        Z2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1u
+        dW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+
+        UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVh
+        c2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwv
+        UHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NDUuMWNjNjg2
+        ZmMtNGFiYS00N2E0LWIzN2MtMDE0N2U0MzVmMzJmLnN0YXR1czwvTmFtZT48
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3
+        OjA4OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlDNjg2
+        QzdERjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTA5PC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+eVRpNC9pSEc1aWhYeXBEdjRKbkIrQT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3Rh
+        dHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFi
+        bGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFt
+        ZT52bXRlc3Q0NV9kNDZhMzYyNC1kMDliLTQ2MzUtOGIxOS0wODczOTM0Yzk4
+        NzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwg
+        MTEgSmFuIDIwMTYgMTc6MDk6MzQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFn
+        PjB4OEQzMUFBOUZBODQ2RTYyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYz
+        NjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGlj
+        YXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5j
+        b2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT55ZnJD
+        SUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250
+        cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVl
+        bmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9i
+        VHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2Vk
+        PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3Rh
+        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q0Ni5j
+        YmU4NzA5MS1kOTU1LTQzNGYtOWUzNy0xMTg1OTg4N2YxZjguc3RhdHVzPC9O
+        YW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIw
+        MTYgMTc6MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFB
+        OUMzNkM5Q0I4PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8L0NvbnRlbnQt
+        TGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt
+        PC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1M
+        YW5ndWFnZSAvPjxDb250ZW50LU1ENT43L2YrLzN2VUYxRTVHVytSR2VnYVJn
+        PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlz
+        cG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDQ2X2I5NThiODRlLTViMTYtNGYyNi04NmE5LTQwNDE3
+        NmFjNzkxNS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+
+        TW9uLCAxMSBKYW4gMjAxNiAxNzowOTo1OCBHTVQ8L0xhc3QtTW9kaWZpZWQ+
+        PEV0YWc+MHg4RDMxQUFBMDhDOTY0Qjg8L0V0YWc+PENvbnRlbnQtTGVuZ3Ro
+        PjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5h
+        cHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVu
+        dC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1
+        PnlmckNJRnkrWWdqM1Y2MFZwc0hsdlE9PTwvQ29udGVudC1NRDU+PENhY2hl
+        LUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+
+        PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5s
+        b2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVh
+        c2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnZtdGVz
+        dDQ3LmMyZWI3ZmJlLTFhZDEtNDQ0MS1hYzg1LTk4MDQ3Y2ZlYWJhZi5zdGF0
+        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBK
+        YW4gMjAxNiAxNzowNzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMxQUE5Qjk5MkVEQjU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUwOTwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PkI5eTc2ZTNSZVYxdktPT2Iv
+        RXMrWWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0NDdfNTVjNDc2YzgtMzI0Ni00NmM0LWExNDEt
+        ZjczY2IxYjg1MmMxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2Rp
+        ZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjEwOjIxIEdNVDwvTGFzdC1Nb2Rp
+        ZmllZD48RXRhZz4weDhEMzFBQUExNkJFQjFEMjwvRXRhZz48Q29udGVudC1M
+        ZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1U
+        eXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxD
+        b250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVu
+        dC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBzSGx2UT09PC9Db250ZW50LU1ENT48
+        Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMt
+        YmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51
+        bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1
+        cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
+        PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
+        dm10ZXN0NS45NTlmYWMzMi03OWQ2LTQ4ZDMtOGRkZC03MDM3NGU1Y2RjOGUu
+        c3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwg
+        MDggRGVjIDIwMTUgMjI6Mjk6MTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFn
+        PjB4OEQzMDAxRjAxMEFEODFEPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MDk8
+        L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0
+        ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48
+        Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5tS1ZyUjU5MVhsMksw
+        b2pJcTZLdk93PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENv
+        bnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9i
+        VHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFz
+        ZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjxCbG9iPjxOYW1lPnZtdGVzdDU1LmIyYzc1Y2VhLTNjM2UtNGI0YS1h
+        YjdiLWM3MzJkYzVjNmI5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowODowNCBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxQUE5QzRCNjhDQUQ8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
+        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
+        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
+        TUQ1PkxiMnQzMkUzUjBxcnhoMXlUeXhtR0E9PTwvQ29udGVudC1NRDU+PENh
+        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlw
+        ZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwv
+        TGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRl
+        PjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NTVfZDgy
+        YzFjMTMtZjIwYy00YjUzLWFkZjktZWY5NmM1YjUwNGYzLnZoZDwvTmFtZT48
+        UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3
+        OjA5OjI4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQTlGNkI4
+        MkI5NjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250
+        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
+        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
+        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eWZyQ0lGeStZZ2ozVjYwVnBz
+        SGx2UT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
+        LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+Mjwv
+        eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8
+        L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGll
+        cz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NV8wZDY0ZmQ3MC1hMzg1LTQ5
+        ZDEtYTQ5OS1lNDI1MDYwNjEzMDQudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxM
+        YXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6MzA6NDYgR01UPC9M
+        YXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRjM3Njk1NkREPC9FdGFnPjxD
+        b250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxD
+        b250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50
+        LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAv
+        PjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0NvbnRl
+        bnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24g
+        Lz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2Vx
+        dWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExl
+        YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
+        dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT52bXRlc3Q3LjFjMDFhZjZjLWM0N2UtNDczYi05OGIyLTRlYTgz
+        NzE4M2QxNi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+VHVlLCAwOCBEZWMgMjAxNSAyMjoyOTozMiBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMwMDFGMEJCNzRDMjY8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjUwOTwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pml6R3hz
+        YU9jamVNM29Cdm5PaVI2bWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0N184OGM4OWFmYy0xNmY3
+        LTQ2YmYtYTI5MC0wZmNiZmY3YmFhMTAudmhkPC9OYW1lPjxQcm9wZXJ0aWVz
+        PjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDggRGVjIDIwMTUgMjI6MzE6MjEgR01U
+        PC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMDAxRjRDNDFCRkY3PC9FdGFn
+        PjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT55ZnJDSUZ5K1lnajNWNjBWcHNIbHZRPT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2It
+        c2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+
+        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
+        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
+        L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:54 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:44 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/system?comp=list&restype=container
@@ -6987,11 +7221,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:54 GMT
+      - Wed, 03 Feb 2016 14:19:45 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:jq8u8LeebTB/a7Cei9RwEkI0Cpe0xiVjKxQbPyNiIIo=
+      - SharedKey chefprod5120:yvYDPQERaMePKAHbJ/9kL9XrCkYNpuYHLIpZD3r437I=
   response:
     status:
       code: 200
@@ -7004,11 +7238,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5963d4a9-0001-0072-07c0-5220fe000000
+      - 157a0886-0001-0029-0d8d-5e2782000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:55 GMT
+      - Wed, 03 Feb 2016 14:19:44 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7095,7 +7329,7 @@ http_interactions:
         cm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVt
         ZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:55 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:45 GMT
 - request:
     method: get
     uri: https://chefprod5120.blob.core.windows.net/vhds?comp=list&restype=container
@@ -7110,11 +7344,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:55 GMT
+      - Wed, 03 Feb 2016 14:19:45 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:BRDrZ8t8cv3RDlmYRV4BT8+yL/pMfbatW3rC8ENjMl8=
+      - SharedKey chefprod5120:CaYW30KkJPxa7YenhNnlG7YYkyOhChUBoGKrWAhPeV4=
   response:
     status:
       code: 200
@@ -7127,11 +7361,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8f656615-0001-005f-5ac0-52a33e000000
+      - f7fb63a0-0001-0063-2e8d-5e17e5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:49:55 GMT
+      - Wed, 03 Feb 2016 14:19:45 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -7140,19 +7374,19 @@ http_interactions:
         cHJvZDUxMjAuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFt
         ZT0idmhkcyI+PEJsb2JzPjxCbG9iPjxOYW1lPkNoZWYtUHJvZC4zOWM1MzIw
         Yy0wYjAzLTQ2ZTktOWYwZi00NzNlYWQ3NjhmYWIuc3RhdHVzPC9OYW1lPjxQ
-        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMTMgSmFuIDIwMTYgMTI6
-        NTg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUMxOTQ4RTlE
-        RDc0PC9FdGFnPjxDb250ZW50LUxlbmd0aD40MzU8L0NvbnRlbnQtTGVuZ3Ro
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMDIgRmViIDIwMTYgMjA6
+        MzE6NDkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMkMwRkUwNjhE
+        RDI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD40MzU8L0NvbnRlbnQtTGVuZ3Ro
         PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
         ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
-        ZSAvPjxDb250ZW50LU1ENT4wZ3Y2NmFuTzFTcktKYnIvQjNaV2Z3PT08L0Nv
+        ZSAvPjxDb250ZW50LU1ENT5XbFJkcmUxTTVrb3FzclRSM0JkTWpBPT08L0Nv
         bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
         b24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0
         dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJs
         ZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1l
         PkNoZWYtUHJvZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
-        ZWQ+VHVlLCAxOSBKYW4gMjAxNiAxMzo0Njo0NSBHTVQ8L0xhc3QtTW9kaWZp
-        ZWQ+PEV0YWc+MHg4RDMyMEQ2RjhCM0Q2Njc8L0V0YWc+PENvbnRlbnQtTGVu
+        ZWQ+V2VkLCAwMyBGZWIgMjAxNiAwMzo1NToxMCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMyQzRERDAwQzBEQUM8L0V0YWc+PENvbnRlbnQtTGVu
         Z3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
         PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
         ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
@@ -7186,10 +7420,906 @@ http_interactions:
         ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
         c2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFz
         ZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNl
-        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFy
-        a2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        RHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT51YnVu
+        dHVzZXJ2ZXIuMDEyNDcyMzYtNjBjNy00NDJhLTllN2QtMGM4NmEyMTMwYmQx
+        LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQs
+        IDAzIEZlYiAyMDE2IDE0OjE5OjI1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4weDhEMzJDQTUwNTIwNzE2MjwvRXRhZz48Q29udGVudC1MZW5ndGg+Njgz
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+M3FEL3dxQVhiMHUr
+        YWdvUDFPY2RMQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT51YnVudHVzZXJ2ZXIyMDE2MTExNjE5MS52aGQ8
+        L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAwMyBGZWIg
+        MjAxNiAxNDoxNzo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMy
+        Q0E0Qzc1NkJFM0I8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEy
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NC
+        L256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFn
+        ZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3Rh
+        dHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJh
+        dGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9C
+        bG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0
+        cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:55 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:46 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest12_cad095db-8ab2-4b3a-a2da-f69d0b9fd917.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:46 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:srwQqGFH6oIV7Kl1YF+KIA9OUGI1d1W3FxCKtXSps64=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 15:54:29 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320E8D0978BAB"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - eff5f0c6-0001-0011-408d-5e66db000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - faabd640-102c-438a-8c37-7e6b35e8de58
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=v0c1Cbi7ytthQQ11cUPSPhM%2BHaPLE0jKT5AYp4sZuGY%3D&st=2016-01-18T22%3A35%3A07Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 18 Jan 2016 22:50:10 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:45 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:46 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest15_621b09c1-98ea-448b-8f05-ced49a75cb48.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:46 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:RE4JNamhv+KoVgKVIqyqchFfD09Xh8YaqX1G0sKn0yw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 17:06:32 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320F2E17DCB2C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e2b75788-0001-004c-018d-5e96df000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - c3f7e8ce-cd94-4995-bc7a-0287f9e497c2
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=3S%2BgMDEwhNLUID%2FLi04rpf0ifmLV%2FLG%2BP5Ikji%2BLCrA%3D&st=2016-01-19T15%3A42%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 15:57:13 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:46 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:46 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest16_a4ec966d-b191-4892-8a86-e5a350dbf870.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:46 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:024/LHbBMUrNGF8H83o8K45ApOcwncY66VLW25WM4Dw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 17:05:57 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320F2CC8AAC65"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bee66d63-0001-005f-308d-5ea33e000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 9cfc27f6-2685-44ea-84b6-a25e5665b005
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=ZsbBkndmAimFIEs8XOovQy2aCfmjAsXhbQL5CGJo5j8%3D&st=2016-01-19T16%3A02%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 16:17:13 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:46 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:47 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest20_763957a9-774e-4ff3-8df3-741e6d36444d.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:47 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:6XyW22RHUjUv6h4/MCPu0IwpK/5wx/IxeLav2eoD9PA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 19:27:30 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3210692C45E2C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - b14d7573-0001-0085-078d-5e0615000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 0db25f12-5810-4627-8349-dff9db9904c2
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=VskGNGE6QdsgfXKiepmwGlOYJZtertl1qzwvwPJyZvs%3D&st=2016-01-19T16%3A52%3A02Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 17:07:02 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:47 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:47 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest21_504a67a9-b87e-48d4-a821-ed66bf18b726.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:47 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:tLyksWWbNqyxS0pIpmta0loOQwuxuYhTPzdLlarCPkM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 19:27:39 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3210697F52149"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7561fd13-0001-0084-338d-5e07e8000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - ad8c7a06-e2f2-49e5-af6d-55e94ae3cce0
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=uq6JG%2F7Ajn%2B62%2F0GYpcYq%2BqYVRKIe5Z23PN7dVi8DN0%3D&st=2016-01-19T17%3A26%3A22Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 17:41:22 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:47 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:48 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest22_eee2daa6-821b-4ee4-891f-399321eb280f.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:48 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:1hEr2lbovBHGc+oruS7WXYoGADz8SffDnc15uceZDVo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 19:28:25 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D32106B3A6B5D7"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 72bece3d-0001-0047-1f8d-5e8eab000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 057f8ec6-5e5f-4065-8309-7532bff4ceb9
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=9EHtPNo%2FbGuc6Ah1r49vqO9ho1mfoFpBti8UpHM9Z1E%3D&st=2016-01-19T17%3A57%3A24Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 18:12:25 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:48 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:48 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest23_c5076ff7-4ac9-4ac4-8056-63ede6121750.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:48 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:m8/iiHUyzpIjl9ZXm3v+OWIsiGc0wRt+hDEwbtXJFhs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 19:27:40 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3210698C597DF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bbf64ffc-0001-0045-308d-5e8c51000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 686e386a-a2fd-4ca7-8280-16b1a1134ea6
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=O6za52NKChuNyAHu3hbmCkqOpEXDv1zwRbb%2B1EOQb20%3D&st=2016-01-19T18%3A23%3A33Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 18:38:34 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:48 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:49 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest25_446a9fec-b89d-4202-9b01-de38a53fbbf7.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:S4OtSnEctk0g4b0fO+Zimh54H3uxhSeVcUH/6NCi+uo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 20:19:24 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3210DD2E1D987"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e0ead8cf-0001-006c-2d8d-5efa13000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - accc3c10-bee1-42bb-be7a-520b29bf4127
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=wYxqNNWMxArAZZIYL5qk7mHKKqMdB3W3saNiYGxsHWo%3D&st=2016-01-19T19%3A17%3A36Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 19:32:37 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:49 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest26_d8dfe089-a159-404c-b512-e508e96f5a8d.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:h7LxI6w61y6zCcqQI767FQJVmFWQZ0ZtPMClbBWiqzs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 20 Jan 2016 20:58:05 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D321DC64D7C406"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e5a328fe-0001-0057-038d-5eb84d000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - bcb70ccf-84eb-450e-99ac-37ea0b6c6388
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=RduQk3RjWdMRWNK1cPeBjSR5V4w76h5muAIzAMshGNc%3D&st=2016-01-19T19%3A41%3A46Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 19:56:47 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:49 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest27_bcb43091-fb5b-43da-ac4a-4ecede0e6f4c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:7uzvg9h4Nb1l48oFv0IWvvPXTX+UGqkH77e7Hlgrsbg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 20 Jan 2016 19:26:17 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D321CF916BE8E2"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 651dc907-0001-001a-308d-5e7eaf000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 30018075-2bef-4c9b-8456-29df506a85ac
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=cnmGrGSx1LXRJjnaoJ2%2FFrQ0wRMgADB1PQARUfM0NLY%3D&st=2016-01-19T20%3A03%3A01Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 20:18:01 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:50 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest28_cac8071d-b323-40bb-8761-74dbee61173c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:50 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:uV8TxTqK+VDVNobXiDrFhf87bNTbssZucxS5xL962Sw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 20 Jan 2016 20:55:30 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D321DC085BEE3F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9876761d-0001-002c-5e8d-5ed3fd000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - efbaec3e-73ad-40e2-ba74-dbe6f3575b99
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=k6Bfig2024PQrh2ucZRtgjaWd7sMX9vrblTXHizqKDg%3D&st=2016-01-19T20%3A22%3A17Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 19 Jan 2016 20:37:17 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:50 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest2_80489376-79fd-4498-b445-907936af91c4.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:50 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:/W2zUB3ed+1uijxD7YbPgUE9dB+VOBpJ5ktS6sUS+3A=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 15:54:52 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320E8DE7DEB1E"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4f19956a-0001-0064-7b8d-5ee160000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - a58f8453-6ed3-43ed-8f51-867b96055d60
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=CptjepdDUREt0VpnOm6gMsYmExj7aqmRP%2F95eeL5uu4%3D&st=2016-01-18T16%3A34%3A27Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 18 Jan 2016 16:49:28 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:49 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:51 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/rgtest_a08973c0-583c-49ac-9724-8d5f6e53d19c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:51 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:ilSbdn2jhmhXQkcA8t4aJxDvT6EG6GNBGBhQiffrRIM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 15:54:50 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320E8DD7E7390"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 27dae6ba-0001-0053-2f8d-5e4dcf000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 4b5e116d-a52e-4f1c-8b8a-9736ef9fd63d
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=fB2%2B%2FYBCK0a6oV8ZexKpU3pjzBNvrFAFqKePpW%2BYGCY%3D&st=2016-01-18T16%3A21%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 18 Jan 2016 16:36:15 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:50 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:51 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/sdfsdf_fd046ba5-2e5c-448b-ad79-65b726812119.vhd
@@ -7204,11 +8334,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:55 GMT
+      - Wed, 03 Feb 2016 14:19:51 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:BVCLX5HRQNBLxWz3qrdZACc5k5uHlmuvjtoSwZ/IXug=
+      - SharedKey chefprod5120:b1HcQ7P3HQRJbR42h7vJfgOXZe33pbfTewvRLfzgyOA=
   response:
     status:
       code: 200
@@ -7229,7 +8359,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cea95837-0001-0087-5fc0-5204ef000000
+      - 46d4301b-0001-0079-668d-5e388a000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7251,12 +8381,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 20:47:48 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:55 GMT
+      - Wed, 03 Feb 2016 14:19:50 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:56 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:51 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_17d270de-9c7c-4a40-afba-30145360e852.vhd
@@ -7271,11 +8401,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:56 GMT
+      - Wed, 03 Feb 2016 14:19:51 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:B8qIH2VD+KPkXRB2NYFPw0RU7F5+6kLA6i8JqL0NAeM=
+      - SharedKey chefprod5120:yP5a2z/MoHFq9bzaSRFUgmGH4y4xnW6aKB/OlFvu6dg=
   response:
     status:
       code: 200
@@ -7296,7 +8426,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f7cb3bc8-0001-0023-1dc0-523e0b000000
+      - ef34eb3d-0001-0077-488d-5ed481000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7318,12 +8448,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 07 Dec 2015 18:00:15 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:56 GMT
+      - Wed, 03 Feb 2016 14:19:51 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:56 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:52 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_270d5d03-cf26-42b0-a4f1-beb107748332.vhd
@@ -7338,11 +8468,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:56 GMT
+      - Wed, 03 Feb 2016 14:19:52 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:pK3DwLyCbn1pw9UqU7uew8dayXZdAiqRvgadEIk7iYE=
+      - SharedKey chefprod5120:IUaob5bjhIXpBwmn+0PULFjiJOkIDIcw5knSmg5Lwik=
   response:
     status:
       code: 200
@@ -7363,7 +8493,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d7c49691-0001-0060-67c0-5214e2000000
+      - c1ecdf30-0001-003a-4c8d-5e1263000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7385,12 +8515,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 07 Dec 2015 17:21:29 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:56 GMT
+      - Wed, 03 Feb 2016 14:19:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:52 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_281afa01-8645-4c33-9f9a-08b17d0ec1ed.vhd
@@ -7405,11 +8535,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:57 GMT
+      - Wed, 03 Feb 2016 14:19:52 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:/SgePpSRDjF/aVr8x2N3B0Q0aYrw7OIX5SstEMOqT6g=
+      - SharedKey chefprod5120:TRso1aWCeYcEecnLxdcaVyzYHABY4AA1CXn4zAPghR4=
   response:
     status:
       code: 200
@@ -7430,7 +8560,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8c343760-0001-0038-5ec0-521099000000
+      - 9b1e31f9-0001-0024-2d8d-5ec88e000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7452,12 +8582,146 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 20:26:26 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:57 GMT
+      - Wed, 03 Feb 2016 14:19:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:53 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_3cbd1269-0900-4416-a5e5-e4746827b15c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:53 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:CKxrHW/SVFuV70u8ThMY5TsUKeNF2njDRrqtsO4XFF0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 26 Jan 2016 19:54:43 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3268A88EF6A2D"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 00d72c7f-0001-0073-3d8d-5e2103000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 0b4033ff-0cb5-42cd-a891-8cfe3837cb7c
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=vVikFRTxj1cb1%2FPMBi%2FYEQemsZ4iLvobE7ynEiFjaHA%3D&st=2016-01-20T20%3A32%3A47Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Jan 2016 20:47:47 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:52 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:53 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_7317d2fc-55ea-4d39-af35-d925b00a7c63.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:53 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:7u/b7TACl2kKbutOq7U5cQqqPYcZnAz0uuWGC0HPyvg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Tue, 19 Jan 2016 15:56:17 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D320E911515186"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - b5ec826d-0001-0035-1a8d-5eff95000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 9ab2002b-d210-45bf-b307-601b5691b7bc
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=Soft8kIuhD5WooXO4UgGnRqWYZSIOHF2eslCf3ug9Ik%3D&st=2016-01-18T16%3A06%3A47Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 18 Jan 2016 16:21:50 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:53 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:54 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_c131001e-41e9-4841-a2e0-3e0e2a03a432.vhd
@@ -7472,11 +8736,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:57 GMT
+      - Wed, 03 Feb 2016 14:19:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:73VV/hWV6bvCieHp/681+Zz3ku7kNRcAXvEzwlxPQjs=
+      - SharedKey chefprod5120:sqRvql5Uoja05amXFEeFc345dF8UpGisT6gNgi2DKhc=
   response:
     status:
       code: 200
@@ -7497,7 +8761,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e4f2e680-0001-004c-03c0-5296df000000
+      - e48a18d3-0001-000c-738d-5ebf31000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7519,12 +8783,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 20:24:28 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:57 GMT
+      - Wed, 03 Feb 2016 14:19:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:57 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:54 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/testprov1_cf162697-ef65-4018-b9c2-b99bcebc5f0e.vhd
@@ -7539,11 +8803,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:57 GMT
+      - Wed, 03 Feb 2016 14:19:54 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:W4s/7orlkO/cox4VOfHNUzRtNFsufXhrSKWELrK3Bdo=
+      - SharedKey chefprod5120:aCPIp/clk7DgRPYikJqHMWxtizKnuiFxDXX+85kWpNI=
   response:
     status:
       code: 200
@@ -7564,7 +8828,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - eb6df35d-0001-0024-6cc0-52c88e000000
+      - c1d8c45f-0001-005b-658d-5e56bc000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7586,12 +8850,79 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 07 Dec 2015 16:09:03 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:58 GMT
+      - Wed, 03 Feb 2016 14:19:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:58 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:54 GMT
+- request:
+    method: head
+    uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest100_8128a9ce-b191-4238-80c6-c61e04c065a7.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:19:54 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey chefprod5120:djq6jzclywnFzm6pR7Fjrlupa0NvWa67mqQHEbZGNiY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - yfrCIFy+Ygj3V60VpsHlvQ==
+      Last-Modified:
+      - Wed, 20 Jan 2016 20:57:31 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D321DC501EF110"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e8ac3a71-0001-005a-1c8d-5e5741000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 4a5ff856-23f7-4ee2-97ae-c81f556a7501
+      X-Ms-Copy-Source:
+      - https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=VNDTpLNb7XOFEVcn9%2FPvYeIEKl39A9bseDmXn23e%2Fhg%3D&st=2016-01-20T16%3A52%3A07Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Jan 2016 17:07:07 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:19:54 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:19:55 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest11_33efffd5-033f-485a-a006-87011e67a71c.vhd
@@ -7606,11 +8937,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:58 GMT
+      - Wed, 03 Feb 2016 14:19:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:YNkgD2Paq/87r852oNvMMYq+AfShkIPajGVcPIQlJf8=
+      - SharedKey chefprod5120:rtnfDRFq5T4A/lBkoWGxHER+8rW4x4jW3bd+a23Tc1k=
   response:
     status:
       code: 200
@@ -7631,7 +8962,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4c2903a8-0001-0088-75c0-52e919000000
+      - 2a3bc8f1-0001-0044-5b8d-5e8dac000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7653,12 +8984,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 20:41:38 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:54 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:58 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:55 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest12_d17aefac-feec-4c5c-baf5-395dfb4b8465.vhd
@@ -7673,11 +9004,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:58 GMT
+      - Wed, 03 Feb 2016 14:19:55 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:KkJxr0o/oDIt9uGwFYgW2niUdfJC7OD0vWoVCGJC7pg=
+      - SharedKey chefprod5120:udGq5KavhVc7PkZZs8vtpEU+FWv8O71kSPML1XetiSc=
   response:
     status:
       code: 200
@@ -7698,7 +9029,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 010266da-0001-0061-3dc0-52151f000000
+      - 4ffba278-0001-0007-1a8d-5ea745000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7720,12 +9051,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 20:50:52 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:54 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:59 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:56 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest13_d25524f6-8fcd-4680-b4bf-5c878fe852fc.vhd
@@ -7740,11 +9071,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Okzq3NuV22OqGwv3H4/zHU7vVp3wFwAO99SKOJqQOLg=
+      - SharedKey chefprod5120:HFrUgvoMkkcaiEgl+n2zbIe5vveQU8cVDf1zWEFSUvw=
   response:
     status:
       code: 200
@@ -7765,7 +9096,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 85c659eb-0001-0075-60c0-52d67b000000
+      - bd8086e5-0001-0006-608d-5ea6b8000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7787,12 +9118,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 20:58:39 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:55 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:49:59 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:56 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest15_5a8d4d35-02d7-4731-9b0c-33820323176a.vhd
@@ -7807,11 +9138,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:56 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:vZfai0u6TdZaO+Rs+P0MwpGMLCXjWDl3cqonx4F8Zxg=
+      - SharedKey chefprod5120:QD4TrWhB5mK6pqUk86Xmb+7ly5wlf0GB3SOP0qbzcFE=
   response:
     status:
       code: 200
@@ -7832,7 +9163,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d89c237d-0001-004d-67c0-529722000000
+      - 2d68e915-0001-0068-058d-5e0f91000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7854,12 +9185,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 12:43:35 GMT
       Date:
-      - Tue, 19 Jan 2016 13:49:59 GMT
+      - Wed, 03 Feb 2016 14:19:55 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:00 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:57 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest16_ddac6a34-4fbf-4b18-92f5-ec59504d64fa.vhd
@@ -7874,11 +9205,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:00 GMT
+      - Wed, 03 Feb 2016 14:19:57 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:E5ewjmOXbqXajwtV9jSFeBLsWavAZQ5P4ngioet/5V8=
+      - SharedKey chefprod5120:IFzACoKqyC8+Al+86g0OifYk1CmaUIINZLeCtklyNb8=
   response:
     status:
       code: 200
@@ -7899,7 +9230,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - bb827bdd-0001-0039-16c0-521164000000
+      - be181379-0001-0050-7d8d-5e4ec8000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7921,12 +9252,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 12:59:28 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:00 GMT
+      - Wed, 03 Feb 2016 14:19:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:00 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:57 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest17_16d5d1c9-e10e-4fe4-850a-3f10612ea3e9.vhd
@@ -7941,11 +9272,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:00 GMT
+      - Wed, 03 Feb 2016 14:19:57 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:zIUryFCfolhQx6qoY3f7q9PLJsK6eYo9SO63rMLhrm0=
+      - SharedKey chefprod5120:rcT1oU8hYiZLBalpVKql2T3tMN+Wm5BpWLXLhTneoj4=
   response:
     status:
       code: 200
@@ -7966,7 +9297,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d6e484a1-0001-0089-41c0-52e8e4000000
+      - e57dc67c-0001-0067-3c8d-5ee267000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -7988,12 +9319,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 14:55:40 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:00 GMT
+      - Wed, 03 Feb 2016 14:19:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:01 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:58 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest19_5e18ce5a-94b3-45eb-8e15-2a4d71ef0a19.vhd
@@ -8008,11 +9339,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:01 GMT
+      - Wed, 03 Feb 2016 14:19:58 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:qgUKAYW5IHvRldDbIueszd8ankOQIAZ9QkUWBmI6+f4=
+      - SharedKey chefprod5120:hqTh7mVM6PT6aYgz6Wfyu1Uahy1e5/Kex/he+0Hb8qo=
   response:
     status:
       code: 200
@@ -8033,7 +9364,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ef6fda14-0001-003a-28c0-521263000000
+      - f5af4e72-0001-0052-6a8d-5e4c32000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8055,12 +9386,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 15:36:54 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:01 GMT
+      - Wed, 03 Feb 2016 14:19:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:01 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:58 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest21_eed0d4e3-b1e9-46f5-9c31-3a69e213f808.vhd
@@ -8075,11 +9406,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:01 GMT
+      - Wed, 03 Feb 2016 14:19:58 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:tTUQ8VaJOJrjNqoSKEFuOG+ReMUO/drq6SFq5Z84wEw=
+      - SharedKey chefprod5120:C9eUljbpvuJup+KIU6M2CNRyb8kfKJ4Y/6S+UO5Tq1s=
   response:
     status:
       code: 200
@@ -8100,7 +9431,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a3e40ce1-0001-0076-5ac0-52d57c000000
+      - fe60d19a-0001-0013-768d-5e6421000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8122,12 +9453,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 16:08:42 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:01 GMT
+      - Wed, 03 Feb 2016 14:19:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:59 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest22_0c3153c3-9ce0-4816-9c23-f7958d5f2552.vhd
@@ -8142,11 +9473,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:02 GMT
+      - Wed, 03 Feb 2016 14:19:59 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:EVkBoCskM/g8pu1gEZlGcj1SdrgFUxDz4QYsYdu3zCM=
+      - SharedKey chefprod5120:ol3pu/aLiUx5prQpE8xJ8tKvwZwAKuk/qMrOyNSYO3U=
   response:
     status:
       code: 200
@@ -8167,7 +9498,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8483e544-0001-0026-08c0-52ca74000000
+      - 38d4bf0f-0001-0076-148d-5ed57c000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8189,12 +9520,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 19:49:17 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:02 GMT
+      - Wed, 03 Feb 2016 14:19:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+  recorded_at: Wed, 03 Feb 2016 14:19:59 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest23_e41c1487-0087-49d6-9445-ee0ea297d278.vhd
@@ -8209,11 +9540,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:02 GMT
+      - Wed, 03 Feb 2016 14:19:59 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Xyjz4VQzep/66xd3kgRIovhuCflqaNbHJxQNNGMaWrw=
+      - SharedKey chefprod5120:fr4H4uQ8s3R96j4jcVtds5UVINkrQ0xa3Pygf0pN8Ns=
   response:
     status:
       code: 200
@@ -8234,7 +9565,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 254a33e3-0001-0012-22c0-5265dc000000
+      - e9104823-0001-0088-598d-5ee919000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8256,12 +9587,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 19:58:37 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:02 GMT
+      - Wed, 03 Feb 2016 14:19:59 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:02 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:00 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest25_677eb115-7cd6-456c-bc79-cd4e72a90620.vhd
@@ -8276,11 +9607,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:02 GMT
+      - Wed, 03 Feb 2016 14:20:00 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:f1T2ld1mHldKBdcpKy7oxeE+RbV84ABKIjZkhEQhZ6A=
+      - SharedKey chefprod5120:Pj2Q12aX2wv4w4diqfU2upS3oIWnhQqJZ9suQj88QkM=
   response:
     status:
       code: 200
@@ -8301,7 +9632,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 957b2fc8-0001-004e-3ac0-529425000000
+      - 5924a73a-0001-0087-318d-5e04ef000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8323,12 +9654,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 20:54:00 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:03 GMT
+      - Wed, 03 Feb 2016 14:19:59 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:03 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:00 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest26_81126e18-87ba-4fcb-b7c1-9fefdd034065.vhd
@@ -8343,11 +9674,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:03 GMT
+      - Wed, 03 Feb 2016 14:20:00 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:gmY10+HCIQG2QfGOb6h1zY/JjL9TcgF/GdT7XFB7/r8=
+      - SharedKey chefprod5120:enBteV9BJaItQ5lVvWoWP4uBeOUlFo4winfuu30EkqI=
   response:
     status:
       code: 200
@@ -8368,7 +9699,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d21f48df-0001-0062-55c0-521618000000
+      - 0dc203a2-0001-0086-468d-5e0512000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8390,12 +9721,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 21:14:04 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:03 GMT
+      - Wed, 03 Feb 2016 14:19:59 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:03 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:00 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest27_1b72fe7f-380c-49b7-9555-a2e2565a7eda.vhd
@@ -8410,11 +9741,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:03 GMT
+      - Wed, 03 Feb 2016 14:20:00 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:JHJ4mQLP3RH6eFUTu/17UK/DtoKku13SHw4p1tYHcoQ=
+      - SharedKey chefprod5120:2BtpSmiLW8FQ4m4ourX2E4t8fcZyiZSH/b0aqzt5Jak=
   response:
     status:
       code: 200
@@ -8435,7 +9766,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 558b1ddf-0001-003b-4fc0-52139e000000
+      - c9d095c5-0001-0070-6c8d-5e2204000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8457,12 +9788,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 21:35:44 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:04 GMT
+      - Wed, 03 Feb 2016 14:20:00 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:04 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:01 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest27_97ee2f5b-7bfe-42cb-abb5-233d7c7bae39.vhd
@@ -8477,11 +9808,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:04 GMT
+      - Wed, 03 Feb 2016 14:20:01 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:beV05QK6xZxHqjEAP20kWbifQiGq1PMshuLhmnGj2go=
+      - SharedKey chefprod5120:IYzPc4TbghRme8YDydrOSeeEzvkVhAe557iLtupNQ1Y=
   response:
     status:
       code: 200
@@ -8502,7 +9833,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ec551915-0001-0027-7fc0-52cb89000000
+      - 5cbe8091-0001-0058-5f8d-5e55bb000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8524,12 +9855,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 11 Dec 2015 20:27:49 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:03 GMT
+      - Wed, 03 Feb 2016 14:20:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:04 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:01 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest28_be9b1fce-5a07-4eb4-87e9-642ca85853e1.vhd
@@ -8544,11 +9875,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:04 GMT
+      - Wed, 03 Feb 2016 14:20:01 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:+Zc1hXQI43rcsvWDA7FJ7Pvrb3vZPR0zFTf9OzsPK+0=
+      - SharedKey chefprod5120:QByQnO6TgcDM9F6rZXy+mjlvWnDkyEWcXXxYEPcLlH4=
   response:
     status:
       code: 200
@@ -8569,7 +9900,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 39660048-0001-0063-78c0-5217e5000000
+      - 0cb2418b-0001-007f-7a8d-5ecff2000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8591,12 +9922,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 09 Dec 2015 22:15:13 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:04 GMT
+      - Wed, 03 Feb 2016 14:20:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:05 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:02 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest29_016f9994-c090-403b-b31f-398e284e9f95.vhd
@@ -8611,11 +9942,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:05 GMT
+      - Wed, 03 Feb 2016 14:20:02 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:WUylYhN12yeG1bDuChHb4iATMBWQO5MJ/v0EYrCsHsU=
+      - SharedKey chefprod5120:kkUKaS+HEEfUjUGzcUUozRBa55vZoYbq0i9CXL8T/n4=
   response:
     status:
       code: 200
@@ -8636,7 +9967,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 98840223-0001-0077-23c0-52d481000000
+      - 1ada6b9b-0001-0056-7d8d-5eb9b0000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8658,12 +9989,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 11 Dec 2015 21:39:51 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:06 GMT
+      - Wed, 03 Feb 2016 14:20:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:05 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:02 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest32_bdb498bc-0dfa-4ae0-aa2b-17500056dfe3.vhd
@@ -8678,11 +10009,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:05 GMT
+      - Wed, 03 Feb 2016 14:20:02 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:xa2l0SKt6nOG+IccgoXxgRyrScUIRZGAdKiaMWXB4uY=
+      - SharedKey chefprod5120:Wf9wpEuoPHWeDxE5K5mzO0bSAPFc/PEudN/52m3sKWA=
   response:
     status:
       code: 200
@@ -8703,7 +10034,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d1df53e8-0001-0013-7ac0-526421000000
+      - 57e2d995-0001-007d-6e8d-5ecd08000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8725,12 +10056,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 21 Dec 2015 18:59:20 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:05 GMT
+      - Wed, 03 Feb 2016 14:20:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:06 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:03 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest3_635f4d79-3ab7-422b-ad86-64433cd11dcd.vhd
@@ -8745,11 +10076,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:06 GMT
+      - Wed, 03 Feb 2016 14:20:03 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:quVE3hov+Sf1Mfc09IPYoHlMOkYNNFE0cptcoTk/o2Q=
+      - SharedKey chefprod5120:VZPgsqhzVoUdd3uwuMspBOjw5d7Xoiws1zwWm3gckbk=
   response:
     status:
       code: 200
@@ -8770,7 +10101,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f2ab6c09-0001-004f-60c0-5295d8000000
+      - 2413e1b6-0001-0028-5c8d-5e267f000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8792,12 +10123,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 07 Dec 2015 23:20:08 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:06 GMT
+      - Wed, 03 Feb 2016 14:20:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:06 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:03 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest40_182f4104-04c2-47ec-b517-1732c286fb91.vhd
@@ -8812,11 +10143,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:06 GMT
+      - Wed, 03 Feb 2016 14:20:03 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:Lex2bmtN0pM+ZxQizD3klL+kBIZ7QJNQAkZEXhV0z34=
+      - SharedKey chefprod5120:1eGu8GIlXiM++nqNZol3VicfduiUteVmRzDOw0Adwnk=
   response:
     status:
       code: 200
@@ -8837,7 +10168,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cbf7bf53-0001-0051-63c0-524f35000000
+      - 0fb3989b-0001-0017-798d-5e91a3000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8859,12 +10190,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 22 Dec 2015 19:08:35 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:06 GMT
+      - Wed, 03 Feb 2016 14:20:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:04 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest41_1a7221a1-7c4c-4fb6-8299-f7d95c44fce6.vhd
@@ -8879,11 +10210,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:04 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:hNTbIYf3VPp3t0SnhvS+6Q7tQQPYK33ZDv2POATr4ZE=
+      - SharedKey chefprod5120:56b7DD6YntClYSKzpa3d4yVtS0cMlomsL1fc8L9z4xI=
   response:
     status:
       code: 200
@@ -8904,7 +10235,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 60532bd2-0001-0065-7bc0-52e09d000000
+      - ac76e78d-0001-003e-0e8d-5ee7e1000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8926,12 +10257,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 23 Dec 2015 16:24:43 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:03 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:04 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest42_4fd99aa1-640f-4762-bbb4-d046e0002d75.vhd
@@ -8946,11 +10277,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:04 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:jOsHDEyrTsC3+9cgDn3/4duuCghg9tN/9KHjBmcWU4c=
+      - SharedKey chefprod5120:/0d5at6lqZgUQ3G9JLTwKywKX+yU1G5QqGzK9wDZKos=
   response:
     status:
       code: 200
@@ -8971,7 +10302,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 38b69968-0001-0015-35c0-529359000000
+      - fd2102cc-0001-004f-108d-5e95d8000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -8993,12 +10324,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 06 Jan 2016 19:55:45 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:03 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:07 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:04 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest45_d46a3624-d09b-4635-8b19-0873934c9871.vhd
@@ -9013,11 +10344,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:04 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:bshjQGeDdDKMYahWX4OeNNMqEl++g0YtpOQN/YyG2vM=
+      - SharedKey chefprod5120:aXok7aJ8I3IsThhPkswR226WsT5cxTrrKt8FIG0aJLE=
   response:
     status:
       code: 200
@@ -9038,7 +10369,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8b9ecbc4-0001-0001-75c0-52503d000000
+      - ccf02e77-0001-0061-3c8d-5e151f000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9060,12 +10391,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 06 Jan 2016 20:25:46 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:07 GMT
+      - Wed, 03 Feb 2016 14:20:04 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:08 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:05 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest46_b958b84e-5b16-4f26-86a9-404176ac7915.vhd
@@ -9080,11 +10411,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:08 GMT
+      - Wed, 03 Feb 2016 14:20:05 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:VvsZ3zoOXSKsEpsmu2SkX0vnLJjW36h2029m4fLuvSk=
+      - SharedKey chefprod5120:hTsca33Icj9CGMS8rDTFfzGNjNlg1HIK0npUej8xFMs=
   response:
     status:
       code: 200
@@ -9105,7 +10436,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2f1ad670-0001-003d-68c0-52e4e6000000
+      - 121b5bc5-0001-0037-0b8d-5efd6f000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9127,12 +10458,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 08 Jan 2016 15:12:24 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:08 GMT
+      - Wed, 03 Feb 2016 14:20:04 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:08 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:05 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest47_55c476c8-3246-46c4-a141-f73cb1b852c1.vhd
@@ -9147,11 +10478,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:08 GMT
+      - Wed, 03 Feb 2016 14:20:05 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:F50e1PBRFoEZfvHPTOot08IYhirg78kVlljhteY4/vQ=
+      - SharedKey chefprod5120:XhOD+sA2ntLPkHwvNtWiADr/ohiw4wrsKFcuZXoqSws=
   response:
     status:
       code: 200
@@ -9172,7 +10503,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d85b51b3-0001-0029-14c0-522782000000
+      - c409768f-0001-000e-3f8d-5ebdcb000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9194,12 +10525,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 08 Jan 2016 15:55:03 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:08 GMT
+      - Wed, 03 Feb 2016 14:20:05 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:09 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:06 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest55_d82c1c13-f20c-4b53-adf9-ef96c5b504f3.vhd
@@ -9214,11 +10545,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:09 GMT
+      - Wed, 03 Feb 2016 14:20:06 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:JowyoN8UT+Mm6J7EfeI0KjR5juhyWDOrQIk7VLnDhU0=
+      - SharedKey chefprod5120:ZpnB9c8DWdSoHV7ftUb4TL1Y8DS8pNWEEwhwj10+Aqs=
   response:
     status:
       code: 200
@@ -9239,7 +10570,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1f72fb94-0001-0079-71c0-52388a000000
+      - e8563034-0001-0034-688d-5efe68000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9261,12 +10592,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 11 Jan 2016 15:17:24 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:09 GMT
+      - Wed, 03 Feb 2016 14:20:05 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:09 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:06 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest5_0d64fd70-a385-49d1-a499-e42506061304.vhd
@@ -9281,11 +10612,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:09 GMT
+      - Wed, 03 Feb 2016 14:20:06 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:bbJJ8z4alIFQz9ldvMp+yjWHeEspmRzc6q0hPg7Zxw0=
+      - SharedKey chefprod5120:RxLesSni49iLXfFLjXekIW6LfwQPwbvkdwdEwYnyOUI=
   response:
     status:
       code: 200
@@ -9306,7 +10637,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 466bc3fd-0001-0052-72c0-524c32000000
+      - 69944855-0001-0083-1b8d-5ef16d000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9328,12 +10659,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 19:17:42 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:09 GMT
+      - Wed, 03 Feb 2016 14:20:06 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:10 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:06 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/manageiq/vmtest7_88c89afc-16f7-46bf-a290-0fcbff7baa10.vhd
@@ -9348,11 +10679,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:10 GMT
+      - Wed, 03 Feb 2016 14:20:06 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:TjKr0ZhbxdsmIUvSXLEOKO7VSBMrYrO0+J/cS3H4vbg=
+      - SharedKey chefprod5120:qOF3bAmu+BMb5L/8ccSQrLW63XXfHLda0Wsc2BL4Owc=
   response:
     status:
       code: 200
@@ -9373,7 +10704,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2013ec8f-0001-003e-12c0-52e7e1000000
+      - e173ea56-0001-001e-548d-5e8b2d000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -9395,12 +10726,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 08 Dec 2015 19:33:35 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:10 GMT
+      - Wed, 03 Feb 2016 14:20:07 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:10 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:07 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/postgres-cont/postgres-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -9415,11 +10746,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:10 GMT
+      - Wed, 03 Feb 2016 14:20:07 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:OH6Z7rZy+3SrDzitv/f9V1UYFnETnkqgmPzmzYnzxpg=
+      - SharedKey chefprod5120:9l4RuVGGcayy0Ls5LGXnXKnEH+2V5newtAsB6fV+K0Y=
   response:
     status:
       code: 200
@@ -9440,11 +10771,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d3e53076-0001-007a-17c0-523b8d000000
+      - bff51bc0-0001-0059-6f8d-5e5446000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
-      - "/Subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
+      - "/Subscriptions/(AZURE_SUBSCRIPTION_ID)/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
       X-Ms-Meta-Microsoftazurecompute-Imagetype:
       - OSDisk
       X-Ms-Meta-Microsoftazurecompute-Osstate:
@@ -9470,12 +10801,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:23:36 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:10 GMT
+      - Wed, 03 Feb 2016 14:20:08 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:11 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:08 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psg/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -9490,11 +10821,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:11 GMT
+      - Wed, 03 Feb 2016 14:20:08 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:ijFuqbIUlTmbIGOcXgVrfiJy+w9q/ZvcKWYUMg6BjEc=
+      - SharedKey chefprod5120:ChABqt8gFZYhLK9VaBHqIta5a9DxlOuV22Em0XqDBlI=
   response:
     status:
       code: 200
@@ -9515,11 +10846,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2ae57e1d-0001-0002-01c0-52533a000000
+      - 09e0570b-0001-0078-038d-5e3977000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
-      - "/Subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
+      - "/Subscriptions/(AZURE_SUBSCRIPTION_ID)/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
       X-Ms-Meta-Microsoftazurecompute-Imagetype:
       - OSDisk
       X-Ms-Meta-Microsoftazurecompute-Osstate:
@@ -9545,12 +10876,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:18:59 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:11 GMT
+      - Wed, 03 Feb 2016 14:20:08 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:11 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:08 GMT
 - request:
     method: head
     uri: https://chefprod5120.blob.core.windows.net/system/Microsoft.Compute/Images/psgcont/psg-osDisk.fcf3dcec-fb8d-49f5-9d8c-b15edcff704c.vhd
@@ -9565,11 +10896,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:11 GMT
+      - Wed, 03 Feb 2016 14:20:09 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey chefprod5120:dZCzKmeTIJtC3HUVWNY78hCk36X2uMDIeOnBhLF7pnk=
+      - SharedKey chefprod5120:zVtWf+pwlpxf1TLFq3TVzJKmbmeWyklar0UBV4Av7Mk=
   response:
     status:
       code: 200
@@ -9590,11 +10921,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9a0813b5-0001-002a-38c0-522485000000
+      - a2f2369f-0001-003f-638d-5ee61c000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
-      - "/Subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
+      - "/Subscriptions/(AZURE_SUBSCRIPTION_ID)/ResourceGroups/CHEF-PROD/VMs/POSTGRES-DEV"
       X-Ms-Meta-Microsoftazurecompute-Imagetype:
       - OSDisk
       X-Ms-Meta-Microsoftazurecompute-Osstate:
@@ -9620,15 +10951,15 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 25 Sep 2015 19:21:32 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:11 GMT
+      - Wed, 03 Feb 2016 14:20:08 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:12 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -9642,7 +10973,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -9663,19 +10994,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3c4ee9f7-a175-47bf-840f-1b5124c09e86
+      - 540e51ad-006e-4fe0-b681-36446d398ced
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14994'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 3c4ee9f7-a175-47bf-840f-1b5124c09e86
+      - 540e51ad-006e-4fe0-b681-36446d398ced
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135017Z:3c4ee9f7-a175-47bf-840f-1b5124c09e86
+      - NORTHCENTRALUS:20160203T142010Z:540e51ad-006e-4fe0-b681-36446d398ced
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:16 GMT
+      - Wed, 03 Feb 2016 14:20:10 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9694,10 +11025,10 @@ http_interactions:
         P3zwcOfhw4e3ZOwAl1vzdfgWvoy+xXw7+Bp/G32vZV4Yeo+/jbxHHKMD9tjS
         EZ+ovJmp6TMwZoxtCfTXYcvv/5Lk/wEjcGCNjAUAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:17 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:10 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/computevms1392/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/computevms1392/listKeys?api-version=2015-05-01-preview
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -9711,7 +11042,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
       Content-Length:
       - '0'
   response:
@@ -9734,19 +11065,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
+      - 347b63b1-a2d8-4b9a-a7e1-2e553877f2b4
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
+      - 347b63b1-a2d8-4b9a-a7e1-2e553877f2b4
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135018Z:e75c8df0-d2c7-4c82-a7e8-660b8ea0fd7e
+      - NORTHCENTRALUS:20160203T142012Z:347b63b1-a2d8-4b9a-a7e1-2e553877f2b4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:17 GMT
+      - Wed, 03 Feb 2016 14:20:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9759,7 +11090,7 @@ http_interactions:
         iydfXK+/mkx3f+LN3peftG9f/j6/1/zL5f6bt8/X7+59+eL3WZ3OL/euXp79
         oqf7F9TDL0n+H9NZ3UDGAAAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:18 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:12 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/?comp=list
@@ -9774,11 +11105,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:18 GMT
+      - Wed, 03 Feb 2016 14:20:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:ibrdH33UT0RGGsx265UcfPYtlYEzsVk0zILM4/yh7v4=
+      - SharedKey computevms1392:v0whokP8yu33rPZQx7mFc4+OvnSA+6GGpECxRZWMw7o=
   response:
     status:
       code: 200
@@ -9791,11 +11122,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cd008f14-0001-0084-02c0-5290c2000000
+      - 9e2826d5-0001-000a-4b8d-5edf63000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:19 GMT
+      - Wed, 03 Feb 2016 14:20:11 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9821,7 +11152,7 @@ http_interactions:
         PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
         dHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:19 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:12 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -9836,11 +11167,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:19 GMT
+      - Wed, 03 Feb 2016 14:20:12 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:uzglOr7gEznLJAQ/fDyBXOQZ89BRAGfHIQhY+6pZ+Ww=
+      - SharedKey computevms1392:973g/O832EBn42IeMpaWiqevAVFx160BvhamWSkBy1M=
   response:
     status:
       code: 200
@@ -9853,69 +11184,118 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c37e038e-0001-006d-0bc0-526cc4000000
+      - 4e6291d0-0001-0027-6d8d-5e5ca3000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:18 GMT
+      - Wed, 03 Feb 2016 14:20:12 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
         bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9jb21w
         dXRldm1zMTM5Mi5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJO
-        YW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPnZtdGVzdDQ4Ljk0
-        NDkyODZmLWRiZTYtNDczOS1hNDY1LWE0NzdhYjczNTE2Yi5zdGF0dXM8L05h
-        bWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMSBKYW4gMjAx
-        NiAxNzowNzo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMxQUE5
-        QkYyNEYxQkU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjI3NzwvQ29udGVudC1M
+        YW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmNsb3VkaW5pdDcu
+        YzY4ZmQyMDctYjdjNS00OWRjLWI2ZDQtZjA1YTI1MWY5NTAzLnN0YXR1czwv
+        TmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDIwIEphbiAy
+        MDE2IDIzOjQ3OjM3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzIx
+        RjQxMzg0NjBCNjwvRXRhZz48Q29udGVudC1MZW5ndGg+Mjc3PC9Db250ZW50
+        LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVh
+        bTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQt
+        TGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Z1AzeGFtREVqekdHaU44MmtadnBh
+        Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURp
+        c3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExl
+        YXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5h
+        dmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48Qmxv
+        Yj48TmFtZT5jbG91ZGluaXQ3XzQ0ZmI1NTVmLTUxMzUtNDAzNi05YzA3LTMy
+        NjZhYjM2ZjA4ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+RnJpLCAyMiBKYW4gMjAxNiAxNTowMTowOSBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMyMzNDRENCNzgyRjY8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBl
+        PmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250
+        ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1N
+        RDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2Fj
+        aGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+MTE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1i
+        ZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+
+        dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwv
+        TGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmNs
+        b3VkaW5pdDguMmZjOGUzODItNWNmOC00OTFhLTlmZjctYzEyMDg3NDUzNDAz
+        LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Gcmks
+        IDIyIEphbiAyMDE2IDA2OjUxOjA0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRh
+        Zz4weDhEMzIyRjg2NUVDMUZCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+Mjc3
+        PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29j
+        dGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+
+        PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+b2QxdVZLa2VqZUVO
+        T3ZWcWdieWhYQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxD
+        b250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48QmxvYj48TmFtZT5jbG91ZGluaXQ4XzJlMjNmZDQxLTQxMDQtNGRm
+        Ni1iZTQ2LTZhODU2MGQzNTQ5NS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExh
+        c3QtTW9kaWZpZWQ+RnJpLCAyMiBKYW4gMjAxNiAxNTowMTowMyBHTVQ8L0xh
+        c3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMzNDRDhGQzU1RTY8L0V0YWc+PENv
+        bnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29u
+        dGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1U
+        eXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48
+        Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50
+        LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+
+        PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE8L3gtbXMtYmxvYi1zZXF1
+        ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVh
+        c2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2
+        YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9i
+        PjxOYW1lPnZtdGVzdDQ4Ljk0NDkyODZmLWRiZTYtNDczOS1hNDY1LWE0Nzdh
+        YjczNTE2Yi5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZp
+        ZWQ+TW9uLCAxMSBKYW4gMjAxNiAxNzowNzo1NCBHTVQ8L0xhc3QtTW9kaWZp
+        ZWQ+PEV0YWc+MHg4RDMxQUE5QkYyNEYxQkU8L0V0YWc+PENvbnRlbnQtTGVu
+        Z3RoPjI3NzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNh
+        dGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNv
+        ZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1Pkp2YWkv
+        TmxVSHk3Y3B3cXlrYlJ5QVE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRy
+        b2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Js
+        b2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0
+        dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVy
+        dGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0NDhfZWZlZjQ0YTEtNzY3
+        Ni00NjgxLTk3ZjEtMjUzNmIyM2VmNTVmLnZoZDwvTmFtZT48UHJvcGVydGll
+        cz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA5OjU0IEdN
+        VDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzFBQUEwNjgzRTU3RjwvRXRh
+        Zz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3Ro
+        PjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250
+        ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFn
+        ZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0IvbnprV2V1aFdBPT08L0Nv
+        bnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRp
+        b24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dm10ZXN0NTMuNjAxZjFhYzktNTY0ZS00MmRlLWE0ZTgt
+        MzEyNThiYTU5MDYxLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1N
+        b2RpZmllZD5Nb24sIDExIEphbiAyMDE2IDE3OjA4OjAxIEdNVDwvTGFzdC1N
+        b2RpZmllZD48RXRhZz4weDhEMzFBQTlDMzMzMjAyNjwvRXRhZz48Q29udGVu
+        dC1MZW5ndGg+Mjc3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFw
+        cGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50
+        LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+
+        dTdTY1BBcDgwdUtITEUwZ1YvN1BRQT09PC9Db250ZW50LU1ENT48Q2FjaGUt
+        Q29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJs
+        b2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFz
+        ZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Q
+        cm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT52bXRlc3Q1M185MWM1MGU4
+        Yi0wNGIzLTQ5MzctYTZmYi00NGQxMTZiYzAyNWMudmhkPC9OYW1lPjxQcm9w
+        ZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6MDk6
+        NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzMUFBQTA4Q0M4ODFD
+        PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1M
         ZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08
         L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxh
-        bmd1YWdlIC8+PENvbnRlbnQtTUQ1Pkp2YWkvTmxVSHk3Y3B3cXlrYlJ5QVE9
+        bmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9
         PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNw
-        b3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFz
-        ZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZh
-        aWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+
-        PE5hbWU+dm10ZXN0NDhfZWZlZjQ0YTEtNzY3Ni00NjgxLTk3ZjEtMjUzNmIy
-        M2VmNTVmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5N
-        b24sIDExIEphbiAyMDE2IDE3OjA5OjU0IEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMzFBQUEwNjgzRTU3RjwvRXRhZz48Q29udGVudC1MZW5ndGg+
-        MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBw
-        bGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQt
-        RW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5o
-        S2RPamthdXA3c0IvbnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1D
-        b250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNl
-        cXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48
-        QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxv
-        Y2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFz
-        ZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dm10ZXN0
-        NTMuNjAxZjFhYzktNTY0ZS00MmRlLWE0ZTgtMzEyNThiYTU5MDYxLnN0YXR1
-        czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDExIEph
-        biAyMDE2IDE3OjA4OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhE
-        MzFBQTlDMzMzMjAyNjwvRXRhZz48Q29udGVudC1MZW5ndGg+Mjc3PC9Db250
-        ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0
-        cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRl
-        bnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+dTdTY1BBcDgwdUtITEUwZ1Yv
-        N1BRQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50
-        LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+
-        PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0
-        ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48
-        QmxvYj48TmFtZT52bXRlc3Q1M185MWM1MGU4Yi0wNGIzLTQ5MzctYTZmYi00
-        NGQxMTZiYzAyNWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlm
-        aWVkPk1vbiwgMTEgSmFuIDIwMTYgMTc6MDk6NTggR01UPC9MYXN0LU1vZGlm
-        aWVkPjxFdGFnPjB4OEQzMUFBQTA4Q0M4ODFDPC9FdGFnPjxDb250ZW50LUxl
-        bmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlw
-        ZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29u
-        dGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQt
-        TUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENh
-        Y2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJs
-        b2Itc2VxdWVuY2UtbnVtYmVyPjExPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVt
-        YmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVz
-        PnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8
-        L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0
-        TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        b3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjExPC94LW1z
+        LWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxv
+        YlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVh
+        c2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwv
+        QmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
+        dHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:19 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:13 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/system?comp=list&restype=container
@@ -9930,11 +11310,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:19 GMT
+      - Wed, 03 Feb 2016 14:20:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:1D0iZU4luZFHOfqboafTi7mr+3CksiK56jiG5PlA9No=
+      - SharedKey computevms1392:c46SPxiKUNVhMdAN2ZXXv4vz8cvNpAYi5qIPMEpI1PM=
   response:
     status:
       code: 200
@@ -9947,11 +11327,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 441bf2ef-0001-007f-4fc0-5258d8000000
+      - efb3757b-0001-003c-7d8d-5e7231000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:19 GMT
+      - Wed, 03 Feb 2016 14:20:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -9987,7 +11367,7 @@ http_interactions:
         UHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51
         bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:20 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:13 GMT
 - request:
     method: get
     uri: https://computevms1392.blob.core.windows.net/vhds?comp=list&restype=container
@@ -10002,11 +11382,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:20 GMT
+      - Wed, 03 Feb 2016 14:20:13 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:taqHzm3K7ALwIzc7iUW0huSV1AFfPM4Kgfks6U45G5o=
+      - SharedKey computevms1392:vrh9GeyIP9lNGt26BaplFQxmBBRGD34bgnuKi8mMMnw=
   response:
     status:
       code: 200
@@ -10019,11 +11399,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e8d7d6f3-0001-0069-50c0-529946000000
+      - fc007738-0001-0061-248d-5e8235000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:20 GMT
+      - Wed, 03 Feb 2016 14:20:13 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10127,20 +11507,20 @@ http_interactions:
         cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxl
         PC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+
         Y2hlZnNlcnZlcjEuODE2Nzk3YzAtNmIzZS00YzIxLThlMjMtNDhkMjk2ZDhk
-        ZTEyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5X
-        ZWQsIDE5IEF1ZyAyMDE1IDE3OjQ3OjM1IEdNVDwvTGFzdC1Nb2RpZmllZD48
-        RXRhZz4weDhEMkE4QkU0NDY3ODQyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+
-        NjgyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
+        ZTEyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5G
+        cmksIDIyIEphbiAyMDE2IDA2OjUxOjI5IEdNVDwvTGFzdC1Nb2RpZmllZD48
+        RXRhZz4weDhEMzIyRjg3NEUwRUFDMjwvRXRhZz48Q29udGVudC1MZW5ndGg+
+        NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9u
         L29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5n
-        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+M1VUM1ZFSC9O
-        THlFUFNsWDhIVXRSQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
+        IC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RlYyR3pPVzhK
+        SUdMWXpXV1RqeW1PZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAv
         PjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwv
         QmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48
         TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVz
         PjwvQmxvYj48QmxvYj48TmFtZT5jaGVmc2VydmVyMS52aGQ8L05hbWU+PFBy
-        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxOSBBdWcgMjAxNSAxNzo0
-        ODowNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDJBOEJFNTZCMUFB
-        MzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBKYW4gMjAxNiAwNjo1
+        MTo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMkY4N0YxRDVC
+        NjE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50
         LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVh
         bTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQt
         TGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhX
@@ -10199,7 +11579,141 @@ http_interactions:
         YmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48
         TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:20 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:14 GMT
+- request:
+    method: head
+    uri: https://computevms1392.blob.core.windows.net/manageiq/cloudinit7_44fb555f-5135-4036-9c07-3266ab36f08e.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:20:14 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey computevms1392:MPuptDe0ykyrSPf5F5TNyAT52rq/8iWxun3v30w7TX8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Fri, 22 Jan 2016 15:01:09 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3233CDCB782F6"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - cfd2d79c-0001-0086-278d-5e9238000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '11'
+      X-Ms-Copy-Id:
+      - 0860c104-53fb-4c78-b956-efb697ea986b
+      X-Ms-Copy-Source:
+      - https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=loKX98OSi%2F4V0nF0uV%2B6qVSB3japHCOwHWl%2FkjsMAwU%3D&st=2016-01-20T20%3A43%3A55Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Jan 2016 20:58:56 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:20:14 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:20:14 GMT
+- request:
+    method: head
+    uri: https://computevms1392.blob.core.windows.net/manageiq/cloudinit8_2e23fd41-4104-4df6-be46-6a8560d35495.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:20:14 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey computevms1392:kKyV6H86+IGYpcUwG5joMKLUSydqjNrRul9ytttM5pM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Fri, 22 Jan 2016 15:01:03 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3233CD8FC55E6"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3aa498d5-0001-001f-508d-5e1dfa000000
+      X-Ms-Version:
+      - '2015-02-21'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '11'
+      X-Ms-Copy-Id:
+      - 42148d02-eb71-476f-aefa-48bc9603caaa
+      X-Ms-Copy-Source:
+      - https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=1AGUgTwA16CqpHljUAHTRryQ%2BZmL4WT7MUWOW46e258%3D&st=2016-01-20T20%3A52%3A30Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Jan 2016 21:07:30 GMT
+      Date:
+      - Wed, 03 Feb 2016 14:20:14 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:20:15 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/manageiq/vmtest48_efef44a1-7676-4681-97f1-2536b23ef55f.vhd
@@ -10214,11 +11728,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:20 GMT
+      - Wed, 03 Feb 2016 14:20:15 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:pnwqB3M7FZZ0Vp15Wke+/9Oa0hhtsuxoDi+QJOlKhiU=
+      - SharedKey computevms1392:oVUT+pcmVZG+I1zb2SfRcDJzg3j0QZciNn6M0VuZ0l4=
   response:
     status:
       code: 200
@@ -10239,7 +11753,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - decfbe0f-0001-002a-23c0-52b3af000000
+      - 7da11807-0001-0044-558e-5e1a86000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -10261,12 +11775,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 08 Jan 2016 16:11:20 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:15 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:15 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/manageiq/vmtest53_91c50e8b-04b3-4937-a6fb-44d116bc025c.vhd
@@ -10281,11 +11795,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:15 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:7HM8jklpnuyOxbY+g1PPpxP7Y2lF1U4QxPfpPFGwHxk=
+      - SharedKey computevms1392:K6hvtZbk5CXXp/jsthKbacAzlu2GHK/zUHq6bAeHxxg=
   response:
     status:
       code: 200
@@ -10306,7 +11820,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 76cf4723-0001-0026-6dc0-525d5e000000
+      - 03f3e735-0001-0006-398e-5e3192000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -10328,12 +11842,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Fri, 08 Jan 2016 20:58:35 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:15 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/system/Microsoft.Compute/Images/bronagh-images/image-osDisk.cc111202-6a2a-4f3c-b8ba-ecd66f98158c.vhd
@@ -10348,11 +11862,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:15 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:BvTsIhSg1wV6A+79cX2+6ks9HQAjucmiV7icnaeLBcQ=
+      - SharedKey computevms1392:vdQO0QAyhK5gBjyIuW26ch1boLzR/MkXlBfso0sPVBo=
   response:
     status:
       code: 200
@@ -10373,11 +11887,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ff7643f5-0001-0023-02c0-52a921000000
+      - 0ed520c3-0001-002c-1c8e-5e44d7000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
-      - "/Subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/ResourceGroups/COMPUTEVMS/VMs/ERP"
+      - "/Subscriptions/(AZURE_SUBSCRIPTION_ID)/ResourceGroups/COMPUTEVMS/VMs/ERP"
       X-Ms-Meta-Microsoftazurecompute-Imagetype:
       - OSDisk
       X-Ms-Meta-Microsoftazurecompute-Osstate:
@@ -10403,12 +11917,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Mon, 28 Sep 2015 14:53:18 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:15 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:21 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:16 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/MIQCompute2.vhd
@@ -10423,11 +11937,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:21 GMT
+      - Wed, 03 Feb 2016 14:20:16 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:2e6CCf8aE0a2TdMDHSqcHNpwCbxJ+RQqvzq+MLeyJek=
+      - SharedKey computevms1392:plqvlEYNYbT5L0PkE/B+QkoZm+e5YTNJdlhq0IuRDYg=
   response:
     status:
       code: 200
@@ -10448,7 +11962,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 907481bb-0001-0070-55c0-52b52e000000
+      - 86aab5b5-0001-0065-4d8e-5e77b7000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -10470,12 +11984,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 18:38:50 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:22 GMT
+      - Wed, 03 Feb 2016 14:20:16 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:22 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:17 GMT
 - request:
     method: head
     uri: https://computevms1392.blob.core.windows.net/vhds/pubtest.vhd
@@ -10490,11 +12004,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:22 GMT
+      - Wed, 03 Feb 2016 14:20:17 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey computevms1392:YBmUpELcfB+cBxK5ZGVpWVqHD22/uvbp4Gv0f0gm+7k=
+      - SharedKey computevms1392:zu+++IWykV3q8F7rodNjhDAYxXetduZ8N9BRSxTP938=
   response:
     status:
       code: 200
@@ -10515,7 +12029,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - bdb89821-0001-0082-0ec0-5267ba000000
+      - 2f832b08-0001-0039-248e-5e864e000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -10537,15 +12051,15 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Wed, 22 Jul 2015 19:08:18 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:22 GMT
+      - Wed, 03 Feb 2016 14:20:16 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:23 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:17 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/spec1storage1/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/ComputeVMs/providers/Microsoft.Storage/storageAccounts/spec1storage1/listKeys?api-version=2015-05-01-preview
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -10559,7 +12073,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
       Content-Length:
       - '0'
   response:
@@ -10582,19 +12096,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 699e31ee-a303-4fe9-95d6-830248a6eae6
+      - cc52f6dd-e498-430a-812c-4837207e40ce
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 699e31ee-a303-4fe9-95d6-830248a6eae6
+      - cc52f6dd-e498-430a-812c-4837207e40ce
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135023Z:699e31ee-a303-4fe9-95d6-830248a6eae6
+      - NORTHCENTRALUS:20160203T142018Z:cc52f6dd-e498-430a-812c-4837207e40ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:23 GMT
+      - Wed, 03 Feb 2016 14:20:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10607,7 +12121,7 @@ http_interactions:
         Nl88/fzs5f5Pvn795envdTXP3l5e59XznS9evdv9ielPPz9/+MnBF6ffvrtq
         L97eRQ+/JPl/AL0oAMzGAAAA
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:24 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:18 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/?comp=list
@@ -10622,11 +12136,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:24 GMT
+      - Wed, 03 Feb 2016 14:20:18 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:mfOPcbpfl6ybgiiuYFLGf8tc/0Zkwnc1Jy5UnBFI03o=
+      - SharedKey spec1storage1:hAu7ae/FoiUYpmZ6Y07j4PVvMBPq1wj9yqlkmyTt6vs=
   response:
     status:
       code: 200
@@ -10639,11 +12153,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 397e3d20-0001-0065-20c0-52ee1f000000
+      - fb51720d-0001-0056-048e-5eb732000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:25 GMT
+      - Wed, 03 Feb 2016 14:20:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10671,7 +12185,7 @@ http_interactions:
         ZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:25 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:18 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm0-ea17ea24-adad-44c3-a889-0043fb2159f2?comp=list&restype=container
@@ -10686,11 +12200,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:25 GMT
+      - Wed, 03 Feb 2016 14:20:18 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:NoGipI76Lb17zF4CsiPNnk+5auWJYM4M1ASdPViDn9A=
+      - SharedKey spec1storage1:LwXrm1lEctgFm2gIR5WYGyP3U4JoC76zs89pN/T7he8=
   response:
     status:
       code: 200
@@ -10703,11 +12217,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 812b43b6-0001-0067-16c0-52ece5000000
+      - 8cea1fe7-0001-0078-1d8e-5e37f5000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:25 GMT
+      - Wed, 03 Feb 2016 14:20:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10730,7 +12244,7 @@ http_interactions:
         cGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVy
         YXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:25 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:19 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/bootdiagnostics-specvm1-0b5a2a4f-1d67-41de-a12c-31d07169262e?comp=list&restype=container
@@ -10745,11 +12259,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:25 GMT
+      - Wed, 03 Feb 2016 14:20:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:mS6JCA9crWU1lDmNX/wPXwuux5Ce6wVzYQvVR1bEQaY=
+      - SharedKey spec1storage1:3RAaOvi3iY23F49l/8rumCm8u4bic94Fvm/wHpbw0Wo=
   response:
     status:
       code: 200
@@ -10762,11 +12276,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5ec60d2c-0001-0054-51c0-52b5c8000000
+      - 40fac738-0001-000e-268e-5eb349000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:25 GMT
+      - Wed, 03 Feb 2016 14:20:18 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10788,7 +12302,7 @@ http_interactions:
         PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9F
         bnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:19 GMT
 - request:
     method: get
     uri: https://spec1storage1.blob.core.windows.net/vhds?comp=list&restype=container
@@ -10803,11 +12317,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:26 GMT
+      - Wed, 03 Feb 2016 14:20:19 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey spec1storage1:yzUbUiXIfz+gk+bTF3ApyJehHn86VZ71wzuIiL30B9E=
+      - SharedKey spec1storage1:AG+aIM9OtYOtQIME+2SPLKgYGFYXfmSybEv37eVz2uI=
   response:
     status:
       code: 200
@@ -10820,11 +12334,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e57416bd-0001-006a-29c0-5203e9000000
+      - 3ba92de9-0001-006c-3d8e-5ef491000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:27 GMT
+      - Wed, 03 Feb 2016 14:20:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10882,10 +12396,10 @@ http_interactions:
         L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0Vu
         dW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:26 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/Default-Storage-EastUS/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -10899,7 +12413,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -10920,19 +12434,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
+      - c14e1618-97a1-4592-afa5-d55af6c7f0d7
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
+      - c14e1618-97a1-4592-afa5-d55af6c7f0d7
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135027Z:485d4a3a-1e8d-4fde-984a-8b68c27b5f9b
+      - NORTHCENTRALUS:20160203T142021Z:c14e1618-97a1-4592-afa5-d55af6c7f0d7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:26 GMT
+      - Wed, 03 Feb 2016 14:20:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -10941,10 +12455,10 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:27 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -10958,7 +12472,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -10979,19 +12493,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 65b2952f-d7fb-4b76-8531-abc2014c2fd3
+      - f6dfd268-80ec-42d0-be94-de647b9f2a0d
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 65b2952f-d7fb-4b76-8531-abc2014c2fd3
+      - f6dfd268-80ec-42d0-be94-de647b9f2a0d
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135027Z:65b2952f-d7fb-4b76-8531-abc2014c2fd3
+      - NORTHCENTRALUS:20160203T142022Z:f6dfd268-80ec-42d0-be94-de647b9f2a0d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:27 GMT
+      - Wed, 03 Feb 2016 14:20:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11000,10 +12514,10 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:28 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -11017,7 +12531,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -11038,19 +12552,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 224d0b45-f797-4cfb-88c6-fe2609ff16c4
+      - 7461a511-8ce2-41a9-b17d-366b1bb9d201
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 224d0b45-f797-4cfb-88c6-fe2609ff16c4
+      - 7461a511-8ce2-41a9-b17d-366b1bb9d201
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135028Z:224d0b45-f797-4cfb-88c6-fe2609ff16c4
+      - NORTHCENTRALUS:20160203T142023Z:7461a511-8ce2-41a9-b17d-366b1bb9d201
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:27 GMT
+      - Wed, 03 Feb 2016 14:20:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11067,10 +12581,10 @@ http_interactions:
         vm/yaQVS+29/NzdvN/TGuvny/KX0QN9ll1lRAhXv29cGRvA9IdZmF6A+fpN5
         vZGjPvol3/8lyf8D6+XAwe4CAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:28 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:23 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts/miqazure15827/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure1/providers/Microsoft.Storage/storageAccounts/miqazure15827/listKeys?api-version=2015-05-01-preview
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -11084,7 +12598,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
       Content-Length:
       - '0'
   response:
@@ -11107,19 +12621,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 351d34d6-3adc-4e58-9563-3e817c14b47f
+      - d92fc914-38c0-4863-8051-a375b7da9cd1
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 351d34d6-3adc-4e58-9563-3e817c14b47f
+      - d92fc914-38c0-4863-8051-a375b7da9cd1
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135029Z:351d34d6-3adc-4e58-9563-3e817c14b47f
+      - NORTHCENTRALUS:20160203T142025Z:d92fc914-38c0-4863-8051-a375b7da9cd1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:29 GMT
+      - Wed, 03 Feb 2016 14:20:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11132,7 +12646,7 @@ http_interactions:
         NM93zy/eHM/qTz/ZefPJ3a8ud/dPLp/WT36f78ya79yb3H36iz6ffbLMJ+38
         6Zvru1fUwy9J/h+s9SVmxgAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:29 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:25 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/?comp=list
@@ -11147,11 +12661,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:29 GMT
+      - Wed, 03 Feb 2016 14:20:25 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:JP8VSjPPcLiDjZT9gupLbiFw3R+bnAwXcxE4SdEsK7Q=
+      - SharedKey miqazure15827:ej7GiG+ZgW4DVQXFAba76NrzBKKcTt8MVzFsDLOtjf8=
   response:
     status:
       code: 200
@@ -11164,26 +12678,91 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 11899256-0001-0014-2dc0-52eb99000000
+      - 6df335e9-0001-007c-468e-5eb5c8000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:30 GMT
+      - Wed, 03 Feb 2016 14:20:25 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
         bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
         enVyZTE1ODI3LmJsb2IuY29yZS53aW5kb3dzLm5ldC8iPjxDb250YWluZXJz
-        PjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFz
-        dC1Nb2RpZmllZD5UdWUsIDE4IEF1ZyAyMDE1IDE4OjMxOjI4IEdNVDwvTGFz
-        dC1Nb2RpZmllZD48RXRhZz4iMHg4RDJBN0ZCM0FGNUYyQjAiPC9FdGFnPjxM
-        ZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+
-        YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5l
-        cj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVz
-        dWx0cz4=
+        PjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLXVidW50dXNlci1h
+        YzFjZDRkMC01MjRiLTRkNWMtYTdkNC01MjViZmExYjAxMzA8L05hbWU+PFBy
+        b3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyMSBKYW4gMjAxNiAwMDox
+        NDowNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzMjFGN0M3M0U1
+        Mzk3IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVz
+        PjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRp
+        ZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT52aGRzPC9OYW1lPjxQ
+        cm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTggQXVnIDIwMTUgMTg6
+        MzE6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMkE3RkIzQUY1
+        RjJCMCI8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+
+        PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9u
+        PmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0NvbnRh
+        aW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9u
+        UmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:30 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:26 GMT
+- request:
+    method: get
+    uri: https://miqazure15827.blob.core.windows.net/bootdiagnostics-ubuntuser-ac1cd4d0-524b-4d5c-a7d4-525bfa1b0130?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      X-Ms-Date:
+      - Wed, 03 Feb 2016 14:20:26 GMT
+      X-Ms-Version:
+      - '2015-02-21'
+      Authorization:
+      - SharedKey miqazure15827:pzJVjyU/Q0iMHuiNeRSzMPr379J0ptW0NBD6NQyLCRA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bc702008-0001-000b-218e-5e3089000000
+      X-Ms-Version:
+      - '2015-02-21'
+      Date:
+      - Wed, 03 Feb 2016 14:20:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51
+        bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFh
+        enVyZTE1ODI3LmJsb2IuY29yZS53aW5kb3dzLm5ldC8iIENvbnRhaW5lck5h
+        bWU9ImJvb3RkaWFnbm9zdGljcy11YnVudHVzZXItYWMxY2Q0ZDAtNTI0Yi00
+        ZDVjLWE3ZDQtNTI1YmZhMWIwMTMwIj48QmxvYnM+PEJsb2I+PE5hbWU+dWJ1
+        bnR1c2VydmVyMS5hYzFjZDRkMC01MjRiLTRkNWMtYTdkNC01MjViZmExYjAx
+        MzAuc2VyaWFsY29uc29sZS5sb2c8L05hbWU+PFByb3BlcnRpZXM+PExhc3Qt
+        TW9kaWZpZWQ+VGh1LCAyMSBKYW4gMjAxNiAwMDoxNzo1MyBHTVQ8L0xhc3Qt
+        TW9kaWZpZWQ+PEV0YWc+MHg4RDMyMUY4NERGQjJDNkE8L0V0YWc+PENvbnRl
+        bnQtTGVuZ3RoPjcxNjg8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGUg
+        Lz48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENv
+        bnRlbnQtTUQ1IC8+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3Np
+        dGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjA8L3gtbXMtYmxv
+        Yi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlw
+        ZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0
+        YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9CbG9i
+        PjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:20:27 GMT
 - request:
     method: get
     uri: https://miqazure15827.blob.core.windows.net/vhds?comp=list&restype=container
@@ -11198,11 +12777,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:30 GMT
+      - Wed, 03 Feb 2016 14:20:27 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:9rlE2FpRDuJF/UDQC+MawgH+GQ8l+2dmiIfQzeWkyT0=
+      - SharedKey miqazure15827:sjmk2RNC3dhu3w5MB7pU4zsNIWnPCiL+8+8mNSu6JU4=
   response:
     status:
       code: 200
@@ -11215,11 +12794,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 743b49ee-0001-00a7-5bc0-52111e000000
+      - 0a41e450-0001-013d-078e-5edb8e000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:30 GMT
+      - Wed, 03 Feb 2016 14:20:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11272,10 +12851,34 @@ http_interactions:
         bmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9i
         VHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2Vk
         PC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3Rh
-        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+
-        PC9FbnVtZXJhdGlvblJlc3VsdHM+
+        dGU+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT51YnVudHVzZXJ2
+        ZXIxLmFjMWNkNGQwLTUyNGItNGQ1Yy1hN2Q0LTUyNWJmYTFiMDEzMC5zdGF0
+        dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBK
+        YW4gMjAxNiAwNjo1MToxMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4
+        RDMyMkY4NkIzREM1NUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjY4MzwvQ29u
+        dGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1z
+        dHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250
+        ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PktyZm1QZlZLSjJnL1Q3WkZT
+        S1ZTOUE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVu
+        dC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3Rh
+        dGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0Jsb2I+
+        PEJsb2I+PE5hbWU+dWJ1bnR1c2VydmVyMS52aGQ8L05hbWU+PFByb3BlcnRp
+        ZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMiBKYW4gMjAxNiAwNjozMzozNCBH
+        TVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDMyMkY1RjQxMDk5QjA8L0V0
+        YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0
+        aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29u
+        dGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3Vh
+        Z2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9D
+        b250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0
+        aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9i
+        LXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBl
+        PjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRl
+        PmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwv
+        TGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5l
+        eHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:31 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:27 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/ERP.vhd
@@ -11290,11 +12893,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:31 GMT
+      - Wed, 03 Feb 2016 14:20:27 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:2mzOrjwWxH6isfN9HD7Potzrx2D1Dy7IbIl7Z8TWGAU=
+      - SharedKey miqazure15827:xSC05c4UJ4AP7Ps9qRAxZ5zoR4EL5KxHQ65cjlloCe0=
   response:
     status:
       code: 200
@@ -11315,7 +12918,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 64d20d38-0001-0072-63c0-5259c3000000
+      - 4cf79779-0001-0002-448e-5e2a07000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -11337,12 +12940,12 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:31:28 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:30 GMT
+      - Wed, 03 Feb 2016 14:20:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:31 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:28 GMT
 - request:
     method: head
     uri: https://miqazure15827.blob.core.windows.net/vhds/MIQ.vhd
@@ -11357,11 +12960,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:31 GMT
+      - Wed, 03 Feb 2016 14:20:28 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey miqazure15827:nXfOn2+00JDaR+mBQ9no9dm5hiHzitLZF4G/QLjEFQY=
+      - SharedKey miqazure15827:rtst1AEYzRZ2Li+VUqjW8we/Nq10h2VNwG0bWk9SNrQ=
   response:
     status:
       code: 200
@@ -11382,7 +12985,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 46ed489a-0001-0035-03c0-5286a8000000
+      - 49d88037-0001-0094-6a8e-5e4833000000
       X-Ms-Version:
       - '2015-02-21'
       X-Ms-Lease-Status:
@@ -11404,15 +13007,15 @@ http_interactions:
       X-Ms-Copy-Completion-Time:
       - Tue, 18 Aug 2015 18:33:10 GMT
       Date:
-      - Tue, 19 Jan 2016 13:50:31 GMT
+      - Wed, 03 Feb 2016 14:20:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:32 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/miqazure2/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/miqazure2/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -11426,7 +13029,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -11447,78 +13050,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a807e2ff-f76f-44cc-83b4-bf0520677519
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14996'
-      X-Ms-Correlation-Request-Id:
-      - a807e2ff-f76f-44cc-83b4-bf0520677519
-      X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135032Z:a807e2ff-f76f-44cc-83b4-bf0520677519
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Date:
-      - Tue, 19 Jan 2016 13:50:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
-        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
-        AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
-        /5ck/w9tfFqvGwAAAA==
-    http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/MIQVM1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Content-Encoding:
-      - gzip
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 485f6067-26e9-47ab-80bd-50c267eacf0e
+      - e53a4bc7-e520-4117-8574-e024b2e494b8
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14993'
       X-Ms-Correlation-Request-Id:
-      - 485f6067-26e9-47ab-80bd-50c267eacf0e
+      - e53a4bc7-e520-4117-8574-e024b2e494b8
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135033Z:485f6067-26e9-47ab-80bd-50c267eacf0e
+      - NORTHCENTRALUS:20160203T142028Z:e53a4bc7-e520-4117-8574-e024b2e494b8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:32 GMT
+      - Wed, 03 Feb 2016 14:20:28 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11527,10 +13071,10 @@ http_interactions:
         AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
         /5ck/w9tfFqvGwAAAA==
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:33 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/MIQVM1/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
     body:
       encoding: US-ASCII
       string: ''
@@ -11544,7 +13088,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
   response:
     status:
       code: 200
@@ -11565,19 +13109,78 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 56e540b0-d0f2-4607-8d39-1e902677a0b1
+      - 29afa8cf-f00d-4ee4-806f-bc9396997957
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14995'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 56e540b0-d0f2-4607-8d39-1e902677a0b1
+      - 29afa8cf-f00d-4ee4-806f-bc9396997957
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135034Z:56e540b0-d0f2-4607-8d39-1e902677a0b1
+      - NORTHCENTRALUS:20160203T142029Z:29afa8cf-f00d-4ee4-806f-bc9396997957
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:33 GMT
+      - Wed, 03 Feb 2016 14:20:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3m
+        kuwdaUcjKasqgcplVmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZk
+        AWz2zkrayZ4hgKrIHz9+fB8/In7xR8v8Xfu8WL796NFHH40+uszKdf7Ro+99
+        /5ck/w9tfFqvGwAAAA==
+    http_version: 
+  recorded_at: Wed, 03 Feb 2016 14:20:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts?api-version=2015-05-01-preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Content-Encoding:
+      - gzip
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0876a106-26d9-4a7b-91df-58d175af46e6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 0876a106-26d9-4a7b-91df-58d175af46e6
+      X-Ms-Routing-Request-Id:
+      - NORTHCENTRALUS:20160203T142030Z:0876a106-26d9-4a7b-91df-58d175af46e6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Date:
+      - Wed, 03 Feb 2016 14:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11593,10 +13196,10 @@ http_interactions:
         iL7SZpN4J/xF5JVfYgf3PEZjouhl0dCnxfKCKNgC9uv1dJrns3xG3zf02br5
         8vylwKBvs8usKNEZQLfZBWiF32QWbpz1j37J939J8v8ApmXS5o0CAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:34 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:30 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/462f2af8-e67e-40c6-9fbf-02824d1dd485/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts/nyrg9184/listKeys?api-version=2015-05-01-preview
+    uri: https://management.azure.com/subscriptions/(AZURE_SUBSCRIPTION_ID)/resourceGroups/NYRG/providers/Microsoft.Storage/storageAccounts/nyrg9184/listKeys?api-version=2015-05-01-preview
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -11610,7 +13213,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTMyMTEwMzcsIm5iZiI6MTQ1MzIxMTAzNywiZXhwIjoxNDUzMjE0OTM3LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.MYhOO64sMW4i6smKZI1I54GZ-WhUgpbfZp95K6O5qjRgT3W22_98O342dCNkbflLKzgBY2nbga2VkzRL15fx1SmMzJtTo2vXoMnntDgrcE5ZGR_rSzLQNErA-AHHdvp5_ob5rBbOBk8dySQnCX0fWydD_XO4smPm7HEqvrUHaZBlqAWmBm6KBv1O_3AKQEiETZEHkm0_zZYCyU-ANg0IqX3NnkNMZOzEeM982BT00Zq7yRZYjVqh7_SN-cO2qSgKJW0woiaYdvtmQvJKhW8PGBRkzxPPZB2Sd65aYTf_C8ugTsDcgqhbR7LM_mi_VtHjOpl9sSgIsG7PYTCJ0jBUiQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSIsImtpZCI6Ik1uQ19WWmNBVGZNNXBPWWlKSE1iYTlnb0VLWSJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJpYXQiOjE0NTQ1MDg4MzUsIm5iZiI6MTQ1NDUwODgzNSwiZXhwIjoxNDU0NTEyNzM1LCJhcHBpZCI6ImY4OTViNWVmLTNiYjUtNDM2Ni04Y2U1LWVlOTIwMDE2OTgzYiIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2E1MGY5OTgzLWQxYTItNGE4ZC1iZTdkLTlkMjZlMGZkZGEwYi8iLCJvaWQiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJzdWIiOiJjMDc1Zjg4Ni1hMjU4LTQ2MTktOWFhYi1hYjYwNTQwYjBmZTciLCJ0aWQiOiJhNTBmOTk4My1kMWEyLTRhOGQtYmU3ZC05ZDI2ZTBmZGRhMGIiLCJ2ZXIiOiIxLjAifQ.jJblMex7lWieXDURFrvVYGa7V0R_LYSt-fWVs5cehrBMTj2LuED2JON1a7484X0D6q-liqIGrqRyFSWMC_53FW-M8vZV5S-PlIXKN6FGd01kB-_Cpye-_WsozKylNNtG7-jXPeg0TJFodrK7hwNPyQzVR27ypvmssOSFeSYTNhI1e4lF6RzH1ToGaL-izx_kJXQTTpPzWOI0cQGRBC39TmNT6EBZ_A-TQfjp6Ul_djcm-gtkt50qWW2BD7j6XvOjetbxHIJEkxRQbBJITQzb0-artkyS4tlbsM5B_lHGO7hCmE5qmNs_NrMVNvh2jrm8Urs1yLD-x42mgL7E6cs33A
       Content-Length:
       - '0'
   response:
@@ -11633,19 +13236,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e81325a4-06e5-4fd0-816e-67cdbc54ea8f
+      - 0502d881-794e-4f1b-8fdb-fa9dda6b9fef
       Server:
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - e81325a4-06e5-4fd0-816e-67cdbc54ea8f
+      - 0502d881-794e-4f1b-8fdb-fa9dda6b9fef
       X-Ms-Routing-Request-Id:
-      - NORTHCENTRALUS:20160119T135034Z:e81325a4-06e5-4fd0-816e-67cdbc54ea8f
+      - NORTHCENTRALUS:20160203T142031Z:0502d881-794e-4f1b-8fdb-fa9dda6b9fef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Date:
-      - Tue, 19 Jan 2016 13:50:34 GMT
+      - Wed, 03 Feb 2016 14:20:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11658,7 +13261,7 @@ http_interactions:
         ExeLVyfPPzm92rt+9vDz3/vdV7/o8tXDr3Z3fp/rez85+/zpt8vfq9mp2rNv
         n/wEevglyf8D3ICuGMYAAAA=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:35 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:31 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/?comp=list
@@ -11673,11 +13276,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:35 GMT
+      - Wed, 03 Feb 2016 14:20:31 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:4QL2nLws8Yc9gAxlLpCJCfS+QPXHd5dspb6Dn4rScpQ=
+      - SharedKey nyrg9184:Hzc3hgoNJPlC4AU0TRdOruTEjVEgS4DtYcyta1lPnPE=
   response:
     status:
       code: 200
@@ -11690,11 +13293,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 908244c2-0001-0042-19c0-52d10a000000
+      - 699aee83-0001-008b-588e-5e41c0000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:35 GMT
+      - Wed, 03 Feb 2016 14:20:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11716,7 +13319,7 @@ http_interactions:
         PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3Vs
         dHM+
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:35 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:31 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/bootdiagnostics-salesforc-cdf0af79-304d-4d73-9cc5-8551b19dce07?comp=list&restype=container
@@ -11731,11 +13334,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:35 GMT
+      - Wed, 03 Feb 2016 14:20:31 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:hSaVFNzwr8a6bsZt6KAp2rR6EDpqNh25S6FTphbEOYs=
+      - SharedKey nyrg9184:uYz1Dm5rd05jQxiOeujCyITpQk3OBSghLFNwBF42Clk=
   response:
     status:
       code: 200
@@ -11748,11 +13351,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0cfd5f98-0001-0104-35c0-5249c9000000
+      - 8c56e3c2-0001-00c1-6a8e-5e71a7000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:36 GMT
+      - Wed, 03 Feb 2016 14:20:31 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11775,7 +13378,7 @@ http_interactions:
         b3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1l
         cmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:36 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:32 GMT
 - request:
     method: get
     uri: https://nyrg9184.blob.core.windows.net/vhds?comp=list&restype=container
@@ -11790,11 +13393,11 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.0.rc1 (darwin14.5.0 x86_64) ruby/2.2.3p173
       X-Ms-Date:
-      - Tue, 19 Jan 2016 13:50:36 GMT
+      - Wed, 03 Feb 2016 14:20:32 GMT
       X-Ms-Version:
       - '2015-02-21'
       Authorization:
-      - SharedKey nyrg9184:mQIpGPZAhy+RGjIdPZ+Scllc4EfFxZbXmaZYFHUjvx0=
+      - SharedKey nyrg9184:xHnzLp97xIhUXkwbYHZ5CVZ1PFyaUcH8NovWqdpvWec=
   response:
     status:
       code: 200
@@ -11807,11 +13410,11 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4b6ad39d-0001-00fe-0ec0-52c67b000000
+      - 0add3870-0001-0007-1a8e-5e0c9b000000
       X-Ms-Version:
       - '2015-02-21'
       Date:
-      - Tue, 19 Jan 2016 13:50:35 GMT
+      - Wed, 03 Feb 2016 14:20:32 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -11845,5 +13448,5 @@ http_interactions:
         bj48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48
         L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Tue, 19 Jan 2016 13:50:36 GMT
+  recorded_at: Wed, 03 Feb 2016 14:20:32 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
This is a followup to #6249. It replaces hard coded credential information with instance variables gleaned from our local config/secrets.yml file for the Azure refresher specs. This is a WIP at the moment for a couple reasons.

First, the subscription we were using for inventory was disabled, and I need the updated credential information in order for the specs to actually run successfully, and to update the refresher.yml file.

Second, there are some yaml files under cloud_manager/discover that have hard coded values in them, and will need to be updated, but I'm not yet sure what the appropriate approach is.

