### PR TITLE
Encrypt ldap bind password when queuing to MiqQueue

### DIFF
--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -96,6 +96,7 @@ describe Authenticator::Amazon do
     allow(MiqServer).to receive(:my_server).and_return(
       double(:my_server, :permitted_groups => [wibble, wobble])
     )
+    allow(MiqLdap).to receive(:using_ldap?) { false }
   end
 
   let(:user_data) do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -23,6 +23,7 @@ describe Authenticator::Httpd do
     allow(MiqServer).to receive(:my_server).and_return(
       double(:my_server, :permitted_groups => [wibble, wobble])
     )
+    allow(MiqLdap).to receive(:using_ldap?) { false }
   end
 
   describe '#uses_stored_password?' do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -93,6 +93,7 @@ describe Authenticator::Ldap do
 
   before(:each) do
     allow(MiqLdap).to receive(:new) { FakeLdap.new(user_data) }
+    allow(MiqLdap).to receive(:using_ldap?) { true }
   end
 
   describe '#uses_stored_password?' do
@@ -163,6 +164,20 @@ describe Authenticator::Ldap do
     let(:username) { 'alice' }
     let(:password) { 'secret' }
 
+    context "when using LDAP" do
+      let(:config) { super().merge(:ldap_role => true) }
+
+      before do
+        allow(MiqQueue).to receive(:put)
+        allow(MiqTask).to receive(:create).and_return(double(:id => :return_value))
+      end
+
+      it "encrypts password for queuing" do
+        expect(subject).to receive(:encrypt_ldap_password)
+        authenticate
+      end
+    end
+
     context "with correct password" do
       context "using local authorization" do
         it "succeeds" do
@@ -199,6 +214,15 @@ describe Authenticator::Ldap do
       context "using external authorization" do
         let(:config) { super().merge(:ldap_role => true) }
         before(:each) { allow(subject).to receive(:authorize_queue?).and_return(false) }
+
+        context "with an LDAP user" do
+          before { allow(subject).to receive(:run_task) }
+
+          it "decrypts password after dequeuing" do
+            expect(subject).to receive(:decrypt_ldap_password)
+            subject.authorize(22, 'alice', 1)
+          end
+        end
 
         it "enqueues an authorize task" do
           expect(subject).to receive(:authorize_queue).and_return(123)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1297576

This PR encrypts the Ldap bind password when placing it on the MiqQueue in Args
and decrypts it when popping the message off the MiqQueue. This ensures unencrypted
passwords are not in the DB and also prevents them from being logged.
