### PR TITLE
[auth] Adding support for SAML external authentication

### DIFF
--- a/app/assets/stylesheets/patternfly_overrides.scss
+++ b/app/assets/stylesheets/patternfly_overrides.scss
@@ -124,6 +124,17 @@ li.brand-white-label.whitelabeled {
   padding-bottom: 0 !important;
 }
 
+div#saml-login {
+  padding-bottom: 8px;
+}
+
+div#saml-login hr {
+  display: inline-block;
+  position: relative;
+  top: 15px;
+  width: 43%;
+}
+
 #notification {
   position:absolute;
   left:0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1135,7 +1135,10 @@ class ApplicationController < ActionController::Base
 
     return if action_name == 'auth_error'
 
-    if RequestRefererService.allowed_access?(request, controller_name, action_name, session['referer'])
+    trusted_referer = session[:saml_login_request]
+    session[:saml_login_request] = nil
+
+    if RequestRefererService.allowed_access?(request, controller_name, action_name, session['referer'], trusted_referer)
       # if we came in directly and were allowed then
       # we need to make sure we have the referer in the session for future requests
       session['referer'] = request.base_url + '/' unless session['referer'].present?

--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -680,6 +680,8 @@ module OpsController::Settings::Common
         @authmode_changed = true
       end
       auth[:sso_enabled] = (params[:sso_enabled].to_s == "1") if params[:sso_enabled]
+      auth[:saml_enabled] = (params[:saml_enabled].to_s == "1") if params[:saml_enabled]
+      auth[:local_login_disabled] = (params[:local_login_disabled].to_s == "1") if params[:local_login_disabled]
       auth[:default_group_for_users] = params[:authentication_default_group_for_users] if params[:authentication_default_group_for_users]
     when "settings_workers"                                       # Workers Settings tab
       wb  = new.config[:workers][:worker_base]
@@ -852,6 +854,8 @@ module OpsController::Settings::Common
       @edit[:current].config[:authentication][:user_proxies] ||= [{}]
       @edit[:current].config[:authentication][:follow_referrals] ||= false
       @edit[:current].config[:authentication][:sso_enabled] ||= false
+      @edit[:current].config[:authentication][:saml_enabled] ||= false
+      @edit[:current].config[:authentication][:local_login_disabled] ||= false
       @sb[:newrole] = @edit[:current].config[:authentication][:ldap_role]
       @sb[:new_amazon_role] = @edit[:current].config[:authentication][:amazon_role]
       @sb[:new_httpd_role] = @edit[:current].config[:authentication][:httpd_role]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1504,4 +1504,11 @@ module ApplicationHelper
     end
     true
   end
+
+  def ext_auth?(auth_option = nil)
+    auth_config = get_vmdb_config[:authentication]
+    return false unless auth_config[:mode] == "httpd"
+    auth_option ? auth_config[auth_option] : true
+  end
+  public :ext_auth?
 end

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -10,7 +10,7 @@ module Authenticator
                     :firstname => request.headers['X-REMOTE-USER-FIRSTNAME'],
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
                     :email     => request.headers['X-REMOTE-USER-EMAIL']}
-      membership_list = (request.headers['X-REMOTE-USER-GROUPS'] || '').split(":")
+      membership_list = (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)
 
       super(username, request, user_attrs, membership_list)
     end

--- a/app/services/request_referer_service.rb
+++ b/app/services/request_referer_service.rb
@@ -1,6 +1,6 @@
 class RequestRefererService
-  def self.allowed_access?(request, controller_name, action_name, referer)
-    new.allowed_access?(request, controller_name, action_name, referer)
+  def self.allowed_access?(request, controller_name, action_name, referer, trusted_referer = nil)
+    new.allowed_access?(request, controller_name, action_name, referer, trusted_referer)
   end
 
   def self.access_whitelisted?(request, controller_name, action_name)
@@ -167,8 +167,9 @@ class RequestRefererService
     :vm_or_template       => %w(download_data)
   }.freeze
 
-  def allowed_access?(request, controller_name, action_name, referer)
+  def allowed_access?(request, controller_name, action_name, referer, trusted_referer = nil)
     access_whitelisted?(request, controller_name, action_name) ||
+      trusted_referer ||
       referer_valid?(request.referer, referer, request.headers, controller_name, action_name) ||
       (ENV['MIQ_DISABLE_RRS'] && Rails.env.development?)
   end

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -12,11 +12,11 @@ class UserValidationService
   # Validate user login credentials
   #   return <url for redirect> as part of the result
   #
-  def validate_user(user, task_id = nil, request = nil)
+  def validate_user(user, task_id = nil, request = nil, authenticate_options = {})
     if task_id.present?
       validation = validate_user_collect_task(user, task_id)
     else # First time thru, kick off authenticate task
