### PR TITLE
Do not add root node in TreeBuilder when add_root is set to false

### DIFF
--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -199,7 +199,8 @@ class TreeBuilder
   end
 
   def set_nodes(nodes)
-    add_root_node(nodes)
+    # Add the root node even if it is not set
+    add_root_node(nodes) if @options.fetch(:add_root, :true)
     @tree_nodes = nodes.to_json
     @locals_for_render = set_locals_for_render
   end


### PR DESCRIPTION
I found one occasion in TreeBuilders where the `add_root` [can be](https://github.com/ManageIQ/manageiq/blob/master/app/presenters/tree_builder_region.rb#L6) to `false`. It can be reviewed on the `Optimize -> Utilization` page, but the nodes are a bit inconsistent.

When the `ent.is_enterprise?` is `true`:
![screenshot from 2016-02-01 13-27-30](https://cloud.githubusercontent.com/assets/649130/12717603/3c4131ee-c8e9-11e5-8c71-b5f1fd79d420.png)

When the `ent.is_enterprise?` is `false`:
![screenshot from 2016-02-01 13-30-02](https://cloud.githubusercontent.com/assets/649130/12717619/4d3ff066-c8e9-11e5-8da2-d5b87548651a.png)

The problem is that the  `add_root_node` method is called even if the `add_root` is set to `false`. 

After this PR it will look more consistent:
![screenshot from 2016-02-01 13-27-43](https://cloud.githubusercontent.com/assets/649130/12717645/677ea4a4-c8e9-11e5-82df-556aa1164e59.png)
