### PR TITLE
Fix gettext invocations using string interpolations phase 1

### DIFF
--- a/app/controllers/application_controller/buttons.rb
+++ b/app/controllers/application_controller/buttons.rb
@@ -15,7 +15,7 @@ module ApplicationController::Buttons
     assert_privileges("ab_group_reorder")
     case params[:button]
     when "cancel"
-      add_flash(_("%s Group Reorder cancelled") % ui_lookup(:model => "CustomButton"))
+      add_flash(_("%{model_name} Group Reorder cancelled") % {:model_name => ui_lookup(:model => "CustomButton")})
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
       replace_right_cell(x_node)
@@ -40,7 +40,7 @@ module ApplicationController::Buttons
         st.options[:button_order] = button_order
         st.save
       end
-      add_flash(_("%s Group Reorder saved") % ui_lookup(:model => "CustomButton"))
+      add_flash(_("%{model_name} Group Reorder saved") % {:model_name => ui_lookup(:model => "CustomButton")})
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
       replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
@@ -218,7 +218,7 @@ module ApplicationController::Buttons
   def ab_group_delete
     assert_privileges("ab_group_delete")
     if x_node.split('_').last == "ub"
-      add_flash(_("'%s' can not be deleted") % "Unassigned Buttons Group", :error)
+      add_flash(_("'Unassigned Buttons Group' can not be deleted"), :error)
       get_node_info
       replace_right_cell(x_node)
       return
@@ -285,9 +285,10 @@ module ApplicationController::Buttons
       begin
         button.invoke(obj)    # Run the task
       rescue StandardError => bang
-        add_flash(_("Error executing: \"%s\" ") % params[:desc] << bang.message, :error) # Push msg and error flag
+        add_flash(_("Error executing: \"%{task_description}\" %{error_message}") %
+          {:task_description => params[:desc], :error_message => bang.message}, :error) # Push msg and error flag
       else
-        add_flash(_("\"%s\" was executed") % params[:desc])
+        add_flash(_("\"%{task_description}\" was executed") % {:task_description => params[:desc]})
       end
       render :update do |page|                    # Use RJS to update the display
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
@@ -304,9 +305,11 @@ module ApplicationController::Buttons
 
   def group_button_cancel(typ)
     if typ == "update"
-      add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "CustomButtonSet"), :name => @edit[:current][:name]})
+      add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
+        {:model => ui_lookup(:model => "CustomButtonSet"), :name => @edit[:current][:name]})
     else
-      add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "CustomButtonSet"))
+      add_flash(_("Add of new %{model_name} was cancelled by the user") %
+        {:model_name => ui_lookup(:model => "CustomButtonSet")})
     end
     @edit = session[:edit] = nil  # clean out the saved info
     ab_get_node_info(x_node) if x_active_tree == :ab_tree
@@ -352,7 +355,8 @@ module ApplicationController::Buttons
         replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
       else
         @custom_button_set.errors.each do |field, msg|
-          add_flash(_("Error during '%s': ") % "edit" << "#{field.to_s.capitalize} #{msg}", :error)
+          add_flash(_("Error during 'edit': %{field_name} %{error_message}") %
+            {:field_name => field.to_s.capitalize, :error_message => msg}, :error)
         end
         @lastaction = "automate_button"
         @layout     = "miq_ae_automate_button"
@@ -386,7 +390,8 @@ module ApplicationController::Buttons
         replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
       else
         @custom_button_set.errors.each do |field, msg|
-          add_flash(_("Error during '%s': ") % "add" << "#{field.to_s.capitalize} #{msg}", :error)
+          add_flash(_("Error during 'add': %{field_name} %{error_name}") %
+            {:field_name => field.to_s.capitalize, :error_message => msg}, :error)
         end
         @lastaction = "automate_button"
         @layout     = "miq_ae_automate_button"
@@ -427,7 +432,8 @@ module ApplicationController::Buttons
       if typ == "update"
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "CustomButton"), :name => @edit[:current][:name]})
       else
-        add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "CustomButton"))
+        add_flash(_("Add of new %{model_name} was cancelled by the user") %
+          {:model_name => ui_lookup(:model => "CustomButton")})
       end
       @edit = session[:edit] = nil  # clean out the saved info
       ab_get_node_info(x_node) if x_active_tree == :ab_tree
@@ -489,8 +495,8 @@ module ApplicationController::Buttons
           replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
         else
           @custom_button.errors.each do |field, msg|
-            add_flash(_("Error during '%s': ") % "add" <<
-                      @custom_button.errors.full_message(field, msg), :error)
+            add_flash(_("Error during 'add': %{error_message}") %
+              {:error_message => @custom_button.errors.full_message(field, msg)}, :error)
           end
           @lastaction = "automate_button"
           @layout = "miq_ae_automate_button"
@@ -527,7 +533,8 @@ module ApplicationController::Buttons
           replace_right_cell(x_node, x_active_tree == :ab_tree ? [:ab] : [:sandt])
         else
           @custom_button.errors.each do |field, msg|
-            add_flash(_("Error during '%s': ") % "edit" << "#{field.to_s.capitalize} #{msg}", :error)
+            add_flash(_("Error during 'edit': %{field_name} %{error_message}") %
+              {:field_name => field.to_s.capitalize, :error_message => msg}, :error)
           end
           @breadcrumbs = []
           drop_breadcrumb(:name => "Edit of Button", :url => "/miq_ae_customization/button_edit")
@@ -587,7 +594,7 @@ module ApplicationController::Buttons
         CustomButtonSet.new :
         CustomButtonSet.find(from_cid(params[:id]))
     if typ == "edit" && x_node.split('_').last == "ub"
-      add_flash(_("'%s' can not be edited") % "Unassigned Buttons Group", :error)
+      add_flash(_("'Unassigned Buttons Group' can not be edited"), :error)
       get_node_info
       replace_right_cell(x_node)
       return
@@ -688,12 +695,12 @@ module ApplicationController::Buttons
 
   def move_cols_top
     if !params[:selected_fields] || params[:selected_fields].length == 0 || params[:selected_fields][0] == ""
