### PR TITLE
Switch headers in containers table view

### DIFF
--- a/product/views/Container.yaml
+++ b/product/views/Container.yaml
@@ -47,8 +47,8 @@ col_order:
 headers:
 - Name
 - Pod Name
-- State
 - Image
+- State
 
 # Condition(s) string for the SQL query
 conditions: 


### PR DESCRIPTION
Containers table shows image name in 'State' column and state in 'Image' column.
Fix it by switching headers.

Before:
![screenshot from 2016-02-10 18-32-39](https://cloud.githubusercontent.com/assets/2181522/12954240/6d60c2aa-d026-11e5-9634-ed169b9e505f.jpg)
After:
![screenshot from 2016-02-10 18-33-06](https://cloud.githubusercontent.com/assets/2181522/12954239/6d5b4226-d026-11e5-8e91-bca0cb177fbd.jpg)

