### PR TITLE
Fix incorrect gettext invocations

### DIFF
--- a/app/controllers/application_controller/performance.rb
+++ b/app/controllers/application_controller/performance.rb
@@ -523,7 +523,7 @@ module ApplicationController::Performance
       msg = "Chart menu selection not yet implemented"
     end
 
-    msg ? add_flash(msg, :warning) : add_flash(_("Unknown error has occurred", :error))
+    msg ? add_flash(msg, :warning) : add_flash(_("Unknown error has occurred"), :error)
     render :update do |page|
       page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       page << "miqSparkle(false);"

--- a/app/controllers/report_controller/menus.rb
+++ b/app/controllers/report_controller/menus.rb
@@ -463,7 +463,7 @@ module ReportController::Menus
           if !user.admin_user? && r.miq_group_id.to_i != user.current_group.id.to_i && flg == 0
             flg = 1
             # only show this flash message once for all reports
-            add_flash(_("One or more selected reports are not owned by your group, they cannot be moved", :field => "fields"), :warning)
+            add_flash(_("One or more selected reports are not owned by your group, they cannot be moved"), :warning)
           end
           if user.admin_user? || r.miq_group_id.to_i == user.current_group.id.to_i
             @edit[:available_reports].push(nf) if @edit[:user_typ] || r.miq_group_id.to_i == user.current_group.id.to_i             # Add to the available fields list


### PR DESCRIPTION
_() takes one argument only: string.

Introduced in 80fbeeceecf0701ebebdabc6acd484df86af64ea

https://bugzilla.redhat.com/show_bug.cgi?id=1300861