### PR TITLE
[WIP] Automate Expression Methods

### DIFF
--- a/app/controllers/application_controller/filter.rb
+++ b/app/controllers/application_controller/filter.rb
@@ -70,6 +70,10 @@ module ApplicationController::Filter
         else
           page.replace("exp_editor_div", :partial => "layouts/exp_editor")
         end
+
+        if @edit[:expression_method]
+          page.replace("exp_editor_div", :partial => "layouts/exp_editor")
+        end
         if ["not", "discard", "commit", "remove"].include?(params[:pressed])
           page << javascript_hide("exp_buttons_on")
           page << javascript_hide("exp_buttons_not")
@@ -964,15 +968,20 @@ module ApplicationController::Filter
       end
       @edit.delete(:exp_token)                                          # Remove any existing atom being edited
     else                                                                # Create new exp fields
-      @edit = {}
+      @edit ||= {}
       @edit[@expkey] ||= Expression.new
       @edit[@expkey][:expression] = []                           # Store exps in an array
       @edit[@expkey][:expression] = {"???" => "???"}                      # Set as new exp element
       @edit[@expkey][:use_mytags] = true                                # Include mytags in tag search atoms
       @edit[:custom_search] = false                                     # setting default to false
-      @edit[:new] = {}
-      @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
+      @edit[:new] ||= {}
+      if @edit[:new][@expkey]
+        @edit[@expkey][:expression] = @edit[:new][@expkey]                # Copy to new exp
+      else
+        @edit[:new][@expkey] = @edit[@expkey][:expression]                # Copy to new exp
+      end
       @edit[@expkey].history.reset(@edit[@expkey][:expression])
+      exp_array(:init, @edit[@expkey][:expression])                     # Initialize the exp array
       @edit[:adv_search_open] = false
       @edit[@expkey][:exp_model] = model.to_s
     end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -920,7 +920,7 @@ class MiqAeClassController < ApplicationController
       @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
       render :update do |page|
         page << javascript_prologue
-        page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""})  if @edit[:new][:location] == 'expression'
+        page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""}) if @edit[:new][:location] == 'expression'
         page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && @prev_location != @edit[:new][:location]
         # page.replace_html("hider_1", :partial=>"method_data", :locals=>{:field_name=>@field_name})  if @prev_location != @edit[:new][:location]
         if params[:cls_field_datatype]
@@ -2565,11 +2565,7 @@ class MiqAeClassController < ApplicationController
       @sb[:active_tab] = "methods"
       if @record.location == 'expression'
         hash = YAML.load(@record.data)
-        if hash[:expression]
-          @expression = MiqExpression.new(hash[:expression]).to_human
-        else
-          @expression = ""
-        end
+        @expression = hash[:expression] ? MiqExpression.new(hash[:expression]).to_human : ""
       end
       domain_overrides
       set_right_cell_text(x_node, @record)

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -920,7 +920,7 @@ class MiqAeClassController < ApplicationController
       @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
       render :update do |page|
         page << javascript_prologue
-        page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""})
+        page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""})  if @edit[:new][:location] == 'expression'
         page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && @prev_location != @edit[:new][:location]
         # page.replace_html("hider_1", :partial=>"method_data", :locals=>{:field_name=>@field_name})  if @prev_location != @edit[:new][:location]
         if params[:cls_field_datatype]

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -979,6 +979,7 @@ class MiqAeClassController < ApplicationController
           end
         end
         page << javascript_for_miq_button_visibility_changed(@changed)
+        page << "miqSparkle(false)"
       end
     end
   end

--- a/app/controllers/miq_ae_class_controller.rb
+++ b/app/controllers/miq_ae_class_controller.rb
@@ -737,8 +737,17 @@ class MiqAeClassController < ApplicationController
     @edit[:new][:scope] = "instance"
     @edit[:new][:language] = "ruby"
     @edit[:new][:available_locations] = MiqAeMethod.available_locations
+    @edit[:new][:available_expression_objects] = MiqAeMethod.available_expression_objects.sort
     @edit[:new][:location] = @ae_method.location.nil? ? "inline" : @ae_method.location
-    @edit[:new][:data] = @ae_method.data.to_s
+    if @edit[:new][:location] == "expression"
+      hash = YAML.load(@ae_method.data)
+      if hash[:db] && hash[:expression]
+        @edit[:new][:expression] = hash[:expression]
+        expression_setup(hash[:db])
+      end
+    else
+      @edit[:new][:data] = @ae_method.data.to_s
+    end
     if @edit[:new][:location] == "inline" && !@ae_method.data
       @edit[:new][:data] = MiqAeMethod.default_method_text
     end
