### PR TITLE
Remove redundant UiConstants inclusions

### DIFF
--- a/app/presenters/tree_node_builder.rb
+++ b/app/presenters/tree_node_builder.rb
@@ -1,5 +1,4 @@
 class TreeNodeBuilder
-  include UiConstants
   include MiqAeClassHelper
 
   # method to build non-explorer tree nodes

--- a/spec/controllers/application_controller/automate_spec.rb
+++ b/spec/controllers/application_controller/automate_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqAeCustomizationController, "ApplicationController::Automate" do
   context "#resolve" do
     before(:each) do

--- a/spec/controllers/application_controller/build_audit_spec.rb
+++ b/spec/controllers/application_controller/build_audit_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ApplicationController do
   context "audit events" do
     it "tests build_config_audit" do

--- a/spec/controllers/application_controller/buttons_spec.rb
+++ b/spec/controllers/application_controller/buttons_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ApplicationController do
   context "#custom_buttons" do
     let(:resource_action) { FactoryGirl.create(:resource_action, :dialog_id => 1) }

--- a/spec/controllers/application_controller/ci_processing_spec.rb
+++ b/spec/controllers/application_controller/ci_processing_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ApplicationController do
   before do
     EvmSpecHelper.local_miq_server

--- a/spec/controllers/application_controller/filter_spec.rb
+++ b/spec/controllers/application_controller/filter_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ApplicationController, "::Filter" do
   before :each do
     controller.instance_variable_set(:@sb, {})

--- a/spec/controllers/application_controller/tree_support_spec.rb
+++ b/spec/controllers/application_controller/tree_support_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ApplicationController do
   context "#tree_autoload_dynatree" do
     describe "verify @edit object" do

--- a/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/custom_buttons_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqAeCustomizationController do
   before(:each) do
     set_user_privileges

--- a/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/dialogs_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqAeCustomizationController do
   context "::Dialogs" do
     context "#dialog_delete" do

--- a/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
+++ b/spec/controllers/miq_ae_customization_controller/old_dialogs_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqAeCustomizationController do
   context "::OldDialogs" do
     context "#old_dialogs_button_operation" do

--- a/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
+++ b/spec/controllers/miq_policy_controller/alert_profiles_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqPolicyController do
   context "::AlertProfiles" do
     before do

--- a/spec/controllers/miq_policy_controller/miq_actions_spec.rb
+++ b/spec/controllers/miq_policy_controller/miq_actions_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqPolicyController do
   context "::MiqActions" do
     context "#action_edit" do

--- a/spec/controllers/miq_policy_controller/policies_spec.rb
+++ b/spec/controllers/miq_policy_controller/policies_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqPolicyController do
   before :each do
     set_user_privileges

--- a/spec/controllers/miq_policy_controller/rsop_spec.rb
+++ b/spec/controllers/miq_policy_controller/rsop_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe MiqPolicyController do
   render_views
   before :each do

--- a/spec/controllers/miq_report_controller/menus_spec.rb
+++ b/spec/controllers/miq_report_controller/menus_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ReportController do
   context "::Menus" do
     context "#menu_update" do

--- a/spec/controllers/miq_report_controller/reports/editor_spec.rb
+++ b/spec/controllers/miq_report_controller/reports/editor_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ReportController do
   context "::Reports::Editor" do
     context "#set_form_vars" do

--- a/spec/controllers/miq_report_controller/reports_spec.rb
+++ b/spec/controllers/miq_report_controller/reports_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ReportController, "::Reports" do
   describe "#check_tabs" do
     tabs = {

--- a/spec/controllers/ops_controller/diagnostics_spec.rb
+++ b/spec/controllers/ops_controller/diagnostics_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 shared_examples "logs_collect" do |type|
   let(:klass) { type.classify.constantize }
   let(:zone) { double("Zone", :name => "foo") }

--- a/spec/controllers/ops_controller/ops_rbac_spec.rb
+++ b/spec/controllers/ops_controller/ops_rbac_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe OpsController do
   render_views
 

--- a/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
+++ b/spec/controllers/pxe_controller/pxe_customization_templates_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe PxeController do
   context "#template_create_update" do
     it "correct method is being called when reset button is pressed" do

--- a/spec/controllers/report_controller/menu_spec.rb
+++ b/spec/controllers/report_controller/menu_spec.rb
@@ -1,5 +1,3 @@
-include UiConstants
-
 describe ReportController do
   context "#edit_folder" do
     before(:each) do

--- a/spec/controllers/report_controller_spec.rb
+++ b/spec/controllers/report_controller_spec.rb
@@ -1,5 +1,4 @@
 require "helpers/report_helper_spec"
-include UiConstants
 
 describe ReportController do
   context "Get form variables" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -100,7 +100,6 @@ describe ApplicationHelper do
     end
 
     context "when with :main_tab_id" do
-      include UiConstants
       it "and entitled" do
         expect(Menu::DefaultMenu.services_menu_section.visible?).to be_truthy
       end


### PR DESCRIPTION
~~**This is experimental. Do not merge.**~~ Ready for review/merging

Follow up of discussion [here](https://github.com/ManageIQ/manageiq/pull/6559/files#r52390396)

TLDR: We include UiConstants everywhere and don't need to. Never in the specs, as they are included via RSpec configuration metadata, and never in the application because...they are purposely [included globally here.](https://github.com/manageiq/manageiq/blob/012b5c4675e71c00a8733e041a43b26f9b37b15e/app/helpers/ui_constants.rb#L592-L593)

While ideally the proper fix would be to not include them globally, this PR addresses the fact that we can minimize the confusion and make the diff for any future fix easier to grok.