### PR TITLE
Enable RSpec 3's --only-failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ public/stylesheets/jmaki-3column-footer.css
 public/stylesheets/jmaki-standard-no-sidebars.css
 public/stylesheets/jmaki-standard-right-sidebar.css
 
+# spec/
+spec/examples.txt
+
 # tmp/
 tmp/*
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,9 @@ RSpec.configure do |config|
   # `post` methods in spec/controllers, without specifying type
   config.infer_spec_type_from_file_location!
 
+  # File store for --only-failures option
+  config.example_status_persistence_file_path = "./spec/examples.txt"
+
   config.include VMDBConfigurationHelper
 
   config.define_derived_metadata(:file_path => /spec\/lib\/miq_automation_engine\/models/) do |metadata|


### PR DESCRIPTION
This enables the --only-failures option by setting a file store, a useful tool with a large set of specs such as these.

The --only-failures option filters what examples are run so that only those that failed the last time they ran are executed. There's also a --next-failure option. It allows you to repeatedly focus on just one of the currently failing examples, then move on to the next failure, etc.