### PR TITLE
Add instance resize to openstack provider

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -40,6 +40,18 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     true
   end
 
+  def resize(new_flavor)
+    raw_resize(new_flavor)
+  end
+
+  def resize_confirm
+    raw_resize_confirm
+  end
+
+  def resize_revert
+    raw_resize_revert
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::Openstack::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
   include_concern 'Operations'
   include_concern 'RemoteConsole'
+  include_concern 'Resize'
 
   belongs_to :cloud_tenant
 

--- a/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/vm/resize.rb
@@ -1,0 +1,45 @@
+module ManageIQ::Providers::Openstack::CloudManager::Vm::Resize
+  def validate_resize
+    %w(ACTIVE SHUTOFF).include? raw_power_state
+  end
+
+  def raw_resize(new_flavor)
+    # TODO(maufart): check if a new flavor disk space is not smaller that the actual one?
+    ext_management_system.with_provider_connection(compute_connection_options) do |service|
+      service.resize_server(ems_ref, new_flavor.ems_ref)
+    end
+  rescue => err
+    _log.error "vm=[#{name}], flavor=[#{new_flavor.name}], error: #{err}"
+    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+  end
+
+  def validate_resize_confirm
+    raw_power_state == 'VERIFY_RESIZE'
+  end
+
+  def raw_resize_confirm
+    ext_management_system.with_provider_connection(compute_connection_options) do |service|
+      service.confirm_resize_server(ems_ref)
+    end
+  rescue => err
+    _log.error "vm=[#{name}], error: #{err}"
+    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+  end
+
+  def validate_resize_revert
+    raw_power_state == 'VERIFY_RESIZE'
+  end
+
+  def raw_resize_revert
+    ext_management_system.with_provider_connection(compute_connection_options) do |service|
+      service.revert_resize_server(ems_ref)
+    end
+  rescue => err
+    _log.error "vm=[#{name}], error: #{err}"
+    raise MiqException::MiqOpenstackApiRequestError, err.to_s, err.backtrace
+  end
+
+  def compute_connection_options
+    {:service => 'Compute', :tenant_name => cloud_tenant.name}
+  end
+end

--- a/spec/factories/vm_openstack.rb
+++ b/spec/factories/vm_openstack.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :vm_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::Vm", :parent => :vm_cloud do
     vendor          "openstack"
     raw_power_state "ACTIVE"
-    ems_ref         "openstack-vm"
+    sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
   end
 
   factory :vm_perf_openstack, :parent => :vm_openstack do


### PR DESCRIPTION
Vm resize methods were added to Openstack Cloud provider.
This commit contains a backend code and validate methods.
Resize Vm means change it's Flavor.