### PR TITLE
Report info and errors messages from appliance_console_cli

### DIFF
--- a/gems/pending/appliance_console/logging.rb
+++ b/gems/pending/appliance_console/logging.rb
@@ -57,17 +57,15 @@ module ApplianceConsole
 
     # TODO: move say_error and say_info to prompting module?
     def say_error(method, output)
-      if interactive?
-        log = "\nSee #{ApplianceConsole::Logging.log_filename} for details." if ApplianceConsole::Logging.log_filename
-        text = "#{method.to_s.humanize} failed with error - #{output.truncate(200)}.#{log}"
-        say(text)
-        press_any_key
-        raise MiqSignalError
-      end
+      log = "\nSee #{ApplianceConsole::Logging.log_filename} for details." if ApplianceConsole::Logging.log_filename
+      text = "#{method.to_s.humanize} failed with error - #{output.truncate(200)}.#{log}"
+      say(text)
+      press_any_key if interactive?
+      raise MiqSignalError
     end
 
     def say_info(method, output)
-      say("#{method.to_s.humanize} #{output}") if interactive?
+      say("#{method.to_s.humanize} #{output}")
     end
 
     def log_and_feedback(method)

--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -1,6 +1,5 @@
 # TODO: add appropriate requires instead of depending on appliance_console.rb.
 # TODO: Further refactor these unrelated methods.
-require "appliance_console/internal_database_configuration"
 require "util/postgres_admin"
 require "awesome_spawn"
 

--- a/gems/pending/spec/appliance_console/database_configuration_spec.rb
+++ b/gems/pending/spec/appliance_console/database_configuration_spec.rb
@@ -233,8 +233,9 @@ describe ApplianceConsole::DatabaseConfiguration do
 
   it "#say_error interactive=> false" do
     config = described_class.new(:interactive => false)
-    expect(config).to receive(:say).never
-    config.say_error(:create_region, "Error message")
+    expect(config).to receive(:say)
+    expect(config).to_not receive(:press_any_key)
+    expect { config.say_error(:create_region, "Error message") }.to raise_error(MiqSignalError)
   end
 
   context "#log_and_feedback" do

--- a/gems/pending/spec/appliance_console/logging_spec.rb
+++ b/gems/pending/spec/appliance_console/logging_spec.rb
@@ -49,7 +49,11 @@ describe ApplianceConsole::Logging do
     it "should log_and_feedback when non-interactively failing" do
       begin
         subject.interactive = false
-        expect(subject.log_and_feedback("test") { raise "Issue" }).to be_nil
+        expect(subject).to receive(:say).with("Test starting")
+        expect(subject).to receive(:say).with(/Test.*error.*Issue/)
+        expect(subject).to_not receive(:press_any_key)
+
+        expect { subject.log_and_feedback("test") { raise "Issue" } }.to raise_error(MiqSignalError)
       ensure
         subject.interactive = true
       end


### PR DESCRIPTION
A user of the appliance_console_cli has little indication of progress and no indication of failures.
This PR exposes more helpful output to the user of the cli.

https://bugzilla.redhat.com/show_bug.cgi?id=1302868