### PR TITLE
Specify the has_many through source using the belongs_to, not an alias.

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -66,7 +66,7 @@ class VmOrTemplate < ApplicationRecord
 
   has_one                   :miq_provision, :dependent => :nullify, :as => :destination
   has_many                  :miq_provisions_from_template, :class_name => "MiqProvision", :as => :source, :dependent => :nullify
-  has_many                  :miq_provision_vms, :through => :miq_provisions_from_template, :source => :vm, :class_name => "Vm"
+  has_many                  :miq_provision_vms, :through => :miq_provisions_from_template, :source => :destination, :source_type => "VmOrTemplate"
   has_many                  :miq_provision_requests, :as => :source, :dependent => :destroy
 
   has_many                  :guest_applications, :dependent => :destroy

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -506,4 +506,30 @@ describe VmOrTemplate do
       expect(vm.tenant).to eq(tenant2)
     end
   end
+
+  it "#miq_provision_vms" do
+    ems      = FactoryGirl.create(:ems_vmware_with_authentication)
+    template = FactoryGirl.create(:template_vmware, :ext_management_system => ems)
+    vm       = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+
+    options = {
+      :vm_name        => vm.name,
+      :vm_target_name => vm.name,
+      :src_vm_id      => [template.id, template.name]
+    }
+
+    provision = FactoryGirl.create(
+      :miq_provision_vmware,
+      :destination  => vm,
+      :source       => template,
+      :request_type => 'clone_to_vm',
+      :state        => 'finished',
+      :status       => 'Ok',
+      :options      => options
+    )
+
+    template.miq_provisions_from_template << provision
+
+    expect(template.miq_provision_vms.collect(&:id)).to eq([vm.id])
+  end
 end


### PR DESCRIPTION
Also, specify the source_type as rails requests.

Note, we specify VmOrTemplate here because VmOrTemplate is where this
has_many is located.  It seems like this has_many may belong in MiqTemplate.

Fixes the following error:
```
ActiveRecord::HasManyThroughSourceAssociationNotFoundError:
  Could not find the source association(s) :vm in model MiqProvision.
  Try 'has_many :miq_provision_vms, :through => :miq_provisions_from_template, :source => <name>'.
  Is it one of miq_request, source, destination, miq_request_tasks, miq_request_task, or tenant?
```

This resolves the model bug reported in:
https://bugzilla.redhat.com/show_bug.cgi?id=1303074

We still need to see if we can generate reports based on this now fixed
has_many :through.