@@ -857,6 +866,18 @@ class MiqAeClassController < ApplicationController
     end
   end
 
+  def expression_setup(db)
+    @edit[:expression_method] = true
+    @edit[:new][:exp_object] = db
+    adv_search_build(db)
+  end
+
+  def expression_cleanup
+    @edit[:expression_method] = false
+    # @edit[:new][:expression]  = nil
+    # @edit[:expression] = nil
+  end
+
   # AJAX driven routine to check for changes in ANY field on the form
   def form_method_field_changed
     if !@sb[:form_vars_set]  # workaround to prevent an error that happens when IE sends a transaction form form even after save button is clicked when there is text_area in the form
@@ -865,6 +886,15 @@ class MiqAeClassController < ApplicationController
       return unless load_edit("aemethod_edit__#{params[:id]}", "replace_cell__explorer")
       @prev_location = @edit[:new][:location]
       get_method_form_vars
+
+      if @edit[:new][:location] == 'expression'
+        @edit[:new][:exp_object] ||= @edit[:new][:available_expression_objects].first
+        exp_object = params[:cls_exp_object] || params[:exp_object] || @edit[:new][:exp_object]
+        expression_setup(exp_object) if exp_object
+      else
+        expression_cleanup
+      end
+
       if row_selected_in_grid?
         @refresh_div = "class_methods_div"
         @refresh_partial = "class_methods"
@@ -890,6 +920,7 @@ class MiqAeClassController < ApplicationController
       @edit[:default_verify_status] = @edit[:new][:location] == "inline" && @edit[:new][:data] && @edit[:new][:data] != ""
       render :update do |page|
         page << javascript_prologue
+        page.replace_html('form_div', :partial => 'method_form', :locals => {:prefix => ""})
         page.replace_html(@refresh_div, :partial => @refresh_partial)  if @refresh_div && @prev_location != @edit[:new][:location]
         # page.replace_html("hider_1", :partial=>"method_data", :locals=>{:field_name=>@field_name})  if @prev_location != @edit[:new][:location]
         if params[:cls_field_datatype]
@@ -1196,6 +1227,11 @@ class MiqAeClassController < ApplicationController
       @changed = session[:changed] = (@edit[:new] != @edit[:current])
       replace_right_cell(:replace_trees => [:ae])
     end
+  end
+
+  def data_for_expression
+    {:db         => @edit[:new][:exp_object],
+     :expression => @edit[:new][:expression]}.to_yaml
   end
 
   def create_method
@@ -2165,7 +2201,11 @@ class MiqAeClassController < ApplicationController
     miqaemethod.scope = @edit[:new][:scope]
     miqaemethod.location = @edit[:new][:location]
     miqaemethod.language = @edit[:new][:language]
-    miqaemethod.data = @edit[:new][:data]
+    miqaemethod.data = if @edit[:new][:location] == 'expression'
+                         data_for_expression
+                       else
+                         @edit[:new][:data]
+                       end
     miqaemethod.class_id = from_cid(@edit[:ae_class_id])
   end
 
@@ -2522,6 +2562,14 @@ class MiqAeClassController < ApplicationController
       inputs = @record.inputs
       @sb[:squash_state] = true
       @sb[:active_tab] = "methods"
+      if @record.location == 'expression'
+        hash = YAML.load(@record.data)
+        if hash[:expression]
+          @expression = MiqExpression.new(hash[:expression]).to_human
+        else
+          @expression = ""
+        end
+      end
       domain_overrides
       set_right_cell_text(x_node, @record)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -880,6 +880,7 @@ module ApplicationHelper
   QS_VALID_USER_INPUT_OPERATORS = ["=", "!=", ">", ">=", "<", "<=", "INCLUDES", "STARTS WITH", "ENDS WITH", "CONTAINS"]
   QS_VALID_FIELD_TYPES = [:string, :boolean, :integer, :float, :percent, :bytes, :megabytes]
   def qs_show_user_input_checkbox?
+    return true if @edit[:expression_method]
     return false unless @edit[:adv_search_open]  # Only allow user input for advanced searches
     return false unless QS_VALID_USER_INPUT_OPERATORS.include?(@edit[@expkey][:exp_key])
     val = (@edit[@expkey][:exp_typ] == "field" && # Field atoms with certain field types return true

--- a/app/views/miq_ae_class/_method_form.html.haml
+++ b/app/views/miq_ae_class/_method_form.html.haml
@@ -28,6 +28,12 @@
                         :maxlength         => MAX_NAME_LEN,
                         :class => "form-control",
                         "data-miq_observe" => obs)