-      add_flash(_("No %s were selected to move top") % "fields", :error)
+      add_flash(_("No fields were selected to move top"), :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?
     if !consecutive
-      add_flash(_("Select only one or consecutive %s to move to the top") % "fields", :error)
+      add_flash(_("Select only one or consecutive fields to move to the top"), :error)
     else
       if first_idx > 0
         @edit[:new][:fields][first_idx..last_idx].reverse_each do |field|
@@ -709,12 +716,12 @@ module ApplicationController::Buttons
 
   def move_cols_bottom
     if !params[:selected_fields] || params[:selected_fields].length == 0 || params[:selected_fields][0] == ""
-      add_flash(_("No %s were selected to move bottom") % "fields", :error)
+      add_flash(_("No fields were selected to move bottom"), :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?
     if !consecutive
-      add_flash(_("Select only one or consecutive %s to move to the bottom") % "fields", :error)
+      add_flash(_("Select only one or consecutive fields to move to the bottom"), :error)
     else
       if last_idx < @edit[:new][:fields].length - 1
         @edit[:new][:fields][first_idx..last_idx].each do |field|
@@ -731,16 +738,18 @@ module ApplicationController::Buttons
   def button_valid?
     name = @edit[:new][:instance_name].blank? ? @edit[:new][:other_name] : @edit[:new][:instance_name]
     if @edit[:new][:name].blank? || @edit[:new][:name].strip == ""
-      add_flash(_("%s is required") % "Button Text", :error)
+      add_flash(_("Button Text is required"), :error)
     end
     if @edit[:new][:button_image].blank? || @edit[:new][:button_image] == 0
-      add_flash(_("%s must be selected") % "Button Image", :error)
+      add_flash(_("Button Image must be selected"), :error)
     end
-    add_flash(_("%s is required") % "Button Hover Text", :error) if @edit[:new][:description].blank?
+    add_flash(_("Button Hover Text is required"), :error) if @edit[:new][:description].blank?
     #   add_flash("Object Attribute Name must be entered", :error) if @edit[:new][:target_attr_name].blank?
-    add_flash(_("%s is required") % "Starting Process", :error) if name.blank?
-    add_flash(_("%s is required") % "Request", :error) if @edit[:new][:object_request].blank?
-    add_flash(_("At least one %s must be selected") % "Role", :error) if @edit[:new][:visibility_typ] == "role" && @edit[:new][:roles].blank?
+    add_flash(_("Starting Process is required"), :error) if name.blank?
+    add_flash(_("Request is required"), :error) if @edit[:new][:object_request].blank?
+    if @edit[:new][:visibility_typ] == "role" && @edit[:new][:roles].blank?
+      add_flash(_("At least one Role must be selected"), :error)
+    end
     !flash_errors?
   end
 
@@ -1018,12 +1027,12 @@ module ApplicationController::Buttons
 
   def move_cols_up
     if !params[:selected_fields] || params[:selected_fields].length == 0 || params[:selected_fields][0] == ""
-      add_flash(_("No %s were selected to move up") % "fields", :error)
+      add_flash(_("No fields were selected to move up"), :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?
     if !consecutive
-      add_flash(_("Select only one or consecutive %s to move up") % "fields", :error)
+      add_flash(_("Select only one or consecutive fields to move up"), :error)
     else
       if first_idx > 0
         @edit[:new][:fields][first_idx..last_idx].reverse_each do |field|
@@ -1039,12 +1048,12 @@ module ApplicationController::Buttons
 
   def move_cols_down
     if !params[:selected_fields] || params[:selected_fields].length == 0 || params[:selected_fields][0] == ""
-      add_flash(_("No %s were selected to move down") % "fields", :error)
+      add_flash(_("No fields were selected to move down"), :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?
     if !consecutive
-      add_flash(_("Select only one or consecutive %s to move down") % "fields", :error)
+      add_flash(_("Select only one or consecutive fields to move down"), :error)
     else
       if last_idx < @edit[:new][:fields].length - 1
         insert_idx = last_idx + 1   # Insert before the element after the last one

--- a/app/controllers/application_controller/compare.rb
+++ b/app/controllers/application_controller/compare.rb
@@ -904,13 +904,13 @@ module ApplicationController::Compare
       title = request.parameters["controller"].pluralize.titleize
     end
     if vms.length < 2
-      add_flash(_("At least 2 %{model} must be selected for %{action}") % {:model => title, :action => "Compare"}, :error)
+      add_flash(_("At least 2 %{model} must be selected for Compare") % {:model => title}, :error)
       if @layout == "vm" # In vm controller, refresh show_list, else let the other controller handle it
         show_list
         @refresh_partial = "layouts/gtl"
       end
     elsif vms.length > 32
-      add_flash(_("No more than %{max} %{model} can be selected for %{action}") % {:max => 32, :model => title, :action => "Compare"}, :error)
+      add_flash(_("No more than 32 %{model} can be selected for Compare") % {:model => title}, :error)
       if @layout == "vm" # In vm controller, refresh show_list, else let the other controller handle it
         show_list
         @refresh_partial = "layouts/gtl"
@@ -955,11 +955,11 @@ module ApplicationController::Compare
     identify_obj
     tss = find_checked_items                                        # Get the indexes of the checked timestamps
     if tss.length < 2
-      add_flash(_("At least 2 %{model} must be selected for %{action}") % {:model => "Analyses", :action => "Drift"}, :error)
+      add_flash(_("At least 2 Analyses must be selected for Drift"), :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
     elsif tss.length > 10
-      add_flash(_("No more than %{max} %{model} can be selected for %{action}") % {:max => 10, :model => "Analyses", :action => "Drift"}, :error)
+      add_flash(_("No more than 10 Analyses can be selected for Drift"), :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
     else

--- a/app/controllers/application_controller/dialog_runner.rb
+++ b/app/controllers/application_controller/dialog_runner.rb
@@ -26,7 +26,7 @@ module ApplicationController::DialogRunner
       begin
         result = @edit[:wf].submit_request
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Provisioning" << bang.message, :error)
+        add_flash(_("Error during 'Provisioning': %{error_message}") % {:error_message => bang.message}, :error)
         render :update do |page|                    # Use RJS to update the display
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
@@ -40,7 +40,7 @@ module ApplicationController::DialogRunner
             page.replace("flash_msg_div", :partial => "layouts/flash_msg")
           end
         else
-          flash = _("%s Request was Submitted") % "Order"
+          flash = _("Order Request was Submitted")
           if role_allows(:feature => "miq_request_show_list", :any => true)
             @sb[:action] = @edit = nil
             @in_a_form = false
@@ -77,7 +77,7 @@ module ApplicationController::DialogRunner
       end
     else
       return unless load_edit("dialog_edit__#{params[:id]}", "replace_cell__explorer")
-      add_flash(_("%s Button not yet implemented") % "#{params[:button].capitalize}", :error)
+      add_flash(_("%{button_name} Button not yet implemented") % {:button_name => params[:button].capitalize}, :error)
       render :update do |page|                    # Use RJS to update the display
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end

--- a/app/controllers/application_controller/explorer.rb
+++ b/app/controllers/application_controller/explorer.rb
@@ -199,7 +199,7 @@ module ApplicationController::Explorer
   def x_edit_tags_cancel
     id = params[:id]
     return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}", "replace_cell__explorer")
-    add_flash(_("%s was cancelled by the user") % "Tag Edit")
+    add_flash(_("Tag Edit was cancelled by the user"))
     get_node_info(x_node)
     @edit = nil # clean out the saved info
     replace_right_cell
@@ -235,7 +235,8 @@ module ApplicationController::Explorer
     unless kls.where(:id => from_cid(rec_id)).exists?
       @replace_trees = [@sb[:active_accord]] # refresh trees
       self.x_node = "root"
-      add_flash(_("Last selected %s no longer exists") % ui_lookup(:model => kls.to_s), :error)
+      add_flash(_("Last selected %{record_name} no longer exists") %
+        {:record_name => ui_lookup(:model => kls.to_s)}, :error)
     end
     x_node
   end

--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -595,7 +595,7 @@ module ApplicationController::Filter
     case params[:button]
     when "saveit"
       if @edit[:new_search_name].nil? || @edit[:new_search_name] == ""
-        add_flash(_("%s is required") % "Search Name", :error)
+        add_flash(_("Search Name is required"), :error)
         params[:button] = "save"                                    # Redraw the save screen
       else
         #       @edit[:new][@expkey] = copy_hash(@edit[@expkey][:expression]) # Copy the current expression to new
@@ -639,7 +639,8 @@ module ApplicationController::Filter
         s.filter = MiqExpression.new(@edit[:new][@expkey])      # Set the new expression
         if s.save
           #         AuditEvent.success(build_created_audit(s, s_old))
-          add_flash(_("%{model} \"%{name}\" was saved") % {:model => "#{ui_lookup(:model => @edit[@expkey][:exp_model])} search", :name => @edit[:new_search_name]})
+          add_flash(_("%{model} search \"%{name}\" was saved") %
+            {:model => ui_lookup(:model => @edit[@expkey][:exp_model]), :name => @edit[:new_search_name]})
           adv_search_build_lists
 
           @edit[@expkey][:exp_last_loaded] = {:id => s.id, :name => s.name, :description => s.description, :typ => s.search_type}     # Save the last search loaded (saved)
@@ -674,7 +675,8 @@ module ApplicationController::Filter
       @edit[@expkey][:exp_table] = exp_build_table(@edit[@expkey][:expression])       # Build the expression table
       exp_array(:init, @edit[@expkey][:expression])
       @edit[@expkey][:exp_token] = nil                                        # Clear the current selected token
-      add_flash(_("%{model} \"%{name}\" was successfully loaded") % {:model => "#{ui_lookup(:model => @edit[@expkey][:exp_model])} search", :name => @edit[:new_search_name]})
+      add_flash(_("%{model} search \"%{name}\" was successfully loaded") %
+        {:model => ui_lookup(:model => @edit[@expkey][:exp_model]), :name => @edit[:new_search_name]})
 
     when "delete"
       s = MiqSearch.find(@edit[@expkey][:selected][:id])              # Fetch the latest record
@@ -683,8 +685,8 @@ module ApplicationController::Filter
       begin
         s.destroy                                                   # Delete the record
       rescue StandardError => bang
-        add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => ui_lookup(:model => "MiqSearch"), :name  => sname, :task  => "delete"} << bang.message,
-                  :error)
+        add_flash(_("%{model} \"%{name}\": Error during 'delete': %{error_message}") %
+          {:model => ui_lookup(:model => "MiqSearch"), :name => sname, :error_message => bang.message}, :error)
       else
         if @settings[:default_search] && @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym] # See if a default search exists
           def_search = @settings[:default_search][@edit[@expkey][:exp_model].to_s.to_sym]
@@ -695,7 +697,8 @@ module ApplicationController::Filter
             @edit[:adv_search_applied] = nil          # clearing up applied search results
           end
         end
-        add_flash(_("%{model} \"%{name}\": Delete successful") % {:model => "#{ui_lookup(:model => @edit[@expkey][:exp_model])} search", :name => sname})
+        add_flash(_("%{model} search \"%{name}\": Delete successful") %
+          {:model => ui_lookup(:model => @edit[@expkey][:exp_model]), :name => sname})
         audit = {:event        => "miq_search_record_delete",
                  :message      => "[#{sname}] Record deleted",
                  :target_id    => id,
@@ -1363,7 +1366,7 @@ module ApplicationController::Filter
     case @edit[@expkey][:exp_typ]
     when "field"
       if @edit[@expkey][:exp_field].nil?
-        add_flash(_("A %s must be chosen to commit this expression element") % "field", :error)
+        add_flash(_("A field must be chosen to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_value] != :user_input &&
             e = MiqExpression.atom_error(@edit[@expkey][:exp_field],
                                          @edit[@expkey][:exp_key],
@@ -1371,7 +1374,7 @@ module ApplicationController::Filter
                                            @edit[@expkey][:exp_value] :
                                            (@edit[@expkey][:exp_value].to_s + (@edit[:suffix] ? ".#{@edit[:suffix]}" : ""))
                                         )
-        add_flash(_("%{field} Value Error: %{msg}") % {:field => "Field", :msg => e}, :error)
+        add_flash(_("Field Value Error: %{msg}") % {:msg => e}, :error)
       else
         # Change datetime and date values from single element arrays to text string
         if [:datetime, :date].include?(@edit[@expkey][:val1][:type])
@@ -1392,7 +1395,7 @@ module ApplicationController::Filter
     when "count"
       if @edit[@expkey][:exp_value] != :user_input &&
          e = MiqExpression.atom_error(:count, @edit[@expkey][:exp_key], @edit[@expkey][:exp_value])
-        add_flash(_("%{field} Value Error: %{msg}") % {:field => "Field", :msg => e}, :error)
+        add_flash(_("Field Value Error: %{msg}") % {:msg => e}, :error)
       else
         exp.delete(@edit[@expkey][:exp_orig_key])                     # Remove the old exp fields
         exp[@edit[@expkey][:exp_key]] = {}                        # Add in the new key
@@ -1402,9 +1405,9 @@ module ApplicationController::Filter
       end
     when "tag"
       if @edit[@expkey][:exp_tag].nil?
-        add_flash(_("A %s must be chosen to commit this expression element") % "tag category", :error)
+        add_flash(_("A tag category must be chosen to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_value].nil?
-        add_flash(_("A %s must be chosen to commit this expression element") % "tag value", :error)
+        add_flash(_("A tag value must be chosen to commit this expression element"), :error)
       else
         if exp.present?
           exp.delete(@edit[@expkey][:exp_orig_key])                     # Remove the old exp fields
@@ -1416,11 +1419,11 @@ module ApplicationController::Filter
       end
     when "regkey"
       if @edit[@expkey][:exp_regkey].blank?
-        add_flash(_("A %s must be entered to commit this expression element") % "registry key name", :error)
+        add_flash(_("A registry key name must be entered to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_regval].blank? && @edit[@expkey][:exp_key] != "KEY EXISTS"
-        add_flash(_("A %s must be entered to commit this expression element") % "registry value name", :error)
+        add_flash(_("A registry value name must be entered to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_key].include?("REGULAR EXPRESSION") && e = MiqExpression.atom_error(:regexp, @edit[@expkey][:exp_key], @edit[@expkey][:exp_value])
-        add_flash(_("%{field} Value Error: %{msg}") % {:field => "Registry", :msg => e}, :error)
+        add_flash(_("Registry Value Error: %{msg}") % {:msg => e}, :error)
       else
         exp.delete(@edit[@expkey][:exp_orig_key])                     # Remove the old exp fields
         exp[@edit[@expkey][:exp_key]] = {}                        # Add in the new key
@@ -1436,10 +1439,10 @@ module ApplicationController::Filter
       end
     when "find"
       if @edit[@expkey][:exp_field].nil?
-        add_flash(_("A %s must be chosen to commit this expression element") % "find field", :error)
+        add_flash(_("A find field must be chosen to commit this expression element"), :error)
       elsif ["checkall", "checkany"].include?(@edit[@expkey][:exp_check]) &&
             @edit[@expkey][:exp_cfield].nil?
-        add_flash(_("A %s must be chosen to commit this expression element") % "check field", :error)
+        add_flash(_("A check field must be chosen to commit this expression element"), :error)
       elsif @edit[@expkey][:exp_check] == "checkcount" &&
             (@edit[@expkey][:exp_cvalue].nil? || is_integer?(@edit[@expkey][:exp_cvalue]) == false)
         add_flash(_("The check count value must be an integer to commit this expression element"), :error)
@@ -1449,14 +1452,14 @@ module ApplicationController::Filter
                                            @edit[@expkey][:exp_value] :
                                            (@edit[@expkey][:exp_value].to_s + (@edit[:suffix] ? ".#{@edit[:suffix]}" : ""))
                                         )
-        add_flash(_("%{field} Value Error: %{msg}") % {:field => "Find", :msg => e}, :error)
+        add_flash(_("Find Value Error: %{msg}") % {:msg => e}, :error)
       elsif e = MiqExpression.atom_error(@edit[@expkey][:exp_check] == "checkcount" ? :count : @edit[@expkey][:exp_cfield],
                                          @edit[@expkey][:exp_ckey],
                                          @edit[@expkey][:exp_cvalue].kind_of?(Array) ?
                                            @edit[@expkey][:exp_cvalue] :
                                            (@edit[@expkey][:exp_cvalue].to_s + (@edit[:suffix2] ? ".#{@edit[:suffix2]}" : ""))
                                         )
-        add_flash(_("%{field} Value Error: %{msg}") % {:field => "Check", :msg => e}, :error)
+        add_flash(_("Check Value Error: %{msg}") % {:msg => e}, :error)
       else
         # Change datetime and date values from single element arrays to text string
         if [:datetime, :date].include?(@edit[@expkey][:val1][:type])
@@ -1493,7 +1496,7 @@ module ApplicationController::Filter
       end
     else
       add_flash(_("Select an expression element type"), :error)
-      add_flash(_("%s must be selected") % "Expression element type", :error)
+      add_flash(_("Expression element type must be selected"), :error)
     end
   end
 

--- a/app/controllers/application_controller/tags.rb
+++ b/app/controllers/application_controller/tags.rb
@@ -120,7 +120,8 @@ module ApplicationController::Tags
       recs = [params[:id]]
     end
     if recs.length < 1
-      add_flash(_("One or more %{model} must be selected to %{task}") % {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize, :task => "Smart Tagging"}, :error)
+      add_flash(_("One or more %{model} must be selected to Smart Tagging") %
+        {:model => Dictionary.gettext(db.to_s, :type => :model, :notfound => :titleize).pluralize}, :error)
       @refresh_div = "flash_msg_div"
       @refresh_partial = "layouts/flash_msg"
       return
@@ -172,7 +173,7 @@ module ApplicationController::Tags
   def tagging_edit_tags_cancel
     id = params[:id]
     return unless load_edit("#{session[:tag_db]}_edit_tags__#{id}")
-    add_flash(_("%s was cancelled by the user") % "Tag Edit")
+    add_flash(_("Tag Edit was cancelled by the user"))
     session[:tag_items] = nil                                 # reset tag_items in session
     if tagging_explorer_controller?
       @edit = nil # clean out the saved info
@@ -225,7 +226,7 @@ module ApplicationController::Tags
                                       :delete_ids => @edit[:current][:assignments] - @edit[:new][:assignments]
                                     })
   rescue StandardError => bang
-    add_flash(_("Error during '%s': ") % "Save Tags" << bang.message, :error) # Push msg and error flag
+    add_flash(_("Error during 'Save Tags': %{error_message}") % {:error_message => bang.message}, :error)
   else
     add_flash(_("Tag edits were successfully saved"))
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -90,9 +90,11 @@ class CatalogController < ApplicationController
     case params[:button]
     when "cancel"
       if session[:edit][:rec_id]
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => "#{ui_lookup(:model => 'ServiceTemplate')}", :name => session[:edit][:new][:description]})
+        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
+          {:model => ui_lookup(:model => 'ServiceTemplate'), :name => session[:edit][:new][:description]})
       else
-        add_flash(_("Add of new %s was cancelled by the user") % "#{ui_lookup(:model => 'ServiceTemplate')}")
+        add_flash(_("Add of new %{model} was cancelled by the user") %
+          {:model => ui_lookup(:model => 'ServiceTemplate')})
       end
       @edit = @record = nil
       @in_a_form = false
@@ -329,15 +331,18 @@ class CatalogController < ApplicationController
     if params[:id]
       elements.push(params[:id])
       process_sts(elements, 'destroy') unless elements.empty?
-      add_flash(_("The selected %s was deleted") % ui_lookup(:table => "service_template")) if @flash_array.nil?
+      add_flash(_("The selected %{record} was deleted") %
+        {:record => ui_lookup(:table => "service_template")}) if @flash_array.nil?
       self.x_node = "root"
     else # showing 1 element, delete it
       elements = find_checked_items
       if elements.empty?
-        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:tables => "service_template"), :task => "deletion"}, :error)
+        add_flash(_("No %{model} were selected for deletion") %
+          {:model => ui_lookup(:tables => "service_template")}, :error)
       end
       process_sts(elements, 'destroy') unless elements.empty?
-      add_flash(_("The selected %s were deleted") % pluralize(elements.length, ui_lookup(:table => "service_template"))) unless flash_errors?
+      add_flash(_("The selected %{record} were deleted") %
+        {:record => pluralize(elements.length, ui_lookup(:table => "service_template"))}) unless flash_errors?
     end
     params[:id] = nil
     replace_right_cell(nil, trees_to_replace([:sandt, :svccat]))
@@ -351,7 +356,7 @@ class CatalogController < ApplicationController
       if session[:edit][:rec_id]
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => "Catalog Bundle", :name => session[:edit][:new][:description]})
       else
