### PR TITLE
Add option to disable RequestRefererService in development

### DIFF
--- a/app/services/request_referer_service.rb
+++ b/app/services/request_referer_service.rb
@@ -167,7 +167,8 @@ class RequestRefererService
 
   def allowed_access?(request, controller_name, action_name, referer)
     access_whitelisted?(request, controller_name, action_name) ||
-      referer_valid?(request.referer, referer, request.headers, controller_name, action_name)
+      referer_valid?(request.referer, referer, request.headers, controller_name, action_name) ||
+      (ENV['MIQ_DISABLE_RRS'] && Rails.env.development?)
   end
 
   def referer_valid?(referer, saved_referer, headers, controller_name, action_name)


### PR DESCRIPTION
This feature is very obtrusive in local development. Visiting URLs directly is a must if you're causing interruptions and exceptions in development, and logging in every single time wastes quite a bit time.

Originally I figured we could just disable locally, but I figure some people might not appreciate that distinction of environments. This is purposely over protective in that you must opt-in with the environment variable (it's not disabled by default) _and_ be in the development environment, to keep as much parity with production behavior as possible and avoid any unfortunate confusion.