### PR TITLE
Simplify archived? and orphaned? to not use associations

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -123,8 +123,8 @@ class VmOrTemplate < ApplicationRecord
   include ReportableMixin
 
   virtual_column :active,                               :type => :boolean
-  virtual_column :archived,                             :type => :boolean,    :uses => [:host, :storage]
-  virtual_column :orphaned,                             :type => :boolean,    :uses => [:host, :storage]
+  virtual_column :archived,                             :type => :boolean
+  virtual_column :orphaned,                             :type => :boolean
   virtual_column :disconnected,                         :type => :boolean
   virtual_column :is_evm_appliance,                     :type => :boolean,    :uses => :miq_server
   virtual_column :os_image_name,                        :type => :string,     :uses => [:operating_system, :hardware]
@@ -1333,12 +1333,12 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def archived?
-    ext_management_system.nil? && storage.nil?
+    ems_id.nil? && storage_id.nil?
   end
   alias_method :archived, :archived?
 
   def orphaned?
-    ext_management_system.nil? && !storage.nil?
+    ems_id.nil? && !storage_id.nil?
   end
   alias_method :orphaned, :orphaned?
 

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -22,10 +22,6 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
     prune_rbac(tree)
     sort_tree(tree)
 
-    # The node builder uses normalized_state to determine the icon on each VM,
-    #   which, in turn, needs the EMS
-    preload_ems_for_vms(tree)
-
     tree
   end
 
@@ -99,10 +95,5 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
       datacenter = object.kind_of?(EmsFolder) ? object.is_datacenter? : false
       [SORT_CLASSES.index(object.class.base_class), datacenter ? 0 : 1, object.name.downcase]
     end
-  end
-
-  def preload_ems_for_vms(tree)
-    vms = extract_vms(tree)
-    MiqPreloader.preload(vms, :ext_management_system)
   end
 end

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -125,7 +125,8 @@ describe MiqProvisionWorkflow do
     end
 
     it 'with orphaned source' do
-      allow(template).to receive(:storage).and_return([])
+      template.storage = FactoryGirl.create(:storage)
+
       expect(template.orphaned?).to be_truthy
       expect(described_class.class_for_source(template.id)).to eq(workflow_class)
     end


### PR DESCRIPTION
In doing so, the TreeBuilderVmsAndTemplates no longer needs
to preload the EMS.

https://bugzilla.redhat.com/show_bug.cgi?id=1281999

@kbrock Please review.