### PR TITLE
Replace images with font icons on Button Group editing/reordering page

### DIFF
--- a/app/views/shared/buttons/_column_lists.html.haml
+++ b/app/views/shared/buttons/_column_lists.html.haml
@@ -16,28 +16,34 @@
             :style    => "width: 450px",
             :size     => 8,
             :id       => "available_fields")
-        %td{:width => "30", :valign => "middle"}
-          - if @edit[:new][:available_fields].length == 0
-            = image_tag(image_path('toolbars/right.png'), :class => "dimmed rollover small")
-          - else
-            - t = _("Move selected fields right")
-            = link_to(image_tag(image_path('toolbars/right.png'), :class => "rollover small", :alt => t),
-              {:action => 'group_form_field_changed', :button => 'right', :id => @custom_button_set.id || 'new'},
-              "data-submit" => 'column_lists',
-              :remote       => true,
-              "data-method" => :post,
-              :title        => t)
-
-          - if @edit[:new][:fields].length == 0
-            = image_tag(image_path('toolbars/left.png'), :class => "dimmed rollover small")
-          - else
-            - t = _("Move selected fields left")
-            = link_to(image_tag(image_path('toolbars/left.png'), :class => "rollover small", :alt => t),
-              {:action => 'group_form_field_changed', :button => 'left', :id => @custom_button_set.id || 'new'},
-              "data-submit" => 'column_lists',
-              :remote       => true,
-              "data-method" => :post,
-              :title        => t)
+        %td.text-center{:width => "40"}
+          .btn-group-vertical
+            - if @edit[:new][:available_fields].length == 0
+              %button.btn.btn-default.btn-disabled
+                %i.fa.fa-angle-right.fa-lg
+            - else
+              - t = _("Move selected fields right")
+              %button.btn.btn-default{:title           => t,
+                                      :remote          => true,
+                                      "data-submit"    => 'column_lists',
+                                      "data-method"    => :post,
+                                      "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                           :button => 'right',
+                                                                           :id     => @custom_button_set.id || 'new')}.to_json}
+                %i.fa.fa-angle-right.fa-lg
+            - if @edit[:new][:fields].length == 0
+              %button.btn.btn-default.btn-disabled
+                %i.fa.fa-angle-left.fa-lg
+            - else
+              - t = _("Move selected fields left")
+              %button.btn.btn-default{:title           => t,
+                                      :remote          => true,
+                                      "data-submit"    => 'column_lists',
+                                      "data-method"    => :post,
+                                      "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                           :button => 'left',
+                                                                           :id     => @custom_button_set.id || 'new')}.to_json}
+                %i.fa.fa-angle-left.fa-lg
       %td{:align => "left", :valign => "top"}
         = select_tag('selected_fields[]',
           options_for_select(@edit[:new][:fields], @selected),
@@ -47,44 +53,54 @@
           :id       => "selected_fields")
       %td{:width => "30", :valign => "middle"}
         - if @edit[:new][:fields].length < 2
-          = image_tag(image_path('toolbars/top.png'), :class => "dimmed rollover small")
+          %button.btn.btn-default.btn-disabled
+            %i.fa.fa-angle-double-up.fa-lg
         - else
           - t = _("Move selected fields to top")
