### PR TITLE
BZ1303024 - Fix for SSUI specific dynamic dropdown setup with auto refresh not working properly

### DIFF
--- a/app/models/dialog_field_date_control.rb
+++ b/app/models/dialog_field_date_control.rb
@@ -12,7 +12,7 @@ class DialogFieldDateControl < DialogField
   end
 
   def automate_output_value
-    return nil unless @value
+    return nil if @value.blank?
     Date.parse(@value).iso8601
   end
 

--- a/app/models/dialog_field_date_time_control.rb
+++ b/app/models/dialog_field_date_time_control.rb
@@ -2,7 +2,7 @@ class DialogFieldDateTimeControl < DialogFieldDateControl
   AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only)
 
   def automate_output_value
-    return nil unless @value
+    return nil if @value.blank?
     with_current_user_timezone { Time.zone.parse(@value).utc.iso8601 }
   end
 

--- a/spa_ui/self_service/client/app/services/dialog-field-refresh.service.js
+++ b/spa_ui/self_service/client/app/services/dialog-field-refresh.service.js
@@ -77,7 +77,11 @@
           dialogField.default_value = String(newDialogField.values[0][0]);
         }
       } else {
-        dialogField.default_value = newDialogField.values;
+        if (dialogField.type === 'DialogFieldDateControl' || dialogField.type === 'DialogFieldDateTimeControl') {
+          dialogField.default_value = new Date(newDialogField.values);
+        } else {
+          dialogField.default_value = newDialogField.values;
+        }
       }
 
       function copyDynamicAttributes(currentDialogField, newDialogField) {

--- a/spa_ui/self_service/client/app/services/dialog-field-refresh.service.spec.js
+++ b/spa_ui/self_service/client/app/services/dialog-field-refresh.service.spec.js
@@ -32,37 +32,108 @@ describe('app.services.DialogFieldRefresh', function() {
     describe('when the API call is successful', function() {
       var successResponse;
 
-      beforeEach(function() {
-        successResponse = {
-          result: {
-            dialog1: {
-              data_type: 'string',
-              options: 'options',
-              read_only: false,
-              required: false,
-              values: 'Text'
+      describe('when the dialogfield type is DialogFieldDateControl', function() {
+        beforeEach(function() {
+          successResponse = {
+            result: {
+              dialog1: {
+                type: 'DialogFieldDateControl',
+                options: 'options',
+                read_only: false,
+                required: false,
+                values: '2016-01-02T00:00:00+00:00Z'
+              }
             }
-          }
-        };
+          };
 
-        triggerAutoRefreshSpy = sinon.stub(DialogFieldRefresh, 'triggerAutoRefresh');
-        collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+          triggerAutoRefreshSpy = sinon.stub(DialogFieldRefresh, 'triggerAutoRefresh');
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+        });
+
+        it('updates the attributes for the dialog field', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(dialog1.options).to.eq('options');
+          expect(dialog1.read_only).to.be.false;
+          expect(dialog1.required).to.be.false;
+          expect(dialog1.default_value).to.eq(new Date('2016-01-02T00:00:00+00:00Z'));
+        });
+
+        it('triggers an auto-refresh', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(triggerAutoRefreshSpy).to.have.been.called;
+        });
       });
 
-      it('updates the attributes for the dialog field', function(done) {
-        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
-        done();
-        expect(dialog1.data_type).to.eq('string');
-        expect(dialog1.options).to.eq('options');
-        expect(dialog1.read_only).to.be.false;
-        expect(dialog1.required).to.be.false;
-        expect(dialog1.default_value).to.eq('Text');
+      describe('when the dialogfield type is DialogFieldDateTimeControl', function() {
+        beforeEach(function() {
+          successResponse = {
+            result: {
+              dialog1: {
+                type: 'DialogFieldDateTimeControl',
+                options: 'options',
+                read_only: false,
+                required: false,
+                values: '2016-01-02T12:34:00+00:00Z'
+              }
+            }
+          };
+
+          triggerAutoRefreshSpy = sinon.stub(DialogFieldRefresh, 'triggerAutoRefresh');
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+        });
+
+        it('updates the attributes for the dialog field', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(dialog1.options).to.eq('options');
+          expect(dialog1.read_only).to.be.false;
+          expect(dialog1.required).to.be.false;
+          expect(dialog1.default_value).to.eq('Text');
+          expect(dialog1.default_value).to.eq(new Date('2016-01-02T12:34:00+00:00Z'));
+        });
+
+        it('triggers an auto-refresh', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(triggerAutoRefreshSpy).to.have.been.called;
+        });
       });
 
-      it('triggers an auto-refresh', function(done) {
-        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
-        done();
-        expect(triggerAutoRefreshSpy).to.have.been.called;
+      describe('when the dialogfield type is anything else', function() {
+        beforeEach(function() {
+          successResponse = {
+            result: {
+              dialog1: {
+                data_type: 'string',
+                options: 'options',
+                read_only: false,
+                required: false,
+                values: 'Text'
+              }
+            }
+          };
+
+          triggerAutoRefreshSpy = sinon.stub(DialogFieldRefresh, 'triggerAutoRefresh');
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+        });
+
+        it('updates the attributes for the dialog field', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(dialog1.data_type).to.eq('string');
+          expect(dialog1.options).to.eq('options');
+          expect(dialog1.read_only).to.be.false;
+          expect(dialog1.required).to.be.false;
+          expect(dialog1.default_value).to.eq('Text');
+        });
+
+        it('triggers an auto-refresh', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(triggerAutoRefreshSpy).to.have.been.called;
+        });
       });
     });
   });

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -146,8 +146,8 @@ describe DialogFieldDateControl do
   describe "#automate_output_value" do
     let(:dialog_field) { described_class.new(:value => value) }
 
-    context "when the dialog_field does not have a value" do
-      let(:value) { nil }
+    context "when the dialog_field is blank" do
+      let(:value) { "" }
 
       it "returns nil" do
         expect(dialog_field.automate_output_value).to be_nil

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -47,6 +47,40 @@ describe DialogFieldDateTimeControl do
     end
   end
 
+  describe "#automate_output_value" do
+    let(:dialog_field) { described_class.new(:value => value) }
+
+    before do
+      allow(described_class).to receive(:server_timezone).and_return("UTC")
+    end
+
+    context "when the dialog_field is blank" do
+      let(:value) { "" }
+
+      it "returns nil" do
+        expect(dialog_field.automate_output_value).to be_nil
+      end
+    end
+
+    context "when the dialog_field has a value" do
+      context "when the value is a date formatted in ISO" do
+        let(:value) { "2013-08-07T12:34:00+00:00" }
+
+        it "returns the date and time in ISO format" do
+          expect(dialog_field.automate_output_value).to eq("2013-08-07T12:34:00Z")
+        end
+      end
+
+      context "when the value is a date formatted in %m/%d/%Y %H:%M" do
+        let(:value) { "08/07/2013 12:34" }
+
+        it "returns the date in ISO format" do
+          expect(dialog_field.automate_output_value).to eq("2013-08-07T12:34:00Z")
+        end
+      end
+    end
+  end
+
   describe "#value" do
     let(:dialog_field) { described_class.new(:dynamic => dynamic, :value => value) }
 


### PR DESCRIPTION
Dates and date time dialog fields were not being handled correctly when refreshed, causing the default date to be set instead of the date that was sent back from the API. I also found an issue while testing where the first refresh of a date field would return a script error so that has been fixed as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1303024