### PR TITLE
Remove unused MiqGroup methods

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -143,12 +143,6 @@ class MiqGroup < ApplicationRecord
     user_groups.first
   end
 
-  def get_user_scope(options = {})
-    scope = filters.kind_of?(MiqUserScope) ? filters : MiqUserScope.hash_to_scope(filters)
-
-    scope.get_filters(options)
-  end
-
   def get_filters(type = nil)
     if type
       (filters.respond_to?(:key?) && filters[type.to_s]) || []

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -46,10 +46,6 @@ class MiqGroup < ApplicationRecord
     description
   end
 
-  def all_users
-    User.all_users_of_group(self)
-  end
-
   def self.allows?(_group, _options = {})
     # group: Id || Instance
     # :identifier => Feature Identifier

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -46,22 +46,6 @@ class MiqGroup < ApplicationRecord
     description
   end
 
-  def self.allows?(_group, _options = {})
-    # group: Id || Instance
-    # :identifier => Feature Identifier
-    # :object => Vm, Host, etc.
-
-    # TODO
-    # group = self.extract_objects(group)
-    # return true if self.filters.nil? # TODO - Man need to check for filters like {:managed => [], :belongsto => []}
-    #
-    # feature_type = MiqProductFeature.feature_details(identifier)[:feature_type]
-    #
-    # self.filters = MiqUserScope.hash_to_scope(self.filters) unless self.filters.kind_of?(MiqUserScope)
-
-    true # Remove once this is implemented
-  end
-
   def self.next_sequence
     maximum(:sequence).to_i + 1
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -325,20 +325,6 @@ describe MiqGroup do
     end
   end
 
-  describe "#all_users" do
-    it "finds users" do
-      g  = FactoryGirl.create(:miq_group)
-      g2 = FactoryGirl.create(:miq_group)
-
-      FactoryGirl.create(:user)
-      u_one  = FactoryGirl.create(:user, :miq_groups => [g])
-      u_two  = FactoryGirl.create(:user, :miq_groups => [g, g2], :current_group => g)
-
-      expect(g.all_users).to match_array([u_one, u_two])
-      expect(g2.all_users).to match_array([u_two])
-    end
-  end
-
   describe "#read_only" do
     it "is not read_only for regular groups" do
       expect(FactoryGirl.create(:miq_group)).not_to be_read_only


### PR DESCRIPTION
These methods aren't being used. Removing them as part of the separation of Users <-> MiqGroups.