### PR TITLE
Allow skipping the loading of primordial seeds

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -32,7 +32,12 @@ class EvmDatabase
   end
 
   def self.seed_primordial
-    seed(PRIMORDIAL_CLASSES)
+    if ENV['SKIP_PRIMORDIAL_SEED'] && MiqDatabase.count > 0
+      puts "** Primordial seedings is skipped."
+      puts "** Unset SKIP_PRIMORDIAL_SEED to re-enable"
+    else
+      seed(PRIMORDIAL_CLASSES)
+    end
   end
 
   def self.seed_last


### PR DESCRIPTION
Typically, when I create a database, I migrate and seed it.
When starting up the application, running primordial seeds is a NO-OP, but it
runs 6k queries and adds 2.5s to startup: 9s -> 12s (>20%)

One time over VPN, I was seeing 25 second improvement. This is due to
the added latency of the connection. the 6k queries really added up. Since I
run in production mode and restart the app frequently, this change saved me
~30 minutes that day.
**NOTE:** Typical VPN savings is only 5 seconds per startup.

This change allows developers to skip these seeds if `PRIMORDIAL=false`
and the database has already been seeded (`MiqDatabase` record exists)

As added bonus, it no longer locks or modifies a database upon startup.
This is desirable when connecting dev code to QE environments

/cc @jrafanie @Fryguy This is not worth a discussions. Just toss if it is too esoteric/scary.
/cc @chessbyte @matthewd FYI