### PR TITLE
Do not reset edit & view in session when api transaction comes in.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2409,9 +2409,11 @@ class ApplicationController < ActionController::Base
       @view ||= session[:view]                              #   Remember the previous @view
     end
 
-    session[:edit] = @edit ? @edit : nil                    # Set or clear session edit hash
+    unless controller_name == "api"
+      session[:edit] = @edit ? @edit : nil     # Set or clear session edit hash
+      session[:view] = @view ? @view : nil     # Set or clear view in session hash
+    end
 
-    session[:view] = @view ? @view : nil                    # Set or clear view in session hash
     unless params[:controller] == "miq_task"                # Proxy needs data for delete all
       session[:view].table = nil if session[:view]          # Don't need to carry table data around
     end


### PR DESCRIPTION
api transaction are causing edit & view to be set to nil, this breaks UI if user is in the middle of an edit session on a non-angular form or it can blow up if user tries to perform certain actions on list view

@himdel can you please review this, please let me know if there is a better way to handle this. Currently api transactions are breaking non-angular forms causing UI to blow up.