### PR TITLE
dont load models in migrations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ RSpec.configure do |config|
   # end
 
   config.before(:each) do
-    EmsRefresh.debug_failures = true
+    EmsRefresh.debug_failures = true if defined?(EmsRefresh) && EmsRefresh.respond_to?(:debug_failures)
     ApplicationController.handle_exceptions = false
   end
   config.after(:each) do


### PR DESCRIPTION
This line loads models in specs. Not an issue in regular specs, but not good in migration specs.

This change no longer loads models in migration specs.
