### PR TITLE
Fix to clear Rails schema cache

### DIFF
--- a/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
+++ b/db/migrate/20160120151642_migrate_url_from_provider_to_endpoints.rb
@@ -12,6 +12,8 @@ class MigrateUrlFromProviderToEndpoints < ActiveRecord::Migration
   end
 
   def up
+    Endpoint.connection.schema_cache.clear!
+    Endpoint.reset_column_information
     say_with_time("Migrating Provider URL attribute to Endpoints") do
       ExtManagementSystem.all.each do |ems|
         next if ems.provider_id.nil?


### PR DESCRIPTION
Due to Rails caching the schema this migration brakes on a migration