-          = link_to(image_tag(image_path('toolbars/top.png'), :class => "rollover small", :alt => t),
-            {:action  => 'group_form_field_changed', :button  => 'top', :id => @custom_button_set.id || "new"},
-            "data-submit" => 'column_lists',
-            :remote       => true,
-            "data-method" => :post,
-            :title        => t)
-
+          %button.btn.btn-default{:title           => t,
+                                  :remote          => true,
+                                  "data-submit"    => 'column_lists',
+                                  "data-method"    => :post,
+                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                       :button => 'top',
+                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
+            %i.fa.fa-angle-double-up.fa-lg
         - if @edit[:new][:fields].length < 2
-          = image_tag(image_path('toolbars/up.png'), :class => "dimmed rollover small")
+          %button.btn.btn-default.btn-disabled
+            %i.fa.fa-angle-up.fa-lg
         - else
           - t = _("Move selected fields up")
-          = link_to(image_tag(image_path('toolbars/up.png'), :class => "rollover small", :alt => t),
-          {:action => 'group_form_field_changed', :button => 'up', :id => @custom_button_set.id || "new"},
-          "data-submit" => 'column_lists',
-          :remote       => true,
-          "data-method" => :post,
-          :title        => t)
+          %button.btn.btn-default{:title           => t,
+                                  :remote          => true,
+                                  "data-submit"    => 'column_lists',
+                                  "data-method"    => :post,
+                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                       :button => 'up',
+                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
+            %i.fa.fa-angle-up.fa-lg
         - if @edit[:new][:fields].length < 2
-          = image_tag(image_path('toolbars/down.png'), :class => "dimmed rollover small")
+          %button.btn.btn-default.btn-disabled
+            %i.fa.fa-angle-down.fa-lg
         - else
           - t = _("Move selected fields down")
-          = link_to(image_tag(image_path('toolbars/down.png'), :class => "rollover small", :alt => t),
-            {:action => 'group_form_field_changed', :button => 'down', :id => @custom_button_set.id || 'new'},
-            "data-submit" => 'column_lists',
-            :remote       => true,
-            "data-method" => :post,
-            :title        => t)
-
+          %button.btn.btn-default{:title           => t,
+                                  :remote          => true,
+                                  "data-submit"    => 'column_lists',
+                                  "data-method"    => :post,
+                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                       :button => 'down',
+                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
+            %i.fa.fa-angle-down.fa-lg
         - if @edit[:new][:fields].length < 2
-          = image_tag(image_path('toolbars/bottom.png'), :class => "dimmed rollover small")
+          %button.btn.btn-default.btn-disabled
+            %i.fa.fa-angle-double-down.fa-lg
         - else
           - t = _("Move selected fields to bottom")
-          = link_to(image_tag(image_path('toolbars/bottom.png'), :class => "rollover small", :alt => t),
-            {:action => 'group_form_field_changed', :button => 'bottom', :id => @custom_button_set.id || 'new'},
-            "data-submit" => 'column_lists',
-            :remote       => true,
-            "data-method" => :post,
-            :title        => t)
+          %button.btn.btn-default{:title           => t,
+                                  :remote          => true,
+                                  "data-submit"    => 'column_lists',
+                                  "data-method"    => :post,
+                                  "data-click_url" => {:url => url_for(:action => 'group_form_field_changed',
+                                                                       :button => 'bottom',
+                                                                       :id     => @custom_button_set.id || 'new')}.to_json}
+            %i.fa.fa-angle-double-down.fa-lg

--- a/app/views/shared/buttons/_group_order_form.html.haml
+++ b/app/views/shared/buttons/_group_order_form.html.haml
@@ -18,25 +18,30 @@
                 :id       => "selected_fields")
             %td{:width => "30", :align => "left", :valign => "middle"}
               - if @edit[:new][:fields].length < 2
-                = image_tag(image_path('toolbars/up.png'), :class => "dimmed small")
+                %button.btn.btn-default.btn-disabled
+                  %i.fa.fa-angle-up.fa-lg
               - else
                 - t = _("Move selected fields up")
-                = link_to(image_tag(image_path('toolbars/up.png'), :class => "rollover small", :alt => t),
-                  {:action => 'group_reorder_field_changed', :button => 'up', :id => "seq"},
-                  "data-submit" => "column_lists",
-                  :remote       => true,
-                  "data-method" => :post,
-                  :title        => t)
-
+                %button.btn.btn-default{:title           => t,
+                                        :remote          => true,
+                                        "data-submit"    => "column_list",
+                                        "data-method"    => :post,
+                                        "data-click_url" => {:url => url_for(:action => 'group_reorder_field_changed',
+                                                                             :button => 'up',
+                                                                             :id     => "seq")}.to_json}
+                  %i.fa.fa-angle-up.fa-lg
               - if @edit[:new][:fields].length < 2
-                = image_tag(image_path('toolbars/down.png'), :class => "dimmed small")
+                %button.btn.btn-default.btn-disabled
+                  %i.fa.fa-angle-down.fa-lg
               - else
                 - t = _("Move selected fields down")
-                = link_to(image_tag(image_path('toolbars/down.png'), :class => "rollover small", :alt => t),
-                  {:action => 'group_reorder_field_changed', :button => 'down', :id => "seq"},
-                  "data-submit" => "column_lists",
-                  :remote       => true,
-                  "data-method" => :post,
-                  :title        => t)
+                %button.btn.btn-default{:title           => t,
+                                        :remote          => true,
+                                        "data-submit"    => "column_list",
+                                        "data-method"    => :post,
+                                        "data-click_url" => {:url => url_for(:action => 'group_reorder_field_changed',
+                                                                             :button => 'down',
+                                                                             :id     => "seq")}.to_json}
+                  %i.fa.fa-angle-down.fa-lg
           .note
             = _('* Select one or more consecutive groups to move up or down.')


### PR DESCRIPTION
Trello task: https://trello.com/c/dNu0u279/153-8-replace-images-with-font-icons-in-forms

Before:
![screencapture-localhost-3000-miq_ae_customization-explorer-1454927653396](https://cloud.githubusercontent.com/assets/1187051/12883391/0140ae20-ce58-11e5-8d0f-1f4ba21dfa23.png)

After:
![screencapture-localhost-3000-miq_ae_customization-explorer-1454927612002](https://cloud.githubusercontent.com/assets/1187051/12883392/02c9fad0-ce58-11e5-9653-7aea5205add4.png)

___

Before:
![screencapture-localhost-3000-miq_ae_customization-explorer-1454942533672](https://cloud.githubusercontent.com/assets/1187051/12888485/b2f77bb8-ce7a-11e5-9434-7c780f1e22c3.png)
After:
![screencapture-localhost-3000-miq_ae_customization-explorer-1454942225141](https://cloud.githubusercontent.com/assets/1187051/12888486/b6c2f95c-ce7a-11e5-95ec-d4ae9d441538.png)
