### PR TITLE
UI generates icon name false

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -8,8 +8,8 @@ class TreeNodeBuilder
     node = {
       :key   => key,
       :title => text,
-      :icon  => ActionController::Base.helpers.image_path("100/#{image}"),
     }
+    node[:icon]         = ActionController::Base.helpers.image_path("100/#{image}") if image
     node[:addClass]     = options[:style_class]      if options[:style_class]
     node[:cfmeNoClick]  = true                       if options[:cfme_no_click]
     node[:expand]       = options[:expand]           if options[:expand]


### PR DESCRIPTION
UI generates icon name false, instead of taking the false as
condition for not generating the icon

Fixes GH issue:
https://github.com/ManageIQ/manageiq/issues/6434