### PR TITLE
Fixed wording of the flash message when schedules are enabled/disabled

### DIFF
--- a/app/controllers/ops_controller/settings/schedules.rb
+++ b/app/controllers/ops_controller/settings/schedules.rb
@@ -196,9 +196,9 @@ module OpsController::Settings::Schedules
 
   def schedule_toggle(enable)
     msg = if enable
-            _("No %s were selected to be enabled")
+            _("The selected %s were enabled")
           else
-            _("No %s were selected to be disabled")
+            _("The selected %s were disabled")
           end
 
     schedules = find_checked_items

--- a/spec/controllers/ops_settings_spec.rb
+++ b/spec/controllers/ops_settings_spec.rb
@@ -19,13 +19,13 @@ describe OpsController do
       it "#schedule_enable" do
         controller.schedule_enable
         flash_messages = controller.instance_variable_get(:@flash_array)
-        expect(flash_messages.first).to eq(:message => "No Schedules were selected to be enabled", :level => :error)
+        expect(flash_messages.first).to eq(:message => "The selected Schedules were enabled", :level => :error)
       end
 
       it "#schedule_disable" do
         controller.schedule_disable
         flash_messages = controller.instance_variable_get(:@flash_array)
-        expect(flash_messages.first).to eq(:message => "No Schedules were selected to be disabled", :level => :error)
+        expect(flash_messages.first).to eq(:message => "The selected Schedules were disabled", :level => :error)
       end
     end
 


### PR DESCRIPTION
Fixed the wording to reflect that the *"The selected schedules"* would be enabled or disabled.
Also ensured that the wording is consistent with the Report schedules.

https://bugzilla.redhat.com/show_bug.cgi?id=1212272

/cc @dclarizio (super low-hanging fruit) :)