-      validation = validate_user_kick_off_task(user, request)
+      validation = validate_user_kick_off_task(user, request, authenticate_options)
       return validation unless validation.result == :pass
     end
 
@@ -92,12 +92,12 @@ class UserValidationService
     end
   end
 
-  def validate_user_kick_off_task(user, request)
+  def validate_user_kick_off_task(user, request, authenticate_options = {})
     validate_user_pre_auth_checks(user).tap { |result| return result if result }
 
     # Call the authentication, use wait_for_task if a task is spawned
     begin
-      user_or_taskid = User.authenticate(user[:name], user[:password], request)
+      user_or_taskid = User.authenticate(user[:name], user[:password], request, authenticate_options)
     rescue MiqException::MiqEVMLoginError
       user[:name] = nil
       return ValidateResult.new(:fail, _("Sorry, the username or password you entered is incorrect."))

--- a/app/services/user_validation_service.rb
+++ b/app/services/user_validation_service.rb
@@ -98,9 +98,14 @@ class UserValidationService
     # Call the authentication, use wait_for_task if a task is spawned
     begin
       user_or_taskid = User.authenticate(user[:name], user[:password], request, authenticate_options)
-    rescue MiqException::MiqEVMLoginError
+    rescue MiqException::MiqEVMLoginError => err
       user[:name] = nil
-      return ValidateResult.new(:fail, _("Sorry, the username or password you entered is incorrect."))
+      err_message = if err.message.present? && authenticate_options[:require_user]
+                      err.message
+                    else
+                      _("Sorry, the username or password you entered is incorrect.")
+                    end
+      return ValidateResult.new(:fail, err_message)
     end
 
     if user_or_taskid.kind_of?(User)

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -16,6 +16,20 @@
 
         = render :partial => "layouts/flash_msg"
 
+        - if ext_auth?(:saml_enabled)
+          .form-group
+            .col-xs-1.col-md-1.submit
+              = link_to(_("SAML Login"), {:action => "initiate_saml_login",
+                                          :button => "saml_login"},
+                        :id                   => "saml_login",
+                        :class                => "btn btn-primary",
+                        :alt                  => "SAML Login",
+                        :title                => _("SAML Login"),
+                        :remote               => true,
+                        "data-method"         => :post,
+                        "data-miq_sparkle_on" => true,
+                        "data-submit"         => 'login_div')
+
         .form-group
           %label.col-md-3.control-label= _('Username')
           .col-md-9
@@ -106,12 +120,15 @@
   miqClearTreeState();
 
 - auto_login  = session[:auto_login]  # Set to false via dashboard/logout
-- sso_enabled = get_vmdb_config[:authentication][:sso_enabled]
 - session[:auto_login] = true
-- if auth_mode == "httpd" && sso_enabled
+- if ext_auth?(:sso_enabled)
   - if auto_login != false
-    :javascript
-      var miq_after_onload = "$('#sso_login').click()";
+    - if ext_auth?(:saml_enabled)
+      :javascript
+        var miq_after_onload = "$('#saml_login').click()";
+    - else
+      :javascript
+        var miq_after_onload = "$('#sso_login').click()";
 - elsif @user_name  # If user name is pre-populated by the server, press the Login button automatically
   :javascript
     var miq_after_onload = "$('#login').click()";

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -30,9 +30,13 @@
                         "data-method"         => :post,
                         "data-miq_sparkle_on" => true,
                         "data-submit"         => 'login_div')
-              .spacer
-                %p.text-center
-                  = _('- or - ')
+
+              %div#saml-login.text-center
+                %hr#saml-login
+                &nbsp;
+                = _('Or')
+                &nbsp;
+                %hr#saml-login
 
         .form-group
           %label.col-md-3.control-label= _('Username')

--- a/app/views/dashboard/login.html.haml
+++ b/app/views/dashboard/login.html.haml
@@ -18,17 +18,21 @@
 
         - if ext_auth?(:saml_enabled)
           .form-group
