### PR TITLE
Consolidate on FIXTURE_DIR assignments

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  FIXTURE_DIR = Rails.root.join("db/fixtures")
 end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -41,8 +41,6 @@ class Chargeback < ActsAsArModel
     :total_cost               => :float
   )
 
-  RATES = YAML.load_file(File.join(Rails.root, "db/fixtures/chargeback_rates.yml"))
-
   def self.build_results_for_report_chargeback(options)
     # Options:
     #   :rpt_type => chargeback

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -11,8 +11,6 @@ class ChargebackRate < ApplicationRecord
   validates_uniqueness_of   :guid
   validates_uniqueness_of   :description, :scope => :rate_type
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
-
   VALID_CB_RATE_TYPES = ["Compute", "Storage"]
 
   def self.validate_rate_type(type)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -32,7 +32,7 @@ class Classification < ApplicationRecord
   default_value_for :single_value, false
   default_value_for :show,         true
 
-  FIXTURE_FILE = File.join(Rails.root, "db/fixtures/classifications.yml")
+  FIXTURE_FILE = FIXTURE_DIR.join("classifications.yml")
 
   def self.hash_all_by_type_and_name(conditions = {})
     ret = {}

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -40,8 +40,6 @@ class MiqAction < ApplicationRecord
   # Add a instance method to store the sequence and synchronous values from the policy contents
   attr_accessor :sequence, :synchronous, :reserved
 
-  FIXTURE_DIR = Rails.root.join("db/fixtures")
-
   SCRIPT_DIR = Rails.root.join("product/conditions/scripts").expand_path
   SCRIPT_DIR.mkpath
 

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -26,8 +26,6 @@ class MiqAlert < ApplicationRecord
 
   acts_as_miq_set_member
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
-
   ASSIGNMENT_PARENT_ASSOCIATIONS = [:host, :ems_cluster, :ext_management_system, :my_enterprise]
 
   HOURLY_TIMER_EVENT   = "_hourly_timer_"

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -18,8 +18,6 @@ class MiqEventDefinition < ApplicationRecord
 
   attr_accessor :reserved
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
-
   def self.all_events
     where(:event_type => "Default")
   end

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -20,6 +20,6 @@ class MiqEventDefinitionSet < ApplicationRecord
   end
 
   def self.fixture_path
-    Rails.root.join("db/fixtures/#{to_s.pluralize.underscore}.csv")
+    FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -38,8 +38,6 @@ class MiqGroup < ApplicationRecord
   include TimezoneMixin
   include TenancyMixin
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
-
   alias_method :current_tenant, :tenant
 
   def name

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -23,7 +23,7 @@ module MiqProvision::Naming
         options        = prov_obj.options
         options[:tags] = prov_obj.get_tags
 
-        load File.join(File.expand_path(Rails.root), 'db/fixtures/miq_provision_naming.rb')
+        load ApplicationRecord::FIXTURE_DIR.join("miq_provision_naming.rb")
         unresolved_vm_name = MiqProvisionNaming.naming(options)
       end
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -3,8 +3,7 @@
 module MiqReport::Formatting
   extend ActiveSupport::Concern
 
-  fixture_dir = File.join(Rails.root, "db/fixtures")
-  format_hash = YAML.load_file(File.expand_path(File.join(fixture_dir, "miq_report_formats.yml")))
+  format_hash = YAML.load_file(ApplicationRecord::FIXTURE_DIR.join("miq_report_formats.yml"))
   FORMATS                       = format_hash[:formats].freeze
   FORMAT_DEFAULTS_AND_OVERRIDES = format_hash[:defaults_and_overrides].freeze
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -27,7 +27,6 @@ class MiqSchedule < ApplicationRecord
   serialize :filter
   serialize :run_at
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
   SYSTEM_SCHEDULE_CLASSES = ["MiqReport", "MiqAlert", "MiqWidget"]
   VALID_INTERVAL_UNITS = ['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'once']
   ALLOWED_CLASS_METHOD_ACTIONS = ["db_backup", "db_gc"]

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -28,7 +28,7 @@ class MiqShortcut < ApplicationRecord
   end
 
   def self.fixture_file_name
-    @fixture_file_name ||= File.join(Rails.root, "db/fixtures", "miq_shortcuts.yml")
+    @fixture_file_name ||= FIXTURE_DIR.join("miq_shortcuts.yml")
   end
 
   def self.seed_data

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -20,7 +20,6 @@ class MiqUserRole < ApplicationRecord
 
   include ReportableMixin
 
-  FIXTURE_DIR  = File.join(Rails.root, "db/fixtures")
   FIXTURE_PATH = File.join(FIXTURE_DIR, table_name)
   FIXTURE_YAML = "#{FIXTURE_PATH}.yml"
 

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -25,7 +25,7 @@ class ServerRole < ApplicationRecord
   end
 
   def self.fixture_path
-    Rails.root.join("db/fixtures/#{to_s.pluralize.underscore}.csv")
+    FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
 
   def self.to_role(server_role)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,8 +49,6 @@ class User < ApplicationRecord
 
   @role_changed = false
 
-  FIXTURE_DIR = File.join(Rails.root, "db/fixtures")
-
   serialize     :settings, Hash   # Implement settings column as a hash
   default_value_for(:settings) { Hash.new }
 


### PR DESCRIPTION
Because ETOOMANYFIXTUREDIRS.

We define FIXTURE_DIR all over the place, and we don't need to.