### PR TITLE
aws-sdk-v2 orchestration stack

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -3,7 +3,8 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
     orchestration_manager.with_provider_connection(:service => "CloudFormation") do |service|
-      service.stacks.create(stack_name, template.content, options).stack_id
+      stack_options = options.merge(:stack_name => stack_name, :template_body => template.content)
+      service.create_stack(stack_options).stack_id
     end
   rescue => err
     _log.error "stack=[#{stack_name}], error: #{err}"
@@ -11,9 +12,9 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
   end
 
   def raw_update_stack(template, options)
-    update_options = {:template => template.content}.merge(options.except(:disable_rollback, :timeout))
+    update_options = {:template_body => template.content}.merge(options.except(:disable_rollback, :timeout))
     ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
-      service.stacks[name].update(update_options)
+      service.stack(name).update(update_options)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
@@ -22,7 +23,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
 
   def raw_delete_stack
     ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
-      service.stacks[name].try(:delete)
+      service.stack(name).try!(:delete)
     end
   rescue => err
     _log.error "stack=[#{name}], error: #{err}"
@@ -31,8 +32,8 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
 
   def raw_status
     ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
-      raw_stack = service.stacks[name]
-      Status.new(raw_stack.status, raw_stack.status_reason)
+      raw_stack = service.stack(name)
+      Status.new(raw_stack.stack_status, raw_stack.stack_status_reason)
     end
   rescue => err
     if err.to_s =~ /[S|s]tack.+does not exist/

--- a/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager/orchestration_stack.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
   require_nested :Status
 
   def self.raw_create_stack(orchestration_manager, stack_name, template, options = {})
-    orchestration_manager.with_provider_connection(:service => "CloudFormation") do |service|
+    orchestration_manager.with_provider_connection(:service => :CloudFormation, :sdk_v2 => true) do |service|
       stack_options = options.merge(:stack_name => stack_name, :template_body => template.content)
       service.create_stack(stack_options).stack_id
     end
@@ -13,7 +13,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
 
   def raw_update_stack(template, options)
     update_options = {:template_body => template.content}.merge(options.except(:disable_rollback, :timeout))
-    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+    ext_management_system.with_provider_connection(:service => :CloudFormation, :sdk_v2 => true) do |service|
       service.stack(name).update(update_options)
     end
   rescue => err
@@ -22,7 +22,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
   end
 
   def raw_delete_stack
-    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+    ext_management_system.with_provider_connection(:service => :CloudFormation, :sdk_v2 => true) do |service|
       service.stack(name).try!(:delete)
     end
   rescue => err
@@ -31,7 +31,7 @@ class ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack < ::Orchestr
   end
 
   def raw_status
-    ext_management_system.with_provider_connection(:service => "CloudFormation") do |service|
+    ext_management_system.with_provider_connection(:service => :CloudFormation, :sdk_v2 => true) do |service|
       raw_stack = service.stack(name)
       Status.new(raw_stack.stack_status, raw_stack.stack_status_reason)
     end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/orchestration_stack_spec.rb
@@ -1,68 +1,100 @@
+require_relative "../aws_helper"
+
 describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
