### PR TITLE
Security Groups support for Azure instance provisioning

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -103,7 +103,10 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
       network_options = {
         :location   => region,
         :properties => {
-          :ipConfigurations => [
+          :networkSecurityGroup => {
+            :id => security_group.ems_ref
+          },
+          :ipConfigurations     => [
             :name       => dest_name,
             :properties => {
               :subnet          => {

--- a/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/options_helper.rb
@@ -6,4 +6,8 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::OptionsHelper
   def resource_group
     @resource_group ||= ResourceGroup.find_by(:id => options[:resource_group])
   end
+
+  def security_group
+    @security_group ||= SecurityGroup.find_by(:id => get_option(:security_groups))
+  end
 end

--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -284,10 +284,9 @@ module ManageIQ::Providers
         uid = security_group.id
 
         description = [
-          security_group.name,
           security_group.resource_group,
           security_group.location
-        ].join(' - ')
+        ].join('-')
 
         new_result = {
           :type           => self.class.security_group_type,

--- a/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_azure_dialogs_template.yaml
@@ -172,7 +172,7 @@
             :method: :allowed_security_groups
           :description: Security Groups
           :required: false
-          :display: :hide
+          :display: :edit
           :data_type: :integer
       :display: :show
     :service:

--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -70,6 +70,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
     context "#prepare_for_clone_task" do
       before do
         allow(subject).to receive(:instance_type).and_return(flavor)
+        allow(subject).to receive(:dest_name).and_return(vm.name)
       end
 
       context "nic settings" do

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -95,7 +95,7 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
     expect(@sg).to have_attributes(
       :name        => "Chef-Prod",
-      :description => "Chef-Prod - Chef-Prod - eastus"
+      :description => "Chef-Prod-eastus"
     )
 
     expected_firewall_rules = [


### PR DESCRIPTION
This PR adds network security groups support for Azure provisioning. A couple of points to note:
1) An instance can only belong to one network security group, looks like an instance can belong to many in Amazon and OpenStack. For this reason, I decided to override the security_groups method in options_helper.rb
2) In Azure, the security group is a property of the NIC, not the instance itself.