### PR TITLE
Fix bad parsing of failed systemctl service

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1134,7 +1134,7 @@ class Host < ApplicationRecord
   def refresh_services(ssu)
     xml = MiqXml.createDoc(:miq).root.add_element(:services)
 
-    services = ssu.shell_exec("systemctl -a --type service")
+    services = ssu.shell_exec("systemctl -a --type service --no-legend")
     if services
       # If there is a systemd use only that, chconfig is calling systemd on the background, but has misleading results
       services = MiqLinux::Utils.parse_systemctl_list(services)

--- a/gems/pending/metadata/linux/LinuxUtils.rb
+++ b/gems/pending/metadata/linux/LinuxUtils.rb
@@ -122,7 +122,7 @@ module MiqLinux
       lines.each_line.map do |line|
         line = line.chomp
         parts = line.split(' ')
-        next unless /^.*?\.service$/ =~ parts[0]
+        next if (/^.*?\.service$/ =~ parts[0]).nil?
 
         name, = parts[0].split('.')
 
@@ -138,7 +138,7 @@ module MiqLinux
          :enable_run_level  => nil,
          :disable_run_level => nil,
          :running           => parts[3] == 'running'}
-      end.compact!
+      end.compact
     end
 
     def self.parse_openstack_status(lines)


### PR DESCRIPTION
Failed services were not parsed, because if special characters