-            .col-xs-1.col-md-1.submit
-              = link_to(_("SAML Login"), {:action => "initiate_saml_login",
-                                          :button => "saml_login"},
+            %label.col-md-3.control-label
+            .col-md-9
+              = link_to(_("Login to Corporate System"), {:action => "initiate_saml_login",
+                                                         :button => "saml_login"},
                         :id                   => "saml_login",
-                        :class                => "btn btn-primary",
-                        :alt                  => "SAML Login",
-                        :title                => _("SAML Login"),
+                        :class                => "btn btn-primary form-control",
+                        :alt                  => "Login",
+                        :title                => _("Login to Corporate System"),
                         :remote               => true,
                         "data-method"         => :post,
                         "data-miq_sparkle_on" => true,
                         "data-submit"         => 'login_div')
+              .spacer
+                %p.text-center
+                  = _('- or - ')
 
         .form-group
           %label.col-md-3.control-label= _('Username')

--- a/app/views/ops/_settings_authentication_tab.html.haml
+++ b/app/views/ops/_settings_authentication_tab.html.haml
@@ -240,6 +240,19 @@
           = check_box_tag("sso_enabled", "1",
                           @edit[:new][:authentication][:sso_enabled],
                           "data-miq_observe_checkbox" => {:url => url}.to_json)
+      .form-group
+        %label.col-md-2.control-label
+          = _("Enable SAML")
+        .col-md-4
+          = check_box_tag("saml_enabled", "1",
+                          @edit[:new][:authentication][:saml_enabled],
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)
+        %label.col-md-2.control-label
+          = _("Disable Local Login")
+        .col-md-4
+          = check_box_tag("local_login_disabled", "1",
+                          @edit[:new][:authentication][:local_login_disabled],
+                          "data-miq_observe_checkbox" => {:url => url}.to_json)
     %hr/
 
   = hidden_div_if(@edit[:new][:authentication][:mode] != "httpd", :id => "httpd_role_div") do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -805,6 +805,7 @@ Vmdb::Application.routes.draw do
         index
         login
         logout
+        saml_login
         maintab
         render_csv
         render_pdf
@@ -818,6 +819,7 @@ Vmdb::Application.routes.draw do
       ),
       :post => %w(
         kerberos_authenticate
+        initiate_saml_login
         authenticate
         change_group
         csp_report
@@ -2484,6 +2486,7 @@ Vmdb::Application.routes.draw do
   }
 
   root :to => 'dashboard#login'
+  get '/saml_login(/*path)' => 'dashboard#saml_login'
 
   # Let's serve pictures directly from the DB
   get '/pictures/:basename' => 'picture#show', :basename => /[\da-zA-Z]+\.[\da-zA-Z]+/

--- a/gems/pending/spec/util/miq_apache/conf_spec.rb
+++ b/gems/pending/spec/util/miq_apache/conf_spec.rb
@@ -42,6 +42,7 @@ describe MiqApache::Conf do
       output = MiqApache::Conf.create_redirects_config(default_options).lines.to_a
       expect(output).to include("RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts)) /self_service/index.html [L]\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/proxy_pages\n")
+      expect(output).to include("RewriteCond \%{REQUEST_URI} !^/saml2\n")
       expect(output).to include("RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n")
       expect(output).to include("RewriteRule ^/ balancer://evmcluster_ui\%{REQUEST_URI} [P,QSA,L]\n")
       expect(output).to include("ProxyPassReverse / balancer://evmcluster_ui/\n")

--- a/gems/pending/util/miq_apache/miq_apache.rb
+++ b/gems/pending/util/miq_apache/miq_apache.rb
@@ -208,6 +208,7 @@ module MiqApache
         if redirect == "/"
           content << "RewriteRule ^/self_service(?!/(assets|images|img|styles|js|fonts)) /self_service/index.html [L]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
+          content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"
           content << "RewriteCond \%{REQUEST_URI} !^/api\n"
           content << "RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n"
           content << "RewriteRule ^#{redirect} balancer://#{opts[:cluster]}\%{REQUEST_URI} [P,QSA,L]\n"

--- a/spec/services/request_referer_service_spec.rb
+++ b/spec/services/request_referer_service_spec.rb
@@ -14,6 +14,22 @@ describe RequestRefererService do
   let(:get_request_no_id)    { double(:request_method => 'GET',  :parameters => {},          :xml_http_request? => false) }
   let(:get_request_xml_http) { double(:request_method => 'GET',  :parameters => {'id' => 1}, :xml_http_request? => true)  }
 
+  describe "#allowed_access?" do
+    let(:req) { ActionDispatch::Request.new Rack::MockRequest.env_for '/?controller=dashboard' }
+
+    describe "when the referer is external but trusted" do
+      it "returns true" do
+        expect(request_referer_service.allowed_access?(req, "dashboard", "show", "/external_idp", true)).to be_truthy
+      end
+    end
+
+    describe "when the referer is external but not-trusted" do
+      it "returns false" do
+        expect(request_referer_service.allowed_access?(req, "dashboard", "show", "/external_idp")).to be_falsey
+      end
+    end
+  end
+
   describe "#referer_valid?" do
     let(:referer)    { "PotatoHead" }
     let(:useragent)  { {"HTTP_USER_AGENT" => "Tater"} }


### PR DESCRIPTION
[auth] Adding support for SAML external authentication

-   Supporting SAML enablement in Ext Auth config screen
-   Supporting Disabling local login in Ext Auth config screen for SAML
-   Support X_REMOTE_USER in normal /saml_login protected path
-   Support both : and ; seperated group lists
-   Adding SAML Login to main login screen

    
Trello: https://trello.com/c/YIUK4qLT
