### PR TITLE
fix resizable_sidebar_spec - narrow sidebar

### DIFF
--- a/spec/javascripts/resizable_sidebar_spec.js
+++ b/spec/javascripts/resizable_sidebar_spec.js
@@ -73,7 +73,11 @@ describe('resizable-sidebar.js', function () {
   });
 
   it('narrow sidebar', function () {
-    for (var i=5; i<=2; i--) {
+    for (var i=2; i<5; i++) {
+      $('.resize-right').click();
+    }
+
+    for (var i=5; i>=2; i--) {
       expect($('#left')).not.toHaveClass('col-md-' + (i+1));
       expect($('#left')).not.toHaveClass('col-md-pull-' + (13-i));
       expect($('#left')).toHaveClass('col-md-' + i);
@@ -84,7 +88,7 @@ describe('resizable-sidebar.js', function () {
       expect($('#right')).toHaveClass('col-md-' + (12-i));
       expect($('#right')).toHaveClass('col-md-push-' + i);
 
-      $('.resize-right').click();
+      $('.resize-left').click();
     }
   });
 


### PR DESCRIPTION
This test wouldn't run at all because 5 is never <= 2, fixed to check >= 2.

Also, narrowing should test `resize-left`, not `resize-right`, and given the fixture is set up in before each and the test clearly expects to run after `expand sidebar` - added a bunch of right clicks to the beginning.

(Also gets rid of the `Spec 'resizable-sidebar.js narrow sidebar' has no expectations.` message while running JS tests.)