### PR TITLE
[WIP] Added chargeback to container groups

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -63,6 +63,7 @@ class Chargeback < ActsAsArModel
     cb = new
     report_user = User.find_by(:userid => options[:userid])
 
+    #_log.info("Aritag - options: #{options}")
     # Find Vms by user or by tag
     if options[:owner]
       user = User.find_by_userid(options[:owner])
@@ -72,8 +73,11 @@ class Chargeback < ActsAsArModel
       end
       vms = user.vms
     elsif options[:tag]
-      vms = Vm.find_tagged_with(:all => options[:tag], :ns => "*")
+      #_log.info("Aritag - elsif options[:tag]")
+      vms = [].concat(Vm.find_tagged_with(:all => options[:tag], :ns => "*"))
       vms &= report_user.accessible_vms if report_user && report_user.self_service?
+      vms.concat(ContainerGroup.find_tagged_with(:all => options[:tag], :ns => "*"))
+      #_log.info("Aritag - vms - #{vms}")
     else
       raise "must provide options :owner or :tag"
     end
@@ -96,8 +100,8 @@ class Chargeback < ActsAsArModel
 
     (start_time..end_time).step_value(1.day).each_cons(2) do |query_start_time, query_end_time|
       if options[:tag] && (report_user.nil? || !report_user.self_service?)
-        cond = ["resource_type = ? and resource_id IS NOT NULL and timestamp >= ? and timestamp < ? and capture_interval_name = ? and tag_names like ? ",
-                "VmOrTemplate",
+        cond = ["resource_type IN (?) and resource_id IS NOT NULL and timestamp >= ? and timestamp < ? and capture_interval_name = ? and tag_names like ? ",
+                ["VmOrTemplate", "ContainerGroup"],
                 query_start_time,
                 query_end_time,
                 "hourly",
@@ -113,11 +117,12 @@ class Chargeback < ActsAsArModel
                ]
       end
       _log.debug("Conditions: #{cond.inspect}")
-
+      #_log.info("Aritag - Conditions - #{cond.inspect}")
       recs = MetricRollup
              .where(cond)
              .includes(
                :resource           => :hardware,
+               :resource           => {:container_node => :hardware},
                :parent_host        => :tags,
                :parent_ems_cluster => :tags,
                :parent_storage     => :tags,
@@ -143,18 +148,17 @@ class Chargeback < ActsAsArModel
               "end_date"      => end_ts,
               "display_range" => display_range,
               "interval_name" => interval,
-              "vm_name"       => perf.resource_name,
+              "vm_name"       => perf.resource_name || perf.resource.name,
               "owner_name"    => vm_owners[perf.resource_id]
             }
           end
-
           rates_to_apply = cb.get_rates(perf)
           calculate_costs(perf, data[key], rates_to_apply)
         end
       end
     end
     _log.info("Calculating chargeback costs...Complete")
-
+    #_log.info("Aritag - Calculating chargeback costs...Complete")
     [data.map { |r| new(r.last) }]
   end
 

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -2,6 +2,7 @@ class ContainerGroup < ApplicationRecord
   include CustomAttributeMixin
   include ReportableMixin
   include NewWithTypeStiMixin
+  include OwnershipMixin
 
   # :name, :uid, :creation_timestamp, :resource_version, :namespace
   # :labels, :restart_policy, :dns_policy
@@ -30,6 +31,7 @@ class ContainerGroup < ApplicationRecord
 
   # Needed for metrics
   delegate :my_zone, :to => :ext_management_system
+  delegate :hardware, :to => :container_node
 
   def ready_condition
     container_conditions.find_by(:name => "Ready")


### PR DESCRIPTION
Initial hacky PR - Chargeback for tagged container groups now appear in chargeback report for tagged vm's and instances.

End result - chargeback for a pod:
![chargeback_result](https://cloud.githubusercontent.com/assets/11256940/12886546/d5755808-ce76-11e5-9af7-702cbdb5746f.png)

forming a new report(no change):
![chargeback_report2](https://cloud.githubusercontent.com/assets/11256940/12886547/d576898a-ce76-11e5-979a-514a8a907a4b.png)
![chargeback_report](https://cloud.githubusercontent.com/assets/11256940/12886549/d57976f4-ce76-11e5-9234-94e43d5bd605.png)

Setting rates(no change):
![chargeback_rates](https://cloud.githubusercontent.com/assets/11256940/12886548/d57768be-ce76-11e5-832a-3a1b5cda4aa1.png)

@simon3z @gtanzillo Please tell me which direction I should take this.