### PR TITLE
collect_children now support's has_ones by returning them as an array.

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -137,10 +137,8 @@ class Condition < ApplicationRecord
     list = ref.send(method)
     return [] if list.nil?
 
-    result = []
-    result = list if methods.empty?
-    list = [list] unless list.kind_of?(Array)
-    list.each do|obj|
+    result = methods.empty? ? Array(list) : []
+    Array(list).each do |obj|
       result.concat(collect_children(obj, methods)) unless methods.empty?
     end
     result

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -3,7 +3,7 @@ describe Condition do
     context "expression with <find>" do
       before do
         @cluster = FactoryGirl.create(:ems_cluster)
-        @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster)
+        @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster, :name => "XXX")
         @host2 = FactoryGirl.create(:host, :ems_cluster => @cluster)
         @rp1 = FactoryGirl.create(:resource_pool)
         @rp2 = FactoryGirl.create(:resource_pool)
@@ -21,6 +21,11 @@ describe Condition do
       it "valid expression" do
         expr = "<find><search><value ref=emscluster, type=boolean>/virtual/vms/active</value> == 'false'</search><check mode=count><count> >= 2</check></find>"
         expect(Condition.subst(expr, @cluster, nil)).to be_truthy
+      end
+
+      it "has_one support" do
+        expr = "<find><search><value ref=vm, type=string>/virtual/host/name</value> == 'XXX'</search><check mode=count><count> == 1</check></find>"
+        expect(Condition.subst(expr, @vm1, nil)).to be_truthy
       end
 
       it "invalid expression should not raise security error because it is now parsed and not evaluated" do


### PR DESCRIPTION
Callers of collect_children expect arrays.

Fixes:

```
undefined method `empty?' for #<Host:0x007f9dbdbd9dd8>
  /~/.gem/ruby/2.2.4/gems/activemodel-4.2.5.1/lib/active_model/attribute_methods.rb:433:in `method_missing'
  ./app/models/condition.rb:165:in `_subst_find'
```