### PR TITLE
Add a refresh button in the Container Provider summary page

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -396,6 +396,13 @@ module EmsCommon
         end
         return
       end
+      if params[:pressed] == "refresh_server_summary"
+        render :update do |page|
+          page.redirect_to  :back
+        end
+        return
+      end
+
       custom_buttons if params[:pressed] == "custom_button"
 
       return if ["custom_button"].include?(params[:pressed])    # custom button screen, so return, let custom_buttons method handle everything

--- a/product/toolbars/ems_cloud_center_tb.yaml
+++ b/product/toolbars/ems_cloud_center_tb.yaml
@@ -6,6 +6,9 @@
 :button_groups:
 - :name: ems_cloud_vmdb
   :items:
+  - :button: refresh_server_summary
+    :icon: fa fa-repeat fa-lg
+    :title: 'Reload Current Display'
   - :buttonSelect: ems_cloud_vmdb_choice
     :icon: fa fa-cog fa-lg
     :title: Configuration

--- a/product/toolbars/ems_container_center_tb.yaml
+++ b/product/toolbars/ems_container_center_tb.yaml
@@ -6,6 +6,9 @@
 :button_groups:
 - :name: ems_container_vmdb
   :items:
+  - :button: refresh_server_summary
+    :icon: fa fa-repeat fa-lg
+    :title: 'Reload Current Display'
   - :buttonSelect: ems_container_vmdb_choice
     :icon: fa fa-cog fa-lg
     :title: Configuration

--- a/product/toolbars/ems_infra_center_tb.yaml
+++ b/product/toolbars/ems_infra_center_tb.yaml
@@ -6,6 +6,9 @@
 :button_groups:
 - :name: ems_infra_vmdb
   :items:
+  - :button: refresh_server_summary
+    :icon: fa fa-repeat fa-lg
+    :title: 'Reload Current Display'
   - :buttonSelect: ems_infra_vmdb_choice
     :icon: fa fa-cog fa-lg
     :title: Configuration


### PR DESCRIPTION
There should be the standard refresh button in the provider summary as well.
I does exactly the same thing as configuration -> refresh.

![screenshot 2016-02-07 14-45-59](https://cloud.githubusercontent.com/assets/2181522/12872364/46710282-cdaa-11e5-9821-cebf6d046224.png)
