### PR TITLE
Removed word (v2_key) at the end of questions in appliance console menu

### DIFF
--- a/gems/pending/appliance_console/key_configuration.rb
+++ b/gems/pending/appliance_console/key_configuration.rb
@@ -30,10 +30,10 @@ module ApplianceConsole
 
       if fetch_key?
         say("")
-        @host      = ask_for_ip_or_hostname("hostname for appliance with encryption key (v2_key)", @host)
+        @host      = ask_for_ip_or_hostname("hostname for appliance with encryption key", @host)
         @login     = ask_for_string("appliance SSH login", @login)
         @password  = ask_for_password("appliance SSH password", @password)
-        @key_path  = ask_for_string("path of remote encryption key (v2_key)", @key_path)
+        @key_path  = ask_for_string("path of remote encryption key", @key_path)
       end
       @action
     end


### PR DESCRIPTION
Having `(v2_key)` at the end of the line in the appliance console confused users and made them think it was a default value.

Removed word (v2_key) at the end of questions in appliance console menu to remove this confusion.

https://bugzilla.redhat.com/show_bug.cgi?id=1291301

@kbrock

**updated:** description @kbrock