### PR TITLE
MiqStorage.metrics_rollup_class instantiated only

### DIFF
--- a/app/models/miq_storage_metric.rb
+++ b/app/models/miq_storage_metric.rb
@@ -96,7 +96,7 @@ class MiqStorageMetric < ApplicationRecord
   end
 
   def metrics_rollups_by_rollup_type(rollup_type)
-    miq_metrics_rollups.where(rollup_type => rollup_type).to_a
+    miq_metrics_rollups.where(:rollup_type => rollup_type).to_a
   end
 
   def addDerivedMetric(derivedMetrics)
@@ -222,7 +222,7 @@ class MiqStorageMetric < ApplicationRecord
   # Called directly from MiqStorageMetric.
   #
   def self.metrics_rollup_class_names
-    subclasses.map(&:metrics_rollup_class_name).compact
+    sub_classes.map(&:metrics_rollup_class_name).compact
   end
 
   #

--- a/spec/models/miq_storage_metric_spec.rb
+++ b/spec/models/miq_storage_metric_spec.rb
@@ -62,18 +62,14 @@ describe MiqStorageMetric do
   describe '.metrics_rollup_class_names' do
     it "works" do
       OntapAggregateMetric.create
-      expect(MiqStorageMetric.metrics_rollup_class_names).to match_array(
-        %w(OntapAggregateMetricsRollup OntapDiskMetricsRollup OntapLunMetricsRollup
-           OntapSystemMetricsRollup OntapVolumeMetricsRollup))
+      expect(MiqStorageMetric.metrics_rollup_class_names).to match_array(%w(OntapAggregateMetricsRollup))
     end
   end
 
   describe '.metrics_rollup_classes' do
     it "works" do
       OntapAggregateMetric.create
-      expect(MiqStorageMetric.metrics_rollup_classes).to match_array([
-        OntapAggregateMetricsRollup, OntapDiskMetricsRollup, OntapLunMetricsRollup,
-        OntapSystemMetricsRollup, OntapVolumeMetricsRollup])
+      expect(MiqStorageMetric.metrics_rollup_classes).to match_array([OntapAggregateMetricsRollup])
     end
   end
 
@@ -130,6 +126,14 @@ describe MiqStorageMetric do
       stub_server_configuration(:storage => {:metrics_history => {}})
       OntapAggregateMetric.create
       MiqStorageMetric.purge_all_timer
+    end
+  end
+
+  describe '.metrics_rollup_by_rollup_type' do
+    it "works" do
+      met = OntapDiskMetric.create()
+      rollups = 2.times.map { met.miq_metrics_rollups.create(:rollup_type => "hourly") }
+      expect(met.metrics_rollups_by_rollup_type("hourly")).to match_array(rollups)
     end
   end
 end


### PR DESCRIPTION
Fixes bug introduced in b9a542661dbd3f82f6677ab94c0c1d1d9b503a7b

need to only return the metrics that are instantiated

---

Found this bug while I was working on perf_loader.
I introduced earlier this month