### PR TITLE
Disable RSpec's --only-failures in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,10 @@ RSpec.configure do |config|
   # `post` methods in spec/controllers, without specifying type
   config.infer_spec_type_from_file_location!
 
-  # File store for --only-failures option
-  config.example_status_persistence_file_path = "./spec/examples.txt"
+  unless ENV['CI']
+    # File store for --only-failures option
+    config.example_status_persistence_file_path = "./spec/examples.txt"
+  end
 
   config.include VMDBConfigurationHelper
 


### PR DESCRIPTION
Because we don't want to even take the tiniest chance of a performance hit on the already-slow CI runs for a feature you'd never run on CI.

Followup of discussion [here](https://github.com/ManageIQ/manageiq/pull/6537#issuecomment-182097128).