### PR TITLE
Added database protection in case MiqDatabase isn't defind

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   include Vmdb::Logging
 
   if Vmdb::Application.config.action_controller.allow_forgery_protection
-    protect_from_forgery :secret => MiqDatabase.first.csrf_secret_token, :except => :csp_report, :with => :exception
+    protect_from_forgery :secret =>  MiqDatabase.connected? ? MiqDatabase.first.csrf_secret_token : SecureRandom.hex(64), :except => :csp_report, :with => :exception
   end
 
   helper ChartingHelper


### PR DESCRIPTION
This pr would add the ability to monkey-patch controllers in initializers, as for now we can't override any controller functionality in initializers,
example: 
running `rake assets:precompile` will also run the initializers but won't have database defined at run time.