### PR TITLE
user_id should be userid

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -193,7 +193,7 @@ module RetirementMixin
     event_hash[retirement_base_model_name.underscore.to_sym] = self
     event_hash[:host] = host if self.respond_to?(:host)
     if requester
-      event_hash[:user_id] = requester
+      event_hash[:userid] = requester
       event_hash[:retirement_initiator] = "user"
     end
     event_hash[:type] ||= self.class.name

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -33,7 +33,7 @@ describe "Service Retirement Management" do
     expect(@stack.retirement_state).to be_nil
     event_name = 'request_orchestration_stack_retire'
     event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
-                  :retirement_initiator => "user", :user_id => "freddy"}
+                  :retirement_initiator => "user", :userid => "freddy"}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash).once
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -33,7 +33,7 @@ describe "Service Retirement Management" do
     expect(@service.retirement_state).to be_nil
     event_name = 'request_service_retire'
     event_hash = {:service => @service, :type => "Service",
-                  :retirement_initiator => "user", :user_id => "freddy"}
+                  :retirement_initiator => "user", :userid => "freddy"}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash).once
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -33,7 +33,7 @@ describe "VM Retirement Management" do
   it "#retire_now with userid" do
     event_name = 'request_vm_retire'
     event_hash = {:vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm",
-                  :retirement_initiator => "user", :user_id => 'freddy'}
+                  :retirement_initiator => "user", :userid => 'freddy'}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash).once
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1306835

During retirement the userid of the inititator should be stored
as userid and not as user_id.