### PR TITLE
Add UI for Cloud VM Migration

### DIFF
--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -3,8 +3,8 @@ ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$
     auto_select_host:    true,
     cluster_id:          null,
     destination_host_id: null,
-    block_migration:     null,
-    disk_over_commit:    null
+    block_migration:     false,
+    disk_over_commit:    false
   };
   $scope.clusters = [];
   $scope.hosts = [];

--- a/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
+++ b/app/assets/javascripts/controllers/vm_cloud/vm_cloud_live_migrate_form_controller.js
@@ -1,0 +1,35 @@
+ManageIQ.angular.app.controller('vmCloudLiveMigrateFormController', ['$http', '$scope', 'vmCloudLiveMigrateFormId', 'miqService', function($http, $scope, vmCloudLiveMigrateFormId, miqService) {
+  $scope.vmCloudModel = {
+    auto_select_host:    true,
+    cluster_id:          null,
+    destination_host_id: null,
+    block_migration:     null,
+    disk_over_commit:    null
+  };
+  $scope.clusters = [];
+  $scope.hosts = [];
+  $scope.filtered_hosts = [];
+  $scope.formId = vmCloudLiveMigrateFormId;
+  $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+
+  ManageIQ.angular.scope = $scope;
+
+  $http.get('/vm_cloud/live_migrate_form_fields/' + vmCloudLiveMigrateFormId).success(function(data) {
+    $scope.clusters = data.clusters;
+    $scope.hosts = data.hosts;
+    $scope.modelCopy = angular.copy( $scope.vmCloudModel );
+    miqService.sparkleOff();
+  });
+
+  $scope.cancelClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=cancel';
+    miqService.miqAjaxButton(url);
+  };
+
+  $scope.submitClicked = function() {
+    miqService.sparkleOn();
+    var url = '/vm_cloud/live_migrate_vm/' + vmCloudLiveMigrateFormId + '?button=submit';
+    miqService.miqAjaxButton(url, true);
+  };
+}]);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1941,7 +1941,6 @@ class ApplicationController < ActionController::Base
     prov_redirect("migrate")
   end
   alias_method :miq_template_migrate, :vm_migrate
-  alias_method :instance_migrate, :vm_migrate
 
   def vm_publish
     prov_redirect("publish")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1941,6 +1941,7 @@ class ApplicationController < ActionController::Base
     prov_redirect("migrate")
   end
   alias_method :miq_template_migrate, :vm_migrate
+  alias_method :instance_migrate, :vm_migrate
 
   def vm_publish
     prov_redirect("publish")

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -43,13 +43,13 @@ module ApplicationController::Explorer
     'shelve'           => :s1, 'shelve_offload'            => :s1,
 
     # group 2
-    'clone'     => :s2, 'compare'          => :s2, 'drift'           => :s2,
-    'edit'      => :s2, 'evm_relationship' => :s2, 'migrate'         => :s2,
-    'ownership' => :s2, 'policy_sim'       => :s2, 'protect'         => :s2,
-    'publish'   => :s2, 'reconfigure'      => :s2, 'miq_request_new' => :s2,
-    'retire'    => :s2, 'right_size'       => :s2, 'snapshot_add'    => :s2,
-    'tag'       => :s2, 'timeline'         => :s2, 'resize'          => :s2,
-
+    'clone'        => :s2, 'compare'          => :s2, 'drift'           => :s2,
+    'edit'         => :s2, 'evm_relationship' => :s2, 'migrate'         => :s2,
+    'ownership'    => :s2, 'policy_sim'       => :s2, 'protect'         => :s2,
+    'publish'      => :s2, 'reconfigure'      => :s2, 'miq_request_new' => :s2,
+    'retire'       => :s2, 'right_size'       => :s2, 'snapshot_add'    => :s2,
+    'tag'          => :s2, 'timeline'         => :s2, 'resize'          => :s2,
+    'live_migrate' => :s2,
     # specials
     'perf'         => :show,
     'download_pdf' => :show,
@@ -78,7 +78,7 @@ module ApplicationController::Explorer
     elsif X_BUTTON_ALLOWED_ACTIONS[action] == :s2
       # don't need to set params[:id] and do find_checked_items for methods
       # like ownership, the code in those methods handle it
