### PR TITLE
Fixed an issue where rpt_options could be nil for some OOTB reports.

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -253,7 +253,10 @@ class MiqReportResult < ApplicationRecord
 
       # temporarily stick last_run_on time into report object
       # to be used by report_formatter while generating downloadable text report
-      rpt.rpt_options.merge!(:last_run_on => last_run_on) if result_type.to_sym == :txt
+      if result_type.to_sym == :txt
+        rpt.rpt_options ||= {}
+        rpt.rpt_options[:last_run_on] = last_run_on
+      end
 
       new_res.report_results = user.with_my_timezone do
         case result_type.to_sym


### PR DESCRIPTION
Downloading txt reports can fail on merge! if rpt_options is nil

https://bugzilla.redhat.com/show_bug.cgi?id=1196377
https://bugzilla.redhat.com/show_bug.cgi?id=1292574
https://bugzilla.redhat.com/show_bug.cgi?id=1292579

@dclarizio please review, this is fix for a BZ that failed QE verification.