### PR TITLE
Clarify (change) User#miq_group_description=

### DIFF
--- a/app/controllers/api_controller/authentication.rb
+++ b/app/controllers/api_controller/authentication.rb
@@ -94,7 +94,7 @@ class ApiController
       if group_name.present?
         group_obj = user_obj.miq_groups.find_by_description(group_name)
         raise AuthenticationError, "Invalid Authorization Group #{group_name} specified" if group_obj.nil?
-        user_obj.miq_group_description = group_name
+        user_obj.current_group_by_description = group_name
       end
     end
 

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -60,7 +60,7 @@ class MiqRequestWorkflow
     group_description = values[:requester_group]
     if group_description && group_description != @requester.miq_group_description
       @requester = @requester.clone
-      @requester.miq_group_description = group_description
+      @requester.current_group_by_description = group_description
     end
     @values.merge!(options) unless options.blank?
   end

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -62,7 +62,7 @@ module MiqProvisionMixin
       email = get_option(:owner_email).try(:downcase)
       return if email.blank?
       User.find_by_lower_email(email, get_user).tap do |owner|
-        owner.miq_group_description = get_option(:owner_group) if owner
+        owner.current_group_by_description = get_option(:owner_group) if owner
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
   before_validation :dummy_password_for_external_auth
   before_destroy :destroy_subscribed_widget_sets
 
-  def miq_group_description=(group_description)
+  def current_group_by_description=(group_description)
     if group_description
       desired_group = miq_groups.detect { |g| g.description == group_description }
       desired_group ||= MiqGroup.find_by_description(group_description) if super_admin_user?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -516,41 +516,44 @@ describe User do
     end
   end
 
-  describe "#miq_group_description=" do
+  describe "#current_group_by_description=" do
+    subject { FactoryGirl.create(:user, :miq_groups => [g1, g2], :current_group => g1) }
     let(:g1) { FactoryGirl.create(:miq_group) }
     let(:g2) { FactoryGirl.create(:miq_group) }
-    let(:u)  { FactoryGirl.create(:user, :miq_groups => [g1, g2], :current_group => g1) }
 
     it "ignores blank" do
-      u.miq_group_description = ""
-      expect(u.current_group).to eq(g1)
-      expect(u.miq_group_description).to eq(g1.description)
+      subject.current_group_by_description = ""
+      expect(subject.current_group).to eq(g1)
+      expect(subject.miq_group_description).to eq(g1.description)
     end
 
     it "ignores not found" do
-      u.miq_group_description = "not_found"
-      expect(u.current_group).to eq(g1)
-      expect(u.miq_group_description).to eq(g1.description)
+      subject.current_group_by_description = "not_found"
+      expect(subject.current_group).to eq(g1)
+      expect(subject.miq_group_description).to eq(g1.description)
     end
 
     it "ignores a group that you do not belong" do
-      u.miq_group_description = FactoryGirl.create(:miq_group).description
-      expect(u.current_group).to eq(g1)
-      expect(u.miq_group_description).to eq(g1.description)
+      subject.current_group_by_description = FactoryGirl.create(:miq_group).description
+      expect(subject.current_group).to eq(g1)
+      expect(subject.miq_group_description).to eq(g1.description)
     end
 
     it "sets by description" do
-      u.miq_group_description = g2.description
-      expect(u.current_group).to eq(g2)
-      expect(u.miq_group_description).to eq(g2.description)
+      subject.current_group_by_description = g2.description
+      expect(subject.current_group).to eq(g2)
+      expect(subject.miq_group_description).to eq(g2.description)
     end
 
-    it "sets any group to super admin" do
-      a = FactoryGirl.create(:user, :role => "super_administrator")
-      expect(a).to be_super_admin_user
+    context "as a super admin" do
+      subject { FactoryGirl.create(:user, :role => "super_administrator") }
 
-      a.miq_group_description = g2.description
-      expect(a.current_group).to eq(g2)
+      it "sets any group, regardless of group membership" do
+        expect(subject).to be_super_admin_user
+
+        subject.current_group_by_description = g2.description
+        expect(subject.current_group).to eq(g2)
+      end
     end
   end
 


### PR DESCRIPTION
This writer is somewhat confusing to those unfamiliar with the project because it looks like a vanilla attr_writer instead of something that sets an association based on its description. Also needs to be renamed anyway with the transition to user groups.

Quick spec refactor included.