-        add_flash(_("Add of new %s was cancelled by the user") % "Catalog Bundle")
+        add_flash(_("Add of new Catalog Bundle was cancelled by the user"))
       end
       @edit = @record = nil
       @in_a_form = false
@@ -360,13 +365,13 @@ class CatalogController < ApplicationController
       return unless load_edit("st_edit__#{params[:id] || "new"}", "replace_cell__explorer")
       get_form_vars
       if @edit[:new][:name].blank?
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
       end
 
       if @edit[:new][:selected_resources].empty?
-        add_flash(_("%s must be selected") % "Resource", :error)
+        add_flash(_("Resource must be selected"), :error)
       end
-      add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:fqname].blank?
+      add_flash(_("Provisioning Entry Point is required"), :error) if @edit[:new][:fqname].blank?
       dialog_catalog_check
 
       if @flash_array
@@ -601,9 +606,11 @@ class CatalogController < ApplicationController
     case params[:button]
     when "cancel"
       if session[:edit][:rec_id]
-        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => "ServiceTemplateCatalog", :name => session[:edit][:new][:name]})
+        add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") %
+          {:model => ui_lookup(:model => "ServiceTemplateCatalog"), :name => session[:edit][:new][:name]})
       else
-        add_flash(_("Add of new %s was cancelled by the user") % "ServiceTemplateCatalog")
+        add_flash(_("Add of new %{model} was cancelled by the user") %
+          {:model => ui_lookup(:model => "ServiceTemplateCatalog")})
       end
       @edit = nil
       @in_a_form = false
