### PR TITLE
Add nakayoshi_fork to be more copy-on-write friendly :cow:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "default_value_for",              "~>3.0.1"
 gem "draper",                         "~>2.1.0"
 gem "hamlit-rails",                   "~>0.1.0"
 gem "high_voltage",                   "~>2.4.0"
+gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "novnc-rails",                    "~>0.2"
 gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>2.13"

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -341,7 +341,7 @@ class MiqWorker < ApplicationRecord
 
   def start
     self.class.before_fork
-    pid = fork do
+    pid = fork(:cow_friendly => true) do
       self.class.after_fork
       self.class::Runner.start_worker(worker_options)
       exit!


### PR DESCRIPTION
It provides a more CoW friendly fork which basically does
GC.start a few times before fork.

These GC runs increment the age bit for all objects so they're old and won't be
incremented in the child process, which would normally cause a CoW page fault
leading to the page being copied.

This has a very minor improvement of 2-8 MB unique set size memory (private)
on our forked workers.