### PR TITLE
Clean up User's MiqGroup methods

### DIFF
--- a/app/controllers/report_controller/saved_reports.rb
+++ b/app/controllers/report_controller/saved_reports.rb
@@ -21,7 +21,7 @@ module ReportController::SavedReports
       return
     end
     @right_cell_text ||= _("%{model} \"%{name}\"") % {:name => "#{rr.name} - #{format_timezone(rr.created_on, Time.zone, "gt")}", :model => "Saved Report"}
-    if admin_user? || current_user.groups_include?(rr.miq_group)
+    if admin_user? || current_user.miq_group_ids.include?(rr.miq_group_id)
       @report_result_id = session[:report_result_id] = rr.id
       session[:report_result_runtime] = rr.last_run_on
       task = MiqTask.find_by_id(rr.miq_task_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,10 +216,6 @@ class User < ApplicationRecord
     self.current_group = groups.first if current_group.nil? || !groups.include?(current_group)
   end
 
-  def miq_group_ids
-    miq_groups.collect(&:id)
-  end
-
   def self.all_users_of_group(group)
     User.includes(:miq_groups).select { |u| u.miq_groups.include?(group) }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,10 +228,6 @@ class User < ApplicationRecord
     miq_groups
   end
 
-  def groups_include?(group)
-    miq_group_ids.include?(group.id)
-  end
-
   def admin?
     userid == "admin"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,10 +220,6 @@ class User < ApplicationRecord
     User.includes(:miq_groups).select { |u| u.miq_groups.include?(group) }
   end
 
-  def all_groups
-    miq_groups
-  end
-
   def admin?
     userid == "admin"
   end


### PR DESCRIPTION
This PR removes some unnecessary methods in the User model regarding MiqGroups found while working on our user groups transition.