@@ -617,14 +624,12 @@ class CatalogController < ApplicationController
       begin
         @stc.save
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Catalog Edit" << bang.message, :error)
+        add_flash(_("Error during 'Catalog Edit': %{error_message}") % {:error_message => bang.message}, :error)
       else
         if @stc.errors.empty?
           add_flash(_("%{model} \"%{name}\" was saved") %
-                      {:model => "#{ui_lookup(:model => 'ServiceTemplateCatalog')}",
-                       :name  => @edit[:new][:name]
-                      }
-                   )
+                      {:model => ui_lookup(:model => 'ServiceTemplateCatalog'),
+                       :name  => @edit[:new][:name]})
         else
           @stc.errors.each do |field, msg|
             add_flash("#{field.to_s.capitalize} #{msg}", :error)
@@ -671,8 +676,8 @@ class CatalogController < ApplicationController
       begin
         st.public_send(task.to_sym) if st.respond_to?(task)    # Run the task
       rescue StandardError => bang
-        add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => model_name, :name => st_name, :task => task} << bang.message,
-                  :error)
+        add_flash(_("%{model} \"%{name}\": Error during '%{task}': %{error_message}") %
+          {:model => model_name, :name => st_name, :task => task, :error_message => bang.message}, :error)
       else
         AuditEvent.success(audit)
       end
@@ -697,7 +702,8 @@ class CatalogController < ApplicationController
     checked[0] = params[:id] if checked.blank? && params[:id]
     @record = find_by_id_filtered(OrchestrationTemplate, checked[0])
     if @record.in_use?
-      add_flash(_("Orchestration template \"%s\" is read-only and cannot be edited.") % @record.name, :error)
+      add_flash(_("Orchestration template \"%{name}\" is read-only and cannot be edited.") %
+        {:name => @record.name}, :error)
       get_node_info(x_node)
       replace_right_cell(x_node)
       return
@@ -751,14 +757,16 @@ class CatalogController < ApplicationController
     elements = OrchestrationTemplate.where(:id => checked)
     elements.each do |ot|
       if ot.stacks.length > 0
-        add_flash(_("Orchestration template \"%s\" is read-only and cannot be deleted.") % ot.name, :error)
+        add_flash(_("Orchestration template \"%{name}\" is read-only and cannot be deleted.") %
+          {:name => ot.name}, :error)
       else
         begin
           ot.delete
         rescue StandardError => bang
-          add_flash(_("Error during '%s': ") % "Orchestration Template Deletion" << bang.message, :error)
+          add_flash(_("Error during 'Orchestration Template Deletion': %{error_message}") %
+            {:error_message => bang.message}, :error)
         else
-          add_flash(_("Orchestration Template \"%s\" was deleted.") % ot.name)
+          add_flash(_("Orchestration Template \"%{name}\" was deleted.") % {:name => ot.name})
         end
       end
     end
@@ -855,9 +863,9 @@ class CatalogController < ApplicationController
     return unless load_edit("prov_edit__#{id}", "show_list")
     if @edit[:new][:name].blank?
       # check for service template required fields before creating a request
-      add_flash(_("%s is required") % "Name", :error)
+      add_flash(_("Name is required"), :error)
     end
-    add_flash(_("%s is required") % "Provisioning Entry Point", :error) if @edit[:new][:fqname].blank?
+    add_flash(_("Provisioning Entry Point is required"), :error) if @edit[:new][:fqname].blank?
 
     # Check for a Dialog if Display in Catalog is selected
     dialog_catalog_check
@@ -993,7 +1001,8 @@ class CatalogController < ApplicationController
       begin
         ot.save_with_format_validation!
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Orchestration Template Edit" << bang.message, :error)
+        add_flash(_("Error during 'Orchestration Template Edit': %{error_message}") %
+          {:error_message => bang.message}, :error)
         ot_action_submit_flash
       else
         add_flash(_("%{model} \"%{name}\" was saved") %
@@ -1029,13 +1038,12 @@ class CatalogController < ApplicationController
     old_ot = OrchestrationTemplate.find_by_id(id)
     if params[:template_content] == old_ot.content
       add_flash(
-        _("Unable to create a new template copy \"%s\": old and new template content have to differ.") %
-          @edit[:new][:name], :error)
+        _("Unable to create a new template copy \"%{name}\": old and new template content have to differ.") %
+          {:name => @edit[:new][:name]}, :error)
       ot_action_submit_flash
     elsif params[:template_content].nil? || params[:template_content] == ""
