### PR TITLE
Removed no longer used x_node parsing of double underscore

### DIFF
--- a/app/controllers/ops_controller.rb
+++ b/app/controllers/ops_controller.rb
@@ -624,7 +624,7 @@ class OpsController < ApplicationController
         if %w(save reset).include?(params[:button]) && is_browser_ie?
           presenter[:extra_js] << "ManageIQ.oneTransition.IEButtonPressed = true;"
         end
-      elsif x_node.split("-").first.split("__")[1] == "svr" && my_server_id != active_id.to_i
+      elsif x_node.split("-").first == "svr" && my_server_id != active_id.to_i
         # show only 4 tabs if not on current server node
         @selected_server ||= MiqServer.find(@sb[:selected_server_id])  # Reread the server record
       end

--- a/app/views/ops/_all_tabs.html.haml
+++ b/app/views/ops/_all_tabs.html.haml
@@ -85,7 +85,7 @@
             = render :partial => "settings_rhn_tab"
     -# Diagnostics
   - when :diagnostics_tree
-    - if x_node.split("__").last.split("-")[0] == "z"
+    - if x_node.split("-")[0] == "z"
       %ul.nav.nav-tabs
         = miq_tab_header("diagnostics_roles_servers", @sb[:active_tab]) do
           = _("Roles by Servers")
@@ -108,7 +108,7 @@
           = render :partial => "diagnostics_collect_logs_tab"
         = miq_tab_content("diagnostics_cu_repair", @sb[:active_tab]) do
           = render :partial => "diagnostics_cu_repair_tab"
-    - elsif x_node.split("__").last.split("-")[0] == "svr"
+    - elsif x_node.split("-")[0] == "svr"
       %ul.nav.nav-tabs
         - if @sb[:selected_server_id] == my_server_id || @selected_server.started?
           = miq_tab_header("diagnostics_summary", @sb[:active_tab]) do


### PR DESCRIPTION
From https://github.com/ManageIQ/manageiq/issues/6211#issuecomment-177294414

> These underscore checks are left over from Dhtmlxtrees, __ are no longer there after treebuilder presenter was introduced, those occurrences in OPS area can be changed to x_node.split("-")[0]