### PR TITLE
aws-sdk-v2 cloud_manager#orchestration_template_validate

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -182,7 +182,9 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   # @return [nil] if the template is valid
   # @return [String] if the template is invalid this is the error message
   def orchestration_template_validate(template)
-    nil if cloud_formation.client.validate_template(:template_body => template.content)
+    with_provider_connection(:service => :CloudFormation, :sdk_v2 => true) do |cloud_formation|
+      nil if cloud_formation.client.validate_template(:template_body => template.content)
+    end
   rescue Aws::CloudFormation::Errors::ValidationError => validation_error
     validation_error.message
   rescue => err

--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -178,8 +178,13 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
     _log.error "vm=[#{vm.name}], error: #{err}"
   end
 
+  # @param [OrchestrationTemplateCfn] template
+  # @return [nil] if the template is valid
+  # @return [String] if the template is invalid this is the error message
   def orchestration_template_validate(template)
-    cloud_formation.validate_template(template.content)[:message]
+    nil if cloud_formation.client.validate_template(:template_body => template.content)
+  rescue Aws::CloudFormation::Errors::ValidationError => validation_error
+    validation_error.message
   rescue => err
     _log.error "template=[#{template.name}], error: #{err}"
     raise MiqException::MiqOrchestrationValidationError, err.to_s, err.backtrace

--- a/spec/fixtures/orchestration_templates/cfn_parameters.json
+++ b/spec/fixtures/orchestration_templates/cfn_parameters.json
@@ -50,5 +50,14 @@
       "Description" : "The list of AvailabilityZones for your Virtual Private Cloud (VPC)",
       "ConstraintDescription" : "must be a list if valid EC2 availability zones for the selected Virtual Private Cloud"
     }
+  },
+
+  "Resources" : {
+    "MyEC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId" : "ami-2f726546"
+      }
+    }
   }
 }


### PR DESCRIPTION
cloud_manager#orchestration_template_validate now uses aws sdk-v2 
and is properly tested

I had to fix the fixture for 'AWS CloudFormation Template' for that
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html

@miq_bot add_labels enhancement,providers/amazon,technical debt