### PR TITLE
Reduce N+1 queries for perf_capture_timer - part 2

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -102,9 +102,7 @@ class MiqRegion < ApplicationRecord
     active_miq_servers.detect(&:is_master?)
   end
 
-  def self.my_region
-    find_by(:region => my_region_number)
-  end
+  cache_with_timeout(:my_region) { find_by(:region => my_region_number) }
 
   def self.seed
     # Get the region by looking at an existing MiqDatabase instance's id


### PR DESCRIPTION
Due to the way we were accessing the database, many associations were not being set.
This resulted in a very large number of queries, and objects being created.

This cuts the number of objects/queries created by 65%

/cc @Fryguy thanks for help.
/cc @dmetzger57 

https://bugzilla.redhat.com/show_bug.cgi?id=1227008

---
individual commits have numbers as well.

|VmOrTemplate|Host|Storage|ExtManagementSystem|MiqRegion|Zone|
|-----------:|---:|------:|------------------:|--------:|---:|
|     10,000 |200 |   221 |                 1 |       1 |  1 |

**before:**

|        ms |    sql |    sqlms | comments
|       ---:|    ---:|      ---:| ---
|  35,108.3 | 17,412 | 14,458.7 | 100_000-master-1
|  32,624.4 | 17,385 | 14,075.0 | 100_000-master-2
|  34,083.5 | 17,387 | 14,450.4 | 100_000-master-3
|  35,820.5 | 17,385 | 15,012.7 | 100_000-master-4

**after:**

|        ms |   sql |    sqlms | comments
|       ---:|   ---:|      ---:| ---
|  23,150.4 | 6,369 | 11,700.0 | 100_000-all3-1
|  22,552.4 | 6,342 | 12,025.3 | 100_000-all3-2
|  22,446.5 | 6,342 | 11,914.5 | 100_000-all3-3
|  23,225.2 | 6,342 | 12,141.9 | 100_000-all3-4
