### PR TITLE
Add orderable column to orchestration_templates

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -991,7 +991,7 @@ class CatalogController < ApplicationController
         ot.draft = @edit[:new][:draft]
       end
       begin
-        ot.save_with_format_validation!
+        ot.save_as_orderable!
       rescue StandardError => bang
         add_flash(_("Error during '%s': ") % "Orchestration Template Edit" << bang.message, :error)
         ot_action_submit_flash
@@ -1045,7 +1045,7 @@ class CatalogController < ApplicationController
         :content     => params[:template_content],
         :draft       => @edit[:new][:draft] == true || @edit[:new][:draft] == "true")
       begin
-        ot.save_with_format_validation!
+        ot.save_as_orderable!
       rescue StandardError => bang
         add_flash(_("Error during '%s': ") % "Orchestration Template Copy" << bang.message, :error)
         ot_action_submit_flash
@@ -1091,7 +1091,7 @@ class CatalogController < ApplicationController
         :content     => params[:content],
         :draft       => @edit[:new][:draft])
       begin
-        ot.save_with_format_validation!
+        ot.save_as_orderable!
       rescue StandardError => bang
         add_flash(_("Error during '%s': ") % "Orchestration Template creation" << bang.message, :error)
         ot_action_submit_flash

--- a/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/refresh_parser.rb
@@ -512,6 +512,7 @@ class ManageIQ::Providers::Amazon::CloudManager::RefreshParser < ManageIQ::Provi
       :name        => stack.name,
       :description => stack.description,
       :content     => stack.client.get_template(:stack_name => stack.name).template_body,
+      :orderable   => false
     }
     return uid, new_result
   end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -426,7 +426,8 @@ module ManageIQ::Providers
           :type        => "OrchestrationTemplateAzure",
           :name        => deployment.name,
           :description => "contentVersion: #{ver}",
-          :content     => content
+          :content     => content,
+          :orderable   => false
         }
         return uid, new_result
       end

--- a/app/models/manageiq/providers/openstack/refresh_parser_common/orchestration_stacks.rb
+++ b/app/models/manageiq/providers/openstack/refresh_parser_common/orchestration_stacks.rb
@@ -71,7 +71,8 @@ module ManageIQ::Providers
             :type        => template_type,
             :name        => stack.stack_name,
             :description => template.description,
-            :content     => template.content
+            :content     => template.content,
+            :orderable   => false
           }
           return uid, new_result
         end

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -10,6 +10,7 @@ class OrchestrationTemplate < ApplicationRecord
   has_many :stacks, :class_name => "OrchestrationStack"
 
   default_value_for :draft, false
+  default_value_for :orderable, true
 
   validates :md5,
             :uniqueness => {:scope => :draft, :message => "of content already exists (content must be unique)"},
@@ -27,12 +28,13 @@ class OrchestrationTemplate < ApplicationRecord
     end
   end
 
+  # available templates for ordering an orchestration service
   def self.available
-    where(:draft => false)
+    where(:draft => false, :orderable => true)
   end
 
   def self.find_with_content(template_content)
-    available.find_by(:md5 => calc_md5(with_universal_newline(template_content)))
+    where(:draft => false).find_by(:md5 => calc_md5(with_universal_newline(template_content)))
   end
 
   # Find only by template content. Here we only compare md5 considering the table is expected
@@ -51,7 +53,7 @@ class OrchestrationTemplate < ApplicationRecord
       end
     end
 
-    existing_templates = available.where(:md5 => md5s).index_by(&:md5)
+    existing_templates = where(:draft => false, :md5 => md5s).index_by(&:md5)
 
     hashes.zip(md5s).collect do |hash, md5|
       template = existing_templates[md5]
@@ -108,13 +110,43 @@ class OrchestrationTemplate < ApplicationRecord
     raise NotImplementedError, "validate_format must be implemented in subclass"
   end
 
-  def save_with_format_validation!
+  # use cases for md5 conflict:
+  # draft: always save, new or existing
+  # existing:
+  #   discovered duplicate: take over stacks and delete the discovered one
+  #   orderable duplicate: raise error through save! validation
+  # new:
+  #   discovered duplicate: promote discovered to orderable
+  #   orderable duplicate: raise error through save! validation)
+  def save_as_orderable!
     error_msg = validate_format unless draft
     raise MiqException::MiqParsingError, error_msg if error_msg
-    save!
+
+    self.orderable = true
+    return save! if draft?
+
+    old_template = self.class.find_with_content(content)
+    return save! if old_template.nil? || old_template.orderable
+
+    new_record? ? replace_with_old_template(old_template) : transfer_stacks(old_template)
   end
 
   private
+
+  # This is an unsaved template. Replace with an existing one after it is updated
+  def replace_with_old_template(old_template)
+    old_template.update(:name => name, :description => description, :orderable => true)
+    self.id = old_template.id
+    reload
+    true
+  end
+
+  # Take over stacks belongs to the old template and delete the old template
+  def transfer_stacks(old_template)
+    old_template.stacks.update_all(:orchestration_template_id => id)
+    old_template.delete
+    save!
+  end
 
   def md5=(_md5)
     super

--- a/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
+++ b/db/migrate/20160203101130_add_orderable_to_orchestration_templates.rb
@@ -1,0 +1,15 @@
+class AddOrderableToOrchestrationTemplates < ActiveRecord::Migration
+  class OrchestrationTemplate < ActiveRecord::Base; end
+
+  def self.up
+    add_column :orchestration_templates, :orderable, :boolean
+
+    say_with_time("Update OrchestrationTemplate orderable") do
+      OrchestrationTemplate.update_all(:orderable => true)
+    end
+  end
+
+  def self.down
+    remove_column :orchestration_templates, :orderable
+  end
+end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/refresher_spec.rb
@@ -474,6 +474,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::Refresher do
     @orch_template = OrchestrationTemplateCfn.where(:md5 => "e929859521d64ac28ee29f8526d33e8f").first
     expect(@orch_template.description).to start_with("AWS CloudFormation Sample Template WordPress_Simple:")
     expect(@orch_template.content).to start_with("{\n  \"AWSTemplateFormatVersion\" : \"2010-09-09\",")
+    expect(@orch_template).to have_attributes(:draft => false, :orderable => false)
   end
 
   def assert_specific_orchestration_stack


### PR DESCRIPTION
User added templates are orderable by default.
Auto collected templates from provider are default to non-orderable.

https://bugzilla.redhat.com/show_bug.cgi?id=1302810

The migration will treat all existing templates as orderable.
The UI Service -> Catalogs -> Orchestration Templates should show only orderable templates.