### PR TITLE
Fix typo in condition with 'contains' and tag in MiqExpression

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -685,7 +685,7 @@ class MiqExpression
         tag = exp[operator]["value"]
         klass = klass.constantize
         ids = klass.find_tagged_with(:any => tag, :ns => ns).pluck(:id)
-        clause = klass.send(:sanitize_sql_for_conditions, ["#{model.table_name}.id IN (?)", ids])
+        clause = klass.send(:sanitize_sql_for_conditions, ["#{klass.table_name}.id IN (?)", ids])
       else
         db, field = exp[operator]["field"].split(".")
         model = db.constantize

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :tag do
+  end
+end

--- a/spec/models/miq_expression/miq_expression_spec.rb
+++ b/spec/models/miq_expression/miq_expression_spec.rb
@@ -7,6 +7,21 @@ describe MiqExpression do
     ]}
   end
 
+  describe "#to_sql" do
+    let(:tag) { FactoryGirl.create(:tag, :name => "/managed/operations/analysis_failed") }
+
+    before do
+      @vm = FactoryGirl.create(:vm_vmware, :tags => [tag])
+    end
+
+    it "returns condition with ids of the model, when operation is 'CONTAINS' some tag in expression" do
+      expression_with_tag = {"CONTAINS" => {"tag" => "VmInfra.managed-operations", "value" => "analysis_failed"}}
+      expression = MiqExpression.new(expression_with_tag)
+      sql_clause = expression.to_sql.first
+      expect(sql_clause).to eq("vms.id IN (#{@vm.id})")
+    end
+  end
+
   describe ".to_ruby" do
     # Based on FogBugz 6181: something INCLUDES []
     it "detects value empty array" do


### PR DESCRIPTION
Infrastructure->Virtual Machines->VMS -> All VMS -> Analysis Failed is throwing error:
`undefined local variable or method `model' for #<MiqExpression:0x007fc382f2bf00>`

it seems like typo after https://github.com/ManageIQ/manageiq/pull/6400

@matthewd please review, thank you