### PR TITLE
Renamed samples of policy reports

### DIFF
--- a/product/reports/520_Events - Policy/110_Policy Events.yaml
+++ b/product/reports/520_Events - Policy/110_Policy Events.yaml
@@ -3,7 +3,7 @@ where_clause:
 dims: 
 created_on: 2009-04-03 16:56:10 Z
 reserved: 
-title: Policy Events for Last Week
+title: Policy Events for Last Week - Sample 1
 conditions: !ruby/object:MiqExpression
   exp:
     ">=":
@@ -12,7 +12,7 @@ conditions: !ruby/object:MiqExpression
 updated_on: 2009-04-06 20:19:27 Z
 order: Ascending
 graph: 
-menu_name: Policy Events for Last Week
+menu_name: Policy Events for Last Week - Sample 1
 rpt_group: Custom
 priority: 
 col_order: 

--- a/product/reports/520_Events - Policy/120_Policy Events2.yaml
+++ b/product/reports/520_Events - Policy/120_Policy Events2.yaml
@@ -3,7 +3,7 @@ where_clause:
 dims: 
 created_on: 2009-04-03 23:04:39 Z
 reserved: 
-title: Policy Events2 for Last Week
+title: Policy Events for Last Week - Sample 2
 conditions: !ruby/object:MiqExpression
   exp:
     ">=":
@@ -12,7 +12,7 @@ conditions: !ruby/object:MiqExpression
 updated_on: 2009-04-06 20:18:30 Z
 order: Ascending
 graph: 
-menu_name: Policy Events2 for Last Week
+menu_name: Policy Events for Last Week - Sample 2
 rpt_group: Custom
 priority: 
 col_order: 


### PR DESCRIPTION
Change names of policy reports to  "Policy Events for Last Week - Sample 1" and "Policy Events for Last Week - Sample 2"

https://bugzilla.redhat.com/show_bug.cgi?id=1303778