### PR TITLE
fix Tag#find_or_create_by_name [deprecation warning]

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,7 +11,7 @@ class Tag < ApplicationRecord
   def self.add(list, options = {})
     ns = Tag.get_namespace(options)
     Tag.parse(list).each do |name|
-      Tag.find_or_create_by_name(File.join(ns, name))
+      Tag.find_or_create_by(:name => find_by_name(File.join(ns, name)))
     end
   end
 


### PR DESCRIPTION
remove deprecation warning

```
DEPRECATION WARNING: This dynamic method is deprecated. Please use e.g. Post.find_or_create_by(name: 'foo') instead.
(called from block in add at app/models/tag.rb:14)
```

this is trivial but wanted to test this in isolation.
