### PR TITLE
Query results don't need manual casting

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -14,26 +14,15 @@ module ActiveRecord
       end
 
       def client_connections
-        data = select(<<-SQL, "Client Connections")
+        data = select(<<-SQL, "Client Connections").to_a
                       SELECT client_addr   AS client_address
                            , datname       AS database
                            , pid           AS spid
-                           , waiting       AS number_waiting
+                           , waiting       AS is_waiting
                            , query
                         FROM pg_stat_activity
                        ORDER BY 1, 2
                       SQL
-
-        integer_columns = %w(
-          spid
-          number_waiting
-        )
-
-        data.each do |datum|
-          integer_columns.each   { |c| datum[c] = datum[c].to_i }
-        end
-
-        data.to_a
       end
 
       # Taken from: https://github.com/bucardo/check_postgres/blob/2.19.0/check_postgres.pl#L3492

--- a/spec/models/vmdb_database_spec.rb
+++ b/spec/models/vmdb_database_spec.rb
@@ -77,8 +77,10 @@ describe VmdbDatabase do
       connections = described_class.report_client_connections
       expect(connections).to be_kind_of(Array)
 
-      expected_keys = ["client_address", "database", "spid", "number_waiting", "query"]
+      expected_keys = ["client_address", "database", "spid", "is_waiting", "query"]
       expect(connections.first.keys).to match_array(expected_keys)
+
+      expect(connections.first['spid']).to be_kind_of(Fixnum)
     end
   end
 


### PR DESCRIPTION
... and `waiting` is a boolean, not an integer. (That part's not new; it was just wrong before.)