### PR TITLE
Add Services features to OOTB self_service roles

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -762,6 +762,13 @@
   - miq_request_view
   - my_settings_default_views
   - my_settings_visuals
+  - service_edit
+  - service_delete
+  - service_reconfigure
+  - service_tag
+  - service_retire_now
+  - service_view
+  - svc_catalog_provision
   - vm_clone
   - vm_cloud_explorer
   - vm_filter_accord
@@ -807,6 +814,13 @@
   - miq_request_admin
   - miq_request_view
   - provider_foreman_explorer
+  - service_edit
+  - service_delete
+  - service_reconfigure
+  - service_tag
+  - service_retire_now
+  - service_view
+  - svc_catalog_provision
   - vm_console
   - vm_clone
   - vm_cloud_explorer


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1304833

We noticed that the self_service roles did not have the product features to access the Services tabs, so they are being added here.

Before:
![self_service_before](https://cloud.githubusercontent.com/assets/3433754/12901766/3b1e5f7e-ce72-11e5-8986-298b4d96b6e8.png)

After:
![self_service_after](https://cloud.githubusercontent.com/assets/3433754/12901770/437b5c1c-ce72-11e5-9952-583dcb01075b.png)
