### PR TITLE
Remove ruby_prof from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,6 @@ gem "sshkey",                         "~>1.8.0",   :require => false
 unless ENV['APPLIANCE']
   group :development do
     gem "gettext",          "3.1.4",    :require => false  # Used for finding translations
-    gem "ruby-prof",                    :require => false
     gem "ruby-graphviz",                :require => false  # Used by state_machine:draw Rake Task
   end
 


### PR DESCRIPTION
Developers can add gems to `Gemfile.dev.rb`, so there is no reason to add optional
developer dependencies to the global `Gemfile`

I use a local copy of `ruby_prof`, so it works better for me if I can manage
the dependency in my local `Gemfile.dev.rb`.

(currently I have to stash / un-stash when ever I make a change)

/cc @jrafanie @Fryguy @matthewd 