### PR TITLE
[api] Refactor filtering to use MiqExpressions

### DIFF
--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -46,12 +46,8 @@ class ApiController
         unless virtual_or_physical_attribute?(target_class(klass, parts), attr)
           raise BadRequestError, "attribute #{attr} does not exist"
         end
-        field = if parts.empty?
-                  "#{klass.name}-#{attr}"
-                else
-                  # parts.map { |assoc| ".#{assoc}"}
-                  "#{klass.name}.#{parts.join(".")}-#{attr}"
-                end
+        associations = parts.map { |assoc| ".#{assoc}" }.join
+        field = "#{klass.name}#{associations}-#{attr}"
         target = parsed_filter[:logical_or] ? or_expressions : and_expressions
         target << {parsed_filter[:operator] => {"field" => field, "value" => parsed_filter[:value]}}
       end

--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -63,7 +63,7 @@ class ApiController
 
       filter_attr, _, filter_value = filter.partition(operator)
       filter_value.strip!
-      str_method = filter_value =~ /%/ && methods[:regex] || methods[:default]
+      str_method = filter_value =~ /%|\*/ && methods[:regex] || methods[:default]
 
       filter_value, method =
         case filter_value
@@ -77,9 +77,9 @@ class ApiController
           [filter_value, methods[:default]]
         end
 
-      if filter_value =~ /%/
+      if filter_value =~ /%|\*/
         filter_value = "/\\A#{Regexp.escape(filter_value)}\\z/"
-        filter_value.gsub!(/%/, ".*")
+        filter_value.gsub!(/%|\\\*/, ".*")
       end
 
       {:logical_or => logical_or, :operator => method, :attr => filter_attr.strip, :value => filter_value}

--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -43,7 +43,7 @@ class ApiController
         parsed_filter = parse_filter(filter, operators)
         parts = parsed_filter[:attr].split(".")
         field = if parts.one?
-                  unless klass.column_names.include?(parsed_filter[:attr]) || klass.virtual_attribute?(parsed_filter[:attr])
+                  unless klass.attribute_method?(parsed_filter[:attr]) || klass.virtual_attribute?(parsed_filter[:attr])
                     raise BadRequestError, "attribute #{parsed_filter[:attr]} does not exist"
                   end
                   "#{klass.name}-#{parsed_filter[:attr]}"

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -185,18 +185,16 @@ class ApiController
         else
           klass.all
         end
-      sql_filter, ruby_filters = filter_param(klass)
-      res = res.where(sql_filter)                                     if sql_filter.present? && res.respond_to?(:where)
-      ruby_filters.each { |ruby_filter| res = ruby_filter.call(res) } if ruby_filters.present?
 
-      sort_options = sort_params(klass)                               if res.respond_to?(:reorder)
-      res = res.reorder(sort_options)                                 if sort_options.present?
+      sort_options = sort_params(klass) if res.respond_to?(:reorder)
+      res = res.reorder(sort_options) if sort_options.present?
 
-      options = {
-        :user => @auth_user_obj,
-      }
-      options[:order] = sort_options              if sort_options.present?
+      options = {:user => @auth_user_obj}
+      options[:order] = sort_options if sort_options.present?
       options[:offset], options[:limit] = expand_paginate_params if paginate_params?
+
+      miq_expression = filter_param(klass)
+      options[:filter] = miq_expression if miq_expression
 
       Rbac.filtered(res, options)
     end

--- a/app/controllers/api_controller/renderer.rb
+++ b/app/controllers/api_controller/renderer.rb
@@ -177,23 +177,21 @@ class ApiController
     end
 
     def collection_search(is_subcollection, type, klass)
-      miq_expression = filter_param(klass)
-
       res =
         if is_subcollection
           send("#{type}_query_resource", parent_resource_obj)
         elsif by_tag_param
           klass.find_tagged_with(:all => by_tag_param, :ns  => TAG_NAMESPACE)
-        elsif miq_expression
-          sql, _, attrs = miq_expression.to_sql
-          if attrs[:supported_by_sql]
-            klass.where(sql)
-          else
-            klass.all
-          end
         else
           klass.all
         end
+
+      miq_expression = filter_param(klass)
+
+      if miq_expression
+        sql, _, attrs = miq_expression.to_sql
+        res = res.where(sql) if attrs[:supported_by_sql]
+      end
 
       sort_options = sort_params(klass) if res.respond_to?(:reorder)
       res = res.reorder(sort_options) if sort_options.present?

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -134,6 +134,16 @@ describe ApiController do
                                              {"name" => vm1.name, "guid" => vm1.guid}])
     end
 
+    it "supports attribute pattern matching via *" do
+      vm1, _vm2, vm3 = create_vms_by_name(%w(aa_B2 bb aa_A1))
+
+      run_get vms_url, :expand => "resources", :filter => ["name='aa*'"], :sort_by => "name"
+
+      expect_query_result(:vms, 2, 3)
+      expect_result_resources_to_match_hash([{"name" => vm3.name, "guid" => vm3.guid},
+                                             {"name" => vm1.name, "guid" => vm1.guid}])
+    end
+
     it "supports inequality test via !=" do
       vm1, _vm2, vm3 = create_vms_by_name(%w(aa bb cc))
 

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -247,6 +247,19 @@ describe ApiController do
                                              {"name" => vm3.name, "guid" => vm3.guid}])
     end
 
+    it "supports filtering by attributes of associations" do
+      host1 = FactoryGirl.create(:host, :name => "foo")
+      host2 = FactoryGirl.create(:host, :name => "bar")
+      vm1 = FactoryGirl.create(:vm_vmware, :name => "baz", :host => host1)
+      _vm2 = FactoryGirl.create(:vm_vmware, :name => "qux", :host => host2)
+
+      run_get vms_url, :expand => "resources",
+                       :filter => ["host.name='foo'"]
+
+      expect_query_result(:vms, 1, 2)
+      expect_result_resources_to_match_hash([{"name" => vm1.name, "guid" => vm1.guid}])
+    end
+
     it "supports filtering by virtual string attributes" do
       host_a = FactoryGirl.create(:host, :name => "aa")
       host_b = FactoryGirl.create(:host, :name => "bb")


### PR DESCRIPTION
MiqExpressions offers the same flexibility for filtering as before (it
is a straight up refactoring of the JSON API) with the bonus of
providing full support for filtering by virtual columns. This was only
partially supported before.

Resolves https://trello.com/c/iWuQq8cK
Resolves https://trello.com/c/49QssfTG

***

/cc @abellotti, @gtanzillo 
@miq-bot add-label api, refactoring, enhancement