### PR TITLE
List VMs or Templates when filter for host is assigned

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -562,6 +562,10 @@ module Rbac
         end
       elsif klass == Host
         results.concat(get_belongsto_matches_for_host(vcmeta_list.last))
+      elsif vcmeta_list.last.kind_of?(Host) && klass <= VmOrTemplate
+        host = vcmeta_list.last
+        vms_and_templates = host.send(klass.base_model.to_s.tableize).to_a
+        results.concat(vms_and_templates)
       else
         vcmeta_list.each { |vcmeta| results.push(vcmeta) if vcmeta.kind_of?(klass) }
         results.concat(vcmeta_list.last.descendants.select { |obj| obj.kind_of?(klass) })

--- a/spec/models/miq_filter_spec.rb
+++ b/spec/models/miq_filter_spec.rb
@@ -1,0 +1,52 @@
+describe MiqFilter do
+  let(:ems)             { FactoryGirl.create(:ems_vmware, :name => 'ems') }
+  let(:ems_folder_path) { "/belongsto/ExtManagementSystem|#{ems.name}" }
+  let(:datacenter)      { FactoryGirl.create(:ems_folder, :name => "Datacenters") }
+  let(:mtc)             { FactoryGirl.create(:ems_folder, :name => "MTC", :is_datacenter => true) }
+  let(:ems_folder_path) { "/belongsto/ExtManagementSystem|#{ems.name}" }
+  let(:mtc_folder_path) { "#{ems_folder_path}/EmsFolder|#{datacenter.name}/EmsFolder|#{mtc.name}" }
+  let(:host_folder)     { FactoryGirl.create(:ems_folder, :name => "host") }
+  let(:host_1)          { FactoryGirl.create(:host_vmware, :name => "Host_1", :ext_management_system => ems) }
+  let(:host_2)          { FactoryGirl.create(:host_vmware, :name => "Host_2", :ext_management_system => ems) }
+  let(:host_3)          { FactoryGirl.create(:host_vmware, :name => "Host_3") }
+
+  let(:mtc_folder_path_with_host_folder) { "#{mtc_folder_path}/EmsFolder|host" }
+  let(:mtc_folder_path_with_host_1)      { "#{mtc_folder_path_with_host_folder}/Host|#{host_1.name}" }
+
+  before do
+    datacenter.parent = ems
+    mtc.parent = datacenter
+    host_folder.parent = mtc
+
+    host_1.parent = host_folder
+    host_2.parent = host_folder
+  end
+
+  describe ".apply_belongsto_filters" do
+    it "returns all parent's Host objects when most-specialized filter is the Host object" do
+      input_objects = [host_1, host_2]
+      results = MiqFilter.apply_belongsto_filters(input_objects, [mtc_folder_path_with_host_1])
+      expect(results).to match_array(input_objects)
+    end
+
+    it "returns all Host objects when most-specialized filter is Host folder" do
+      input_objects = [host_1, host_2]
+      results = MiqFilter.apply_belongsto_filters(input_objects, [mtc_folder_path_with_host_folder])
+      expect(results).to match_array(input_objects)
+    end
+  end
+
+  describe ".belongsto2object_list" do
+    it "converts belongs_to path to objects" do
+      objects_for_folder_path = {}
+      objects_for_folder_path[mtc_folder_path] = [ems, datacenter, mtc]
+      objects_for_folder_path[mtc_folder_path_with_host_folder] = [ems, datacenter, mtc, host_folder]
+      objects_for_folder_path[mtc_folder_path_with_host_1] = [ems, datacenter, mtc, host_folder, host_1]
+
+      objects_for_folder_path.each do |folder, expected_objects|
+        results = MiqFilter.belongsto2object_list(folder)
+        expect(results).to match_array(expected_objects)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1300809
Filter for host is setting in groups in tab Host and Cluster 

2 bugs here:

a) UI doesn't reflect that group has assigned host filter.

Fixing bad matching of objects in belongs to filters in `belongsto2object_list`.
After this `belongsto2object_list` returns `Host` object moreover, so
we need to skip it here for origin behavior.
This settings is in group, in Host/Nodes& Clusters tab.
When host was checked it was stored in db but not visible in
tree that it is checked.

b) Handle situation when user is using host filter from group settings 

This is handling listing of VMs or Templates for case when we have in belongs_to filter:
/belongsto/ExtManagementSystem|X1/EmsFolder|X2/EmsFolder|X2/EmsFolder|host/Host|HOST1
Then we are determining VMs and Templates by relations from Host object(HOST1).

cc @jrafanie 