### PR TITLE
OpenStack ignore missing volume mountpoint

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb
@@ -321,6 +321,12 @@ module ManageIQ::Providers
       }
 
       volume.attachments.each do |a|
+        if a['device'].blank?
+          $fog_log.warn "#{log_header}: Volume: #{uid}, is missing a mountpoint, skipping the volume processing"
+          $fog_log.warn "#{log_header}:   EMS: #{@ems.name}, Instance: #{a['server_id']}"
+          next
+        end
+
         dev = File.basename(a['device'])
         disks = @data_index.fetch_path(:vms, a['server_id'], :hardware, :disks)
 


### PR DESCRIPTION
Seems like after some operations, the mountpoit of volume can
get missing. Let's ignore that fact and log warn.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1304740