### PR TITLE
Rename HostsStorage model to match database table

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -430,7 +430,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def total_storages
-    HostsStorage.count(:conditions => {:host_id => host_ids}, :select => "DISTINCT storage_id")
+    HostStorage.count(:conditions => {:host_id => host_ids}, :select => "DISTINCT storage_id")
   end
 
   def vm_count_by_state(state)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -47,7 +47,8 @@ class Host < ApplicationRecord
   has_many                  :vms_and_templates, :dependent => :nullify
   has_many                  :vms, :inverse_of => :host
   has_many                  :miq_templates, :inverse_of => :host
-  has_and_belongs_to_many   :storages, :join_table => :host_storages
+  has_many                  :host_storages
+  has_many                  :storages, :through => :host_storages
   has_many                  :switches, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy

--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -1,0 +1,2 @@
+class HostStorage < ApplicationRecord
+end

--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -1,2 +1,4 @@
 class HostStorage < ApplicationRecord
+  belongs_to :host
+  belongs_to :storage
 end

--- a/app/models/hosts_storage.rb
+++ b/app/models/hosts_storage.rb
@@ -1,3 +1,0 @@
-class HostsStorage < ApplicationRecord
-  self.table_name = "host_storages"
-end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -3,7 +3,8 @@ class Storage < ApplicationRecord
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"
   has_many :miq_templates,     :foreign_key => :storage_id
   has_many :vms,               :foreign_key => :storage_id
-  has_and_belongs_to_many :hosts, :join_table => :host_storages
+  has_many :host_storages
+  has_many :hosts,             :through => :host_storages
   has_and_belongs_to_many :all_vms_and_templates, :class_name => "VmOrTemplate", :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_miq_templates,     :class_name => "MiqTemplate",  :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id
   has_and_belongs_to_many :all_vms,               :class_name => "Vm",           :join_table => :storages_vms_and_templates, :association_foreign_key => :vm_or_template_id

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -16,7 +16,7 @@ class Storage < ApplicationRecord
   has_many :storage_files,       :dependent => :destroy
   has_many :storage_files_files, -> { where "rsc_type = 'file'" }, :class_name => "StorageFile", :foreign_key => "storage_id"
   has_many :files,               -> { where "rsc_type = 'file'" }, :class_name => "StorageFile", :foreign_key => "storage_id"
-  has_many :hosts_storages
+  has_many :host_storages
 
   has_many :miq_events, :as => :target, :dependent => :destroy
 
@@ -590,7 +590,7 @@ class Storage < ApplicationRecord
     if @association_cache.include?(:hosts)
       hosts.size
     else
-      hosts_storages.length
+      host_storages.length
     end
   end
 

--- a/product/views/Storage.yaml
+++ b/product/views/Storage.yaml
@@ -40,7 +40,7 @@ include:
 
 # Included tables and columns for query performance
 include_for_find:
-  :hosts_storages: {}
+  :host_storages: {}
 
 # Order of columns (from all tables)
 col_order: 


### PR DESCRIPTION
The hosts_storages table was renamed host_storages, this renames the model accordingly so `self.table_name` isn't required in the model.