### PR TITLE
[WIP] Angular cleanups

### DIFF
--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -104,7 +104,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
     $scope.currentTab = "default";
 
     $scope.$watch("emsCommonModel.name", function() {
-      $scope.form = $scope.angularForm;
       $scope.model = "emsCommonModel";
     });
   };

--- a/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
+++ b/app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js
@@ -102,10 +102,6 @@ ManageIQ.angular.app.controller('emsCommonFormController', ['$http', '$scope', '
       });
     }
     $scope.currentTab = "default";
-
-    $scope.$watch("emsCommonModel.name", function() {
-      $scope.model = "emsCommonModel";
-    });
   };
 
   $scope.changeAuthTab = function(id) {

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -24,6 +24,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
     };
 
     $scope.modelCopy = angular.copy( $scope.hostModel );
+    $scope.model = "hostModel";
     $scope.afterGet = false;
     $scope.formId = hostFormId;
     $scope.validateClicked = miqService.validateWithAjax;
@@ -94,11 +95,7 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
       $scope.afterGet = true;
     }
 
-     $scope.currentTab = "default";
-
-    $scope.$watch("hostModel.name", function() {
-      $scope.model = "hostModel";
-    });
+    $scope.currentTab = "default";
   };
 
   $scope.changeAuthTab = function(id) {

--- a/app/assets/javascripts/controllers/host/host_form_controller.js
+++ b/app/assets/javascripts/controllers/host/host_form_controller.js
@@ -97,7 +97,6 @@ ManageIQ.angular.app.controller('hostFormController', ['$http', '$scope', '$attr
      $scope.currentTab = "default";
 
     $scope.$watch("hostModel.name", function() {
-      $scope.form = $scope.angularForm;
       $scope.model = "hostModel";
     });
   };

--- a/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/diagnostics_database_form_controller.js
@@ -22,8 +22,7 @@ ManageIQ.angular.app.controller('diagnosticsDatabaseFormController', ['$http', '
     ManageIQ.angular.scope = $scope;
 
     $scope.$watch("diagnosticsDatabaseModel.depot_name", function() {
-        $scope.form = $scope.angularForm;
-        $scope.miqDBBackupService = miqDBBackupService;
+      $scope.miqDBBackupService = miqDBBackupService;
     });
   };
 

--- a/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/log_collection_form_controller.js
@@ -54,7 +54,6 @@ ManageIQ.angular.app.controller('logCollectionFormController', ['$http', '$scope
     }
 
     $scope.$watch("logCollectionModel.depot_name", function() {
-      $scope.form = $scope.angularForm;
       $scope.miqDBBackupService = miqDBBackupService;
     });
   };

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -78,12 +78,5 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       $scope.saveClicked();
     };
 
-    $scope.toggleValueForWatch =   function(watchValue, initialValue) {
-      if($scope[watchValue] == initialValue)
-        $scope[watchValue] = "NO-OP";
-      else if($scope[watchValue] == "NO-OP")
-        $scope[watchValue] = initialValue;
-    };
-
     init();
 }]);

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -10,6 +10,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       $scope.formId = tenantFormId;
       $scope.afterGet = false;
       $scope.modelCopy = angular.copy( $scope.tenantModel );
+      $scope.model = "tenantModel";
 
       ManageIQ.angular.scope = $scope;
 
@@ -39,12 +40,7 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
           miqService.sparkleOff();
         });
       }
-
-      $scope.$watch("tenantModel.name", function() {
-        $scope.model = "tenantModel";
-      });
     };
-
 
     var tenantEditButtonClicked = function(buttonName, serializeFields) {
       miqService.sparkleOn();

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -41,7 +41,6 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
       }
 
       $scope.$watch("tenantModel.name", function() {
-        $scope.form = $scope.angularForm;
         $scope.model = "tenantModel";
       });
     };

--- a/app/assets/javascripts/controllers/ops/tenant_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_form_controller.js
@@ -45,11 +45,8 @@ ManageIQ.angular.app.controller('tenantFormController', ['$http', '$scope', 'ten
     var tenantEditButtonClicked = function(buttonName, serializeFields) {
       miqService.sparkleOn();
       var url = '/ops/rbac_tenant_edit/' + tenantFormId + '?button=' + buttonName + '&divisible=' + tenantType;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        miqService.miqAjaxButton(url, serializeFields);
-      }
+
+      miqService.miqAjaxButton(url, serializeFields);
     };
 
     $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -41,11 +41,8 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
   var tenantManageQuotasButtonClicked = function(buttonName, serializeFields) {
     miqService.sparkleOn();
     var url = '/ops/rbac_tenant_manage_quotas/' + tenantQuotaFormId + '?button=' + buttonName + '&divisible=' + tenantType;
-    if(serializeFields === undefined) {
-      miqService.miqAjaxButton(url);
-    } else {
-      miqService.miqAjaxButton(url, serializeFields);
-    }
+
+    miqService.miqAjaxButton(url, serializeFields);
   };
 
   $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -37,7 +37,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
     });
 
     $scope.$watch("tenantQuotaModel", function() {
-      $scope.form = $scope.angularForm;
       $scope.model = "tenantQuotaModel";
     });
   };

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -7,6 +7,7 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
     $scope.formId = tenantQuotaFormId;
     $scope.afterGet = false;
     $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
+    $scope.model = "tenantQuotaModel";
 
     ManageIQ.angular.scope = $scope;
     $scope.newRecord = false;
@@ -34,10 +35,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
       $scope.afterGet = true;
       $scope.modelCopy = angular.copy( $scope.tenantQuotaModel );
       miqService.sparkleOff();
