### PR TITLE
Update li_link method call in Storage/Filers listnav

### DIFF
--- a/app/views/layouts/listnav/_ontap_storage_system.html.haml
+++ b/app/views/layouts/listnav/_ontap_storage_system.html.haml
@@ -13,67 +13,51 @@
     = miq_accordion_panel(_("Relationships"), false, "cim_cs_rel") do
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "ontap_storage_volume_show_list")
-          = li_link_if_nonzero(:count => @record.storage_volumes_size,
-            :record_id                => @record.id,
-            :tables                   => 'ontap_storage_volume',
-            :display                  => 'ontap_storage_volume',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "ontap_storage_volume"))
+          = li_link(:count => @record.storage_volumes_size,
+            :record_id     => @record.id,
+            :tables        => 'ontap_storage_volume',
+            :display       => 'ontap_storage_volume')
 
         - if role_allows(:feature => "ontap_file_share_show_list")
-          = li_link_if_nonzero(:count => @record.hosted_file_shares_size,
-            :record_id                => @record.id,
-            :tables                   => 'ontap_file_share',
-            :display                  => 'ontap_file_share',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "ontap_file_share"))
+          = li_link(:count => @record.hosted_file_shares_size,
+            :record_id     => @record.id,
+            :tables        => 'ontap_file_share',
+            :display       => 'ontap_file_share')
 
         - if role_allows(:feature => "snia_local_file_system_show_list")
-          = li_link_if_nonzero(:count => @record.local_file_systems_size,
-            :record_id                => @record.id,
-            :tables                   => 'snia_local_file_system',
-            :display                  => 'snia_local_file_systems',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "snia_local_file_system"))
+          = li_link(:count => @record.local_file_systems_size,
+            :record_id     => @record.id,
+            :tables        => 'snia_local_file_system',
+            :display       => 'snia_local_file_systems')
 
         - if role_allows(:feature => "ontap_logical_disk_show_list")
-          = li_link_if_nonzero(:count => @record.logical_disks_size,
-            :record_id                => @record.id,
-            :tables                   => 'ontap_logical_disk',
-            :display                  => 'ontap_logical_disks',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "ontap_logical_disk"))
+          = li_link(:count => @record.logical_disks_size,
+            :record_id     => @record.id,
+            :tables        => 'ontap_logical_disk',
+            :display       => 'ontap_logical_disks')
 
         - if role_allows(:feature => "cim_base_storage_extent_show_list")
-          = li_link_if_nonzero(:count => @record.base_storage_extents_size,
-            :record_id                => @record.id,
-            :tables                   => 'cim_base_storage_extent',
-            :display                  => 'cim_base_storage_extents',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "cim_base_storage_extent"))
+          = li_link(:count => @record.base_storage_extents_size,
+            :record_id     => @record.id,
+            :tables        => 'cim_base_storage_extent',
+            :display       => 'cim_base_storage_extents')
 
     = miq_accordion_panel(_("Infrastructure Relationships"), false, "cim_cs_inf_rel") do
       %ul.nav.nav-pills.nav-stacked
         - if role_allows(:feature => "vm_show_list")
-          = li_link_if_nonzero(:count => @record.vms_size,
-            :record_id                => @record.id,
-            :tables                   => 'vm',
-            :display                  => 'vms',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "vm"))
+          = li_link(:count => @record.vms_size,
+            :record_id     => @record.id,
+            :tables        => 'vm',
+            :display       => 'vms')
 
         - if role_allows(:feature => "host_show_list")
-          = li_link_if_nonzero(:count => @record.hosts_size,
-            :record_id                => @record.id,
-            :tables                   => 'host',
-            :display                  => 'hosts',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "host"))
+          = li_link(:count => @record.hosts_size,
+            :record_id     => @record.id,
+            :tables        => 'host',
+            :display       => 'hosts')
 
         - if role_allows(:feature => "storage_show_list")
-          = li_link_if_nonzero(:count => @record.storages_size,
-            :record_id                => @record.id,
-            :tables                   => 'storage',
-            :display                  => 'storages',
-            :action                   => 'show',
-            :title                    => _("Show all %s") % ui_lookup(:tables => "storage"))
+          = li_link(:count => @record.storages_size,
+            :record_id     => @record.id,
+            :tables        => 'storage',
+            :display       => 'storages')


### PR DESCRIPTION
This is fix for Storage/Filers list navigation(now it renders the view again), it updates name of method for building list navigation from ```li_link_if_nonzero``` to renamed method ```li_link```. Also it removes ```:title``` argument as it's created inside ```li_link``` method and ```:action ``` as default is 'show'.