### PR TITLE
Assign inverse operations for VM relationships

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -9,8 +9,8 @@ class EmsCluster < ApplicationRecord
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
   has_many    :hosts, :dependent => :nullify
   has_many    :vms_and_templates
-  has_many    :miq_templates
-  has_many    :vms
+  has_many    :miq_templates, :inverse_of => :ems_cluster
+  has_many    :vms, :inverse_of => :ems_cluster
 
   has_many    :metrics,                :as => :resource  # Destroy will be handled by purger
   has_many    :metric_rollups,         :as => :resource  # Destroy will be handled by purger

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -45,13 +45,13 @@ class Host < ApplicationRecord
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :hardware, :dependent => :destroy
   has_many                  :vms_and_templates, :dependent => :nullify
-  has_many                  :vms
-  has_many                  :miq_templates
+  has_many                  :vms, :inverse_of => :host
+  has_many                  :miq_templates, :inverse_of => :host
   has_and_belongs_to_many   :storages, :join_table => :host_storages
   has_many                  :switches, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy
-  has_many                  :host_services, :class_name => "SystemService", :foreign_key => "host_id"
+  has_many                  :host_services, :class_name => "SystemService", :foreign_key => "host_id", :inverse_of => :host
 
   has_many                  :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many                  :metric_rollups, :as => :resource  # Destroy will be handled by purger

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -18,7 +18,7 @@ class MiqServer < ApplicationRecord
   include ReportableMixin
   include RelationshipMixin
 
-  belongs_to              :vm
+  belongs_to              :vm, :inverse_of => :miq_server
   belongs_to              :zone
   has_many                :messages,  :as => :handler, :class_name => 'MiqQueue'
   has_many                :miq_groups, :as => :resource

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -19,8 +19,8 @@ class Tenant < ApplicationRecord
   has_many :providers
   has_many :ext_management_systems
   has_many :vm_or_templates
-  has_many :vms
-  has_many :miq_templates
+  has_many :vms, :inverse_of => :tenant
+  has_many :miq_templates, :inverse_of => :tenant
   has_many :service_template_catalogs
   has_many :service_templates
 
@@ -32,7 +32,7 @@ class Tenant < ApplicationRecord
   has_many :miq_request_tasks, :dependent => :destroy
   has_many :services, :dependent => :destroy
 
-  belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy, :inverse_of => :tenant
+  belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy
 
   # FUTURE: /uploads/tenant/:id/logos/:basename.:extension # may want style
   has_attached_file :logo,

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -51,7 +51,7 @@ class VmOrTemplate < ApplicationRecord
   validates_presence_of     :name, :location
   validates_inclusion_of    :vendor, :in => VENDOR_TYPES.values
 
-  has_one                   :miq_server, :foreign_key => :vm_id
+  has_one                   :miq_server, :foreign_key => :vm_id, :inverse_of => :vm
 
   has_one                   :operating_system, :dependent => :destroy
   has_one                   :hardware, :dependent => :destroy


### PR DESCRIPTION
This only saves us 2 queries for `perf_capture_timer`. So the numbers aren't there.

But these associations should be assigning in the reverse.
The foreign key, and the ambiguity between `Vm` and `VmOrTemplate` is hurting us.

`default_miq_group` is already handled by the system.

/cc @jrafanie @dmetzger57 