### PR TITLE
Reopen any open File objects inherited from the parent process.

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -324,6 +324,16 @@ class MiqWorker < ApplicationRecord
   def self.after_fork
     close_pg_sockets_inherited_from_parent
     DRb.stop_service
+    reopen_file_objects_inherited_from_parent
+  end
+
+  def self.reopen_file_objects_inherited_from_parent
+    ObjectSpace.each_object(File) do |file|
+      next if file.closed?
+
+      file.reopen(file.path, 'a+')
+      file.sync = true
+    end
   end
 
   # When we fork, the children inherits the parent's file descriptors


### PR DESCRIPTION
Loggers should be fine as is but nonetheless, we should probably be careful
with file descriptors being inherited and not closed/opened.

I didn't touch IO objects as that would include other objects such as STDIN/STDOUT/STDERR but we might want to handle close/open of them too.