### PR TITLE
Process VMware Read-Only Datastores

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -122,7 +122,7 @@ module EmsRefresh::SaveInventoryInfra
                     []
                   end
 
-    child_keys = [:operating_system, :switches, :hardware, :system_services]
+    child_keys = [:operating_system, :switches, :hardware, :system_services, :host_storages]
     extra_keys = [:ems_cluster, :storages, :vms, :power_state, :ems_children]
     remove_keys = child_keys + extra_keys
 
@@ -209,6 +209,26 @@ module EmsRefresh::SaveInventoryInfra
         disconnects.each(&:disconnect_inv)
       end
     end
+  end
+
+  def save_host_storages_inventory(host, hashes, target = nil)
+    target = host if target.nil?
+
+    # Update the associated ids
+    hashes.each do |h|
+      h[:host_id]    = host.id
+      h[:storage_id] = h.fetch_path(:storage, :id)
+    end
+
+    host.host_storages(true)
+    deletes =
+      if target == host
+        host.host_storages.dup
+      else
+        []
+      end
+
+    save_inventory_multi(host.host_storages, hashes, deletes, [:host_id, :storage_id], nil, [:storage])
   end
 
   def save_folders_inventory(ems, hashes, target = nil)

--- a/app/models/ems_refresh/vc_updates.rb
+++ b/app/models/ems_refresh/vc_updates.rb
@@ -143,6 +143,7 @@ module EmsRefresh::VcUpdates
       "capability.directoryHierarchySupported",
       "capability.perFileThinProvisioningSupported",
       "capability.rawDiskMappingsSupported",
+      "host",
       "summary.capacity",
       "summary.datastore",
       "summary.freeSpace",

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1852,5 +1852,13 @@ class Host < ApplicationRecord
     ext_management_system.class == ManageIQ::Providers::Openstack::InfraManager
   end
 
+  def writable_storages
+    storages.where(:host_storages => {:read_only => [false, nil]})
+  end
+
+  def read_only_storages
+    storages.where(:host_storages => {:read_only => true})
+  end
+
   include DeprecatedCpuMethodsMixin
 end

--- a/gems/pending/VMwareWebService/VimPropMaps.rb
+++ b/gems/pending/VMwareWebService/VimPropMaps.rb
@@ -60,7 +60,7 @@ module VimPropMaps
     :Datastore                   => {
       :baseName => "@dataStores",
       :keyPath  => ['summary', 'name'],
-      :props    => ["summary", "info", "capability", "parent"]
+      :props    => ["summary", "info", "host", "capability", "parent"]
     },
     :StoragePod                  => {
       :baseName => "@storagePods",
@@ -331,6 +331,7 @@ module VimPropMaps
       :keyPath  => ['summary', 'name'],
       :props    => [
         "info",
+        "host",
         "capability.directoryHierarchySupported",
         "capability.perFileThinProvisioningSupported",
         "capability.rawDiskMappingsSupported",

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -204,6 +204,20 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(@host.storages.size).to eq(25)
     expect(@host.storages).to      include(@storage)
 
+    expect(@host.writable_storages.size).to  eq(24)
+    expect(@host.read_only_storages.size).to eq(1)
+
+    read_only_storage = @host.read_only_storages.first
+    expect(read_only_storage).to have_attributes(
+      :ems_ref            => "datastore-12282",
+      :name               => "temp1",
+      :store_type         => "VMFS",
+      :total_space        => 2830920318976,
+      :free_space         => 2667552178176,
+      :multiplehostaccess => 1,
+      :location           => "4dce5b88-623e8e7e-0dc0-00188b404015"
+    )
+
     expect(@host.operating_system).to have_attributes(
       :name         => "VI4ESXM1.manageiq.com",
       :product_name => "ESXi",

--- a/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
+++ b/spec/tools/vim_data/miq_vim_inventory/dataStoresByMor.yml
@@ -4,6 +4,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -66,6 +95,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -128,6 +186,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -190,6 +263,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -248,6 +336,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -310,6 +413,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readOnly
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -368,6 +500,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -426,6 +573,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -484,6 +646,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -546,6 +737,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -608,6 +814,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -666,6 +887,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -724,6 +974,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -782,6 +1047,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -840,6 +1134,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -902,6 +1211,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -960,6 +1284,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1018,6 +1371,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1076,6 +1444,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1134,6 +1531,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1196,6 +1622,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1254,6 +1695,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1312,6 +1768,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1374,6 +1859,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1432,6 +1932,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1490,6 +2005,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1548,6 +2092,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1606,6 +2165,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1668,6 +2256,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1730,6 +2333,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1788,6 +2406,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1850,6 +2497,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1908,6 +2570,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -1970,6 +2661,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2032,6 +2752,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2090,6 +2825,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2152,6 +2916,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2210,6 +3003,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2268,6 +3090,7 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2330,6 +3153,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2388,6 +3226,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2446,6 +3313,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2504,6 +3386,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2562,6 +3459,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2620,6 +3546,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2682,6 +3637,7 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2740,6 +3696,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-648
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2798,6 +3769,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2856,6 +3856,21 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-12692
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"
@@ -2914,6 +3929,35 @@
   "@vimType": :Datastore
   "@xsiType": :ManagedObjectReference
 : !map:VimHash 
+  host: !map:VimArray
+    - !map:VimHash
+      key: !str:VimString
+        str: host-9
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
+    - !map:VimHash
+      key: !str:VimString
+        str: host-891
+        "@vimType": :HostSystem
+        "@xsiType": :ManagedObjectReference
+      mountInfo: !map:VimHash
+        accessMode: !str:VimString
+          str: readWrite
+          "@xsiType": :"SOAP::SOAPString"
+          "@vimType":
+        __iv__@vimType:
+        __iv__@xsiType: :HostMountInfo
+      __iv__@vimType:
+      __iv__@xsiType: :DatastoreHostMount
   capability: !map:VimHash 
     perFileThinProvisioningSupported: !str:VimString 
       str: "true"


### PR DESCRIPTION
Collect the DatastoreHostMount property of Datastore so that we can tell if a host has a datastore mounted read-only or read-write, and store the result in the HostStorage model.
When you select a host for provisioning this will let you filter only datastores that can be written to by that host.

https://bugzilla.redhat.com/show_bug.cgi?id=1187819