-      add_flash(
-        _("Unable to create a new template copy \"%s\": new template content cannot be empty.") % @edit[:new][:name],
-        :error)
+      add_flash(_("Unable to create a new template copy \"%{name}\": new template content cannot be empty.") %
+        {:name => @edit[:new][:name]}, :error)
       ot_action_submit_flash
     else
       ot = OrchestrationTemplate.new(
@@ -1047,7 +1055,8 @@ class CatalogController < ApplicationController
       begin
         ot.save_with_format_validation!
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Orchestration Template Copy" << bang.message, :error)
+        add_flash(_("Error during 'Orchestration Template Copy': %{error_message}") %
+          {:error_message => bang.message}, :error)
         ot_action_submit_flash
       else
         add_flash(_("%{model} \"%{name}\" was saved") %
@@ -1078,7 +1087,7 @@ class CatalogController < ApplicationController
     assert_privileges("orchestration_template_add")
     load_edit("ot_add__new", "replace_cell__explorer")
     if !%w(OrchestrationTemplateHot OrchestrationTemplateCfn OrchestrationTemplateAzure).include?(@edit[:new][:type])
-      add_flash(_("\"%s\" is not a valid Orchestration Template type") % @edit[:new][:type], :error)
+      add_flash(_("\"%{type}\" is not a valid Orchestration Template type") % {:type => @edit[:new][:type]}, :error)
       ot_action_submit_flash
     elsif params[:content].nil? || params[:content].strip == ""
       add_flash(_("Error during Orchestration Template creation: new template content cannot be empty"), :error)
@@ -1093,7 +1102,8 @@ class CatalogController < ApplicationController
       begin
         ot.save_with_format_validation!
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Orchestration Template creation" << bang.message, :error)
+        add_flash(_("Error during 'Orchestration Template creation': %{error_message}") %
+          {:error_message => bang.message}, :error)
         ot_action_submit_flash
       else
         add_flash(_("%{model} \"%{name}\" was saved") %
@@ -1133,12 +1143,14 @@ class CatalogController < ApplicationController
       ot = OrchestrationTemplate.find_by_id(params[:id])
       OrchestrationTemplateDialogService.new.create_dialog(@edit[:new][:dialog_name], ot)
     rescue => bang
-      add_flash(_("Error when creating a Service Dialog from Orchestration Template: ") << bang.message, :error)
+      add_flash(_("Error when creating a Service Dialog from Orchestration Template: %{error_message}") %
+        {:error_message => bang.message}, :error)
       render :update do |page|
         page.replace("flash_msg_div", :partial => "layouts/flash_msg")
       end
     else
-      add_flash(_("Service Dialog \"%s\" was successfully created") % @edit[:new][:dialog_name], :success)
+      add_flash(_("Service Dialog \"%{name}\" was successfully created") %
+        {:name => @edit[:new][:dialog_name]}, :success)
       @in_a_form = false
       @edit = @record = nil
       replace_right_cell
@@ -1197,7 +1209,8 @@ class CatalogController < ApplicationController
     else # showing 1 element, delete it
       elements = find_checked_items
       if elements.empty?
-        add_flash(_("No %{model} were selected for %{task}") % {:model => ui_lookup(:models => "ServiceTemplateCatalog"), :task => "deletion"}, :error)
+        add_flash(_("No %{model} were selected for deletion") %
+          {:model => ui_lookup(:models => "ServiceTemplateCatalog")}, :error)
       end
       process_elements(elements, ServiceTemplateCatalog, "destroy") unless elements.empty?
     end
@@ -1271,7 +1284,8 @@ class CatalogController < ApplicationController
                 st.add_resource(rsc, options)
               rescue MiqException::MiqServiceCircularReferenceError => bang
                 @add_rsc = false
-                add_flash(_("Error during '%s': ") % "Resource Add" << bang.message, :error)
+                add_flash(_("Error during 'Resource Add': %{error_message}") %
+                  {:error_message => bang.message}, :error)
                 break
               else
               end

--- a/app/controllers/chargeback_controller.rb
+++ b/app/controllers/chargeback_controller.rb
@@ -146,7 +146,7 @@ class ChargebackController < ApplicationController
       return unless load_edit("cbrate_edit__#{id}", "replace_cell__chargeback")
       @sb[:rate] = @edit[:rate] if @edit && @edit[:rate]
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
-        add_flash(_("%s is required") % "Description", :error)
+        add_flash(_("Description is required"), :error)
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
@@ -298,19 +298,21 @@ class ChargebackController < ApplicationController
     if !params[:id] # showing a list
       rates = find_checked_items
       if rates.empty?
-        add_flash(_("No %s were selected for deletion") % ui_lookup(:models => "ChargebackRate"), :error)
+        add_flash(_("No %{records} were selected for deletion") %
+          {:records => ui_lookup(:models => "ChargebackRate")}, :error)
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       end
       process_cb_rates(rates, "destroy")  unless rates.empty?
-      add_flash(_("The selected %s were deleted") % ui_lookup(:models => "ChargebackRate"), :info, true) unless flash_errors?
+      add_flash(_("The selected %{records} were deleted") %
+        {:records => ui_lookup(:models => "ChargebackRate")}, :info, true) unless flash_errors?
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
       replace_right_cell([:cb_rates])
     else # showing 1 rate, delete it
       if params[:id].nil? || ChargebackRate.find_by_id(params[:id]).nil?
-        add_flash(_("%s no longer exists") % ui_lookup(:model => "ChargebackRate"), :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:model => "ChargebackRate")}, :error)
         render :update do |page|
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
@@ -319,7 +321,8 @@ class ChargebackController < ApplicationController
       end
       cb_rate = ChargebackRate.find_by_id(params[:id])
       process_cb_rates(rates, "destroy")  unless rates.empty?
-      add_flash(_("The selected %s was deleted") % ui_lookup(:model => "ChargebackRate"), :info, true) unless flash_errors?
+      add_flash(_("The selected %{record} was deleted") %
+        {:record => ui_lookup(:model => "ChargebackRate")}, :info, true) unless flash_errors?
       self.x_node = "xx-#{cb_rate.rate_type}"
       cb_rates_list
       @right_cell_text = _("%{typ} %{model}") % {:typ => x_node.split('-').last, :model => ui_lookup(:models => "ChargebackRate")}
@@ -350,12 +353,12 @@ class ChargebackController < ApplicationController
       begin
         ChargebackRate.set_assignments(rate_type, @edit[:set_assignments])
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "Rate assignments" << bang.message, :error)
+        add_flash(_("Error during 'Rate assignments': %{error_message}") % {:error_message => bang.message}, :error)
         render :update do |page|                    # Use RJS to update the display
           page.replace("flash_msg_div", :partial => "layouts/flash_msg")
         end
       else
-        add_flash(_("%s saved") % "Rate Assignments")
+        add_flash(_("Rate Assignments saved"))
         get_node_info(x_node)
         replace_right_cell
       end
@@ -392,8 +395,8 @@ class ChargebackController < ApplicationController
       @report = rr.report_results
       session[:rpt_task_id] = nil
       if @report.blank?
-        add_flash(_("Saved Report \"%s\" not found, Schedule may have failed") %
-          format_timezone(rr.last_run_on, Time.zone, "gtl"), :error)
+        add_flash(_("Saved Report \"%{name}\" not found, Schedule may have failed") %
+          {:name => format_timezone(rr.last_run_on, Time.zone, "gtl")}, :error)
         @saved_reports = cb_rpts_get_all_reps(rr.miq_report_id.to_s)
         rep = MiqReport.find_by_id(rr.miq_report_id)
         if x_active_tree == :cb_reports
@@ -469,7 +472,7 @@ class ChargebackController < ApplicationController
           @right_cell_div = "reports_list_div"
           @right_cell_text = _("%{model} \"%{name}\"") % {:model => "Saved Chargeback Report", :name => format_timezone(s.last_run_on, Time.zone, "gtl")}
         else
-          add_flash(_("Selected %s Report no longer exists") % "Saved Chargeback", :warning)
+          add_flash(_("Selected Saved Chargeback Report no longer exists"), :warning)
           self.x_node = nodes[0..1].join("_")
           cb_rpts_build_tree # Rebuild tree
         end
@@ -484,7 +487,7 @@ class ChargebackController < ApplicationController
           @right_cell_text = _("%{model} \"%{name}\"") % {:model => "Saved Chargeback Reports", :name => miq_report.name}
           @sb[:parent_reports] = nil  unless @sb[:saved_reports].blank?    # setting it to nil so saved reports can be displayed, unless all saved reports were deleted
         else
