### PR TITLE
aws-sdk-v2 metrics capture

### DIFF
--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -1,44 +1,57 @@
-describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
-  before do
-    _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+require_relative "../aws_helper"
 
-    @ems_amazon = FactoryGirl.create(:ems_amazon, :zone => @zone)
-  end
+describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
+  let(:ems) { FactoryGirl.create(:ems_amazon_with_authentication) }
+  let(:vm) { FactoryGirl.build(:vm_perf_amazon, :ext_management_system => ems) }
 
   context "#perf_collect_metrics" do
     it "raises an error when no EMS is defined" do
-      @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => nil)
-      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /No EMS defined/)
+      vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => nil)
+      expect { vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /No EMS defined/)
     end
 
     it "raises an error with no EMS credentials defined" do
-      @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => @ems_amazon)
-      expect { @vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /no credentials defined/)
+      vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => FactoryGirl.create(:ems_amazon))
+      expect { vm.perf_collect_metrics('interval_name') }.to raise_error(RuntimeError, /no credentials defined/)
     end
 
     it "handles when nothing is collected" do
-      @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => @ems_amazon)
-      mc = described_class.new(@vm)
-
-      expect(@vm.ext_management_system).to receive(:connect).and_return(double(:metrics => double(:filter => [])))
-      expect(@vm).to receive(:perf_capture_object).and_return(mc)
-
-      expect(@vm.perf_collect_metrics('realtime')).to eq([{"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
-                                                          {"amazon-perf-vm" => {}}])
+      stubbed_responses = {
+        :cloudwatch => {
+          :list_metrics => {}
+        }
+      }
+      with_aws_stubbed(stubbed_responses) do
+        expect(vm.perf_collect_metrics('realtime')).to eq([
+          {"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
+          {"amazon-perf-vm" => {}}
+        ])
+      end
     end
 
-    it "handles when metrixs are collected for only one counter" do
-      @vm = FactoryGirl.build(:vm_perf_amazon, :ext_management_system => @ems_amazon)
-      mc = described_class.new(@vm)
-
-      filter_double = (double(:name => "NetworkIn", :statistics => [{:timestamp => Time.new(1999).utc, :average => 1}]))
-      ems_double = double(:metrics => double(:filter => [filter_double]))
-
-      expect(@vm.ext_management_system).to receive(:connect).and_return(ems_double)
-      expect(@vm).to receive(:perf_capture_object).and_return(mc)
-
-      expect(@vm.perf_collect_metrics('realtime')).to eq([{"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
-                                                          {"amazon-perf-vm" => {}}])
+    it "handles when metrics are collected for only one counter" do
+      stubbed_responses = {
+        :cloudwatch => {
+          :list_metrics          => {
+            :metrics => [
+              :metric_name => "NetworkIn",
+              :namespace   => "Namespace"
+            ]
+          },
+          :get_metric_statistics => {
+            :datapoints => [
+              :timestamp => Time.new(1999).utc,
+              :average   => 1.0
+            ]
+          }
+        }
+      }
+      with_aws_stubbed(stubbed_responses) do
+        expect(vm.perf_collect_metrics('realtime')).to eq([
+          {"amazon-perf-vm" => described_class::VIM_STYLE_COUNTERS},
+          {"amazon-perf-vm" => {}}
+        ])
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/amazon/cloud_manager/metrics_capture_spec.rb
@@ -32,7 +32,7 @@ describe ManageIQ::Providers::Amazon::CloudManager::MetricsCapture do
     it "handles when metrics are collected for only one counter" do
       stubbed_responses = {
         :cloudwatch => {
-          :list_metrics          => {
+          :list_metrics => {
             :metrics => [
               :metric_name => "NetworkIn",
               :namespace   => "Namespace"


### PR DESCRIPTION
* rework metrics capture to use aws sdk v2
* refactor perf_capture into smaller methods

@miq-bot add_labels providers/amazon,refactoring