### PR TITLE
containers details: "Se Linux" typo -> "SELinux"

### DIFF
--- a/app/helpers/container_helper/textual_summary.rb
+++ b/app/helpers/container_helper/textual_summary.rb
@@ -84,22 +84,22 @@ module ContainerHelper::TextualSummary
 
   def textual_se_linux_user
     se_linux_user = @record.security_context.try(:se_linux_user)
-    {:label => "Se Linux User", :value => se_linux_user} if se_linux_user
+    {:label => "SELinux User", :value => se_linux_user} if se_linux_user
   end
 
   def textual_se_linux_role
     se_linux_role = @record.security_context.try(:se_linux_role)
-    {:label => "Se Linux Role", :value => se_linux_role} if se_linux_role
+    {:label => "SELinux Role", :value => se_linux_role} if se_linux_role
   end
 
   def textual_se_linux_type
     se_linux_type = @record.security_context.try(:se_linux_type)
-    {:label => "Se Linux Type", :value => se_linux_type} if se_linux_type
+    {:label => "SELinux Type", :value => se_linux_type} if se_linux_type
   end
 
   def textual_se_linux_level
     se_linux_level = @record.security_context.try(:se_linux_level)
-    {:label => "Se Linux Level", :value => se_linux_level} if se_linux_level
+    {:label => "SELinux Level", :value => se_linux_level} if se_linux_level
   end
 
   def textual_run_as_non_root


### PR DESCRIPTION
Fix unconventional spelling in container details view.
Reported example:
![selection_015-1](https://cloud.githubusercontent.com/assets/273688/13048713/76cdbf64-d3f0-11e5-918a-2871f83016a0.png)
After:
![screenshot-localhost 3000 2016-02-15 11-52-55](https://cloud.githubusercontent.com/assets/273688/13048718/7e225018-d3f0-11e5-869a-05d743fc6637.png)
(other differences because screenshots taken on different installations)

https://bugzilla.redhat.com/1306331