-          add_flash(_("Selected %s Report no longer exists") % "Chargeback", :warning)
+          add_flash(_("Selected Chargeback Report no longer exists"), :warning)
           self.x_node = nodes[0]
           @saved_reports = nil
           cb_rpts_build_tree # Rebuild tree

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -204,7 +204,7 @@ class ConfigurationController < ApplicationController
           @css.merge!(@settings[:display])
           @css.merge!(THEME_CSS_SETTINGS[@settings[:display][:theme]])
           set_user_time_zone
-          add_flash(_("User Interface settings saved for User %s") % current_user.name)
+          add_flash(_("User Interface settings saved for User %{name}") % {:name => current_user.name})
         else
           add_flash(_("User Interface settings saved for this session"))
         end
@@ -217,7 +217,7 @@ class ConfigurationController < ApplicationController
         if current_user
           settings = merge_settings(current_user.settings, @settings)
           current_user.update_attributes(:settings => settings)
-          add_flash(_("User Interface settings saved for User %s") % current_user.name)
+          add_flash(_("User Interface settings saved for User %{name}") % {:name => current_user.name})
         else
           add_flash(_("User Interface settings saved for this session"))
         end
@@ -367,7 +367,8 @@ class ConfigurationController < ApplicationController
     unless params[:id] # showing a list, scan all selected timeprofiles
       timeprofiles = find_checked_items
       if timeprofiles.empty?
-        add_flash(_("No %s were selected for deletion") % ui_lookup(:models => "TimeProfile"), :error)
+        add_flash(_("No %{records} were selected for deletion") %
+          {:records => ui_lookup(:models => "TimeProfile")}, :error)
       else
         selected_timeprofiles = TimeProfile.find_all_by_id(timeprofiles)
         selected_timeprofiles.each do |tp|
@@ -480,20 +481,20 @@ class ConfigurationController < ApplicationController
     timeprofile_get_form_vars
     case params[:button]
     when "cancel"
-      add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "TimeProfile"))
+      add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "TimeProfile")})
       session[:flash_msgs] = @flash_array.dup                 # Put msgs in session for next transaction
       render :update do |page|
         page.redirect_to :action => 'change_tab', :typ => "timeprofiles", :tab => 4
       end
     when "add"
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
-        add_flash(_("%s is required") % "Description", :error)
+        add_flash(_("Description is required"), :error)
       end
       if @edit[:new][:profile][:days].length <= 0
-        add_flash(_("At least one %s must be selected") % "Day", :error)
+        add_flash(_("At least one Day must be selected"), :error)
       end
       if @edit[:new][:profile][:hours].length <= 0
-        add_flash(_("At least one %s must be selected") % "Hour", :error)
+        add_flash(_("At least one Hour must be selected"), :error)
       end
       unless @flash_array.nil?
         drop_breadcrumb(:name => "Add New Time Profile", :url => "/configuration/timeprofile_edit")
@@ -506,7 +507,7 @@ class ConfigurationController < ApplicationController
       begin
         @timeprofile.save!
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "add" << bang.message, :error)
+        add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         drop_breadcrumb(:name => "Add New Time Profile", :url => "/configuration/timeprofile_edit")
         render :update do |page|
@@ -545,13 +546,13 @@ class ConfigurationController < ApplicationController
       end
     elsif params[:button] == "save"
       if @edit[:new][:description].nil? || @edit[:new][:description] == ""
-        add_flash(_("%s is required") % "Description", :error)
+        add_flash(_("Description is required"), :error)
       end
       if @edit[:new][:profile][:days].length <= 0
-        add_flash(_("At least one %s must be selected") % "Day", :error)
+        add_flash(_("At least one Day must be selected"), :error)
       end
       if @edit[:new][:profile][:hours].length <= 0
-        add_flash(_("At least one %s must be selected") % "Hour", :error)
+        add_flash(_("At least one Hour must be selected"), :error)
       end
       unless @flash_array.nil?
         @changed = session[:changed] = (@edit[:new] != @edit[:current])
@@ -566,8 +567,8 @@ class ConfigurationController < ApplicationController
       begin
         timeprofile.save!
       rescue StandardError => bang
-        add_flash(_("%{model} \"%{name}\": Error during '%{task}': ") % {:model => "TimeProfile", :name => timeprofile.description, :task => "save"} << bang.message,
-                  :error)
+        add_flash(_("%{model} \"%{name}\": Error during 'save': %{error_message}") %
+          {:model => "TimeProfile", :name => timeprofile.description, :error_message => bang.message}, :error)
         @in_a_form = true
         drop_breadcrumb(:name => "Edit '#{timeprofile.description}'", :url => "/configuration/timeprofile_edit")
         render :update do |page|

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -593,7 +593,7 @@ class MiqAeClassController < ApplicationController
       replace_right_cell
     when "save"
       if @edit[:new][:ae_inst]["name"].blank?
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
       end
       if @flash_array
         render :update do |page|
@@ -615,7 +615,7 @@ class MiqAeClassController < ApplicationController
           @ae_inst.save!
         end   # end of transaction
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "save" << bang.message, :error)
+        add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         flash_validation_errors(@ae_inst)
         render :update do |page|
@@ -654,7 +654,7 @@ class MiqAeClassController < ApplicationController
       return unless load_edit("aeinst_edit__new", "replace_cell__explorer")
       get_instances_form_vars
       if @edit[:new][:ae_inst]["name"].blank?
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
       end
       if @flash_array
         render :update do |page|
@@ -1006,7 +1006,7 @@ class MiqAeClassController < ApplicationController
           ae_class.save!
         end  # end of transaction
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "save" << bang.message, :error)
+        add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         session[:changed] = @changed
         @changed = true
         render :update do |page|
@@ -1052,7 +1052,7 @@ class MiqAeClassController < ApplicationController
           ae_class.save!
         end  # end of transaction
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "save" << bang.message, :error)
+        add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         flash_validation_errors(ae_class)
         session[:changed] = @changed = true
         render :update do |page|
@@ -1148,7 +1148,7 @@ class MiqAeClassController < ApplicationController
           ae_method.save!
         end  # end of transaction
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "save" << bang.message, :error)
+        add_flash(_("Error during 'save': %{error_message}") % {:error_message => bang.message}, :error)
         flash_validation_errors(ae_method)
         session[:changed] = @changed
         @changed = true
@@ -1212,7 +1212,7 @@ class MiqAeClassController < ApplicationController
     @in_a_form = true
     case params[:button]
     when "cancel"
-      add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "MiqAeClass"))
+      add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "MiqAeClass")})
       @in_a_form = false
       replace_right_cell([:ae])
     when "add"
@@ -1223,7 +1223,7 @@ class MiqAeClassController < ApplicationController
           add_aeclass.save!
         end
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "add" << bang.message, :error)
+        add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         @in_a_form = true
         render :update do |page|
           page.replace("flash_msg_div_class_props", :partial => "layouts/flash_msg", :locals => {:div_num => "_class_props"})
@@ -1244,7 +1244,7 @@ class MiqAeClassController < ApplicationController
     @in_a_form = true
     case params[:button]
     when "cancel"
-      add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "MiqAeMethod"))
+      add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "MiqAeMethod")})
       @sb[:form_vars_set] = false
       @in_a_form = false
       replace_right_cell
@@ -1260,7 +1260,7 @@ class MiqAeClassController < ApplicationController
           add_aemethod.save!
         end
       rescue StandardError => bang
-        add_flash(_("Error during '%s': ") % "add" << bang.message, :error)
+        add_flash(_("Error during 'add': %{error_message}") % {:error_message => bang.message}, :error)
         flash_validation_errors(add_aemethod)
         @in_a_form = true
         render :update do |page|
@@ -1285,7 +1285,7 @@ class MiqAeClassController < ApplicationController
     get_ns_form_vars
     case params[:button]
     when "cancel"
-      add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => @edit[:typ]))
+      add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => @edit[:typ])})
       @in_a_form = false
       replace_right_cell
     when "add"
@@ -1572,7 +1572,8 @@ class MiqAeClassController < ApplicationController
   def copy_objects
     ids = objects_to_copy
     if ids.blank?