-      if %w(edit right_size resize).include?(action)
+      if %w(edit right_size resize live_migrate).include?(action)
         @_params[:id] = (params[:id] ? [params[:id]] : find_checked_items)[0]
       end
       if ['protect', 'tag'].include?(action)

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -115,8 +115,10 @@ class VmCloudController < ApplicationController
     @record = find_by_id_filtered(VmOrTemplate, params[:id])
     clusters = []
     hosts = []
-    @record.ext_management_system.ems_clusters.each { |c| clusters << {:id => c.id, :name => c.name} }
-    @record.ext_management_system.hosts.each do |h|
+    @record.ext_management_system.find_filtered_children("ems_clusters").each do |c|
+      clusters << {:id => c.id, :name => c.name}
+    end
+    @record.ext_management_system.find_filtered_children("hosts").each do |h|
       hosts << {:id => h.id, :name => h.name, :cluster_id => h.emd_cluster.id}
     end
     clusters.sort

--- a/app/controllers/vm_cloud_controller.rb
+++ b/app/controllers/vm_cloud_controller.rb
@@ -133,18 +133,11 @@ class VmCloudController < ApplicationController
 
     case params[:button]
     when "cancel"
-      if @edit[:explorer]
-        add_flash(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
-          :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
-        @record = @sb[:action] = nil
-        replace_right_cell
-      else
-        add_flash(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
-          :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
-        session[:flash_msgs] = @flash_array.dup
-        render :update do |page|
-          page.redirect_to(previous_breadcrumb_url)
-        end
+      add_flash(_("Live Migration of %{model} \"%{name}\" was cancelled by the user") % {
+        :model => ui_lookup(:table => "vm_cloud"), :name => @record.name})
+      session[:flash_msgs] = @flash_array.dup
+      render :update do |page|
+        page.redirect_to(previous_breadcrumb_url)
       end
     when "submit"
       valid, details = @record.validate_live_migrate

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1612,11 +1612,11 @@ module VmCommon
       presenter.update(:main_div, r[:partial => partial, :locals => partial_locals])
 
       locals = {:action_url => action, :record_id => @record ? @record.id : nil}
-      if %w(clone migrate miq_request_new pre_prov publish reconfigure resize).include?(@sb[:action])
+      if %w(clone migrate miq_request_new pre_prov publish reconfigure resize live_migrate).include?(@sb[:action])
         # don't render a reset button on the screen
         locals[:no_reset]        = true
         # render a submit button instead of a save button
-        locals[:submit_button]   = %(clone migrate publish reconfigure pre_prov resize).include?(@sb[:action])
+        locals[:submit_button]   = %(clone migrate publish reconfigure pre_prov resize live_migrate).include?(@sb[:action])
         # render continue button on the screen
         locals[:continue_button] = ['miq_request_new'].include?(@sb[:action])
         update_buttons(locals) if @edit && @edit[:buttons].present?
@@ -1854,6 +1854,10 @@ module VmCommon
           {:name => name, :vm_or_template => ui_lookup(:model => @sb[:compare_db])}
       end
       action = nil
+    when "live_migrate"
+      partial = "vm_common/live_migrate"
+      header = _("Live Migrating %{model} \"%{name}\"") % {:name => name, :model => ui_lookup(:table => table)}
+      action = "live_migrate_vm"
     when "clone", "migrate", "publish"
       partial = "miq_request/prov_edit"
       task_headers = {"clone"   => _("Clone %{vm_or_template}"),

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -1715,6 +1715,8 @@ module VmCommon
               :record_id  => @edit[:rec_id],
             }
           ])
+        elsif @sb[:action] == 'live_migrate'
+          presenter.update(:form_buttons_div, r[:partial => "layouts/angular/paging_div_buttons"])
         elsif action != "retire" && action != "reconfigure_update"
           presenter.update(:form_buttons_div, r[:partial => 'layouts/x_edit_buttons', :locals => locals])
         end

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -148,7 +148,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :enabled   => false,
           :onwhen    => "1+"),
         button(
-          :instance_migrate,
+          :instance_live_migrate,
           'product product-migrate fa-lg',
           t = N_('Migrate selected Instance'),
           t,

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -153,7 +153,7 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           t = N_('Migrate selected Instance'),
           t,
           :url_parms => 'main_div',
-          :enabled   => 'false',
+          :enabled   => false,
           :onwhen    => '1')
       ]
     ),

