### PR TITLE
Fixes undefined method `miq_alert_statuses' for Cluster

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -17,7 +17,9 @@ class EmsCluster < ApplicationRecord
   has_many    :vim_performance_states, :as => :resource  # Destroy will be handled by purger
 
   has_many    :policy_events, -> { order "timestamp" }
-  has_many    :miq_events,             :as => :target,    :dependent => :destroy
+  has_many    :miq_events,         :as => :target,   :dependent => :destroy
+  has_many    :miq_alert_statuses, :as => :resource, :dependent => :destroy
+
 
   virtual_column :v_ram_vr_ratio,      :type => :float,   :uses => [:aggregate_memory, :aggregate_vm_memory]
   virtual_column :v_cpu_vr_ratio,      :type => :float,   :uses => [:aggregate_cpu_total_cores, :aggregate_vm_cpus]


### PR DESCRIPTION
Fixes  [NoMethodError]: undefined method `miq_alert_statuses' for Cluster