### PR TITLE
Expose direct orchestration stack to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-infra_manager.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_InfraManager < MiqAeServiceEmsInfra
     expose :orchestration_stacks, :association => true
+    expose :direct_orchestration_stacks, :association => true
   end
 end


### PR DESCRIPTION
This method is used in TripleO compute autoscaling examples