### PR TITLE
Ems refresh log parser

### DIFF
--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -1,0 +1,67 @@
+RAILS_ROOT = ENV["RAILS_ENV"] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+$:.push File.join(RAILS_ROOT, "gems/pending/util") unless ENV["RAILS_ENV"]
+
+require 'miq_logger_processor'
+require 'time'
+
+TARGETS = [ "EmsVmware" , "HostVmwareEsx", "VmVmware" ]
+COLUMNS = ["start", "end", "duration", "ems", "target"]
+
+logfiles = ARGV.select { |f| File.file?(f) }
+logfiles << File.join(RAILS_ROOT, "log/evm.log") if logfiles.empty?
+logfiles.map { |f| File.expand_path(f) }
+
+puts "Processing file..."
+
+all_timings = []
+ems_timings = Hash.new { |k, v| k[v] = [] }
+all_targets = Hash.new { |k, v| k[v] = [] }
+
+logfiles.each do |logfile|
+  MiqLoggerProcessor.new(logfile).each do |line|
+    # Find the target type
+    if line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Refreshing target ([^\s]+).+Complete/
+      ems         = $1
+      target_type = $2
+
+      all_targets[ems] << {
+        :time        => line.time,
+        :target_type => target_type
+      }
+    end
+
+    next unless line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Timings:? (\{.+)$/
+    ems     = $1
+    timings = eval($2)
+
+    timings[:end_time]    = Time.parse(line.time + " UTC")
+    timings[:start_time]  = timings[:end_time] - timings[:total_time]
+    timings[:target_type] = all_targets[ems].last[:target_type]
+    timings[:ems]         = ems
+
+    if TARGETS.include?(timings[:target_type])
+      all_timings      << timings
+      ems_timings[ems] << timings
+    end
+  end
+end
+
+print "Found #{all_timings.length} refreshes from #{ems_timings.keys.length} providers\n"
+
+COLUMN_MAX_LENGTH = [ 0, 0, 0, 0, 0]
+all_timings.sort_by { |t| t[:start_time] }.each do |timing|
+  COLUMN_MAX_LENGTH[0] = [COLUMN_MAX_LENGTH[0], timing[:start_time].to_s.length].max
+  COLUMN_MAX_LENGTH[1] = [COLUMN_MAX_LENGTH[1], timing[:end_time].to_s.length].max
+  COLUMN_MAX_LENGTH[2] = [COLUMN_MAX_LENGTH[2], timing[:total_time].to_s.length].max
+  COLUMN_MAX_LENGTH[3] = [COLUMN_MAX_LENGTH[3], timing[:ems].length].max
+  COLUMN_MAX_LENGTH[4] = [COLUMN_MAX_LENGTH[4], timing[:target_type].length].max
+end
+
+COLUMNS.each_with_index do |col, i|
+  print "#{col.ljust(COLUMN_MAX_LENGTH[i])}   "
+end
+print "\n"
+
+all_timings.sort_by { |t| t[:start_time] }.each do |timing|
+  print "#{timing[:start_time].to_s.ljust(COLUMN_MAX_LENGTH[0])} | #{timing[:end_time].to_s.ljust(COLUMN_MAX_LENGTH[1])} | #{timing[:total_time].to_s.ljust(COLUMN_MAX_LENGTH[2])} | #{timing[:ems].to_s.ljust(COLUMN_MAX_LENGTH[3])} | #{timing[:target_type].to_s.ljust(COLUMN_MAX_LENGTH[4])}\n"
+end

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -91,6 +91,40 @@ def parse_refresh_timings(line)
   end
 end
 
+def sort_timings(timings)
+  timings.sort_by { |t| t[:start_time] }
+end
+
+def print_results(all_timings, ems_timings)
+  columns        = [:start_time, :end_time, :total_time, :ems, :target_type, :target]
+  column_lengths = [ 0, 0, 0, 0, 0, 0]
+
+  print "Found #{all_timings.length} refreshes from #{ems_timings.keys.length} providers\n"
+
+  # Calculate how much padding we need for each column
+  sort_timings(all_timings).each do |timing|
+    (0..columns.length - 1).each do |i|
+      column_lengths[i] = [column_lengths[i], timing[columns[i]].to_s.length].max
+    end
+  end
+
+  # Print the column headers
+  columns.each_with_index do |col, i|
+    print "#{col.to_s.ljust(column_lengths[i])}   "
+  end
+
+  print "\n"
+
+  # Print the results for each refresh
+  sort_timings(all_timings).each do |timing|
+    column_lengths.each_with_index do |column_length, i|
+      print "#{timing[columns[i]].to_s.ljust(column_length)} | "
+    end
+    print "\n"
+  end
+end
+
+
 parse_args(ARGV)
 
 puts "Processing file..."
@@ -120,24 +154,4 @@ $logfiles.each do |logfile|
   end
 end
 
-print "Found #{all_timings.length} refreshes from #{ems_timings.keys.length} providers\n"
-
-COLUMNS           = ["start", "end", "duration", "ems", "target-type", "target"]
-COLUMN_MAX_LENGTH = [ 0, 0, 0, 0, 0, 0]
-all_timings.sort_by { |t| t[:start_time] }.each do |timing|
-  COLUMN_MAX_LENGTH[0] = [COLUMN_MAX_LENGTH[0], timing[:start_time].to_s.length].max
-  COLUMN_MAX_LENGTH[1] = [COLUMN_MAX_LENGTH[1], timing[:end_time].to_s.length].max
-  COLUMN_MAX_LENGTH[2] = [COLUMN_MAX_LENGTH[2], timing[:total_time].to_s.length].max
-  COLUMN_MAX_LENGTH[3] = [COLUMN_MAX_LENGTH[3], timing[:ems].length].max
-  COLUMN_MAX_LENGTH[4] = [COLUMN_MAX_LENGTH[4], timing[:target_type].length].max
-  COLUMN_MAX_LENGTH[5] = [COLUMN_MAX_LENGTH[5], timing[:target].length].max
-end
-
-COLUMNS.each_with_index do |col, i|
-  print "#{col.ljust(COLUMN_MAX_LENGTH[i])}   "
-end
-print "\n"
-
-all_timings.sort_by { |t| t[:start_time] }.each do |timing|
-  print "#{timing[:start_time].to_s.ljust(COLUMN_MAX_LENGTH[0])} | #{timing[:end_time].to_s.ljust(COLUMN_MAX_LENGTH[1])} | #{timing[:total_time].to_s.ljust(COLUMN_MAX_LENGTH[2])} | #{timing[:ems].to_s.ljust(COLUMN_MAX_LENGTH[3])} | #{timing[:target_type].to_s.ljust(COLUMN_MAX_LENGTH[4])} | #{timing[:target].to_s.ljust(COLUMN_MAX_LENGTH[5])}\n"
-end
+print_results(all_timings, ems_timings)

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -1,97 +1,64 @@
-RAILS_ROOT = ENV["RAILS_ENV"] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
-$:.push File.join(RAILS_ROOT, "gems/pending/util") unless ENV["RAILS_ENV"]
+RAILS_ROOT = ENV['RAILS_ENV'] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+$LOAD_PATH.push File.join(RAILS_ROOT, 'gems/pending/util') unless ENV['RAILS_ENV']
 
 require 'miq_logger_processor'
+require 'trollop'
 require 'time'
 
-$targets      = nil
-$target_types = nil
-$sort_key     = nil
-$logfiles     = []
-
-def usage
-  %{usage: ruby ems_refresh_timings.rb [OPTION]... [FILE]...
-Description:
-  Parse EMS Refreshes from a set of evm.log files and filter on a set of
-  provided conditions.
-Options:
-  --sort-by=SORT_KEY   Key to sort by, options are start_time, end_time,
-                       total_time, ems, target_type, target
-  --target-type=TYPES  Comma separated list of target types to filter, if not
-                       specified all target types will be shown
-  --target=TARGETS     Comma separated list of targets to filter, if not
-                       specified all targets will be shown.
-  --time=FROM,TO       Range of dates to include (will be the start date).
-  -h, --help           Print this message and exit.
-Files:
-  Set of paths to evm.log files, if not specified the log/evm.log file in
-  RAILS_ROOT will be used.  If multiple files are provided all of their
-  refreshes will be combined and sorted by time.
-Examples:
-  Print all full provider refreshes in main log/evm.log file:
-    ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
-  Print all refreshes between two dates:
-    ruby tools/log_processing/ems_refresh_timings.rb --date=2016-01-23,2016-01-24
-  Print all full provider refreshes for a set of logs:
-    find /path/to/logs -name 'evm.log*' | \\
-    xargs ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
-  }
-end
-
 def parse_args(argv)
-  ARGV.each_with_index do |arg, i|
-    if arg.start_with?('-')
-      flag, optarg = arg.split('=')
-      case flag
-      when '--sort-by'
-        $sort_key = optarg.to_sym
-      when '--target'
-        $targets = optarg.split(',')
-      when '--target-type'
-        $target_types = optarg.split(',')
-      when '--time'
-        # TODO: unimplemented
-        print "--time option not yet implemented, will be ignored\n"
-      when '--help', '-h'
-        print usage()
-        exit
-      else
-        print "unknown argument #{arg}\n"
-        abort(usage())
-      end
-    elsif File.file?(arg)
-      $logfiles << File.expand_path(arg)
-    end
+  logfiles = []
+
+  opts = Trollop.options do
+    banner <<-EOS
+Parse EMS Refreshes from a set of evm.log files and filter on a set of
+provided conditions.
+
+Usage:
+  ruby ems_refresh_timings.rb [OPTION]... <FILE>...
+
+Options:
+EOS
+    opt :sort_by, 'Column to sort by, options are start_time, end_time, '\
+                  'total_time, ems, target_type, and target',
+        :type => :string, :default => 'start_time'
+    opt :target, 'Filter by specific targets, comma separated', :type => :strings
+    opt :target_type, 'Filter by specific target types, comma separated', :type => :strings
+    opt :ems, 'Filter by a specific ems, comma separted', :type => :strings
+  end
+
+  argv.each do |arg|
+    logfiles << File.expand_path(arg) if File.file?(arg)
   end
 
   # If no logs were given on command line default to main project evm.log
-  $logfiles << File.join(RAILS_ROOT, "log/evm.log") if $logfiles.empty?
+  logfiles << File.join(RAILS_ROOT, 'log/evm.log') if logfiles.empty?
 
-  $sort_key = :start_time if $sort_key.nil?
+  [opts, logfiles]
 end
 
-def filter(hash)
-  return false unless $target_types.nil? || $target_types.include?(hash[:target_type])
-  return false unless $targets.nil?      || $targets.include?(hash[:target])
-  return true
+def filter(hash, opts = {})
+  return false unless opts[:target_type].nil? || opts[:target_type].include?(hash[:target_type])
+  return false unless opts[:target].nil? || opts[:target].include?(hash[:target])
+  return false unless opts[:ems].nil? || opts[:ems].include?(hash[:ems])
+  true
 end
 
 def parse_refresh_target(line)
-  if line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Refreshing target ([^\s]+).\[(.*?)\].+Complete/
+  if line =~ /EMS:? \[(.*?)\].+Refreshing target ([^\s]+).\[(.*?)\].+Complete/
     {
       :time        => line.time,
-      :ems         => $1,
-      :target_type => $2,
-      :target      => $3
+      :ems         => Regexp.last_match[1],
+      :target_type => Regexp.last_match[2],
+      :target      => Regexp.last_match[3]
     }
   end
 end
 
 def parse_refresh_timings(line, targets)
-  if line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Timings:? (\{.+)$/
-    ems             = $1
+  if line =~ /EMS:? \[(.*?)\].+Refreshing targets for EMS...Complete - Timings:? (\{.+)$/
+    ems             = Regexp.last_match[1]
     # Refresh timings are printed to the log as a hash, just eval it
-    refresh_timings = eval($2)
+    refresh_timings = eval(Regexp.last_match[2])
 
     # Find the most recent refresh target for our ems, since there is
     # only one refresh worker this "has to be" the right one
@@ -100,7 +67,7 @@ def parse_refresh_timings(line, targets)
 
     # Add other useful information to the refresh timings
     refresh_timings[:ems]         = ems
-    refresh_timings[:end_time]    = Time.parse(line.time + " UTC")
+    refresh_timings[:end_time]    = Time.parse(line.time + ' UTC')
     refresh_timings[:start_time]  = refresh_timings[:end_time] - refresh_timings[:total_time]
     refresh_timings[:target]      = refresh_target[:target]
     refresh_timings[:target_type] = refresh_target[:target_type]
@@ -109,18 +76,18 @@ def parse_refresh_timings(line, targets)
   end
 end
 
-def sort_timings(timings)
-  timings.sort_by { |t| t[$sort_key] }
+def sort_timings(timings, sort_key)
+  timings.sort_by { |t| t[sort_key.to_sym] }
 end
 
-def print_results(all_timings, ems_timings)
+def print_results(all_timings, ems_timings, opts)
   columns        = [:start_time, :end_time, :total_time, :ems, :target_type, :target]
-  column_lengths = [ 0, 0, 0, 0, 0, 0]
+  column_lengths = [0, 0, 0, 0, 0, 0]
 
   print "Found #{all_timings.length} refreshes from #{ems_timings.keys.length} providers\n"
 
   # Calculate how much padding we need for each column
-  sort_timings(all_timings).each do |timing|
+  sort_timings(all_timings, opts[:sort_by]).each do |timing|
     (0..columns.length - 1).each do |i|
       column_lengths[i] = [column_lengths[i], timing[columns[i]].to_s.length].max
     end
@@ -134,7 +101,7 @@ def print_results(all_timings, ems_timings)
   print "\n"
 
   # Print the results for each refresh
-  sort_timings(all_timings).each do |timing|
+  sort_timings(all_timings, opts[:sort_by]).each do |timing|
     column_lengths.each_with_index do |column_length, i|
       print "#{timing[columns[i]].to_s.ljust(column_length)} | "
     end
@@ -142,29 +109,28 @@ def print_results(all_timings, ems_timings)
   end
 end
 
+options, logfiles = parse_args(ARGV)
 
-parse_args(ARGV)
-
-puts "Processing file..."
+puts 'Processing file...'
 
 all_timings = []
 ems_timings = Hash.new { |k, v| k[v] = [] }
 all_targets = Hash.new { |k, v| k[v] = [] }
 
-$logfiles.each do |logfile|
+logfiles.each do |logfile|
   MiqLoggerProcessor.new(logfile).each do |line|
     # Parse out the refresh target or refresh timings
-    if target_hash = parse_refresh_target(line)
+    if (target_hash = parse_refresh_target(line))
       all_targets[target_hash[:ems]] << target_hash
-    elsif refresh_timings = parse_refresh_timings(line, all_targets)
+    elsif (refresh_timings = parse_refresh_timings(line, all_targets))
       ems = refresh_timings[:ems]
 
-      if filter(refresh_timings)
+      if filter(refresh_timings, options)
         ems_timings[ems] << refresh_timings
-        all_timings      << refresh_timings
+        all_timings << refresh_timings
       end
     end
   end
 end
 
-print_results(all_timings, ems_timings)
+print_results(all_timings, ems_timings, options)

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -4,12 +4,70 @@ $:.push File.join(RAILS_ROOT, "gems/pending/util") unless ENV["RAILS_ENV"]
 require 'miq_logger_processor'
 require 'time'
 
-TARGETS = [ "EmsVmware" , "HostVmwareEsx", "VmVmware" ]
-COLUMNS = ["start", "end", "duration", "ems", "target"]
+$targets      = nil
+$target_types = nil
+$logfiles     = []
 
-logfiles = ARGV.select { |f| File.file?(f) }
-logfiles << File.join(RAILS_ROOT, "log/evm.log") if logfiles.empty?
-logfiles.map { |f| File.expand_path(f) }
+def usage
+  %{usage: ruby ems_refresh_timings.rb [OPTION]... [FILE]...
+Description:
+  Parse EMS Refreshes from a set of evm.log files and filter on a set of
+  provided conditions.
+Options:
+  --target-type=TYPES  Comma separated list of target types to filter, if not
+                       specified all target types will be shown
+  --target=TARGETS     Comma separated list of targets to filter, if not
+                       specified all targets will be shown.
+  --time=FROM,TO       Range of dates to include (will be the start date).
+  -h, --help           Print this message and exit.
+Files:
+  Set of paths to evm.log files, if not specified the log/evm.log file in
+  RAILS_ROOT will be used.  If multiple files are provided all of their
+  refreshes will be combined and sorted by time.
+Examples:
+  Print all full provider refreshes in main log/evm.log file:
+    ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
+  Print all refreshes between two dates:
+    ruby tools/log_processing/ems_refresh_timings.rb --date=2016-01-23,2016-01-24
+  Print all full provider refreshes for a set of logs:
+    find /path/to/logs -name 'evm.log*' | \\
+    xargs ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
+}
+end
+
+def parse_args(argv)
+  ARGV.each_with_index do |arg, i|
+    if arg.start_with?('-')
+      flag, optarg = arg.split('=')
+      case flag
+      when '--target'
+        $targets = optarg.split(',')
+      when '--target-type'
+        $target_types = optarg.split(',')
+      when '--time'
+        # TODO: unimplemented
+      when '--help', '-h'
+        print usage()
+        exit
+      else
+        print "unknown argument #{arg}\n"
+        abort(usage())
+      end
+    elsif File.file?(arg)
+      $logfiles << File.expand_path(arg)
+    end
+  end
+
+  $logfiles << File.join(RAILS_ROOT, "log/evm.log") if $logfiles.empty?
+end
+
+def filter(hash)
+  return false unless $target_types.nil? || $target_types.include?(hash[:target_type])
+  return false unless $targets.nil? || $targets.include?(hash[:target])
+  return true
+end
+
+parse_args(ARGV)
 
 puts "Processing file..."
 
@@ -17,15 +75,17 @@ all_timings = []
 ems_timings = Hash.new { |k, v| k[v] = [] }
 all_targets = Hash.new { |k, v| k[v] = [] }
 
-logfiles.each do |logfile|
+$logfiles.each do |logfile|
   MiqLoggerProcessor.new(logfile).each do |line|
     # Find the target type
-    if line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Refreshing target ([^\s]+).+Complete/
+    if line =~ /MIQ\(VcRefresher.refresh\).EMS:? \[(.*?)\].+Refreshing target ([^\s]+).\[(.*?)\].+Complete/
       ems         = $1
       target_type = $2
+      target      = $3
 
       all_targets[ems] << {
         :time        => line.time,
+        :target      => target,
         :target_type => target_type
       }
     end
@@ -37,9 +97,10 @@ logfiles.each do |logfile|
     timings[:end_time]    = Time.parse(line.time + " UTC")
     timings[:start_time]  = timings[:end_time] - timings[:total_time]
     timings[:target_type] = all_targets[ems].last[:target_type]
+    timings[:target]      = all_targets[ems].last[:target]
     timings[:ems]         = ems
 
-    if TARGETS.include?(timings[:target_type])
+    if filter(timings)
       all_timings      << timings
       ems_timings[ems] << timings
     end
@@ -48,13 +109,15 @@ end
 
 print "Found #{all_timings.length} refreshes from #{ems_timings.keys.length} providers\n"
 
-COLUMN_MAX_LENGTH = [ 0, 0, 0, 0, 0]
+COLUMNS           = ["start", "end", "duration", "ems", "target-type", "target"]
+COLUMN_MAX_LENGTH = [ 0, 0, 0, 0, 0, 0]
 all_timings.sort_by { |t| t[:start_time] }.each do |timing|
   COLUMN_MAX_LENGTH[0] = [COLUMN_MAX_LENGTH[0], timing[:start_time].to_s.length].max
   COLUMN_MAX_LENGTH[1] = [COLUMN_MAX_LENGTH[1], timing[:end_time].to_s.length].max
   COLUMN_MAX_LENGTH[2] = [COLUMN_MAX_LENGTH[2], timing[:total_time].to_s.length].max
   COLUMN_MAX_LENGTH[3] = [COLUMN_MAX_LENGTH[3], timing[:ems].length].max
   COLUMN_MAX_LENGTH[4] = [COLUMN_MAX_LENGTH[4], timing[:target_type].length].max
+  COLUMN_MAX_LENGTH[5] = [COLUMN_MAX_LENGTH[5], timing[:target].length].max
 end
 
 COLUMNS.each_with_index do |col, i|
@@ -63,5 +126,5 @@ end
 print "\n"
 
 all_timings.sort_by { |t| t[:start_time] }.each do |timing|
-  print "#{timing[:start_time].to_s.ljust(COLUMN_MAX_LENGTH[0])} | #{timing[:end_time].to_s.ljust(COLUMN_MAX_LENGTH[1])} | #{timing[:total_time].to_s.ljust(COLUMN_MAX_LENGTH[2])} | #{timing[:ems].to_s.ljust(COLUMN_MAX_LENGTH[3])} | #{timing[:target_type].to_s.ljust(COLUMN_MAX_LENGTH[4])}\n"
+  print "#{timing[:start_time].to_s.ljust(COLUMN_MAX_LENGTH[0])} | #{timing[:end_time].to_s.ljust(COLUMN_MAX_LENGTH[1])} | #{timing[:total_time].to_s.ljust(COLUMN_MAX_LENGTH[2])} | #{timing[:ems].to_s.ljust(COLUMN_MAX_LENGTH[3])} | #{timing[:target_type].to_s.ljust(COLUMN_MAX_LENGTH[4])} | #{timing[:target].to_s.ljust(COLUMN_MAX_LENGTH[5])}\n"
 end

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -64,10 +64,14 @@ def parse_refresh_timings(line, targets)
     # only one refresh worker this "has to be" the right one
     # If this changes in the future we'll have to add a PID lookup here
     refresh_target  = targets[ems].last
+    refresh_target = {
+      :target      => "unknown",
+      :target_type => "unknown"
+    } if refresh_target.nil?
 
     # Add other useful information to the refresh timings
     refresh_timings[:ems]         = ems
-    refresh_timings[:end_time]    = Time.parse(line.time + ' UTC')
+    refresh_timings[:end_time]    = Time.parse(line.time + ' UTC').utc
     refresh_timings[:start_time]  = refresh_timings[:end_time] - refresh_timings[:total_time]
     refresh_timings[:target]      = refresh_target[:target]
     refresh_timings[:target_type] = refresh_target[:target_type]


### PR DESCRIPTION
Parse EMS refreshes from multiple evm.log files and print information about them.  This allows viewing refreshes across multiple zones in one list.  The user can specify specific target types, specific targets, and pick which column to sort by.

Help doc:
```
usage: ruby ems_refresh_timings.rb [OPTION]... [FILE]...
Description:
  Parse EMS Refreshes from a set of evm.log files and filter on a set of
  provided conditions.
Options:
  --sort-by=SORT_KEY   Key to sort by, options are start_time, end_time,
                       total_time, ems, target_type, target
  --target-type=TYPES  Comma separated list of target types to filter, if not
                       specified all target types will be shown
  --target=TARGETS     Comma separated list of targets to filter, if not
                       specified all targets will be shown.
  --time=FROM,TO       Range of dates to include (will be the start date).
  -h, --help           Print this message and exit.
Files:
  Set of paths to evm.log files, if not specified the log/evm.log file in
  RAILS_ROOT will be used.  If multiple files are provided all of their
  refreshes will be combined and sorted by time.
Examples:
  Print all full provider refreshes in main log/evm.log file:
    ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
  Print all refreshes between two dates:
    ruby tools/log_processing/ems_refresh_timings.rb --date=2016-01-23,2016-01-24
  Print all full provider refreshes for a set of logs:
    find /path/to/logs -name 'evm.log*' | \
    xargs ruby tools/log_processing/ems_refresh_timings.rb --target-type=EmsVmware
```