### PR TITLE
Update gettext_i18n_rails to version 1.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "spice-html5-rails"
 gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 
 # Needed by the REST API
-gem "gettext_i18n_rails",             "~>1.3.1"
+gem "gettext_i18n_rails",             "~>1.4.0"
 gem "gettext_i18n_rails_js",          "~>1.0.3"
 gem "jbuilder",                       "~>2.3.1"
 gem "paperclip",                      "~>4.3.0"


### PR DESCRIPTION
This version fixes problem with proper creation of model_attributes.rb
and also contains support for Rails 5.