### PR TITLE
Set RACK_RUBY_PROF variable to dump RubyProf profiles per request.

### DIFF
--- a/config/initializers/rack_ruby_prof.rb
+++ b/config/initializers/rack_ruby_prof.rb
@@ -1,0 +1,18 @@
+if ENV['RACK_RUBY_PROF']
+  output = Rails.root.join('tmp/rack_ruby_prof')
+  puts "** Rack::RubyProf is enabled, each request will dump to '#{output}'."
+  puts "** Unset RACK_RUBY_PROF to turn off profiling."
+
+  begin
+    require 'ruby-prof'
+  rescue LoadError
+    puts "Failed! Please make sure ruby-prof is in your Gemfile."
+  else
+    Rails.application.config.middleware.use(
+      Rack::RubyProf,
+      :path        => output,
+      :printers    => {RubyProf::CallStackPrinter => 'call_stack.html'},
+      :min_percent => 2
+    )
+  end
+end


### PR DESCRIPTION
All you have to do is add `gem "ruby-prof"` to the `Gemfile.dev.rb`, run `bundle`.
Setting `RACK_RUBY_PROF` will run your rails server with Rack::RubyProf, which
will dump callstack htmls on each rack request.

**UPDATED:** changed name of gemfile and added ENV var name @kbrock