### PR TITLE
Add support for Dialog checkboxes having a true value of "t"

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1258,14 +1258,7 @@ class MiqRequestWorkflow
 
     dlg_field = dlg_fields[key]
     data_type = dlg_field[:data_type]
-    set_value = case data_type
-                when :integer then value.to_i_with_method
-                when :float   then value.to_f
-                when :boolean then (value.to_s.downcase == 'true')
-                when :time    then Time.parse(value)
-                when :button  then value # Ignore
-                else value # Ignore
-                end
+    set_value = cast_value(value, data_type)
 
     result = nil
     if dlg_field.key?(:values)
@@ -1286,6 +1279,17 @@ class MiqRequestWorkflow
     _log.warn "Unable to find value for key <#{dialog_name}:#{key}(#{data_type})> with input value <#{set_value.inspect}>.  No matching item found." if result.nil?
     _log.info "setting key <#{dialog_name}:#{key}(#{data_type})> to value <#{set_value.inspect}>"
     values[key] = set_value
+  end
+
+  def cast_value(value, data_type)
+    case data_type
+    when :integer then value.to_i_with_method
+    when :float   then value.to_f
+    when :boolean then (value.to_s.downcase == 'true')
+    when :time    then Time.parse(value)
+    when :button  then value # Ignore
+    else value # Ignore
+    end
   end
 
   def set_ws_field_value_by_display_name(values, key, data, dialog_name, dlg_fields, obj_key = :name)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1286,7 +1286,7 @@ class MiqRequestWorkflow
     when :integer then value.to_i_with_method
     when :float   then value.to_f
     when :boolean then value.to_s.downcase.in?(%w(true t))
-    when :time    then Time.parse(value)
+    when :time    then Time.zone.parse(value)
     when :button  then value # Ignore
     else value # Ignore
     end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1285,7 +1285,7 @@ class MiqRequestWorkflow
     case data_type
     when :integer then value.to_i_with_method
     when :float   then value.to_f
-    when :boolean then (value.to_s.downcase == 'true')
+    when :boolean then value.to_s.downcase.in?(%w(true t))
     when :time    then Time.parse(value)
     when :button  then value # Ignore
     else value # Ignore

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -356,6 +356,7 @@ describe MiqRequestWorkflow do
 
     it 'boolean' do
       expect(workflow.cast_value('true', :boolean)).to  be true
+      expect(workflow.cast_value('t', :boolean)).to     be true
 
       expect(workflow.cast_value('false', :boolean)).to be false
       expect(workflow.cast_value('f', :boolean)).to     be false

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -367,7 +367,7 @@ describe MiqRequestWorkflow do
 
     it 'time' do
       time_str   = '2016-02-13 11:00:00.000000000 Z'
-      time_match = Time.parse(time_str)
+      time_match = Time.zone.parse(time_str)
       expect(workflow.cast_value(time_str, :time)).to eq(time_match)
 
       expect(workflow.cast_value('2016-02-13 11:00:00 Z', :time)).to eq(time_match)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -340,4 +340,46 @@ describe MiqRequestWorkflow do
       expect(workflow.folder_to_respool(src)).to be_empty
     end
   end
+
+  describe '#cast_value' do
+    it 'integer' do
+      expect(workflow.cast_value(1,   :integer)).to eq(1)
+      expect(workflow.cast_value('1', :integer)).to eq(1)
+    end
+
+    it 'float' do
+      expect(workflow.cast_value(1,     :float)).to eq(1.0)
+      expect(workflow.cast_value('1',   :float)).to eq(1.0)
+      expect(workflow.cast_value(2.1,   :float)).to eq(2.1)
+      expect(workflow.cast_value('2.1', :float)).to eq(2.1)
+    end
+
+    it 'boolean' do
+      expect(workflow.cast_value('true', :boolean)).to  be true
+
+      expect(workflow.cast_value('false', :boolean)).to be false
+      expect(workflow.cast_value('f', :boolean)).to     be false
+      expect(workflow.cast_value('1', :boolean)).to     be false
+      expect(workflow.cast_value('0', :boolean)).to     be false
+      expect(workflow.cast_value('test', :boolean)).to  be false
+    end
+
+    it 'time' do
+      time_str   = '2016-02-13 11:00:00.000000000 Z'
+      time_match = Time.parse(time_str)
+      expect(workflow.cast_value(time_str, :time)).to eq(time_match)
+
+      expect(workflow.cast_value('2016-02-13 11:00:00 Z', :time)).to eq(time_match)
+    end
+
+    it 'button' do
+      expect(workflow.cast_value('data', :button)).to eq('data')
+      expect(workflow.cast_value(1, :button)).to      eq(1)
+    end
+
+    it 'other' do
+      expect(workflow.cast_value('data', :other)).to eq('data')
+      expect(workflow.cast_value(1, :other)).to      eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Replaces PR #4980: Fixes the case where checkboxes have their option set as false since 't' does not equal 'true'.

Refactored casting of value into separate method for easier testing.
Accept "true" and "t" as boolean values.