### PR TITLE
reset session[:changed] first time on Control/Simulation screen

### DIFF
--- a/app/controllers/miq_policy_controller/rsop.rb
+++ b/app/controllers/miq_policy_controller/rsop.rb
@@ -51,6 +51,7 @@ module MiqPolicyController::Rsop
     else  # No params, first time in
       @breadcrumbs = []
       @accords = [{:name => "rsop", :title => "Options", :container => "rsop_options_div"}]
+      session[:changed] = false
       @sb[:rsop] ||= {}   # Leave exising values
       rsop_put_objects_in_sb(find_filtered(ExtManagementSystem, :all), :emss)
       rsop_put_objects_in_sb(find_filtered(EmsCluster, :all), :clusters)

--- a/spec/controllers/miq_policy_controller/rsop_spec.rb
+++ b/spec/controllers/miq_policy_controller/rsop_spec.rb
@@ -1,0 +1,28 @@
+include UiConstants
+
+describe MiqPolicyController do
+  render_views
+  before :each do
+    EvmSpecHelper.local_miq_server
+    set_user_privileges
+  end
+
+  context "#rsop" do
+    it "first time on RSOP screen, session[:changed] should be false" do
+      session[:changed] = true
+      controller.instance_variable_set(:@current_user,
+                                       FactoryGirl.create(:user,
+                                                          :name       => "foo",
+                                                          :miq_groups => [],
+                                                          :userid     => "foo"))
+      controller.instance_variable_set(:@sb, {})
+      allow(controller).to receive(:rsop_put_objects_in_sb)
+      allow(controller).to receive(:find_filtered)
+      allow(controller).to receive(:appliance_name)
+      get :rsop
+      expect(response.status).to eq(200)
+      expect(session[:changed]).to be_falsey
+      expect(response).to render_template('miq_policy/rsop')
+    end
+  end
+end


### PR DESCRIPTION
when coming from another screen sometimes session[:changed] was still set to true causing "Submit" button to be enabled when going to Control/Simulation screen first time causing it to blow up if user pressed submit button without making selections in the form.

https://bugzilla.redhat.com/show_bug.cgi?id=1304288

@dclarizio please review.