### PR TITLE
SSUI - add Group switcher

### DIFF
--- a/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
@@ -35,6 +35,11 @@
       vm.clearMessages = clearMessages;
       vm.API_BASE = API_BASE;
 
+      vm.group_switch = function(group) {
+        // TODO - reload with X-Miq-Group set to $group
+        console.log('chosen', group);
+      };
+
       function activate() {
         vm.messages = Messages.items;
       }

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.directive.js
@@ -34,11 +34,7 @@
       vm.toggleNavigation = toggleNavigation;
       vm.clearMessages = clearMessages;
       vm.API_BASE = API_BASE;
-
-      vm.group_switch = function(group) {
-        // TODO - reload with X-Miq-Group set to $group
-        console.log('chosen', group);
-      };
+      vm.group_switch = Session.switchGroup;
 
       function activate() {
         vm.messages = Messages.items;

--- a/spa_ui/self_service/client/app/components/navigation/header-nav.html
+++ b/spa_ui/self_service/client/app/components/navigation/header-nav.html
@@ -28,6 +28,33 @@
           <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
+          <!-- Group switcher -->
+          <li class="dropdown-submenu pull-left" ng-if="vm.user().groups.length > 1">
+            <a href="#">
+              <span translate>
+                Change Group:
+              </span>
+              <ul class="dropdown-menu scrollable-menu">
+                <li ng-repeat="group in vm.user().groups">
+                  <a href="#" title="{{'Select to change to another Group' | translate}}" ng-click="vm.group_switch(group)">
+                    {{group}}
+                    <span translate ng-if="group === vm.user().group">
+                      (Current Group)
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </a>
+          </li>
+          <li class="disabled" ng-if="! (vm.user().groups.length > 1)">
+            <a href="#" title="{{'Current Group' | translate}}">
+              {{vm.user().group}}
+            </a>
+          </li>
+          <!-- /Group switcher -->
+
+          <li class="action divider"></li>
+
           <li class="action"><a ui-sref="logout" translate>Logout</a></li>
         </ul>
       </li>

--- a/spa_ui/self_service/client/app/config/authorization.config.js
+++ b/spa_ui/self_service/client/app/config/authorization.config.js
@@ -72,7 +72,10 @@
 
       $sessionStorage.$sync();  // needed when called right on reload
       if ($sessionStorage.token) {
-        Session.create({ auth_token: $sessionStorage.token });
+        Session.create({
+          auth_token: $sessionStorage.token,
+          miqGroup: $sessionStorage.miqGroup,
+        });
 
         return Session.loadUser();
       }

--- a/spa_ui/self_service/client/app/resources/authentication-api.factory.js
+++ b/spa_ui/self_service/client/app/resources/authentication-api.factory.js
@@ -16,7 +16,8 @@
       return $http.get(API_BASE + '/api/auth?requester_type=ui', {
         headers: {
           'Authorization': 'Basic ' + $base64.encode([userLogin, password].join(':')),
-          'X-Auth-Token': void 0
+          'X-Auth-Token': undefined,
+          'X-Miq-Group': undefined,
         }
       }).then(loginSuccess, loginFailure);
 

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -27,13 +27,17 @@
     function create(data) {
       model.token = data.auth_token;
       $http.defaults.headers.common['X-Auth-Token'] = model.token;
+      $http.defaults.headers.common['X-Miq-Group'] = data.miqGroup || undefined;
       $sessionStorage.token = model.token;
+      $sessionStorage.miqGroup = data.miqGroup || null;
     }
 
     function destroy() {
       model.token = null;
       model.user = {};
       delete $http.defaults.headers.common['X-Auth-Token'];
+      delete $http.defaults.headers.common['X-Miq-Group'];
+      delete $sessionStorage.miqGroup;
       delete $sessionStorage.token;
     }
 

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -5,7 +5,7 @@
     .factory('Session', SessionFactory);
 
   /** @ngInject */
-  function SessionFactory($http, moment, $sessionStorage, gettextCatalog) {
+  function SessionFactory($http, moment, $sessionStorage, gettextCatalog, $window) {
     var model = {
       token: null,
       user: {}
@@ -18,6 +18,7 @@
       active: active,
       currentUser: currentUser,
       loadUser: loadUser,
+      switchGroup: switchGroup,
     };
 
     destroy();
@@ -57,6 +58,13 @@
       }
 
       return model.user;
+    }
+
+    function switchGroup(group) {
+      $sessionStorage.miqGroup = group;
+
+      // reload
+      $window.location = $window.location.href;
     }
 
     // Helpers

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -5,7 +5,7 @@
     .factory('Session', SessionFactory);
 
   /** @ngInject */
-  function SessionFactory($http, moment, $sessionStorage, gettextCatalog, $window) {
+  function SessionFactory($http, moment, $sessionStorage, gettextCatalog, $window, $state) {
     var model = {
       token: null,
       user: {}
@@ -63,8 +63,8 @@
     function switchGroup(group) {
       $sessionStorage.miqGroup = group;
 
-      // reload
-      $window.location.reload();
+      // reload .. but on dashboard
+      $window.location.href = $state.href('dashboard');
     }
 
     // Helpers

--- a/spa_ui/self_service/client/app/services/session.service.js
+++ b/spa_ui/self_service/client/app/services/session.service.js
@@ -64,7 +64,7 @@
       $sessionStorage.miqGroup = group;
 
       // reload
-      $window.location = $window.location.href;
+      $window.location.reload();
     }
 
     // Helpers

--- a/spa_ui/self_service/client/app/services/session.service.spec.js
+++ b/spa_ui/self_service/client/app/services/session.service.spec.js
@@ -11,7 +11,13 @@ describe('Session', function() {
       $provide.value('$window', {
         get location() {
           return {
-            href: window.location.href,
+            get href() {
+              return window.location.href;
+            },
+            set href(str) {
+              reloadOk = true;
+            },
+
             reload: function() {
               reloadOk = true;
             },

--- a/spa_ui/self_service/client/app/services/session.service.spec.js
+++ b/spa_ui/self_service/client/app/services/session.service.spec.js
@@ -1,0 +1,39 @@
+/* jshint -W117, -W030 */
+describe('Session', function() {
+  var reloadOk;
+
+  beforeEach(function() {
+    module('app.core', 'gettext');
+
+    reloadOk = false;
+
+    module(function($provide) {
+      $provide.value('$window', {
+        get location() {
+          return {
+            href: window.location.href,
+            reload: function() {
+              reloadOk = true;
+            },
+          };
+        },
+        set location(str) {
+          return;
+        },
+      });
+    });
+
+    bard.inject('Session', '$window', '$sessionStorage');
+  });
+
+  describe('switchGroup', function() {
+    it('should persist and reload', function() {
+      $sessionStorage.miqGroup = 'bad';
+
+      Session.switchGroup('good');
+
+      expect($sessionStorage.miqGroup).to.eq('good');
+      expect(reloadOk).to.eq(true);
+    });
+  });
+});


### PR DESCRIPTION
This adds a group switcher to the header-nav directive in SSUI.

All the group info is already available in the currentUser object (from /api .identity), which contains `group: current_group_name` and `groups: [ list of group names ]`, so we're just using it.

The switch itself will just trigger a reload, with the `X-Miq-Group` header set to the group name. The chosen group is persisted in `$sessionStorage`, the same way as the token itself. It's cleared on new logins or login failures.