-      add_flash(_("%{task} does not apply to selected %{model}") % {:task  => "Copy", :model => ui_lookup(:model => "MiqAeNamespace")}, :error)
+      add_flash(_("Copy does not apply to selected %{model}") %
+        {:model => ui_lookup(:model => "MiqAeNamespace")}, :error)
       @sb[:action] = session[:edit] = nil
       @in_a_form = false
       replace_right_cell
@@ -1698,13 +1699,14 @@ class MiqAeClassController < ApplicationController
     begin
       res = @edit[:typ].copy(options)
     rescue StandardError => bang
-      add_flash(_("Error during '%s': ") % "#{ui_lookup(:model => "#{@edit[:typ]}")} copy" << bang.message, :error)
+      add_flash(_("Error during '%{record} copy': %{error_message}") %
+        {:record => ui_lookup(:model => "#{@edit[:typ]}"), :error_message => bang.message}, :error)
       render :update do |page|
         page.replace("flash_msg_div_copy", :partial => "layouts/flash_msg", :locals  => {:div_num => "_copy"})
       end
     else
       model = @edit[:selected_items].count > 1 ? :models : :model
-      add_flash(_("Copy selected %s was saved") % ui_lookup(model => "#{@edit[:typ]}"))
+      add_flash(_("Copy selected %{record} was saved") % {:record => ui_lookup(model => "#{@edit[:typ]}")})
       @record = res.kind_of?(Array) ? @edit[:typ].find_by_id(res.first) : res
       self.x_node = "#{TreeBuilder.get_prefix_for_model(@edit[:typ])}-#{to_cid(@record.id)}"
       @in_a_form = @changed = session[:changed] = false
@@ -1729,9 +1731,7 @@ class MiqAeClassController < ApplicationController
     @record = session[:edit][:typ].find_by_id(session[:edit][:rec_id])
     model = @edit[:selected_items].count > 1 ? :models : :model
     @sb[:action] = session[:edit] = nil # clean out the saved info
-    add_flash(_("Copy %s was cancelled by the user") % ui_lookup(model => "#{@edit[:typ]}")
-
-             )
+    add_flash(_("Copy %{record} was cancelled by the user") % {:record => ui_lookup(model => "#{@edit[:typ]}")})
     @in_a_form = false
     replace_right_cell
   end
@@ -1860,7 +1860,8 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aeinstances(aeinstances, "destroy") unless aeinstances.empty?
-    add_flash(_("The selected %s were deleted") % ui_lookup(:models => "MiqAeInstances")) if @flash_array.nil?
+    add_flash(_("The selected %{record} were deleted") %
+      {:record => ui_lookup(:models => "MiqAeInstances")}) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 
@@ -1887,7 +1888,8 @@ class MiqAeClassController < ApplicationController
     end
 
     process_aemethods(aemethods, "destroy") unless aemethods.empty?
-    add_flash(_("The selected %s were deleted") % ui_lookup(:models => "MiqAeMethod")) if @flash_array.nil?
+    add_flash(_("The selected %{record} were deleted") %
+      {:record => ui_lookup(:models => "MiqAeMethod")}) if @flash_array.nil?
     replace_right_cell([:ae])
   end
 
@@ -1912,8 +1914,7 @@ class MiqAeClassController < ApplicationController
           aedomains.push(domain.id)
         else
           add_flash(_("Read Only %{model} \"%{name}\" cannot be deleted") %
-                      {:model => ui_lookup(:model => "MiqAeDomain"), :name  => domain.name},
-                    :error)
+            {:model => ui_lookup(:model => "MiqAeDomain"), :name => domain.name}, :error)
         end
       end
     end
@@ -2058,7 +2059,7 @@ class MiqAeClassController < ApplicationController
       end
     elsif params[:button] == "accept"
       if session[:field_data]['name'].blank?
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
         return
       end
       new_fields = {}
@@ -2123,7 +2124,7 @@ class MiqAeClassController < ApplicationController
       session[:field_data] ||= {}
     elsif params[:button] == "accept"
       if @edit[:new_field].blank? || @edit[:new_field][:name].nil? || @edit[:new_field][:name] == ""
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
         return
       end
       new_field = {}
@@ -2318,7 +2319,7 @@ class MiqAeClassController < ApplicationController
 
   def move_selected_fields_up(available_fields, selected_fields, display_name)
     if no_items_selected?(selected_fields)
-      add_flash(_("No %s were selected to move up") % display_name, :error)
+      add_flash(_("No %{name} were selected to move up") % {:name => display_name}, :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?(available_fields, selected_fields)
@@ -2330,14 +2331,14 @@ class MiqAeClassController < ApplicationController
         end
       end
     else
-      add_flash(_("Select only one or consecutive %s to move up") % display_name, :error)
+      add_flash(_("Select only one or consecutive %{name} to move up") % {:name => display_name}, :error)
     end
     @selected = selected_fields
   end
 
   def move_selected_fields_down(available_fields, selected_fields, display_name)
     if no_items_selected?(selected_fields)
-      add_flash(_("No %s were selected to move down") % display_name, :error)
+      add_flash(_("No %{name} were selected to move down") % {:name => display_name}, :error)
       return
     end
     consecutive, first_idx, last_idx = selected_consecutive?(available_fields, selected_fields)
@@ -2351,7 +2352,7 @@ class MiqAeClassController < ApplicationController
         end
       end
     else
-      add_flash(_("Select only one or consecutive %s to move down") % display_name, :error)
+      add_flash(_("Select only one or consecutive %{name} to move down") % {:name => display_name}, :error)
     end
     @selected = selected_fields
   end

--- a/app/controllers/miq_ae_customization_controller.rb
+++ b/app/controllers/miq_ae_customization_controller.rb
@@ -119,7 +119,7 @@ class MiqAeCustomizationController < ApplicationController
       timestamp = format_timezone(Time.current, Time.zone, "export_filename")
       send_data(dialog_yaml, :filename => "dialog_export_#{timestamp}.yml")
     else
-      add_flash(_("At least %{num} %{model} must be selected for %{action}") % {:num => 1, :model => "item", :action => "export"}, :error)
+      add_flash(_("At least 1 item must be selected for export"), :error)
       @sb[:flash_msg] = @flash_array
       redirect_to :action => :explorer
     end

--- a/app/controllers/miq_ae_customization_controller/custom_buttons.rb
+++ b/app/controllers/miq_ae_customization_controller/custom_buttons.rb
@@ -40,7 +40,7 @@ module MiqAeCustomizationController::CustomButtons
     @sb[:buttons] = nil
 
     if @nodetype[0] == "root"
-      @right_cell_text = _("All %s") % "Object Types"
+      @right_cell_text = _("All Object Types")
       @sb[:obj_list] = {}
       if session[:resolve]
         @resolve = session[:resolve]
@@ -51,7 +51,7 @@ module MiqAeCustomizationController::CustomButtons
         @sb[:obj_list][node[0]] = "ab_#{node[0]}"
       end
     elsif @nodetype[0] == "xx-ab" && nodeid.length == 2   # one of the CI's node selected
-      @right_cell_text = _("%{typ} %{model}") % {:typ => @sb[:target_classes].invert[@nodetype[2]], :model => "Button Groups"}
+      @right_cell_text = _("%{typ} Button Groups") % {:typ => @sb[:target_classes].invert[@nodetype[2]]}
       @sb[:applies_to_class] = x_node.split('-').last.split('_').last
       asets = CustomButtonSet.find_all_by_class_name(@nodetype[1])
       @sb[:button_groups] = []
@@ -68,7 +68,8 @@ module MiqAeCustomizationController::CustomButtons
       end
     elsif @nodetype.length == 1 && nodeid[1] == "ub"        # Unassigned buttons group selected
       @sb[:buttons] = []
-      @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ => @sb[:target_classes].invert[nodeid[2]], :model => "Button Group", :name => "Unassigned Buttons"}
+      @right_cell_text = _("%{typ} Button Group \"Unassigned Buttons\"") %
+                         {:typ => @sb[:target_classes].invert[nodeid[2]]}
       uri = CustomButton.buttons_for(nodeid[2]).sort_by(&:name)
       unless uri.blank?
         uri.each do |b|
@@ -120,11 +121,13 @@ module MiqAeCustomizationController::CustomButtons
               end
         @resolve[:new][:target_class] = @sb[:target_classes].invert[kls]
       end
