### PR TITLE
Fix Travis Azure Disk warning

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -243,7 +243,8 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
   end
 
   def assert_specific_disk
-    disk = ManageIQ::Providers::Azure::CloudManager::Disk.where(:device_name => "Chef-Prod").first
+    disk = Disk.where(:device_name => "Chef-Prod").first
+
     expect(disk).to have_attributes(
       :location    => "http://chefprod5120.blob.core.windows.net/vhds/Chef-Prod.vhd",
       :size        => 1023.megabyte


### PR DESCRIPTION
The class `ManageIQ::Providers::Azure::CloudManager::Disk` does not exist but, through ruby constant searching, the parent class `Disk` is found and the test passes however  it generates this warning in the process. This PR resolves this warning.