### PR TITLE
rework aws cloudmanager.discover to be more concise

### DIFF
--- a/app/models/manageiq/providers/amazon/cloud_manager.rb
+++ b/app/models/manageiq/providers/amazon/cloud_manager.rb
@@ -194,26 +194,24 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
   #   will automatically have EmsRefreshes queued up.  If this is a greenfield
   #   discovery, we will at least add an EmsAmazon for us-east-1
   def self.discover(access_key_id, secret_access_key)
-    new_emses = []
+    new_emses         = []
+    all_emses         = includes(:authentications)
+    all_ems_names     = all_emses.map(&:name).to_set
+    known_ems_regions = all_emses.select { |e| e.authentication_userid == access_key_id }.map(&:provider_region)
 
-    all_emses = includes(:authentications)
-    all_ems_names = all_emses.index_by(&:name)
+    ec2 = raw_connect_v2(access_key_id, secret_access_key, :EC2, "us-east-1")
+    region_names_to_discover = ec2.client.describe_regions.regions.map(&:region_name)
 
-    known_emses = all_emses.select { |e| e.authentication_userid == access_key_id }
-    known_ems_regions = known_emses.index_by(&:provider_region)
-
-    ec2 = raw_connect_v2(access_key_id, secret_access_key, "EC2", "us-east-1")
-    ec2.client.describe_regions.regions.each do |region|
-      next if known_ems_regions.include?(region.region_name)
-      resource_for_region = raw_connect_v2(access_key_id, secret_access_key, "EC2", region.region_name)
-      next if resource_for_region.instances.count == 0 && # instances
-              resource_for_region.images(:owners => %w(self)).count == 0 && # private images
-              resource_for_region.images(:executable_users => %w(self)).count == 0 # shared  images
-      new_emses << create_discovered_region(region.region_name, access_key_id, secret_access_key, all_ems_names)
+    (region_names_to_discover - known_ems_regions).each do |region_name|
+      ec2_region = raw_connect_v2(access_key_id, secret_access_key, :EC2, region_name)
+      next if ec2_region.instances.count == 0 && # instances
+              ec2_region.images(:owners => %w(self)).count == 0 && # private images
+              ec2_region.images(:executable_users => %w(self)).count == 0 # shared  images
+      new_emses << create_discovered_region(region_name, access_key_id, secret_access_key, all_ems_names)
     end
 
     # If greenfield Amazon, at least create the us-east-1 region.
-    if new_emses.blank? && known_emses.blank?
+    if new_emses.blank? && known_ems_regions.blank?
       new_emses << create_discovered_region("us-east-1", access_key_id, secret_access_key, all_ems_names)
     end
 
@@ -238,8 +236,8 @@ class ManageIQ::Providers::Amazon::CloudManager < ManageIQ::Providers::CloudMana
 
   def self.create_discovered_region(region_name, access_key_id, secret_access_key, all_ems_names)
     name = region_name
-    name = "#{region_name} #{access_key_id}" if all_ems_names.key?(name)
-    while all_ems_names.key?(name)
+    name = "#{region_name} #{access_key_id}" if all_ems_names.include?(name)
+    while all_ems_names.include?(name)
       name_counter = name_counter.to_i + 1 if defined?(name_counter)
       name = "#{region_name} #{name_counter}"
     end


### PR DESCRIPTION
while trying to refactor everything to use `with_provider_connection`
I realized that this a class method and it wont work well with it.
I think this is more concise and worth the merge :smile:

@miq-bot add_label refactoring,providers/amazon