-      @right_cell_text = _("%{model} \"%{name}\"") % {:model => "Button", :name => @custom_button.name}
+      @right_cell_text = _("Button \"%{name}\"") % {:name => @custom_button.name}
     else                # assigned buttons node/folder
       @sb[:applies_to_class] = @nodetype[1]
       @record = CustomButtonSet.find(from_cid(nodeid.last))
-      @right_cell_text = _("%{typ} %{model} \"%{name}\"") % {:typ => @sb[:target_classes].invert[@nodetype[2]], :model => "Button Group", :name => @record.name.split("|").first}
+      @right_cell_text = _("%{typ} Button Group \"%{name}\"") %
+                         {:typ  => @sb[:target_classes].invert[@nodetype[2]],
+                          :name => @record.name.split("|").first}
       @sb[:button_group] = {}
       @sb[:button_group][:text] =
           @sb[:button_group][:hover_text] =

--- a/app/controllers/miq_ae_customization_controller/dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/dialogs.rb
@@ -471,7 +471,7 @@ module MiqAeCustomizationController::Dialogs
           @edit[:field_values] = copy_array(key[:values])
         end
       else
-        add_flash(_("%{field1} and %{field2} fields can't be blank") % {:field1 => "Value", :field2 => "Description"}, :error)
+        add_flash(_("Value and Description fields can't be blank"), :error)
         focus_field = entry_value == "" ? "entry_value" : "entry_description"
         render_flash do |page|
           page << "$('##{focus_field}').focus();"
@@ -641,7 +641,7 @@ module MiqAeCustomizationController::Dialogs
 
   def move_field_value_up
     if no_items_selected?(:entry_id)
-      add_flash(_("No %s were selected to move up") % "fields", :error)
+      add_flash(_("No fields were selected to move up"), :error)
       return
     end
     prepare_move_field_value
@@ -650,7 +650,7 @@ module MiqAeCustomizationController::Dialogs
 
   def move_field_value_down
     if no_items_selected?(:entry_id)
-      add_flash(_("No %s were selected to move down") % "fields", :error)
+      add_flash(_("No fields were selected to move down"), :error)
       return
     end
     prepare_move_field_value
@@ -664,22 +664,22 @@ module MiqAeCustomizationController::Dialogs
     nodes = x_node.split('_')
     if nodes.length == 1 && @sb[:node_typ].blank? # dialog is being edited
       if @edit[:new][:label].nil? || @edit[:new][:label].strip == ""
-        add_flash(_("%s is required") % "Dialog Label", :error)
+        add_flash(_("Dialog Label is required"), :error)
         res = false
       end
     elsif (nodes.length == 2 && @sb[:node_typ] != "box") || (nodes.length == 1 && @sb[:node_typ] == "tab")  # tab is being added or edited
       if @edit[:tab_label].nil? || @edit[:tab_label].strip == ""
-        add_flash(_("%s is required") % "Tab Label", :error)
+        add_flash(_("Tab Label is required"), :error)
         res = false
       end
     elsif (nodes.length == 3 && @sb[:node_typ] != "element") || (nodes.length == 2 && @sb[:node_typ] == "box")         # #group is being added or edited
       if @edit[:group_label].nil? || @edit[:group_label].strip == ""
-        add_flash(_("%s is required") % "Box Label", :error)
+        add_flash(_("Box Label is required"), :error)
         res = false
       end
     elsif @sb[:node_typ] == "element"         # #field is being added or edited
       if @edit[:field_label].nil? || @edit[:field_label].strip == ""
-        add_flash(_("%s is required") % "Element Label", :error)
+        add_flash(_("Element Label is required"), :error)
         res = false
       end
       if needs_entry_point?
@@ -687,15 +687,15 @@ module MiqAeCustomizationController::Dialogs
         res = false
       end
       if @edit[:field_name].to_s !~ /^[a-z0-9_]+$/i
-        add_flash(_("%s must be alphanumeric characters and underscores without spaces") % "Element Name", :error)
+        add_flash(_("Element Name must be alphanumeric characters and underscores without spaces"), :error)
         res = false
       end
       if ["action", "controller"].include?(@edit[:field_name].to_s)
-        add_flash(_("%s must not be 'action' or 'controller'") % "Element Name", :error)
+        add_flash(_("Element Name must not be 'action' or 'controller'"), :error)
         res = false
       end
       if @edit[:field_typ].nil? || @edit[:field_typ].strip == ""
-        add_flash(_("%s is required") % "Element Type", :error)
+        add_flash(_("Element Type is required"), :error)
         res = false
       end
       if needs_dropdown_values?
@@ -1342,7 +1342,7 @@ module MiqAeCustomizationController::Dialogs
       replace_right_cell(x_node, [:dialogs])
     else # showing 1 dialog
       if params[:id].nil? || Dialog.find_by_id(params[:id]).nil?
-        add_flash(_("%s no longer exists") % ui_lookup(:model => "Dialog"), :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:model => "Dialog")}, :error)
         dialog_list
         @refresh_partial = "layouts/gtl"
       else

--- a/app/controllers/miq_ae_customization_controller/old_dialogs.rb
+++ b/app/controllers/miq_ae_customization_controller/old_dialogs.rb
@@ -80,7 +80,7 @@ module MiqAeCustomizationController::OldDialogs
       replace_right_cell(x_node, [:old_dialogs])
     else # showing 1 vm
       if params[:id].nil? || MiqDialog.find_by_id(params[:id]).nil?
-        add_flash(_("%s no longer exists") % ui_lookup(:model => "MiqDialog"), :error)
+        add_flash(_("%{record} no longer exists") % {:record => ui_lookup(:model => "MiqDialog")}, :error)
         old_dialogs_list
         @refresh_partial = "layouts/gtl"
       else
@@ -104,7 +104,7 @@ module MiqAeCustomizationController::OldDialogs
   def old_dialogs_get_node_info(treenodeid)
     if treenodeid == "root"
       old_dialogs_list
-      @right_cell_text = _("All %s") % ui_lookup(:models => "MiqDialog")
+      @right_cell_text = _("All %{dialogs}") % {:dialogs => ui_lookup(:models => "MiqDialog")}
       @right_cell_div  = "old_dialogs_list"
     else
       nodes = treenodeid.split("_")
@@ -236,7 +236,7 @@ module MiqAeCustomizationController::OldDialogs
     when "cancel"
       @edit = session[:edit] = nil # clean out the saved info
       if !@dialog || @dialog.id.blank?
-        add_flash(_("Add of new %s was cancelled by the user") % ui_lookup(:model => "MiqDialog"))
+        add_flash(_("Add of new %{record} was cancelled by the user") % {:record => ui_lookup(:model => "MiqDialog")})
       else
         add_flash(_("Edit of %{model} \"%{name}\" was cancelled by the user") % {:model => ui_lookup(:model => "MiqDialog"), :name => @dialog.name})
       end
@@ -246,15 +246,15 @@ module MiqAeCustomizationController::OldDialogs
       # dialog = find_by_id_filtered(MiqDialog, params[:id])
       dialog = @dialog.id.blank? ? MiqDialog.new : MiqDialog.find(@dialog.id) # Get new or existing record
       if @edit[:new][:name].blank?
-        add_flash(_("%s is required") % "Name", :error)
+        add_flash(_("Name is required"), :error)
       end
       unless @edit[:new][:dialog_type]
-        add_flash(_("%s must be selected") % "Dialog Type", :error)
+        add_flash(_("Dialog Type must be selected"), :error)
       end
       begin
         YAML.parse(@edit[:new][:content])
       rescue YAML::SyntaxError => ex
-        add_flash("#{_("Syntax error in YAML file: ")}#{ex.message}", :error)
+        add_flash(_("Syntax error in YAML file: %{error_message}") % {:error_message => ex.message}, :error)
       end
       if @flash_array
         render :update do |page|


### PR DESCRIPTION
We're getting rid of:
* unnecessary interpolations: `_("xx %{yy} zz") % {:yy => "yy"}`
  `-> _("xx yy zz")`
* string concatenations: `_("xx ") << yy`
  `-> _("xx %{yy}") % {:yy => yy}`
* unnamed placeholders: `_("xx %s") % yy`
  `-> _("xx %{yy}") % {:yy => yy}`

Fixes after 3293a52c3ee1d2bff64e56aab6e0864c7c763ceb

This is first the batch of the fixed files, to make the review easier.