+    - if @ae_method.created_on
+      .form-group
+        %label.col-md-2.control-label
+          = _("Created On")
+        .col-md-8
+          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
     .form-group
       %label.col-md-2.control-label
         = _('Location')
@@ -39,16 +45,25 @@
                       "data-miq_observe" => {:url => url}.to_json)
         :javascript
           miqInitSelectPicker();
-          miqSelectPickerEvent("#{prefix}method_location", "#{url}")
-    - if @ae_method.created_on
+          miqSelectPickerEvent("#{prefix}method_location", "#{url}",  {beforeSend: true})
+    - if @edit[:new][:location] == 'expression'
       .form-group
         %label.col-md-2.control-label
-          = _("Created On")
+          = _('Expression Object')
         .col-md-8
-          = h(format_timezone(@ae_method.created_on, Time.zone, "gtl"))
-  %hr
-  %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
-  = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
+          = select_tag("#{prefix}exp_object",
+                        options_for_select(@edit[:new][:available_expression_objects],
+                        @edit[:new][:exp_object]),
+                        :class    => "selectpicker",
+                        "data-miq_observe" => {:url => url}.to_json)
+          :javascript
+            miqInitSelectPicker();
+            miqSelectPickerEvent("#{prefix}exp_object", "#{url}",  {beforeSend: true})
+      = render :partial => 'layouts/exp_editor'
+    - else
+      %hr
+      %h3= (@edit[:new][:location] == 'builtin') ? _('Builtin name') : _("Data")
+      = render :partial => "method_data", :locals => {:field_name => "#{prefix}method"}
   %hr
   %h3= _("Input Parameters")
   %table.table.table-bordered.table-striped

--- a/app/views/miq_ae_class/_method_inputs.html.haml
+++ b/app/views/miq_ae_class/_method_inputs.html.haml
@@ -49,6 +49,8 @@
           :mode                    => "ruby",
           :line_numbers            => true,
           :read_only               => true}
+    - elsif @ae_method.location == 'expression'
+      = @expression
     - else
       = @ae_method.data
     -# show inputs parameters grid if there are any inputs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1869,7 +1869,8 @@ Vmdb::Application.routes.draw do
         x_button
         x_history
         x_show
