### PR TITLE
Remove unused parent_id parameter from ApplicationController::Explorer#x_build_node_id method

### DIFF
--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -208,8 +208,8 @@ module ApplicationController::Explorer
     tagging_edit_tags_save_and_replace_right_cell
   end
 
-  def x_build_node_id(object, pid = nil, options = {})
-    TreeNodeBuilder.build_id(object, pid, options)
+  def x_build_node_id(object, options = {})
+    TreeNodeBuilder.build_id(object, nil, options)
   end
 
   # Add the children of a node that is being expanded (autoloaded), called by generic tree_autoload method

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -300,7 +300,7 @@ class CatalogController < ApplicationController
       identify_catalog(from_cid(params[:id]))
       @record ||= ServiceTemplateCatalog.find_by_id(from_cid(params[:id]))
     end
-    params[:id] = x_build_node_id(@record, nil, x_tree(x_active_tree))  # Get the tree node id
+    params[:id] = x_build_node_id(@record, x_tree(x_active_tree))  # Get the tree node id
     tree_select
   end
 
@@ -1716,7 +1716,7 @@ class CatalogController < ApplicationController
            x_tree[:open_nodes].include?(parents.last[:id])
       parents.reverse_each do |p|
         unless p.nil?
-          p_node = x_build_node_id(p, nil, :full_ids => true)
+          p_node = x_build_node_id(p, :full_ids => true)
           unless x_tree[:open_nodes].include?(p_node)
             x_tree[:open_nodes].push(p_node)
             existing_node = p_node

--- a/app/controllers/container_controller.rb
+++ b/app/controllers/container_controller.rb
@@ -148,7 +148,7 @@ class ContainerController < ApplicationController
     respond_to do |format|
       format.js do                  # AJAX, select the node
         @explorer = true
-        params[:id] = x_build_node_id(@record, nil, x_tree(:containers_tree))  # Get the tree node id
+        params[:id] = x_build_node_id(@record, x_tree(:containers_tree))  # Get the tree node id
         tree_select
       end
       format.html do                # HTML, redirect to explorer

--- a/app/controllers/service_controller.rb
+++ b/app/controllers/service_controller.rb
@@ -111,7 +111,7 @@ class ServiceController < ApplicationController
     respond_to do |format|
       format.js do                  # AJAX, select the node
         @explorer = true
-        params[:id] = x_build_node_id(@record, nil, x_tree(:svcs_tree))  # Get the tree node id
+        params[:id] = x_build_node_id(@record, x_tree(:svcs_tree))  # Get the tree node id
         tree_select
       end
       format.html do                # HTML, redirect to explorer


### PR DESCRIPTION
Remove unused parent_id parameter from ApplicationController::Explorer#x_build_node_id method
which allows for the removal of unused parent_id parameter from TreeNodeBuilder.build_id method
which allows for the deletion of meaningless TreeNodeBuilder#format_parent_id method

Running `git grep x_build_node_id` returns
```sh
app/controllers/application_controller/explorer.rb:  def x_build_node_id(object, pid = nil, options = {})
app/controllers/catalog_controller.rb:    params[:id] = x_build_node_id(@record, nil, x_tree(x_active_tree))  # Get the tree node id
app/controllers/catalog_controller.rb:    params[:id] = x_build_node_id(@record)  # Get the tree node id
app/controllers/catalog_controller.rb:          p_node = x_build_node_id(p, nil, :full_ids => true)
app/controllers/chargeback_controller.rb:      nodeid = x_build_node_id(@record)
app/controllers/container_controller.rb:        params[:id] = x_build_node_id(@record, nil, x_tree(:containers_tree))  # Get the tree node id
app/controllers/miq_ae_class_controller.rb:           x_tree[:open_nodes].include?(x_build_node_id(parents.last))
app/controllers/miq_ae_class_controller.rb:        p_node = x_build_node_id(p)
app/controllers/miq_ae_customization_controller.rb:    params[:id] = x_build_node_id(@record)  # Get the tree node id
app/controllers/miq_policy_controller.rb:           x_tree[:open_nodes].include?(x_build_node_id(parents.last))
app/controllers/miq_policy_controller.rb:        p_node = x_build_node_id(p)
app/controllers/ops_controller.rb:    unless parents.empty? || x_tree[:open_nodes].include?(x_build_node_id(parents.last))
app/controllers/ops_controller.rb:        p_node = x_build_node_id(p)
app/controllers/ops_controller/db.rb:    params[:id] = x_build_node_id(@record)  # Get the tree node id
app/controllers/provider_foreman_controller.rb:        params[:id] = x_build_node_id(@record)  # Get the tree node id
app/controllers/report_controller.rb:           x_tree[:open_nodes].include?(x_build_node_id(parents.last))
app/controllers/report_controller.rb:        p_node = x_build_node_id(p)
app/controllers/service_controller.rb:        params[:id] = x_build_node_id(@record, nil, x_tree(:svcs_tree))  # Get the tree node id
app/controllers/vm_common.rb:        params[:id] = x_build_node_id(@record)  # Get the tree node id
app/controllers/vm_common.rb:           x_tree[:open_nodes].include?(x_build_node_id(parents.last))
app/controllers/vm_common.rb:        p_node = x_build_node_id(p)
app/controllers/vm_common.rb:      ems_node = x_build_node_id(record.ext_management_system)
```
Going through each caller, the middle parameter (parent_id or pid) is either left out or `nil`.  ApplicationController::Explorer#x_build_node_id defaults parent_id to nil.  So, in essence it is always nil.  Hence, this PR.

This was discussed [here](https://github.com/ManageIQ/manageiq/issues/6211#issuecomment-176281341) and [here](https://github.com/ManageIQ/manageiq/issues/6211#issuecomment-176305205)