### PR TITLE
Set CORS headers in a before_action, instead of after_action

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -8,7 +8,7 @@ class ApiController < ApplicationController
     head(:ok) if request.request_method == "OPTIONS"
   end
 
-  after_action :set_access_control_headers
+  before_action :set_access_control_headers
   def set_access_control_headers
     headers['Access-Control-Allow-Origin'] = '*'
     headers['Access-Control-Allow-Headers'] = 'origin, content-type, authorization, x-auth-token'


### PR DESCRIPTION
Normally, the latter would be fine, but as we read back our response body in the API controller (for logging), that forces a commit (after which the headers are frozen).