### PR TITLE
Do not display an empty Product Assistance Box for non-admin if the custom url is not defined

### DIFF
--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -23,7 +23,7 @@
       - desc = get_vmdb_config[:server][:custom_support_url_description]
       - url  = get_vmdb_config[:server][:custom_support_url]
       - cond_url      = desc.present? && url.present?
-      - if admin_user? || cond_url
+      - if admin_user? || (!admin_user? && cond_url)
         .col-md-12.col-lg-6
           %fieldset
             %h3= _('Product Assistance')
@@ -43,15 +43,15 @@
                 &nbsp;
                 = link_to((_("%s Guide") % title), docfile_path, :onclick => "return miqClickAndPop(this);")
                 %br
-              - if cond_url
-                %br
-                - url = "http://" + url if !url.starts_with?("http://") && !url.starts_with?("https://")
-                = link_to(desc, url, :onclick => "return miqClickAndPop(this);")
-                %br
+            - if cond_url
               %br
-              - rh_cust_portal = link_to(_("Red Hat Customer Portal"),
-                                         "https://access.redhat.com/home",
-                                         :onclick => "return miqClickAndPop(this);")
-              = _("For questions or problem reporting, go to the")
-              = rh_cust_portal
+              - url = "http://" + url if !url.starts_with?("http://") && !url.starts_with?("https://")
+              = link_to(desc, url, :onclick => "return miqClickAndPop(this);")
               %br
+            %br
+            - rh_cust_portal = link_to(_("Red Hat Customer Portal"),
+                                       "https://access.redhat.com/home",
+                                       :onclick => "return miqClickAndPop(this);")
+            = _("For questions or problem reporting, go to the")
+            = rh_cust_portal
+            %br

--- a/app/views/support/show.html.haml
+++ b/app/views/support/show.html.haml
@@ -48,10 +48,11 @@
               - url = "http://" + url if !url.starts_with?("http://") && !url.starts_with?("https://")
               = link_to(desc, url, :onclick => "return miqClickAndPop(this);")
               %br
-            %br
-            - rh_cust_portal = link_to(_("Red Hat Customer Portal"),
-                                       "https://access.redhat.com/home",
-                                       :onclick => "return miqClickAndPop(this);")
-            = _("For questions or problem reporting, go to the")
-            = rh_cust_portal
-            %br
+            - if admin_user?
+              %br
+              - rh_cust_portal = link_to(_("Red Hat Customer Portal"),
+                                         "https://access.redhat.com/home",
+                                         :onclick => "return miqClickAndPop(this);")
+              = _("For questions or problem reporting, go to the")
+              = rh_cust_portal
+              %br


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1275840

The custom url will be displayed if defined for both admin and non-admin users.