### PR TITLE
don't load miq_server every config param read

### DIFF
--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -164,7 +164,7 @@ module VMDB
 
     def config_mtime_from_db
       # log_header = "[#{@name}]"
-      server = MiqServer.my_server(true)
+      server = MiqServer.my_server
       return Time.at(0) if server.nil?
 
       conf = server.configurations.select("updated_on").where(:typ => @name).first


### PR DESCRIPTION
Every time we do a `Config.new("vmdb")` we load a new `miq_server` record.
In some places of our code we cache this object to avoid this cost, and in others we repeatedly make this call. Removing it saves ~15% for `perf_capture_timer`, but will also improve performance across the app.

https://bugzilla.redhat.com/show_bug.cgi?id=1227008

/cc @Fryguy @jrafanie if you have other ideas how to reduce this load, let me know 
/cc @dmetzger57 FYI

|VmOrTemplate|Storage|ExtManagementSystem|MiqRegion|Zone|
|        ---:|   ---:|               ---:|     ---:|---:|
|        100 |    13 |                 1 |       1 |  1 |

**before:**

|     ms |  sql | sqlms | comments
|    ---:|  ---:|   ---:| ---
| 3344.1 | 1263 | 270.5 | a100-master-1
|  818.6 |  449 |  97.1 | a100-master-2
|  847.6 |  449 |  90.8 | a100-master-3
|  968.1 |  449 | 115.6 | a100-master-4

**after:**

|     ms |  sql | sqlms | comments
|    ---:|  ---:|   ---:| ---
|  3351.0 |1175 |  262.9 | a100-mtime-1
|   730.4 | 361 |   82.0 | a100-mtime-2
|   789.5 | 361 |   79.6 | a100-mtime-3
|   746.8 | 361 |   87.5 | a100-mtime-4