### PR TITLE
Fixed Event Log image in Adding Analysis Profile

### DIFF
--- a/app/views/ops/_ap_form_nteventlog.html.haml
+++ b/app/views/ops/_ap_form_nteventlog.html.haml
@@ -12,7 +12,7 @@
     %tbody
       - if (!params[:add] && session[:nteventlog_data].empty?) || params[:edit_entry]
         %tr#new_tr{:onclick => remote_function(:url => {:action => 'ap_ce_select', :add => 'new', :item1 => "nteventlog", :id => "#{@scan.id || "new"}"}), :title => _("Click to add a new entry")}
-          %td= image_tag(image_path('toolbars/new.png'), :class => "rollover small")
+          %td= image_tag(image_path('toolbars/import.png'), :class => "rollover small")
           %td= _("<New Entry>")
           %td= _("<Click on this row to create a new entry>")
           %td= _("<Click on this row to create a new entry>")


### PR DESCRIPTION
Fixed issue when while adding analysis profile, after loading page there was link on non existing picture.
![firefox_screenshot_2016-02-15t11-05-38 004z](https://cloud.githubusercontent.com/assets/9535558/13049097/de91f512-d3ea-11e5-8da4-26ae13217e71.png)
This is how it look after clicking on it:
![firefox_screenshot_2016-02-15t11-06-01 761z](https://cloud.githubusercontent.com/assets/9535558/13049098/e105b356-d3ea-11e5-90ac-2c4416cb05d3.png)

This is how it looks after my change:
![firefox_screenshot_2016-02-15t12-55-15 669z](https://cloud.githubusercontent.com/assets/9535558/13049247/d6d96336-d3eb-11e5-973e-b07f3b5ecdff.png)
![firefox_screenshot_2016-02-15t12-55-28 502z](https://cloud.githubusercontent.com/assets/9535558/13049250/dadf4bda-d3eb-11e5-9b38-e80e77f01b42.png)
