### PR TITLE
Replace images with font icons on VM Policy Simulation page

### DIFF
--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -6,12 +6,12 @@ module ApplicationController::TreeSupport
     item = "h_#{@record.name}"
     render :update do |page|
       if session[:squash_open] == false
-        page << "$('#squash_img').prop('src', #{ActionController::Base.helpers.image_path('toolbars/squashed-all-false.png')})"
+        page << "$('#squash_img i').attr('class','fa fa-angle-double-up fa-lg')"
         page << "$('#squash_img').prop('title', 'Collapse All')"
         page << "miqDynatreeToggleExpand('#{j_str(session[:tree_name])}', true)"
         session[:squash_open] = true
       else
-        page << "$('#squash_img').prop('src', #{ActionController::Base.helpers.image_path('toolbars/squashed-all-true.png')})"
+        page << "$('#squash_img i').attr('class','fa fa-angle-double-down fa-lg')"
         page << "$('#squash_img').prop('title', 'Expand All')"
         page << "miqDynatreeToggleExpand('#{j_str(session[:tree_name])}', false);"
         page << "miqDynatreeActivateNodeSilently('#{j_str(session[:tree_name])}', '#{item}');"

--- a/app/views/vm_common/_policies.html.haml
+++ b/app/views/vm_common/_policies.html.haml
@@ -5,19 +5,16 @@
   %h3
     = _('Policy Simulation Details')
 
-  - squash_state = session[:squash_open] ? "false" : "true"
+  - squash_state = session[:squash_open] ? "up" : "down"
   - squash_title = session[:squash_open] ? _("Collapse All") : _("Expand All")
-  - link_image = image_tag(image_path("toolbars/squashed-all-#{squash_state}.png"),
-      :id => 'squash_img',
-      :class => "rollover small",
-      :alt => "#{squash_title}",
-      :title => "#{squash_title}")
-  = link_to(link_image,
-      {:action => 'squash_toggle',
-       :id     => @record.id},
-      :remote       => true,
-      "data-method" => :post,
-      :id           => 'squash')
+  %button.btn.btn-default{:title => squash_title,
+                          :remote => true,
+                          :id => 'squash_img',
+                          "data-method" => :post,
+                          "data-miq_sparkle_on" => true,
+                          "data-click_url" => {:url => url_for(:action => 'squash_toggle', :id => @record.id)}.to_json}
+    %i{:class => "fa fa-angle-double-#{squash_state} fa-lg"}
+
 
   %div{:id => "#{session[:tree_name]}box"}
 


### PR DESCRIPTION
Trello task: https://trello.com/c/dNu0u279/153-8-replace-images-with-font-icons-in-forms

Before:
![screencapture-localhost-3000-vm_infra-explorer-1454353137357](https://cloud.githubusercontent.com/assets/1187051/12727700/5f1ca34e-c91e-11e5-93b5-f06e32807dc2.png)

After:
![screencapture-localhost-3000-vm_infra-explorer-1454352945589](https://cloud.githubusercontent.com/assets/1187051/12727706/63fc24a2-c91e-11e5-8eb1-ecc5c50dafb7.png)
![screencapture-localhost-3000-vm_infra-explorer-1454352866093](https://cloud.githubusercontent.com/assets/1187051/12727707/65bc7f62-c91e-11e5-9d46-574a9fcae4f5.png)

@epwinchell @dclarizio 