### PR TITLE
Remove unused methods in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,10 +244,6 @@ class User < ApplicationRecord
     subscribed_widget_sets_for_group(group_id).destroy_all
   end
 
-  def valid_for_login?
-    !!miq_user_role
-  end
-
   def accessible_vms
     if limited_self_service?
       vms

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,10 +244,6 @@ class User < ApplicationRecord
     subscribed_widget_sets_for_group(group_id).destroy_all
   end
 
-  def destroy_orphaned_dashboards
-    (group_ids_of_subscribed_widget_sets - miq_group_ids).each { |group_id| destroy_widget_sets_for_group(group_id) }
-  end
-
   def valid_for_login?
     !!miq_user_role
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -240,10 +240,6 @@ class User < ApplicationRecord
     subscribed_widget_sets.destroy_all
   end
 
-  def destroy_widget_sets_for_group(group_id)
-    subscribed_widget_sets_for_group(group_id).destroy_all
-  end
-
   def accessible_vms
     if limited_self_service?
       vms

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,10 +228,6 @@ class User < ApplicationRecord
     MiqWidgetSet.subscribed_for_user(self)
   end
 
-  def subscribed_widget_sets_for_group(group_id)
-    subscribed_widget_sets.where(:group_id => group_id)
-  end
-
   def destroy_subscribed_widget_sets
     subscribed_widget_sets.destroy_all
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,10 +228,6 @@ class User < ApplicationRecord
     MiqWidgetSet.subscribed_for_user(self)
   end
 
-  def group_ids_of_subscribed_widget_sets
-    subscribed_widget_sets.pluck(:group_id).compact.uniq
-  end
-
   def subscribed_widget_sets_for_group(group_id)
     subscribed_widget_sets.where(:group_id => group_id)
   end

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -29,11 +29,6 @@ describe MiqWidgetSet do
       expect(MiqWidgetSet.count).to eq(2)
     end
 
-    it "no longer belonging to a group" do
-      user.destroy_widget_sets_for_group(group.id)
-      expect(MiqWidgetSet.count).to eq(1)
-    end
-
     it "the belong to group is being deleted" do
       expect { group.destroy }.to raise_error(RuntimeError, /Still has users assigned/)
       expect(MiqWidgetSet.count).to eq(2)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -420,14 +420,6 @@ describe User do
       FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => @user.userid, :group_id => group2.id)
       expect(subject).to match_array([@group.id, group2.id])
     end
-
-    it "a belong to group is deleted" do
-      group2 = FactoryGirl.create(:miq_group, :description => '2nd group')
-      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => @user.userid, :group_id => group2.id)
-
-      @user.destroy_widget_sets_for_group(group2)
-      expect(subject).to eq([@group.id])
-    end
   end
 
   context ".authenticate_with_http_basic" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -396,32 +396,6 @@ describe User do
     expect(user).not_to be_valid
   end
 
-  context "#group_ids_of_subscribed_widget_sets" do
-    subject { @user.group_ids_of_subscribed_widget_sets }
-    before do
-      @group = FactoryGirl.create(:miq_group, :description => 'dev group')
-      @user  = FactoryGirl.create(:user, :name => 'cloud', :userid => 'cloud', :miq_groups => [@group])
-      @ws_group = FactoryGirl.create(:miq_widget_set, :name => 'Home', :owner => @group)
-      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => @user.userid, :group_id => @group.id)
-    end
-
-    it "none group" do
-      @group.users.destroy_all
-      @group.destroy
-      expect(subject).to be_empty
-    end
-
-    it "one group" do
-      expect(subject).to eq([@group.id])
-    end
-
-    it "multiple groups" do
-      group2 = FactoryGirl.create(:miq_group, :description => '2nd group')
-      FactoryGirl.create(:miq_widget_set, :name => 'Home', :userid => @user.userid, :group_id => group2.id)
-      expect(subject).to match_array([@group.id, group2.id])
-    end
-  end
-
   context ".authenticate_with_http_basic" do
     let(:user) { FactoryGirl.create(:user, :password => "dummy") }
 


### PR DESCRIPTION
Removes three methods which aren't being used anywhere in the app. See commit messages for SHAs where they were introduced.