-      )
+      ) + adv_search_post +
+          exp_post
     },
     :miq_ae_customization     => {
       :get  => %w(

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -11,6 +11,7 @@ require 'uri'
 require 'engine/miq_ae_uri'
 require 'engine/miq_ae_path'
 require 'engine/miq_ae_domain_search'
+require 'engine/miq_ae_expression_method'
 
 module MiqAeEngine
   DEFAULT_ATTRIBUTES = %w( User::user MiqServer::miq_server object_name )

--- a/lib/miq_automation_engine/engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_expression_method.rb
@@ -31,7 +31,7 @@ module MiqAeEngine
           raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
         end
       rescue
-          raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
+        raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
       end
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_expression_method.rb
@@ -1,0 +1,119 @@
+require_relative '../../../app/helpers/miq_expression/filter_subst'
+module MiqAeEngine
+  class MiqAeExpressionMethod
+    include FilterSubst
+    def initialize(method_obj, obj, inputs)
+      @edit = {}
+      @name = method_obj.name
+      @workspace = obj.workspace
+      @inputs = inputs
+      @search = MiqSearch.where(:name => method_obj.data).try(:first)
+      raise MiqAeException::MethodExpressionNotFound, "Search expression #{method_obj.data} not found" unless @search
+      process_filter
+    end
+
+    def run
+      @search_objects = Rbac.search(:filter => MiqExpression.new(@exp),
+                                    :class  => @search.db,
+                                    :results_format => :objects).first
+      @search_objects.empty? ? error_handler : set_result
+    end
+
+    private
+
+    def process_filter
+      @exp = @search.filter.exp
+      @exp_table = exp_build_table(@exp)
+      @qs_tokens = create_tokens
+      values = get_args(@qs_tokens.keys.length)
+      values.each_with_index { |v, index| @qs_tokens[index+1][:value] = v }
+      exp_replace_qs_tokens(@exp, @qs_tokens)
+    end
+
+    def result_hash(obj)
+      @inputs['attributes'].each_with_object({}) do |attr, hash| 
+        hash[attr] = result_simple(obj, attr)
+      end
+    end
+
+    def result_array
+      @search_objects.collect { |obj| result_simple(obj, @inputs['attributes'].first) }
+    end
+
+    def result_simple(obj, attr)
+      raise MiqAeException::MethodNotDefined, "Undefined method #{attr} in class #{obj.class}" unless obj.respond_to?(attr.to_sym)
+      obj.send(attr.to_sym);
+    end
+
+    def set_result
+      target_object.attributes[attribute_name] = get_value
+      @workspace.root['ae_result'] = 'ok'
+    end
+
+    def error_handler
+      disposition = @inputs['on_empty'] || 'error'
+      case disposition.to_sym
+      when :error
+        set_error
+      when :warn
+        set_warn
+      when :abort
+        set_abort
+      end
+    end
+
+    def set_error
+      $miq_ae_logger.error("Expression method ends")
+      @workspace.root['ae_result'] = 'error'
+    end
+
+    def set_abort
+      $miq_ae_logger.error("Expression method aborted")
+      raise MiqAeException::AbortInstantiation, "Expression method #{@name} aborted"
+    end
+
+    def set_warn
+      $miq_ae_logger.warn("Expression method ends")
+      @workspace.root['ae_result'] = 'warn'
+      set_default_value
+    end
+
+    def set_default_value
+      return unless @inputs.key?('default')
+      target_object.attributes[attribute_name] = @inputs['default']
+    end
+
+    def attribute_name
+      @inputs['attribute'] || 'method_result'
+    end
+
+    def target_object
+      @workspace.get_obj_from_path(@inputs['target'] || '.').tap do |obj|
+        raise MiqAeException::MethodExpressionTargetObjectMissing, @inputs['target'] unless obj
+      end
+    end
+
+    def get_value
+      case @inputs['result_type'].downcase.to_sym
+      when :hash
+        result_hash(@search_objects.first)
+      when :array
+        result_array
+      when :simple
+        result_simple(@search_objects.first, @inputs['attributes'].first)
+      else
+        raise MiqAeException::MethodExpressionResultTypeInvalid, "Invalid Result type, should be hash, array or simple"
+      end
+    end
+
+    def get_args(num_token)
+      params = []
+      for i in 1..num_token
+        key = "arg#{i}"
+        raise MiqAeException::MethodParameterNotFound, key unless @inputs.key?(key)
+        params[i-1] = @inputs[key]
+      end
+      params
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -64,7 +64,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif ["inline", "builtin", "uri", "expression"].include?(aem.location.downcase.strip)
+      elsif %w(inline builtin uri expression).include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method.rb
@@ -10,6 +10,11 @@ module MiqAeEngine
       raise  MiqAeException::InvalidMethod, "Inline Method Language [#{aem.language}] not supported"
     end
 
+    def self.invoke_expression(aem, obj, inputs)
+      exp_method = MiqAeEngine::MiqAeExpressionMethod.new(aem, obj, inputs)
+      exp_method.run
+    end
+
     def self.invoke_uri(aem, obj, _inputs)
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(aem.data)
       raise  MiqAeException::MethodNotFound, "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file" unless scheme.downcase == "file"
@@ -44,7 +49,7 @@ module MiqAeEngine
       aem.inputs.each do |f|
         key   = f.name
         value = args[key]
-        value = obj.attributes[key] || f.default_value if value.nil?
+        value = obj.attributes[key] || obj.substitute_value(f.default_value) if value.nil?
         inputs[key] = MiqAeObject.convert_value_based_on_datatype(value, f["datatype"])
 
         if obj.attributes[key] && f["datatype"] != "string"
@@ -59,7 +64,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif ["inline", "builtin", "uri"].include?(aem.location.downcase.strip)
+      elsif ["inline", "builtin", "uri", "expression"].include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -24,6 +24,8 @@ module MiqAeException
   class AttributeNotFound < MiqAeEngineError; end
   class UntaggableModel < MiqAeEngineError; end
   class MethodExpressionNotFound < MiqAeEngineError; end
+  class MethodExpressionEmpty < MiqAeEngineError; end
+  class MethodExpressionInvalid < MiqAeEngineError; end
   class MethodExpressionTargetObjectMissing < MiqAeEngineError; end
   class MethodExpressionResultTypeInvalid < MiqAeEngineError; end
   class MethodParameterNotFound < MiqAeEngineError; end

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -23,7 +23,11 @@ module MiqAeException
   class WorkspaceNotFound < MiqAeEngineError; end
   class AttributeNotFound < MiqAeEngineError; end
   class UntaggableModel < MiqAeEngineError; end
-
+  class MethodExpressionNotFound < MiqAeEngineError; end
+  class MethodExpressionTargetObjectMissing < MiqAeEngineError; end
+  class MethodExpressionResultTypeInvalid < MiqAeEngineError; end
+  class MethodParameterNotFound < MiqAeEngineError; end
+  class MethodNotDefined < MiqAeEngineError; end
   class MiqAeDatastoreError < Error; end
   class DomainNotFound < MiqAeDatastoreError; end
   class NamespaceNotFound < MiqAeDatastoreError; end

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -15,7 +15,7 @@ class MiqAeMethod < ApplicationRecord
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
-  AVAILABLE_LOCATIONS  = ["builtin", "inline", "uri"]
+  AVAILABLE_LOCATIONS  = ["builtin", "inline", "uri", "expression"]
   validates_inclusion_of  :location,  :in => AVAILABLE_LOCATIONS
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -32,6 +32,10 @@ class MiqAeMethod < ApplicationRecord
     AVAILABLE_SCOPES
   end
 
+  def self.available_expression_objects
+    Rbac::CLASSES_THAT_PARTICIPATE_IN_RBAC
+  end
+
   # Validate the syntax of the passed in inline ruby code
   def self.validate_syntax(code_text)
     result = MiqSyntaxChecker.check(code_text)

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -15,7 +15,7 @@ class MiqAeMethod < ApplicationRecord
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
-  AVAILABLE_LOCATIONS  = ["builtin", "inline", "uri", "expression"]
+  AVAILABLE_LOCATIONS  = %w(builtin inline uri expression)
   validates_inclusion_of  :location,  :in => AVAILABLE_LOCATIONS
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -15,7 +15,7 @@ class MiqAeMethod < ApplicationRecord
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
-  AVAILABLE_LOCATIONS  = %w(builtin inline uri expression)
+  AVAILABLE_LOCATIONS = %w(builtin inline uri expression).freeze
   validates_inclusion_of  :location,  :in => AVAILABLE_LOCATIONS
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES

--- a/lib/miq_automation_engine/models/miq_ae_method.rb
+++ b/lib/miq_automation_engine/models/miq_ae_method.rb
@@ -33,7 +33,7 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def self.available_expression_objects
-    Rbac::CLASSES_THAT_PARTICIPATE_IN_RBAC
+    Rbac::Filterer::CLASSES_THAT_PARTICIPATE_IN_RBAC
   end
 
   # Validate the syntax of the passed in inline ruby code

--- a/spec/controllers/miq_ae_class_controller_spec.rb
+++ b/spec/controllers/miq_ae_class_controller_spec.rb
@@ -381,6 +381,7 @@ describe MiqAeClassController do
       context "when the record exists" do
         before do
           allow(MiqAeMethod).to receive(:find_by_id).with(123).and_return(miq_ae_method)
+          allow(miq_ae_method).to receive(:location).with(no_args).and_return("inline")
           allow(miq_ae_method).to receive(:ae_class).and_return(miq_ae_class)
           allow(MiqAeMethod).to receive(:get_homonymic_across_domains)
             .with(@user, "fqname").and_return([override, override2])

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -21,9 +21,8 @@ module MiqAeExpressionMethodSpec
     end
 
     let(:vm_search) do
-      FactoryGirl.create(:miq_search,
-                         :db     => "Vm",
-                         :filter => MiqExpression.new(complex_qs_exp))
+      {:db => 'Vm',
+       :expression => complex_qs_exp}.to_yaml
     end
 
     it "expression_method" do
@@ -35,7 +34,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['values']).to match_array(%w(cfme_2.1 cfme_3.1))
@@ -49,7 +48,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['values'].keys).to match_array([vm1.id, vm2.id])
@@ -65,7 +64,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['ae_result']).to eq('error')
@@ -82,7 +81,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['ae_result']).to eq('warn')
@@ -99,7 +98,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['vitalstatistix']).to match_array(%w(cfme_2.1 cfme_3.1))
@@ -115,7 +114,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
       expect(ws.root.attributes['values']).to match_array([400])
