### PR TITLE
Changed session.merge! to session.update

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -664,7 +664,7 @@ class DashboardController < ApplicationController
     data_to_restore = keys_to_restore.each_with_object({}) { |k, v| v[k] = session[k] }
 
     session.clear
-    session.merge!(data_to_restore)
+    session.update(data_to_restore)
 
     # Clear instance vars that end up in the session
     @sb = @edit = @view = @settings = @lastaction = @perf_options = @assign = nil

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -317,6 +317,7 @@ describe DashboardController do
       expect(session[:winW]).to eq(winW)
       expect(session[:user_TZO]).to eq(user_TZO)
       expect(session[:foo]).to eq(nil)
+      expect(browser_info(:version)).to eq(browser_info[:version])
     end
   end
 
@@ -339,5 +340,9 @@ describe DashboardController do
     # TODO: figure out why flash messages are not in result.body
     expect(response.body).to match(/flash_msg_div/) if flash
     # expect(result.body.to match(/flash_msg_div.*replaceWith.*#{msg}/) if flash
+  end
+
+  def browser_info(typ)
+    session.fetch_path(:browser, typ).to_s
   end
 end


### PR DESCRIPTION
session.merge! was not setting keys in Session object in the rails app.

https://bugzilla.redhat.com/show_bug.cgi?id=1297432
https://bugzilla.redhat.com/show_bug.cgi?id=1297074
https://bugzilla.redhat.com/show_bug.cgi?id=1297434

@dclarizio please review. 

@Fryguy changed session.merge! to session.update. Found this link http://makandracards.com/makandra/14851-how-to-fix-session-hash-does-not-get-updated-when-using-merge that suggested to use update instead, as session.merge! does not work in Rails Apps. Please suggest if this can be fixed differently.