### PR TITLE
Conditionally load refresh and controller helpers

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,10 +89,11 @@ RSpec.configure do |config|
   #   EvmSpecHelper.log_ruby_object_usage
   # end
 
-  config.before(:each) do
-    EmsRefresh.debug_failures = true if defined?(EmsRefresh) && EmsRefresh.respond_to?(:debug_failures)
-    ApplicationController.handle_exceptions = false
+  config.before(:each) do |example|
+    EmsRefresh.debug_failures = true if example.metadata[:migrations].blank?
+    ApplicationController.handle_exceptions = false if %w(controller requests).include?(example.metadata[:type])
   end
+
   config.after(:each) do
     EvmSpecHelper.clear_caches
   end


### PR DESCRIPTION
Originally, introduced #6543 to not load models in migration
spec helpers. But it is more predictable to base this upon test type.

Also, don't modify exception handling unless actually running controller
tests

/cc @matthewd thanks for the better solution here
/cc @Fryguy FYI