### PR TITLE
Fix retrieval of ui.mark_translated_strings config value

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -13,7 +13,7 @@ begin
     db_file  = Rails.root.join("config", "vmdb.yml.db")
     template = Rails.root.join("config", "vmdb.tmpl.yml")
     config_file = File.exist?(db_file) ? db_file : template
-    if YAML.load(File.read(config_file)).fetch_path(:ui, :mark_translated_strings)
+    if YAML.load(File.read(config_file)).fetch_path("ui", "mark_translated_strings")
       include Vmdb::Gettext::Debug
     end
   end


### PR DESCRIPTION
The actual config keys need to be strings, rather than symbols.