### PR TITLE
Using LinuxAdmin::Service for calls which used to call `service`

### DIFF
--- a/gems/pending/appliance_console/service_group.rb
+++ b/gems/pending/appliance_console/service_group.rb
@@ -49,7 +49,7 @@ module ApplianceConsole
     private
 
     def enable_miqtop
-      AwesomeSpawn.run("chkconfig", :params => {"--add" => "miqtop"})
+      LinuxAdmin::Service.new("miqtop").enable
     end
 
     def run_service(service, action)

--- a/gems/pending/spec/appliance_console/service_group_spec.rb
+++ b/gems/pending/spec/appliance_console/service_group_spec.rb
@@ -116,8 +116,10 @@ describe ApplianceConsole::ServiceGroup do
 
   # this is private, but since we are stubbing it, make sure it works
   context "#enable_miqtop" do
-    it "calls chkconfig" do
-      expect(AwesomeSpawn).to receive(:run).with("chkconfig", :params => {"--add" => "miqtop"})
+    it "enables the service" do
+      service_double = double
+      expect(LinuxAdmin::Service).to receive(:new).with("miqtop").and_return(service_double)
+      expect(service_double).to receive(:enable)
       group.send(:enable_miqtop)
     end
   end

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -1,4 +1,5 @@
 require 'runcmd'
+require 'linux_admin'
 
 module MiqMemcached
   class Error < RuntimeError; end
@@ -92,14 +93,14 @@ END_OF_CONFIG
 
     def self.start(opts = {})
       MiqMemcached::Config.new(opts).save(CONF_FILE)
-      res = MiqUtil.runcmd("service memcached start >> #{Rails.root}/log/evm.log 2>&1")
-      _log.info("started memcached with options: #{opts.inspect}, result: #{res.to_s.chomp}")
+      LinuxAdmin::Service.new("memcached").start
+      _log.info("started memcached with options: #{opts.inspect}")
       true
     end
 
     def self.stop
-      res = MiqUtil.runcmd("service memcached stop")
-      _log.info("stopped memcached, result: #{res.to_s.chomp}")
+      LinuxAdmin::Service.new("memcached").stop
+      _log.info("stopped memcached")
     end
 
     def self.stop!


### PR DESCRIPTION
LinuxAdmin::Service will detect if it should call `service` or `systemctl` commands
when an instance is created. This makes it more portable than unconditionally
using `service` and `chkconfig`.