### PR TITLE
pass zone into queue_captures

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -36,7 +36,7 @@ module Metric::Capture
 
     targets_by_rollup_parent = calc_targets_by_rollup_parent(targets)
     tasks_by_rollup_parent   = calc_tasks_by_rollup_parent(targets_by_rollup_parent)
-    queue_captures(targets, targets_by_rollup_parent, tasks_by_rollup_parent)
+    queue_captures(zone, targets, targets_by_rollup_parent, tasks_by_rollup_parent)
 
     # Purge tasks older than 4 hours
     MiqTask.delete_older(4.hours.ago.utc, "name LIKE 'Performance rollup for %'")
@@ -48,7 +48,7 @@ module Metric::Capture
     _log.info "Queueing performance capture for range: [#{start_time} - #{end_time}]..."
 
     targets = Metric::Targets.capture_targets(zone, :exclude_storages => true)
-    targets.each { |target| target.perf_capture_queue('historical', :start_time => start_time, :end_time => end_time) }
+    targets.each { |target| target.perf_capture_queue('historical', :start_time => start_time, :end_time => end_time, :zone => zone) }
 
     _log.info "Queueing performance capture for range: [#{start_time} - #{end_time}]...Complete"
   end
@@ -150,13 +150,13 @@ module Metric::Capture
     tasks_by_rollup_parent
   end
 
-  def self.queue_captures(targets, targets_by_rollup_parent, tasks_by_rollup_parent)
+  def self.queue_captures(zone, targets, targets_by_rollup_parent, tasks_by_rollup_parent)
     # Queue the captures for each target
     use_historical = historical_days != 0
     targets.each do |target|
       interval_name = perf_target_to_interval_name(target)
 
-      options = {}
+      options = {:zone => zone}
       target.perf_rollup_parents(interval_name).to_a.compact.each do |parent|
         if tasks_by_rollup_parent.key?("#{parent.class}:#{parent.id}")
           pkey = "#{parent.class}:#{parent.id}"

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -25,7 +25,8 @@ module Metric::CiMixin::Capture
     force      = options[:force] # Force capture to run regardless of last capture time
     priority   = options[:priority] || Metric::Capture.const_get("#{interval_name.upcase}_PRIORITY")
     task_id    = options[:task_id]
-
+    zone       = options[:zone] || my_zone
+    zone = zone.name if zone.respond_to?(:name)
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
     raise ArgumentError, "end_time cannot be specified if start_time is nil" if start_time.nil? && !end_time.nil?
 
@@ -67,7 +68,7 @@ module Metric::CiMixin::Capture
       :method_name => 'perf_capture',
       :role        => 'ems_metrics_collector',
       :queue_name  => queue_name_for_metrics_collection,
-      :zone        => my_zone,
+      :zone        => zone,
       :state       => ['ready', 'dequeue'],
     }
 


### PR DESCRIPTION
pulled out just the zone info per @Fryguy 

It is expensive to determine the zone, especially for
Storages that need to look up a number of objects.
Since it is known, just pass it into enqueue methods

TL;DR:

Running `Metric::Capture.perf_capture_timer` is 15% faster if zones are only looked up once.

https://bugzilla.redhat.com/show_bug.cgi?id=1227008

---

|VmOrTemplate|Storage|ExtManagementSystem|MiqRegion|Zone|
|        ---:|   ---:|               ---:|     ---:|---:|
|        100 |    13 |                 1 |       1 |  1 |

**before:** (master)

|     ms |  sql | sql ms | comments
|    ---:|  ---:|   ---:| ---
| 3344.1 | 1263 | 270.5 | a100-master-1
|  818.6 |  449 |  97.1 | a100-master-2
|  847.6 |  449 |  90.8 | a100-master-3
|  968.1 |  449 | 115.6 | a100-master-4

**after:** (this branch)

|      ms | sql |  sql ms | comments
|     ---:| ---:|    ---:| ---
|  3195.0 |1177 |  261.6 | a100-zone-1
|   742.8 | 363 |   89.8 | a100-zone-2
|   799.5 | 363 |   97.9 | a100-zone-3
|   708.0 | 363 |   84.7 | a100-zone-4

**averages for runs 2-4** (first run loads schema data and tends to be bloated)

metric|before|after|improvement
---|---|---|---
ms|877|749|15%
sql|449|363|19%
sql ms|101|90|10%