### PR TITLE
Deprecation in prep for Rbac#filtered and search

### DIFF
--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -1085,10 +1085,10 @@ describe Rbac do
       expect(Rbac.filtered([], :class => Vm)).to eq([])
     end
 
-    # TODO: return all_vms
-    it "skips rbac on nil targets" do
+    # fix once Rbac filtered is fixed
+    skip "skips rbac on nil targets" do
       all_vms
-      expect(Rbac.filtered(nil, :class => Vm)).to be_nil
+      expect(Rbac.filtered(nil, :class => Vm)).to match_array(all_vms)
     end
 
     # it returns objects too


### PR DESCRIPTION
part of converging rbac parameters and using scopes #5967

Document that we are making `Rbac.filtered` and `Rbac.search` consistent:

**Today:**

1. `Rbac.search` returns results for **all** records when the `targets` are passed in
as `[]` or `nil`.
2. `Rbac.filtered` returns **empty** results for all records when `targets` are
passed in as `[]` or `nil`.

**Future:**

1. `Rbac.search(:targets => nil)` and `Rbac.filtered(nil)` searches **all** records.
2. `Rbac.search(:targets => [])` and `Rbac.filtered([])` returns **empty** results.
