### PR TITLE
Restrict users and groups in 'set ownership' screens

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -77,7 +77,7 @@ module ApplicationController::CiProcessing
   # Build the ownership assignment screen
   def ownership_build_screen
     @users = {}   # Users array for first chooser
-    User.all.each { |u| @users[u.name] = u.id.to_s }
+    User.with_current_user_groups.each { |u| @users[u.name] = u.id.to_s }
     record = @edit[:klass].find(@edit[:ownership_items][0])
     user = record.evm_owner if @edit[:ownership_items].length == 1
     @edit[:new][:user] = user ? user.id.to_s : nil            # Set to first category, if not already set
@@ -86,7 +86,7 @@ module ApplicationController::CiProcessing
     # need to do this only if 1 vm is selected and miq_group has been set for it
     group = record.miq_group if @edit[:ownership_items].length == 1
     @edit[:new][:group] = group ? group.id.to_s : nil
-    MiqGroup.all.each { |g| @groups[g.description] = g.id.to_s }
+    MiqGroup.non_tenant_groups.with_current_user_groups.each { |g| @groups[g.description] = g.id.to_s }
 
     @edit[:new][:user] = @edit[:new][:group] = DONT_CHANGE_OWNER if @edit[:ownership_items].length > 1
 

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -252,6 +252,11 @@ class MiqGroup < ApplicationRecord
     where.not(:group_type => TENANT_GROUP)
   end
 
+  def self.with_current_user_groups
+    current_user = User.current_user
+    current_user.admin_user? ? all : where(:id => current_user.miq_group_ids)
+  end
+
   def self.valid_filters?(filters_hash)
     return true  unless filters_hash                  # nil ok
     return false unless filters_hash.kind_of?(Hash)   # must be Hash

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,6 +322,6 @@ class User < ApplicationRecord
   end
 
   def self.with_current_user_groups
-    includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
+    current_user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
   end
 end

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -271,6 +271,47 @@ describe ApplicationController do
       expect(record).to be_a_kind_of(Host)
     end
   end
+
+  describe "#ownership_build_screen" do
+    before do
+      @admin_user = FactoryGirl.create(:user_admin)
+      @user = FactoryGirl.create(:user_with_group)
+      @vm_or_template = FactoryGirl.create(:vm_or_template)
+      @edit = {:ownership_items => [@vm_or_template.id], :klass => VmOrTemplate, :new => {:user => nil}}
+    end
+
+    it "lists all groups when (admin user is logged)" do
+      login_as(@admin_user)
+      controller.instance_variable_set(:@edit, @edit)
+      controller.ownership_build_screen
+      groups = controller.instance_variable_get(:@groups)
+      expect(groups.count).to eq(MiqGroup.non_tenant_groups.count)
+    end
+
+    it "lists all users when (admin user is logged)" do
+      login_as(@admin_user)
+      controller.instance_variable_set(:@edit, @edit)
+      controller.ownership_build_screen
+      users = controller.instance_variable_get(:@users)
+      expect(users.count).to eq(User.all.count)
+    end
+
+    it "lists users from current user's groups (non-admin user is logged)" do
+      login_as(@user)
+      controller.instance_variable_set(:@edit, @edit)
+      controller.ownership_build_screen
+      users = controller.instance_variable_get(:@users)
+      expect(users.count).to eq(1)
+    end
+
+    it "lists user's groups (non-admin user is logged)" do
+      login_as(@user)
+      controller.instance_variable_set(:@edit, @edit)
+      controller.ownership_build_screen
+      groups = controller.instance_variable_get(:@groups)
+      expect(groups.count).to eq(1)
+    end
+  end
 end
 
 describe HostController do


### PR DESCRIPTION
for example: Infrastructure->VM->detail of any VM, then in toolbar Configuration->Set ownership

Restriction:
Groups: For admin all groups otherwise only groups to which he belongs and nontenant groups removed as well.

Users: For admin all users otherwise only users from groups to which he belongs

Slightly affect https://github.com/ManageIQ/manageiq/pull/6260 for admin user, but according the BZ, request was for 'normal users' so I think that it is OK.
