### PR TITLE
Remove debug puts in the test.

### DIFF
--- a/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/provision_workflow_spec.rb
@@ -50,7 +50,6 @@ describe ManageIQ::Providers::Azure::CloudManager::ProvisionWorkflow do
           sg_cn = FactoryGirl.create(:security_group, :ext_management_system => ems, :cloud_network => cn1)
           ems.security_groups << sg_cn
           filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, SecurityGroup, 'security_groups')
-          puts filtered.first.inspect
           expect(filtered.size).to eq(1)
           expect(filtered.first.name).to eq(sg_cn.name)
         end


### PR DESCRIPTION
Saw this in travis output:

```
..#<SecurityGroup id: 1000000000092, name: "security_group_0000000000044", description: nil, type: nil, ems_id: 1000000001248, ems_ref: nil, cloud_network_id: 1000000000055, cloud_tenant_id: nil, orchestration_stack_id: nil>
```