### PR TITLE
Use AwesomeSpawn over LinuxAdmin for running commands

### DIFF
--- a/gems/pending/appliance_console/database_configuration.rb
+++ b/gems/pending/appliance_console/database_configuration.rb
@@ -88,7 +88,7 @@ module ApplianceConsole
         temp.write(activation_code)
         temp.close
 
-        output = LinuxAdmin.run('script/rails', :chdir => RAILS_ROOT, :params => params).output
+        output = AwesomeSpawn.run('script/rails', :chdir => RAILS_ROOT, :params => params).output
       ensure
         temp.delete
       end

--- a/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/gems/pending/appliance_console/internal_database_configuration.rb
@@ -100,7 +100,7 @@ module ApplianceConsole
     def create_partition_to_fill_disk
       # FIXME: when LinuxAdmin has this feature
       @disk.create_partition_table # LinuxAdmin::Disk.create_partition has this already...
-      LinuxAdmin.run!("parted -s #{@disk.path} mkpart primary 0% 100%")
+      AwesomeSpawn.run!("parted -s #{@disk.path} mkpart primary 0% 100%")
 
       # FIXME: Refetch the disk after creating the partition
       @disk = LinuxAdmin::Disk.local.find { |d| d.path == @disk.path }
@@ -122,14 +122,14 @@ module ApplianceConsole
     def format_logical_volume
       # LogicalVolume#format_to(:ext4) should be a thing
       # LogicalVolume#fs_type => :ext4 should be a thing
-      LinuxAdmin.run!("mkfs.#{PostgresAdmin.database_disk_filesystem} #{@logical_volume.path}")
+      AwesomeSpawn.run!("mkfs.#{PostgresAdmin.database_disk_filesystem} #{@logical_volume.path}")
     end
 
     def mount_database_disk
       # TODO: should this be moved into LinuxAdmin?
       FileUtils.rm_rf(PostgresAdmin.data_directory)
       FileUtils.mkdir_p(PostgresAdmin.data_directory)
-      LinuxAdmin.run!("mount", :params => {"-t" => PostgresAdmin.database_disk_filesystem, nil => [@logical_volume.path, PostgresAdmin.data_directory]})
+      AwesomeSpawn.run!("mount", :params => {"-t" => PostgresAdmin.database_disk_filesystem, nil => [@logical_volume.path, PostgresAdmin.data_directory]})
     end
 
     def update_fstab
@@ -157,7 +157,7 @@ module ApplianceConsole
     end
 
     def run_initdb
-      LinuxAdmin.run!("service", :params => {nil => [PostgresAdmin.service_name, "initdb"]})
+      AwesomeSpawn.run!("service", :params => {nil => [PostgresAdmin.service_name, "initdb"]})
     end
 
     def start_postgres
@@ -187,7 +187,7 @@ module ApplianceConsole
     end
 
     def relabel_postgresql_dir
-      LinuxAdmin.run!("/sbin/restorecon -R -v #{PostgresAdmin.data_directory}")
+      AwesomeSpawn.run!("/sbin/restorecon -R -v #{PostgresAdmin.data_directory}")
     end
   end
 end

--- a/gems/pending/appliance_console/service_group.rb
+++ b/gems/pending/appliance_console/service_group.rb
@@ -49,7 +49,7 @@ module ApplianceConsole
     private
 
     def enable_miqtop
-      LinuxAdmin.run("chkconfig", :params => {"--add" => "miqtop"})  # Is this really needed?
+      AwesomeSpawn.run("chkconfig", :params => {"--add" => "miqtop"})
     end
 
     def run_service(service, action)

--- a/gems/pending/appliance_console/temp_storage_configuration.rb
+++ b/gems/pending/appliance_console/temp_storage_configuration.rb
@@ -34,14 +34,14 @@ module ApplianceConsole
     end
 
     def format_partition(partition)
-      LinuxAdmin.run!("mkfs.#{TEMP_DISK_FILESYSTEM_TYPE} #{partition.path}")
+      AwesomeSpawn.run!("mkfs.#{TEMP_DISK_FILESYSTEM_TYPE} #{partition.path}")
     end
 
     def mount_temp_disk(partition)
       # TODO: should this be moved into LinuxAdmin?
       FileUtils.rm_rf(TEMP_DISK_MOUNT_POINT)
       FileUtils.mkdir_p(TEMP_DISK_MOUNT_POINT)
-      LinuxAdmin.run!("mount", :params => {
+      AwesomeSpawn.run!("mount", :params => {
                         "-t" => TEMP_DISK_FILESYSTEM_TYPE,
                         "-o" => TEMP_DISK_MOUNT_OPTS,
                         nil  => [partition.path, TEMP_DISK_MOUNT_POINT]
@@ -69,7 +69,7 @@ module ApplianceConsole
     def create_partition_to_fill_disk(disk)
       # @disk.create_partition('primary', '100%')
       disk.create_partition_table # LinuxAdmin::Disk.create_partition has this already...
-      LinuxAdmin.run!("parted -s #{disk.path} mkpart primary 0% 100%")
+      AwesomeSpawn.run!("parted -s #{disk.path} mkpart primary 0% 100%")
 
       # FIXME: Refetch the disk after creating the partition
       disk = LinuxAdmin::Disk.local.find { |d| d.path == disk.path }

--- a/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/internal_database_configuration_spec.rb
@@ -44,7 +44,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     disk_double = double(:path => "/dev/vdb")
     expect(disk_double).to receive(:create_partition_table)
     expect(disk_double).to receive(:partitions).and_return(["fake partition"])
-    expect(LinuxAdmin).to receive(:run!).with("parted -s /dev/vdb mkpart primary 0% 100%")
+    expect(AwesomeSpawn).to receive(:run!).with("parted -s /dev/vdb mkpart primary 0% 100%")
     expect(LinuxAdmin::Disk).to receive(:local).and_return([disk_double])
 
     @config.instance_variable_set(:@disk, disk_double)

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -117,7 +117,7 @@ describe ApplianceConsole::ServiceGroup do
   # this is private, but since we are stubbing it, make sure it works
   context "#enable_miqtop" do
     it "calls chkconfig" do
-      expect(LinuxAdmin).to receive(:run).with("chkconfig", :params => {"--add" => "miqtop"})
+      expect(AwesomeSpawn).to receive(:run).with("chkconfig", :params => {"--add" => "miqtop"})
       group.send(:enable_miqtop)
     end
   end


### PR DESCRIPTION
Required to use a linux_admin gem version containing the PR
here https://github.com/ManageIQ/linux_admin/pull/148 which
removes access to the LinuxAdmin::Common module's methods through
any class in LinuxAdmin.