### PR TITLE
Fix seeds and don't swallow exceptions

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -1088,8 +1088,8 @@ module ApplicationController::Filter
     elsif @edit[@expkey][:exp_typ] == "regkey"
       @edit[@expkey][:val1][:type] = :string
     end
-    @edit[@expkey][:val1][:title] = FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:title] if @edit[@expkey][:val1][:type]
-    @edit[@expkey][:val2][:title] = FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:title] if @edit[@expkey][:val2][:type]
+    @edit[@expkey][:val1][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:title] if @edit[@expkey][:val1][:type]
+    @edit[@expkey][:val2][:title] = MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:title] if @edit[@expkey][:val2][:type]
   end
 
   # Get the field type for miqExpressionPrefill using the operator key and field
@@ -1097,7 +1097,7 @@ module ApplicationController::Filter
     return nil unless key && field
     return :regex if key.starts_with?("REG")
     typ = MiqExpression.get_col_info(field)[:format_sub_type] # :human_data_type?
-    if FORMAT_SUB_TYPES.keys.include?(typ)
+    if MiqExpression::FORMAT_SUB_TYPES.keys.include?(typ)
       return typ
     else
       return :string

--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -449,7 +449,7 @@ module ReportController::Reports::Editor
               when :boolean
                 ["DEFAULT", "true"]
               when :integer, :float
-                ["DEFAULT", "", FORMAT_SUB_TYPES.fetch_path(field_sub_type, :units) ? FORMAT_SUB_TYPES.fetch_path(field_sub_type, :units).first : nil]
+                ["DEFAULT", "", MiqExpression::FORMAT_SUB_TYPES.fetch_path(field_sub_type, :units) ? MiqExpression::FORMAT_SUB_TYPES.fetch_path(field_sub_type, :units).first : nil]
               else
                 ["DEFAULT", ""]
               end

--- a/app/helpers/ui_constants.rb
+++ b/app/helpers/ui_constants.rb
@@ -486,9 +486,6 @@ module UiConstants
     "vm-tags"               => "Tagged #{ui_lookup(:tables => "vm")}"
   }
 
-  # Filter/search/expression constants
-  FORMAT_SUB_TYPES = MiqExpression::FORMAT_SUB_TYPES
-
   EXP_COUNT_TYPE = ["Count of", "count"]  # Selection for count based filters
   EXP_FIND_TYPE = ["Find", "find"]        # Selection for find/check filters
   EXP_TYPES = [                           # All normal filters

--- a/app/views/layouts/_user_input_filter.html.haml
+++ b/app/views/layouts/_user_input_filter.html.haml
@@ -37,9 +37,9 @@
                         = "%"
                       - elsif @edit[:qs_tokens][token][:value_type] == :megabytes
                         = "MB"
-                      - elsif FORMAT_SUB_TYPES[@edit[:qs_tokens][token][:value_type]][:units]
+                      - elsif MiqExpression::FORMAT_SUB_TYPES[@edit[:qs_tokens][token][:value_type]][:units]
                         = select_tag("suffix_#{token}",
-                                     options_for_select(FORMAT_SUB_TYPES[@edit[:qs_tokens][token][:value_type]][:units],
+                                     options_for_select(MiqExpression::FORMAT_SUB_TYPES[@edit[:qs_tokens][token][:value_type]][:units],
                                                         nil),
                                      :multiple              => false,
                                      :class                 => "widthed",

--- a/app/views/layouts/exp_atom/_edit_field.html.haml
+++ b/app/views/layouts/exp_atom/_edit_field.html.haml
@@ -146,9 +146,9 @@
             \%
           - elsif @edit[@expkey][:val1][:type] == :megabytes
             MB
-          - elsif FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units]
+          - elsif MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units]
             = select_tag('chosen_suffix',
-              options_for_select(FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units], @edit[:suffix]),
+              options_for_select(MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units], @edit[:suffix]),
               :multiple              => false,
               :class                 => "widthed",
               "data-miq_sparkle_on"  => true,

--- a/app/views/layouts/exp_atom/_edit_find.html.haml
+++ b/app/views/layouts/exp_atom/_edit_find.html.haml
@@ -119,9 +119,9 @@
           "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
         - if @edit[@expkey][:val1][:type] == :percent
           \%
-        - elsif FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units]
+        - elsif MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units]
           = select_tag('chosen_suffix',
-            options_for_select(FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units], @edit[:suffix]),
+            options_for_select(MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val1][:type]][:units], @edit[:suffix]),
             :multiple              => false,
             :class                 => "widthed",
             "data-miq_sparkle_on"  => true,
@@ -240,9 +240,9 @@
               "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
             - if @edit[@expkey][:val2][:type] == :percent
               \%
-            - elsif FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:units]
+            - elsif MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:units]
               = select_tag('chosen_suffix2',
-                options_for_select(FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:units], @edit[:suffix2]),
+                options_for_select(MiqExpression::FORMAT_SUB_TYPES[@edit[@expkey][:val2][:type]][:units], @edit[:suffix2]),
                 :multiple              => false,
                 :class                 => "widthed",
                 "data-miq_sparkle_on"  => true,

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -72,9 +72,9 @@
                       "data-miq_observe" => {:interval => '.5', :url => url}.to_json)
                     - if field_type == :percent
                       \%
-                    - elsif FORMAT_SUB_TYPES.fetch_path(field_type, :units)
+                    - elsif MiqExpression::FORMAT_SUB_TYPES.fetch_path(field_type, :units)
                       = select_tag("stylesuffix_#{f_idx}_#{s_idx}",
-                        options_for_select(FORMAT_SUB_TYPES[field_type][:units], styles[s_idx][:value_suffix]),
+                        options_for_select(MiqExpression::FORMAT_SUB_TYPES[field_type][:units], styles[s_idx][:value_suffix]),
                         :multiple              => false,
                         :class                 => "widthed",
                         "data-miq_sparkle_on"  => true,

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -63,6 +63,7 @@ class EvmDatabase
             klass.seed
           rescue => err
             _log.log_backtrace(err)
+            raise
           end
         else
           _log.error("Class #{klass} does not have a seed")

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -2,10 +2,6 @@
 def ui_lookup(_)
 end
 
-class MiqExpression
-  FORMAT_SUB_TYPES = 'nil'
-end
-
 require_relative '../../app/helpers/ui_constants'
 
 namespace :gettext do


### PR DESCRIPTION
Seeding the database currently swallows exceptions. This is bad because it allows for broken seeds that can go completely unnoticed for a long period of time when things change (such as the user group association work I'm currently doing...)

This PR:
* Reraises exceptions in seeds after logging the error.
* Fixes an existing, blocking seeding issue around the accidental redefinition of MiqExpression in a rake task that's been present since the middle of December. Please see the [commit message](https://github.com/manageiq/manageiq/commit/a34fafc25587c281e8567f3a6713ff5265550cbe) for details.