### PR TITLE
Patch in our own raise on potential false positives

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_spec.rb
@@ -53,17 +53,20 @@ describe ManageIQ::Providers::Azure::CloudManager::Provision do
 
       it "with a blank name" do
         allow(subject).to receive(:dest_name).and_return("")
-        expect { subject.validate_dest_name }.to raise_error
+        expect { subject.validate_dest_name }
+          .to raise_error(MiqException::MiqProvisionError, /Name cannot be blank/)
       end
 
       it "with a nil name" do
         allow(subject).to receive(:dest_name).and_return(nil)
-        expect { subject.validate_dest_name }.to raise_error
+        expect { subject.validate_dest_name }
+          .to raise_error(MiqException::MiqProvisionError, /Name cannot be blank/)
       end
 
       it "with a duplicate name" do
         allow(subject).to receive(:dest_name).and_return(vm.name)
-        expect { subject.validate_dest_name }.to raise_error
+        expect { subject.validate_dest_name }
+          .to raise_error(MiqException::MiqProvisionError, /already exists/)
       end
     end
 

--- a/spec/support/raise_on_potential_false_positives.rb
+++ b/spec/support/raise_on_potential_false_positives.rb
@@ -1,0 +1,32 @@
+module RSpec
+  module Matchers
+    module BuiltIn
+      class RaiseError
+        def warn_about_bare_error
+          raise %(
+            Using the `raise_error` matcher without providing a specific
+            error or message risks false positives, since `raise_error`
+            will match when Ruby raises a `NoMethodError`, `NameError` or
+            `ArgumentError`, potentially allowing the expectation to pass
+            without even executing the method you are intending to call.
+
+            Instead, provide a specific error class or message.
+          )
+        end
+
+        def warn_about_negative_false_positive(expression)
+          raise %(
+            Using #{expression} risks false positives, since literally
+            any other error would cause the expectation to pass,
+            including those raised by Ruby (e.g. NoMethodError, NameError
+            and ArgumentError), meaning the code you are intending to test
+            may not even get reached.
+
+            Instead, use:
+            `expect {}.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using raise_error in certain ways allows for potential false positives. We removed all of them - and found bugs - in the RSpec 3 conversion. A few have been accidentally reintroduced into the specs. Sadly, RSpec doesn't have an option to _raise_ on potential false positives (only warn).

I'm currently adding this functionality but for now, to avoid adding any more before a new version of RSpec is cut, this patches in that behavior.

Note you can see what it looks like when people add potential false positives [here](https://travis-ci.org/ManageIQ/manageiq/jobs/108410420)