### PR TITLE
Update Azure refresher spec

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -5,9 +5,9 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_azure, :zone => zone, :provider_region => "eastus")
 
-    @client_id  = "AZURE_CLIENT_ID"
-    @client_key = "AZURE_CLIENT_SECRET"
-    @tenant_id  = "AZURE_TENANT_ID"
+    @client_id  = Rails.application.secrets.azure.try(:[], 'client_id') || 'AZURE_CLIENT_ID'
+    @client_key = Rails.application.secrets.azure.try(:[], 'client_secret') || 'AZURE_CLIENT_SECRET'
+    @tenant_id  = Rails.application.secrets.azure.try(:[], 'tenant_id') || 'AZURE_TENANT_ID'
 
     cred = {
       :userid   => @client_id,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,8 +123,8 @@ VCR.configure do |c|
     next if [:secret_key_base, :secret_token].include?(provider) # Defaults
     cred_hash = secrets.public_send(provider)
     cred_hash.each do |key, value|
-      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { CGI.escape(value) }
-      c.filter_sensitive_data("<#{provider.upcase}_#{key.upcase}>") { value }
+      c.filter_sensitive_data("#{provider.upcase}_#{key.upcase}") { CGI.escape(value) }
+      c.filter_sensitive_data("#{provider.upcase}_#{key.upcase}") { value }
     end
   end
 


### PR DESCRIPTION
This modifies the refresher spec to use config/secrets.yml by default. Also, remove the brackets in the VCR spec helper because they're invalid URL characters.

This replaces https://github.com/ManageIQ/manageiq/pull/6396.