### PR TITLE
remove url helper from topology - not needed after moving to text icons

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -1,5 +1,4 @@
 class ContainerTopologyService
-  include ActionView::Helpers::AssetUrlHelper
 
   def initialize(provider_id)
     @provider_id = provider_id


### PR DESCRIPTION
@himdel please review