### PR TITLE
Fix list of users and groups with self service user logged

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -266,7 +266,8 @@ module Rbac
       end
 
       cond, incl = MiqExpression.merge_where_clauses_and_includes([find_options[:condition], cond].compact, [find_options[:include]].compact)
-      targets = klass.all(find_options.except(:conditions, :include)).where(cond).includes(incl).references(incl)
+      targets = klass.where(cond).includes(incl).references(incl).group(find_options[:group])
+                     .order(find_options[:order]).offset(find_options[:offset]).limit(find_options[:limit]).to_a
 
       [targets, targets.length, targets.length]
     else

--- a/app/presenters/tree_builder_ops_rbac.rb
+++ b/app/presenters/tree_builder_ops_rbac.rb
@@ -30,8 +30,8 @@ class TreeBuilderOpsRbac < TreeBuilder
   def x_get_tree_custom_kids(object_hash, count_only, _options)
     objects =
       case object_hash[:id]
-      when "u"  then User.in_my_region
-      when "g"  then MiqGroup.non_tenant_groups
+      when "u"  then rbac_filtered_objects(User.in_my_region)
+      when "g"  then rbac_filtered_objects(MiqGroup.non_tenant_groups)
       when "ur" then MiqUserRole.all
       when "tn" then Tenant.roots
       end


### PR DESCRIPTION
Self service user means that user's role has option
"VM & Template Access Restriction" set up to "Only User Owned" or
"Only User or Group Owned"

scenario:
Use user(non-admin but with permission for Configure) to login with role with this restriction. 
Go to Control->Access Control -> click on users or groups then this error generated:
![screen shot 2016-01-29 at 19 10 23](https://cloud.githubusercontent.com/assets/14937244/12683848/fb0a03c4-c6bb-11e5-9d76-fabbf2788054.png)

According this code https://github.com/ManageIQ/manageiq/blob/master/app/models/rbac.rb#L257
it should lists only use current user or current group so I also brought RBAC filter to the tree for users and groups. 