-    });
-
-    $scope.$watch("tenantQuotaModel", function() {
-      $scope.model = "tenantQuotaModel";
     });
   };
 

--- a/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
+++ b/app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js
@@ -84,13 +84,6 @@ ManageIQ.angular.app.controller('tenantQuotaFormController',['$http', '$scope', 
     $scope.angularForm.$setPristine(true);
   };
 
-  $scope.toggleValueForWatch =   function(watchValue, initialValue) {
-    if($scope[watchValue] == initialValue)
-      $scope[watchValue] = "NO-OP";
-    else if($scope[watchValue] == "NO-OP")
-      $scope[watchValue] = initialValue;
-  };
-
   $scope.check_quotas_changed = function() {
     for (var key in $scope.tenantQuotaModel.quotas) {
       if($scope.tenantQuotaModel.quotas.hasOwnProperty(key)){

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -49,10 +49,6 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
           miqService.sparkleOff();
         });
       }
-
-      $scope.$watch("providerForemanModel.name", function() {
-        $scope.form = $scope.angularForm;
-      });
     };
 
     $scope.canValidateBasicInfo = function () {

--- a/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
+++ b/app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js
@@ -71,11 +71,8 @@ ManageIQ.angular.app.controller('providerForemanFormController', ['$http', '$sco
     var providerForemanEditButtonClicked = function(buttonName, serializeFields) {
       miqService.sparkleOn();
       var url = '/provider_foreman/edit/' + providerForemanFormId + '?button=' + buttonName;
-      if (serializeFields === undefined) {
-        miqService.miqAjaxButton(url);
-      } else {
-        miqService.miqAjaxButton(url, serializeFields);
-      }
+
+      miqService.miqAjaxButton(url, serializeFields);
     };
 
     $scope.cancelClicked = function() {

--- a/app/assets/javascripts/controllers/repository/repository_form_controller.js
+++ b/app/assets/javascripts/controllers/repository/repository_form_controller.js
@@ -23,10 +23,6 @@ ManageIQ.angular.app.controller('repositoryFormController', ['$http', '$scope', 
       });
    }
 
-  $scope.$watch("repoModel.repo_name", function() {
-    $scope.form = $scope.repositoryForm;
-  });
-
   $scope.addClicked = function() {
     miqService.sparkleOn();
     var url = 'create/new' + '?button=add&path_type=' + $scope.path_type;

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -133,11 +133,8 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
   var scheduleEditButtonClicked = function(buttonName, serializeFields) {
     miqService.sparkleOn();
     var url = '/ops/schedule_edit/' + scheduleFormId + '?button=' + buttonName;
-    if (serializeFields === undefined) {
-      miqService.miqAjaxButton(url);
-    } else {
-      miqService.miqAjaxButton(url, serializeFields);
-    }
+
+    miqService.miqAjaxButton(url, serializeFields);
   };
 
   $scope.buildLegend = function() {

--- a/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
+++ b/app/assets/javascripts/controllers/schedule/schedule_form_controller.js
@@ -25,6 +25,8 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     $scope.afterGet = false;
     $scope.validateClicked = miqService.validateWithAjax;
     $scope.modelCopy = angular.copy( $scope.scheduleModel );
+    $scope.model = "scheduleModel";
+    $scope.form = $scope.angularForm;
 
     ManageIQ.angular.scope = $scope;
 
@@ -97,11 +99,6 @@ ManageIQ.angular.app.controller('scheduleFormController', ['$http', '$scope', 's
     }
 
     miqService.buildCalendar(oneMonthAgo.year, parseInt(oneMonthAgo.month) + 1, oneMonthAgo.date);
-
-    $scope.$watch("scheduleModel.name", function() {
-      $scope.form = $scope.angularForm;
-      $scope.model = "scheduleModel";
-    });
   };
 
   var buildFilterList = function(data) {

--- a/spec/javascripts/controllers/ops/tenant_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/tenant_form_controller_spec.js
@@ -62,7 +62,7 @@ describe('tenantFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=cancel&divisible=' + tenantType);
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_edit/new?button=cancel&divisible=' + tenantType, undefined);
     });
   });
 

--- a/spec/javascripts/controllers/ops/tenant_quota_form_controller_spec.js
+++ b/spec/javascripts/controllers/ops/tenant_quota_form_controller_spec.js
@@ -64,7 +64,7 @@ describe('tenantQuotaFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_manage_quotas/1000000000001?button=cancel&divisible=');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/rbac_tenant_manage_quotas/1000000000001?button=cancel&divisible=', undefined);
     });
   });
 

--- a/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
+++ b/spec/javascripts/controllers/schedule/schedule_form_controller_spec.js
@@ -293,7 +293,7 @@ describe('scheduleFormController', function() {
     });
 
     it('delegates to miqService.miqAjaxButton', function() {
-      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=cancel');
+      expect(miqService.miqAjaxButton).toHaveBeenCalledWith('/ops/schedule_edit/new?button=cancel', undefined);
     });
   });
 


### PR DESCRIPTION
This is a small angular controller cleanup PR, based on what I've found in other controllers while reviewing #6629.

   * remove unused `toggleValueForWatch` (except from `ScheduleFormController`)
   * remove unused `$scope.form` (except from `ScheduleFormController`)
   * move `$scope.model=` from a `$watch` to `init()`
   * always pass `serializeFields` to `miqAjaxButton`, even when `undefined`

@AparnaKarve, @h-kataria can you please review?

Note to self: rebase on top of #8400 and see what's left :)