@@ -129,7 +128,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
 
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
@@ -145,7 +144,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
 
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
@@ -162,7 +161,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
       end.to raise_error(MiqAeException::MethodExpressionResultTypeInvalid)
@@ -173,7 +172,7 @@ module MiqAeExpressionMethodSpec
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => {},
                                   :method_loc  => 'expression',
-                                  :method_script => vm_search.name)
+                                  :method_script => vm_search)
 
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
@@ -189,7 +188,7 @@ module MiqAeExpressionMethodSpec
 
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
-      end.to raise_error(MiqAeException::MethodExpressionNotFound)
+      end.to raise_error(MiqAeException::MethodExpressionInvalid)
     end
   end
 end

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -58,9 +58,9 @@ module MiqAeExpressionMethodSpec
       vm1
       vm2
       vm3
-      m_params['arg1'] = {'datatype' => 'string',  'default_value' => 'nada'}
-      m_params['default'] = {'datatype' => 'array',  'default_value' => 'nada'}
-      m_params['on_empty'] = {'datatype' => 'string',  'default_value' => 'warn'}
+      m_params['arg1'] = {'datatype' => 'string', 'default_value' => 'nada'}
+      m_params['default'] = {'datatype' => 'array', 'default_value' => 'nada'}
+      m_params['on_empty'] = {'datatype' => 'string', 'default_value' => 'warn'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
@@ -90,7 +90,7 @@ module MiqAeExpressionMethodSpec
       vm1
       vm2
       vm3
-      m_params['distinct'] = {'datatype' => 'array',  'default_value' => 'cpu_shares'}
+      m_params['distinct'] = {'datatype' => 'array', 'default_value' => 'cpu_shares'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
@@ -103,7 +103,7 @@ module MiqAeExpressionMethodSpec
     it "expression_method undefined function" do
       vm1
       vm2
-      m_params['attributes'] = {'datatype' => 'array',  'default_value' => 'nada'}
+      m_params['attributes'] = {'datatype' => 'array', 'default_value' => 'nada'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
@@ -134,7 +134,7 @@ module MiqAeExpressionMethodSpec
       vm1
       vm2
       vm3
-      m_params['result_type'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'nada'}
 
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -20,14 +20,13 @@ module MiqAeExpressionMethodSpec
     end
 
     let(:vm_search) do
-      {:db => 'Vm',
+      {:db         => 'Vm',
        :expression => complex_qs_exp}.to_yaml
     end
 
     before do
       allow(User).to receive(:server_timezone).and_return("UTC")
     end
-
 
     it "expression_method" do
       vm1

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -30,13 +30,30 @@ module MiqAeExpressionMethodSpec
       vm1
       vm2
       vm3
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
-      expect(ws.root.attributes['method_result']).to match_array(%w(cfme_2.1 cfme_3.1))
+
+      expect(ws.root.attributes['values']).to match_array(%w(cfme_2.1 cfme_3.1))
+    end
+
+    it "expression_method dialog_hash" do
+      vm1
+      vm2
+      vm3
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['values'].keys).to match_array([vm1.id, vm2.id])
+      expect(ws.root.attributes['values'].values).to match_array([vm1.name, vm2.name])
     end
 
     it "expression_method no result" do
@@ -49,8 +66,8 @@ module MiqAeExpressionMethodSpec
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
-
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
       expect(ws.root.attributes['ae_result']).to eq('error')
     end
 
@@ -66,10 +83,10 @@ module MiqAeExpressionMethodSpec
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
-
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
       expect(ws.root.attributes['ae_result']).to eq('warn')
-      expect(ws.root.attributes['method_result']).to match_array(%w(nada))
+      expect(ws.root.attributes['values']).to match_array(%w(nada))
     end
 
     it "expression_method result attr" do
@@ -77,12 +94,14 @@ module MiqAeExpressionMethodSpec
       vm2
       vm3
       m_params['result_attr'] = {'datatype' => 'string', 'default_value' => 'vitalstatistix'}
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
       expect(ws.root.attributes['vitalstatistix']).to match_array(%w(cfme_2.1 cfme_3.1))
     end
 
@@ -91,13 +110,15 @@ module MiqAeExpressionMethodSpec
       vm2
       vm3
       m_params['distinct'] = {'datatype' => 'array', 'default_value' => 'cpu_shares'}
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
-      expect(ws.root.attributes['method_result']).to match_array([400])
+
+      expect(ws.root.attributes['values']).to match_array([400])
     end
 
     it "expression_method undefined function" do
@@ -109,6 +130,7 @@ module MiqAeExpressionMethodSpec
                                   :method_name => 'OBELIX', :method_params => m_params,
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
+
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
       end.to raise_error(MiqAeException::MethodNotDefined)
@@ -152,6 +174,7 @@ module MiqAeExpressionMethodSpec
                                   :method_name => 'OBELIX', :method_params => {},
                                   :method_loc  => 'expression',
                                   :method_script => vm_search.name)
+
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
       end.to raise_error(MiqAeException::MethodParameterNotFound)
@@ -163,6 +186,7 @@ module MiqAeExpressionMethodSpec
                                   :method_name => 'OBELIX', :method_params => {},
                                   :method_loc  => 'expression',
                                   :method_script => "nada")
+
       expect do
         MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
       end.to raise_error(MiqAeException::MethodExpressionNotFound)

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -1,12 +1,11 @@
-require 'spec_helper'
-include AutomationSpecHelper
 module MiqAeExpressionMethodSpec
   include MiqAeEngine
   describe MiqAeExpressionMethod do
+    include Spec::Support::AutomationHelper
     let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:vm1) { FactoryGirl.create(:vm, :name => 'cfme_2.1', :cpu_shares => 400) }
