### PR TITLE
Fix test warnings: remove constants from rspecs

### DIFF
--- a/spec/lib/miq_automation_engine/miq_ae_collect_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_collect_spec.rb
@@ -13,7 +13,7 @@ module MiqAeCollectSpec
       MiqAeDatastore.reset
     end
 
-    MONTHS = {"January" => 1, "October" => 10, "June" => 6, "July" => 7, "February" => 2, "May" => 5, "March" => 3, "December" => 12, "August" => 8, "September" => 9, "November" => 11, "April" => 4}
+    let(:months) { {"January" => 1, "October" => 10, "June" => 6, "July" => 7, "February" => 2, "May" => 5, "March" => 3, "December" => 12, "August" => 8, "September" => 9, "November" => 11, "April" => 4} }
     it "collects months" do
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_months", @user)
       expect(ws).not_to be_nil
@@ -23,7 +23,7 @@ module MiqAeCollectSpec
       expect(months).not_to be_nil
       expect(months.class.to_s).to eq("Hash")
       expect(months.length).to eq(12)
-      expect(months).to eq(MONTHS)
+      expect(months).to eq(months)
       expect(ws.root('sort')).to eq([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
       expect(ws.root('rsort')).to eq([12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
       expect(ws.root('count')).to eq(12)
@@ -32,7 +32,7 @@ module MiqAeCollectSpec
       expect(ws.root('mean')).to eq(6.5)
     end
 
-    WEEKDAYS = {"Wednesday" => 4, "Friday" => 6, "Saturday" => 7, "Tuesday" => 3, "Sunday" => 1, "Monday" => 2, "Thursday" => 5}
+    let(:weekdays) { {"Wednesday" => 4, "Friday" => 6, "Saturday" => 7, "Tuesday" => 3, "Sunday" => 1, "Monday" => 2, "Thursday" => 5} }
     it "collects weekdays" do
       ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_weekdays", @user)
       expect(ws).not_to be_nil
@@ -41,7 +41,7 @@ module MiqAeCollectSpec
       expect(weekdays).not_to be_nil
       expect(weekdays.class.to_s).to eq("Hash")
       expect(weekdays.length).to eq(7)
-      expect(weekdays).to eq(WEEKDAYS)
+      expect(weekdays).to eq(weekdays)
       expect(ws.root('sum')).to eq(28)
     end
 

--- a/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_provision_spec.rb
@@ -1,7 +1,8 @@
 module MiqAeProvisionSpec
   include MiqAeEngine
   describe "MiqAeProvision" do
-    EXPECTED_CUSTOMIZATION = {
+    let(:expected_customization) do
+    {
       :password             => {
         :plaintext => "true"
       },
@@ -39,6 +40,7 @@ module MiqAeProvisionSpec
         :deleteAccounts => 0
       }
     }
+    end
 
     context "Using provision yaml model" do
       before(:each) do
@@ -125,7 +127,7 @@ module MiqAeProvisionSpec
       it "should instantiate customization" do
         ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_customization", @user)
         expect(ws).not_to be_nil
-        expect(ws.root("customization")).to eq(EXPECTED_CUSTOMIZATION)
+        expect(ws.root("customization")).to eq(expected_customization)
       end
 
       it "should have Network class" do

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -42,18 +42,14 @@ describe MiqLdap do
     end
   end
 
-  USERS = [
-    'rock@mycompany.com',
-    'smith@mycompany.com',
-    'will@mycompany.com',
-    'john@mycompany.com',
-  ]
+  let(:users) { %w(rock@mycompany.com smith@mycompany.com will@mycompany.com john@mycompany.com) }
+
   it "gets user information" do
     if @userid
       ldap = MiqLdap.new(:host => @host, :basedn => 'dc=mycompany,dc=com', :user_type => 'mail')
       ldap.bind(@userid, @password)
 
-      USERS.sort.each do |u|
+      users.sort.each do |u|
         udata = ldap.get_user_info(u)
         next if udata.nil?
         # puts "\nUser Data for #{udata[:display_name]}:"

--- a/spec/lib/vmdb/configuration_encoder_spec.rb
+++ b/spec/lib/vmdb/configuration_encoder_spec.rb
@@ -44,44 +44,52 @@ describe Vmdb::ConfigurationEncoder do
     end
   end
 
-  VMDB_CONFIG_STRINGS = <<-YAML
+  let(:vmdb_config_strings) do
+  <<-YAML
   one:
     two: two
     three:
       four: four
   YAML
+  end
 
-  VMDB_CONFIG_SYMBOLIZED = <<-YAML
+
+  let(:vmdb_config_symbolized) do
+  <<-YAML
   :one:
     :two: two
     :three:
       four: four
   YAML
+  end
 
-  VMDB_CONFIG_MIXED = <<-YAML
+  let(:vmdb_config_mixed) do
+  <<-YAML
   :one:
     two: two
     :three:
       four: four
   YAML
+  end
 
-  VMDB_CONFIG_NUMERICS = <<-YAML
+  let(:vmdb_config_numerics) do
+  <<-YAML
   :1:
     2: two
   3:
     "4":
       5: five
   YAML
+  end
 
-  VMDB_CONFIG_DIFFERENT_STRINGS = <<-YAML
+  let(:vmdb_config_different_strings) do
+  <<-YAML
   one:
     two: one
     three:
       four: one
   YAML
-
-  VMDB_CONFIG_NUMERICS_SYMBOLIZED_HASH = {:"1" => {:"2" => "two"}, :"3" => {:"4" => {5 => "five"}}}
-  VMDB_CONFIG_SYMBOLIZED_HASH = YAML.load(VMDB_CONFIG_SYMBOLIZED)
+  end
 
   shared_examples_for '.load' do
     it "blank should return empty hash" do
@@ -89,22 +97,24 @@ describe Vmdb::ConfigurationEncoder do
     end
 
     context "symbolizes" do
+      let(:vmdb_config_numerics_symbolized_hash) { {:"1" => {:"2" => "two"}, :"3" => {:"4" => {5 => "five"}}} }
+      let(:vmdb_config_symbolized_hash) { YAML.load(vmdb_config_symbolized) }
       it "two levels of stringed keys" do
-        expect(described_class.load(VMDB_CONFIG_STRINGS)).to eq(VMDB_CONFIG_SYMBOLIZED_HASH)
+        expect(described_class.load(vmdb_config_strings)).to eq(vmdb_config_symbolized_hash)
       end
 
       it "two levels of mixed keys" do
-        expect(described_class.load(VMDB_CONFIG_MIXED)).to eq(VMDB_CONFIG_SYMBOLIZED_HASH)
+        expect(described_class.load(vmdb_config_mixed)).to eq(vmdb_config_symbolized_hash)
       end
 
       it "numerics" do
-        expect(described_class.load(VMDB_CONFIG_NUMERICS)).to eq(VMDB_CONFIG_NUMERICS_SYMBOLIZED_HASH)
+        expect(described_class.load(vmdb_config_numerics)).to eq(vmdb_config_numerics_symbolized_hash)
       end
 
       it "all hashes for easy merging" do
-        string_keyed_hash = described_class.load(VMDB_CONFIG_DIFFERENT_STRINGS)
-        symbol_keyed_hash = described_class.load(VMDB_CONFIG_SYMBOLIZED)
-        expect(string_keyed_hash.merge(symbol_keyed_hash)).to eq(VMDB_CONFIG_SYMBOLIZED_HASH)
+        string_keyed_hash = described_class.load(vmdb_config_different_strings)
+        symbol_keyed_hash = described_class.load(vmdb_config_symbolized)
+        expect(string_keyed_hash.merge(symbol_keyed_hash)).to eq(vmdb_config_symbolized_hash)
       end
     end
 

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -1,7 +1,7 @@
 describe EmsEvent do
-  context ".add_vc" do
-    DATA_DIR = Rails.root.join("spec/models/manageiq/providers/vmware/infra_manager/event_data")
+  let(:data_dir) { Rails.root.join("spec/models/manageiq/providers/vmware/infra_manager/event_data") }
 
+  context ".add_vc" do
     before(:each) do
       @zone = FactoryGirl.create(:small_environment)
       @ems = @zone.ext_management_systems.first
@@ -10,7 +10,7 @@ describe EmsEvent do
     end
 
     it "with a GeneralUserEvent" do
-      raw_event = YAML.load_file(File.join(DATA_DIR, 'general_user_event.yml'))
+      raw_event = YAML.load_file(File.join(data_dir, 'general_user_event.yml'))
       mock_raw_event_vm(raw_event)
       mock_raw_event_host(raw_event)
 
@@ -39,7 +39,7 @@ describe EmsEvent do
 
     context "with an EventEx event" do
       it "with an eventTypeId" do
-        raw_event = YAML.load_file(File.join(DATA_DIR, 'event_ex.yml'))
+        raw_event = YAML.load_file(File.join(data_dir, 'event_ex.yml'))
         mock_raw_event_host(raw_event)
 
         EmsEvent.add_vc(@ems.id, raw_event)
@@ -55,7 +55,7 @@ describe EmsEvent do
       end
 
       it "without an eventTypeId" do
-        raw_event = YAML.load_file(File.join(DATA_DIR, 'event_ex_without_eventtypeid.yml'))
+        raw_event = YAML.load_file(File.join(data_dir, 'event_ex_without_eventtypeid.yml'))
         mock_raw_event_host(raw_event)
 
         EmsEvent.add_vc(@ems.id, raw_event)
@@ -101,12 +101,13 @@ describe EmsEvent do
   end
 
   context ".process_container_entities_in_event!" do
+    let(:ems_ref) { "test_ems_ref" }
+
     before :each do
       @ems = FactoryGirl.create(:ems_kubernetes)
       @container_project = FactoryGirl.create(:container_project, :ext_management_system => @ems)
-      EMS_REF = "test_ems_ref"
       @event_hash = {
-        :ems_ref => EMS_REF,
+        :ems_ref => ems_ref,
         :ems_id  => @ems.id
       }
     end
@@ -116,7 +117,7 @@ describe EmsEvent do
         @container_node = FactoryGirl.create(:container_node,
                                              :ext_management_system => @ems,
                                              :name                  => "Test Node",
-                                             :ems_ref               => EMS_REF)
+                                             :ems_ref               => ems_ref)
       end
 
       it "should link node id to event" do
@@ -131,7 +132,7 @@ describe EmsEvent do
                                               :ext_management_system => @ems,
                                               :container_project     => @container_project,
                                               :name                  => "Test Group",
-                                              :ems_ref               => EMS_REF)
+                                              :ems_ref               => ems_ref)
       end
 
       it "should link pod id to event" do
@@ -146,7 +147,7 @@ describe EmsEvent do
                                                    :ext_management_system => @ems,
                                                    :container_project     => @container_project,
                                                    :name                  => "Test Replicator",
-                                                   :ems_ref               => EMS_REF)
+                                                   :ems_ref               => ems_ref)
       end
 
       it "should link replicator id to event" do


### PR DESCRIPTION
fixes:
```
spec/models/ems_event_spec.rb:107: warning: previous definition of EMS_REF was here
````

Also fixes potential errors

There are a bunch more, maybe get the next pass