-  let(:ems) { FactoryGirl.create(:ems_amazon) }
+  let(:ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
   let(:template) { FactoryGirl.create(:orchestration_template) }
   let(:orchestration_stack) do
     FactoryGirl.create(:orchestration_stack_amazon, :ext_management_system => ems, :name => 'test')
   end
 
-  let(:the_raw_stack) do
-    double.tap do |stack|
-      allow(stack).to receive(:stack_id).and_return('one_id')
-    end
-  end
-
-  let(:raw_stacks) do
-    double.tap do |stacks|
-      handle = double
-      allow(handle).to receive(:stacks).and_return(stacks)
-      allow(ems).to receive(:connect).and_return(handle)
-      allow(stacks).to receive(:[]).with(orchestration_stack.name).and_return(the_raw_stack)
-    end
-  end
-
-  before do
-    raw_stacks
-  end
-
   describe 'stack operations' do
-    context ".create_stack" do
-      it 'creates a stack' do
-        expect(raw_stacks).to receive(:create).and_return(the_raw_stack)
-
-        stack = OrchestrationStack.create_stack(ems, 'mystack', template, {})
-        expect(stack.class).to eq(described_class)
-        expect(stack.name).to eq('mystack')
-        expect(stack.ems_ref).to eq(the_raw_stack.stack_id)
+    context ".raw_create_stack" do
+      it "creates a stack" do
+        stubbed_responses = {
+            :cloudformation => {
+                :create_stack => [:stack_id => "stack_id"],
+                :describe_stacks => {
+                    :stacks =>
+                        [
+                            :stack_name => "mystack",
+                            :creation_time => 10.minutes.ago,
+                            :stack_status => 'CREATE_COMPLETE',
+                            :stack_id => "stack_id"
+                        ]
+                }
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          stack = OrchestrationStack.create_stack(ems, "mystack", template)
+          expect(stack.class).to eq(described_class)
+          expect(stack.name).to eq("mystack")
+          expect(stack.ems_ref).to eq("stack_id")
+        end
       end
 
       it 'catches errors from provider' do
-        expect(raw_stacks).to receive(:create).and_throw('bad request')
-
-        expect { OrchestrationStack.create_stack(ems, 'mystack', template, {}) }.to raise_error(MiqException::MiqOrchestrationProvisionError)
+        stubbed_responses = {
+            :cloudformation => {
+                :create_stack => "AlreadyExistsException"
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            OrchestrationStack.create_stack(ems, "mystack", template)
+          end.to raise_error(MiqException::MiqOrchestrationProvisionError)
+        end
       end
     end
 
     context "#update_stack" do
       it 'updates the stack' do
-        expect(the_raw_stack).to receive(:update)
-        orchestration_stack.update_stack(template, {})
+        stubbed_responses = {
+            :cloudformation => {
+                :update_stack => { :stack_id => "stack_id"}
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect(orchestration_stack.update_stack(template, {}).stack_id).to eq("stack_id")
+        end
       end
 
-      it 'catches errors from provider' do
-        expect(the_raw_stack).to receive(:update).and_throw('bad request')
-        expect { orchestration_stack.update_stack(template, {}) }.to raise_error(MiqException::MiqOrchestrationUpdateError)
+      it "catches errors from provider" do
+        stubbed_responses = {
+            :cloudformation => {
+                :update_stack => "ServiceError"
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            orchestration_stack.update_stack(template, {})
+          end.to raise_error(MiqException::MiqOrchestrationUpdateError)
+        end
       end
     end
 
     context "#delete_stack" do
-      it 'updates the stack' do
-        expect(the_raw_stack).to receive(:delete)
-        orchestration_stack.delete_stack
+      it "deletes the stack" do
+        stubbed_responses = {
+            :cloudformation => {
+                :delete_stack => {}
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect(orchestration_stack.delete_stack).to be_truthy
+        end
       end
 
       it 'catches errors from provider' do
-        expect(the_raw_stack).to receive(:delete).and_throw('bad request')
-        expect { orchestration_stack.delete_stack }.to raise_error(MiqException::MiqOrchestrationDeleteError)
+        stubbed_responses = {
+            :cloudformation => {
+                :delete_stack => "InsufficientCapabilitiesException"
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect do
+            orchestration_stack.delete_stack
+          end.to raise_error(MiqException::MiqOrchestrationDeleteError)
+        end
       end
     end
   end
@@ -70,27 +102,48 @@ describe ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack do
   describe 'stack status' do
     context '#raw_status and #raw_exists' do
       it 'gets the stack status and reason' do
-        allow(the_raw_stack).to receive(:status).and_return('CREATE_COMPLETE')
-        allow(the_raw_stack).to receive(:status_reason).and_return('complete')
+        stubbed_responses = {
+            :cloudformation => {
+                :describe_stacks => {
+                    :stacks => [
+                        :stack_name => "StackName",
+                        :creation_time => 10.minutes.ago,
+                        :stack_status => 'CREATE_COMPLETE',
+                        :stack_status_reason => 'complete'
+                    ]
+                }
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          raw_status = orchestration_stack.raw_status
 
-        rstatus = orchestration_stack.raw_status
-        expect(rstatus).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
-
-        expect(orchestration_stack.raw_exists?).to be_truthy
+          expect(raw_status).to have_attributes(:status => 'CREATE_COMPLETE', :reason => 'complete')
+          expect(orchestration_stack.raw_exists?).to be_truthy
+        end
       end
 
       it 'parses error message to determine stack not exist' do
-        allow(raw_stacks).to receive(:[]).with(orchestration_stack.name).and_throw("Stack xxx does not exist")
-        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
-
-        expect(orchestration_stack.raw_exists?).to be_falsey
+        stubbed_responses = {
+            :cloudformation => {
+                :describe_stacks => Aws::CloudFormation::Errors::ValidationError.new(:no_context, "Stack with id stack_id does not exist")
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStackNotExistError)
+          expect(orchestration_stack.raw_exists?).to be_falsey
+        end
       end
 
       it 'catches errors from provider' do
-        allow(raw_stacks).to receive(:[]).with(orchestration_stack.name).and_throw("bad request")
-        expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
-
-        expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+        stubbed_responses = {
+            :cloudformation => {
+                :describe_stacks => "ServiceError"
+            }
+        }
+        with_aws_stubbed(stubbed_responses) do
+          expect { orchestration_stack.raw_status }.to raise_error(MiqException::MiqOrchestrationStatusError)
+          expect { orchestration_stack.raw_exists? }.to raise_error(MiqException::MiqOrchestrationStatusError)
+        end
       end
     end
   end


### PR DESCRIPTION
reworked aws orchestration stack to work with sdk v2
also rewrote the specs to use client_stubs

@miq-bot add_labels providers/amazon,refactoring