-    let(:vm2) { FactoryGirl.create(:vm, :name => 'cfme_3.1', :cpu_shares => 400) }
-    let(:vm3) { FactoryGirl.create(:vm, :name => 'cfme_4.2', :cpu_shares => 11) }
+    let(:vm1) { FactoryGirl.create(:vm, :name => 'test_2.1', :cpu_shares => 400) }
+    let(:vm2) { FactoryGirl.create(:vm, :name => 'test_3.1', :cpu_shares => 400) }
+    let(:vm3) { FactoryGirl.create(:vm, :name => 'test_4.2', :cpu_shares => 11) }
     let(:complex_qs_exp) do
       {"and" => [{"STARTS WITH" => {"field" => "Vm-name", "value" => :user_input}},
                  {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]
@@ -14,7 +13,7 @@ module MiqAeExpressionMethodSpec
     end
 
     let(:m_params) do
-      {'arg1'       => {'datatype' => 'string', 'default_value' => 'cfme'},
+      {'arg1'       => {'datatype' => 'string', 'default_value' => 'test'},
        'arg2'       => {'datatype' => 'string', 'default_value' => '1'},
        'attributes' => {'datatype' => 'array',  'default_value' => 'name'}
       }
@@ -24,6 +23,11 @@ module MiqAeExpressionMethodSpec
       {:db => 'Vm',
        :expression => complex_qs_exp}.to_yaml
     end
+
+    before do
+      allow(User).to receive(:server_timezone).and_return("UTC")
+    end
+
 
     it "expression_method" do
       vm1
@@ -37,7 +41,7 @@ module MiqAeExpressionMethodSpec
                                   :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
-      expect(ws.root.attributes['values']).to match_array(%w(cfme_2.1 cfme_3.1))
+      expect(ws.root.attributes['values']).to match_array(%w(test_2.1 test_3.1))
     end
 
     it "expression_method dialog_hash" do
@@ -101,7 +105,7 @@ module MiqAeExpressionMethodSpec
                                   :method_script => vm_search)
       ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
 
-      expect(ws.root.attributes['vitalstatistix']).to match_array(%w(cfme_2.1 cfme_3.1))
+      expect(ws.root.attributes['vitalstatistix']).to match_array(%w(test_2.1 test_3.1))
     end
 
     it "expression_method distinct" do

--- a/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_expression_method_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+include AutomationSpecHelper
+module MiqAeExpressionMethodSpec
+  include MiqAeEngine
+  describe MiqAeExpressionMethod do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:vm1) { FactoryGirl.create(:vm, :name => 'cfme_2.1', :cpu_shares => 400) }
+    let(:vm2) { FactoryGirl.create(:vm, :name => 'cfme_3.1', :cpu_shares => 400) }
+    let(:vm3) { FactoryGirl.create(:vm, :name => 'cfme_4.2', :cpu_shares => 11) }
+    let(:complex_qs_exp) do
+      {"and" => [{"STARTS WITH" => {"field" => "Vm-name", "value" => :user_input}},
+                 {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]
+      }
+    end
+
+    let(:m_params) do
+      {'arg1'       => {'datatype' => 'string', 'default_value' => 'cfme'},
+       'arg2'       => {'datatype' => 'string', 'default_value' => '1'},
+       'attributes' => {'datatype' => 'array',  'default_value' => 'name'}
+      }
+    end
+
+    let(:vm_search) do
+      FactoryGirl.create(:miq_search,
+                         :db     => "Vm",
+                         :filter => MiqExpression.new(complex_qs_exp))
+    end
+
+    it "expression_method" do
+      vm1
+      vm2
+      vm3
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      expect(ws.root.attributes['method_result']).to match_array(%w(cfme_2.1 cfme_3.1))
+    end
+
+    it "expression_method no result" do
+      vm1
+      vm2
+      vm3
+      m_params['arg1'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      expect(ws.root.attributes['ae_result']).to eq('error')
+    end
+
+    it "expression_method no result use default value" do
+      vm1
+      vm2
+      vm3
+      m_params['arg1'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      m_params['default'] = {'datatype' => 'array',  'default_value' => 'nada'}
+      m_params['on_empty'] = {'datatype' => 'string',  'default_value' => 'warn'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      expect(ws.root.attributes['ae_result']).to eq('warn')
+      expect(ws.root.attributes['method_result']).to match_array(%w(nada))
+    end
+
+    it "expression_method result attr" do
+      vm1
+      vm2
+      vm3
+      m_params['result_attr'] = {'datatype' => 'string', 'default_value' => 'vitalstatistix'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      expect(ws.root.attributes['vitalstatistix']).to match_array(%w(cfme_2.1 cfme_3.1))
+    end
+
+    it "expression_method distinct" do
+      vm1
+      vm2
+      vm3
+      m_params['distinct'] = {'datatype' => 'array',  'default_value' => 'cpu_shares'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      expect(ws.root.attributes['method_result']).to match_array([400])
+    end
+
+    it "expression_method undefined function" do
+      vm1
+      vm2
+      m_params['attributes'] = {'datatype' => 'array',  'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodNotDefined)
+    end
+
+    it "expression_method target object missing" do
+      vm1
+      vm2
+      vm3
+      m_params['result_obj'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionTargetObjectMissing)
+    end
+
+    it "expression_method invalid result type" do
+      vm1
+      vm2
+      vm3
+      m_params['result_type'] = {'datatype' => 'string',  'default_value' => 'nada'}
+
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionResultTypeInvalid)
+    end
+
+    it "not all parameters provided" do
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => {},
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search.name)
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodParameterNotFound)
+    end
+
+    it "invalid search name" do
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => {},
+                                  :method_loc  => 'expression',
+                                  :method_script => "nada")
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionNotFound)
+    end
+  end
+end

--- a/spec/support/automation_helper.rb
+++ b/spec/support/automation_helper.rb
@@ -35,11 +35,12 @@ module Spec
         attrs = default_ae_model_attributes(attrs)
         method_script = attrs.delete(:method_script)
         method_params = attrs.delete(:method_params) || {}
+        method_loc = attrs.delete(:method_loc) || "inline"
         instance_name = attrs.delete(:instance_name)
         method_name = attrs.delete(:method_name)
         ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
         ae_instances = {instance_name => {'execute' => {:value => method_name}}}
-        ae_methods = {method_name => {:scope => 'instance', :location => 'inline',
+        ae_methods = {method_name => {:scope => 'instance', :location => method_loc,
                                       :data => method_script,
                                       :language => 'ruby', 'params' => method_params}}
 


### PR DESCRIPTION
Adding support for Expression Methods

Expression Methods allow you to use Advance Search Filters as Automate Methods, substituting the user_input from Automate Objects. The advantages of this approach is that the methods run directly in the worker and don't have the overhead of forking a DRb process to run the Automate Methods.
1. Create an expression using the ManageIQ Explorer and any values that need to be set at runtime from automate, mark then as user input. These are positional arguments.
2. Save the expression e.g if my_search (user_admin_my_search)
3. Create a new Automate Method and set the method location to expression
4. In the data field for the method set the expression name (user_admin_my_search)
5. In the Input Arugments create arg1,arg2,arg3... for each of the user input fields from Step 1
6. Create a field called attributes with the list of attributes that you would like to collect from the search objects. e.g (name, id)

Inputs Arguments
- arg1   The first argument in the expression
- arg2    The second argument in the expression
- arg n   The nth argument in the expression
- attributes A comma delimited list of attributes to select from the resultant objects
  or
- distinct     A comma delimited list of attributes which are distinct in the resultant objects

Optional arguments
- result_obj            The object where the result data should be stored (default: current object)
- result_attr            The name of the attribute which stores the result (default: method_result)
- result_type           The result type hash or array (default: hash)
- on_empty             The method behavior when the search returns an empty list
                             warn | error | abort
- default                  The default value in case the result is empty and you select warn

After the method ends
$evm.root['ae_result'] = 'ok' | 'error' | 'warn'
