### PR TITLE
Upgrade sprockets-es6 to 0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ eval_gemfile(File.expand_path("gems/pending/Gemfile", __dir__))
 gem "activerecord-deprecated_finders", "~>1.0.4",  :require => "active_record/deprecated_finders"
 gem "rails",                           "~>4.2.5"
 gem "activerecord-session_store",      "~>0.1.2"
-gem "sprockets-es6",                   "~>0.8.2",  :require => "sprockets/es6"
+gem "sprockets-es6",                   "~>0.9.0",  :require => "sprockets/es6"
 
 # Local gems
 path "gems/" do

--- a/config/initializers/sprockets-es6.rb
+++ b/config/initializers/sprockets-es6.rb
@@ -1,6 +1,7 @@
-# unfortunately there seems no other way to set the options because .call is called directly from sprockets
-Sprockets::ES6.instance.instance_variable_set(:@options, {:optional => %w(
- es7.functionBind
- es7.decorators
- es7.objectRestSpread
-)})
+Sprockets::ES6.configure do |babel5|
+  babel5.optional = %w(
+    es7.functionBind
+    es7.decorators
+    es7.objectRestSpread
+  )
+end


### PR DESCRIPTION
Upgraded to the new `sprockets-es6` release, which can finally be configured cleanly => updated the initializer.