### PR TITLE
Remove unused constants in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,9 +48,6 @@ class User < ApplicationRecord
 
   @role_changed = false
 
-  EVMROLE_SELF_SERVICE_ROLE_NAME         = "EvmRole-user_self_service"
-  EVMROLE_LIMITED_SELF_SERVICE_ROLE_NAME = "EvmRole-user_limited_self_service"
-
   FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
 
   serialize     :settings, Hash   # Implement settings column as a hash


### PR DESCRIPTION
These constants, introduced in 7127e1fb, are no longer used anywhere.