### PR TITLE
ApiController - Disable get/set_global_session_data

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,7 @@
 class ApiController < ApplicationController
+  skip_before_action :get_global_session_data
+  skip_after_action :set_global_session_data
+
   class AuthenticationError < StandardError; end
   class Forbidden < StandardError; end
   class BadRequestError < StandardError; end


### PR DESCRIPTION
API requests should ideally not touch the session at all, but for now, at least don't break it.

Without this, any API request clears `edit`, `view` and `layout` (possibly others) from session, because `set_global_session_data` expects `@edit` (etc) to be populated with the right new value, and `load_edit` is never called in the api (nor does it make sense to call it there).

Fixes #6545