--- a/app/helpers/application_helper/toolbar/vm_clouds_center.rb
+++ b/app/helpers/application_helper/toolbar/vm_clouds_center.rb
@@ -147,6 +147,14 @@ class ApplicationHelper::Toolbar::VmCloudsCenter < ApplicationHelper::Toolbar::B
           :confirm   => N_("Retire the selected items?"),
           :enabled   => false,
           :onwhen    => "1+"),
+        button(
+          :instance_migrate,
+          'product product-migrate fa-lg',
+          t = N_('Migrate selected Instance'),
+          t,
+          :url_parms => 'main_div',
+          :enabled   => 'false',
+          :onwhen    => '1')
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -98,7 +98,13 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           'fa fa-clock-o fa-lg',
           t = N_('Retire this Instance'),
           t,
-          :confirm => N_("Retire this Instance?"))
+          :confirm => N_("Retire this Instance?")),
+        button(
+          :instance_migrate,
+          'product product-migrate fa-lg',
+          t = N_('Migrate Instance'),
+          t,
+          :url_parms => 'main_div')
       ]
     ),
   ])

--- a/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
+++ b/app/helpers/application_helper/toolbar/x_vm_cloud_center.rb
@@ -100,7 +100,7 @@ class ApplicationHelper::Toolbar::XVmCloudCenter < ApplicationHelper::Toolbar::B
           t,
           :confirm => N_("Retire this Instance?")),
         button(
-          :instance_migrate,
+          :instance_live_migrate,
           'product product-migrate fa-lg',
           t = N_('Migrate Instance'),
           t,

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -1,0 +1,66 @@
+%form#form_div{:name => "angularForm", 'ng-controller' => "vmCloudLiveMigrateFormController"}
+  = render :partial => "layouts/flash_msg"
+  %h3
+    = _('Migrate Instance')
+  .form-horizontal
+    .form-group
+      %label.col-md-2.control-label
+        = _('Auto-select Host?')
+      .col-md-8
+        = check_box_tag("auto_select_host",
+                        '1',
+                        @edit[:auto_select_host],
+                        'ng-model'     => "vmCloudModel.auto_select_host",
+                        :miqrequired   => true,
+                        :checkchange   => true)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Block Migration')
+      .col-md-8
+        = check_box_tag("block_migration",
+                        '1',
+                        @edit[:block_migration],
+                        'ng-model'     => "vmCloudModel.block_migration",
+                        :miqrequired   => true,
+                        :checkchange   => true)
+    .form-group
+      %label.col-md-2.control-label
+        = _('Disk Over Commit')
+      .col-md-8
+        = check_box_tag("disk_over_commit",
+                        '1',
+                        @edit[:disk_over_commit],
+                        'ng-model'     => "vmCloudModel.disk_over_commit",
+                        :miqrequired   => true,
+                        :checkchange   => true)
+  #live-migrate-select-destination-host{'ng-hide' => 'vmCloudModel.auto_select_host'}
+    %h3
+      = _('Select Destination Host')
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Cluster')
+        .col-md-8
+          %select{:name => 'cluster_id', 'ng-model' => 'vmCloudModel.cluster', 'ng-options' => 'cluster as cluster.name for cluster in clusters'}
+    .form-horizontal
+      .form-group
+        %label.col-md-2.control-label
+          = _('Destination Host')
+        .col-md-8
+          %select{:name => 'destination_host_id', 'ng-model' => 'vmCloudModel.host', 'ng-options' => 'host.id as host.name for host in hosts | filter : {cluster_id: vmCloudModel.cluster.id}'}
+
+  %table{:width => '100%'}
+    %tr
+      %td{:align => 'right'}
+        #buttons_on
+          = button_tag("Submit",
+                       :class        => "btn btn-primary",
+                       "ng-click"    => "submitClicked()",
+                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
+                       "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
+        = button_tag("Cancel",
+                      :class     => "btn btn-default",
+                      "ng-click" => "cancelClicked()")
+:javascript
+  ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', '#{@record.id}');
+  miq_bootstrap('#form_div');

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -49,18 +49,11 @@
         .col-md-8
           %select{:name => 'destination_host_id', 'ng-model' => 'vmCloudModel.host', 'ng-options' => 'host.id as host.name for host in hosts | filter : {cluster_id: vmCloudModel.cluster.id}'}
 
-  %table{:width => '100%'}
-    %tr
-      %td{:align => 'right'}
-        #buttons_on
-          = button_tag("Submit",
-                       :class        => "btn btn-primary",
-                       "ng-click"    => "submitClicked()",
-                       "ng-disabled" => "angularForm.$pristine || angularForm.$invalid",
-                       "ng-class"    => "{'btn-disabled': angularForm.$pristine || angularForm.$invalid}")
-        = button_tag("Cancel",
-                      :class     => "btn btn-default",
-                      "ng-click" => "cancelClicked()")
+
+  %div_for_paging{'ng-controller'           => "pagingDivButtonGroupController",
+                  'paging_div_buttons_id'   => "angular_paging_div_buttons",
+                  'paging_div_buttons_type' => "Submit"}
+
 :javascript
   ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', '#{@record.id}');
   miq_bootstrap('#form_div');

--- a/app/views/vm_common/_live_migrate.html.haml
+++ b/app/views/vm_common/_live_migrate.html.haml
@@ -12,7 +12,8 @@
                         @edit[:auto_select_host],
                         'ng-model'     => "vmCloudModel.auto_select_host",
                         :miqrequired   => true,
-                        :checkchange   => true)
+                        :checkchange   => true,
+                        'ng-disabled'  => "hosts.length == 0")
     .form-group
       %label.col-md-2.control-label
         = _('Block Migration')
