### PR TITLE
Reports: add support for more container related available fields

### DIFF
--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -75,6 +75,9 @@ class MiqExpression
     configuration_profiles
     configuration_managers
     configured_systems
+    containers
+    container_groups
+    container_projects
     customization_scripts
     customization_script_media
     customization_script_ptables


### PR DESCRIPTION
Adds available fields related to the following container entities:
* Containers
* Pods
* Projects

Newly added available fields:
![manageiq reports2](https://cloud.githubusercontent.com/assets/6347577/12948585/988219c2-d00b-11e5-93c2-51f5a45496fb.png)

Report example: container name - pod name - project name:
![manageiq reports](https://cloud.githubusercontent.com/assets/6347577/12948371/53ad7112-d00a-11e5-9539-727e20e3d7df.png)
