### PR TITLE
Exclude Azure orchestration resources with an action

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -100,7 +100,11 @@ module ManageIQ::Providers
 
       def get_stack_resources(name, group)
         resources = @tds.list_deployment_operations(name, group)
-        resources.reject! { |r| r.try(:properties).try(:target_resource).try(:id).nil? }
+        # exclude empty resources and resources with an action
+        resources.reject! do |r|
+          r.try(:properties).try(:target_resource).try(:id).nil? ||
+            r.properties.target_resource.try(:action_name)
+        end
 
         process_collection(resources, :orchestration_stack_resources) do |resource|
           parse_stack_resource(resource, group)


### PR DESCRIPTION
During provider refresh we collect orchestration resources from deployment operations. The ones with an action should be excluded because their corresponding ones without an action are already collected.

This defect was discovered through the refresh spec test, so no new spec task is added.