@@ -50,9 +51,10 @@
           %select{:name => 'destination_host_id', 'ng-model' => 'vmCloudModel.host', 'ng-options' => 'host.id as host.name for host in hosts | filter : {cluster_id: vmCloudModel.cluster.id}'}
 
 
-  %div_for_paging{'ng-controller'           => "pagingDivButtonGroupController",
-                  'paging_div_buttons_id'   => "angular_paging_div_buttons",
-                  'paging_div_buttons_type' => "Submit"}
+  %div_for_paging{'ng-controller'                    => "pagingDivButtonGroupController",
+                  'paging_div_buttons_state_enabled' => true,
+                  'paging_div_buttons_id'            => "angular_paging_div_buttons",
+                  'paging_div_buttons_type'          => "Submit"}
 
 :javascript
   ManageIQ.angular.app.value('vmCloudLiveMigrateFormId', '#{@record.id}');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2262,6 +2262,8 @@ Vmdb::Application.routes.draw do
         show
         tagging_edit
         resize
+        migrate
+        live_migrate_form_fields
       ) +
                compare_get,
       :post => %w(
@@ -2316,6 +2318,7 @@ Vmdb::Application.routes.draw do
         vm_pre_prov
         wait_for_task
         win32_services
+        live_migrate_vm
       ) +
                adv_search_post +
                compare_post +

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4317,7 +4317,7 @@
       - :name: Migrate Instance
         :description: Migrate Instance
         :feature_type: control
-        :identifier: instance_migrate
+        :identifier: instance_live_migrate
     - :name: Modify
       :description: Modify Instances
       :feature_type: admin

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4314,6 +4314,10 @@
         :description: Reconfigure Instance
         :feature_type: control
         :identifier: instance_resize
+      - :name: Migrate Instance
+        :description: Migrate Instance
+        :feature_type: control
+        :identifier: instance_migrate
     - :name: Modify
       :description: Modify Instances
       :feature_type: admin

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 require 'pathname'
 
 describe MiqProductFeature do
-  let(:expected_feature_count) { 1009 }
+  let(:expected_feature_count) { 1010 }
 
   # - container_dashboard
   # - miq_report_widget_editor


### PR DESCRIPTION
Hooks up a Lifecycle button for migrating Cloud Instances.
![livemigrateinstancemanualselect](https://cloud.githubusercontent.com/assets/628956/14007069/816dfa80-f149-11e5-9578-47dc3d7fd88c.png)
![livemigrateinstancerevision](https://cloud.githubusercontent.com/assets/628956/14007070/816eca8c-f149-11e5-8f92-eb35dc5a356a.png)

When Auto-select Host is unchecked, the Cluster and Host dropdowns appear. The Host dropdown is filtered by the Cluster selection.