### PR TITLE
Don't write the vmdb.yml.db when a test does VMDB::Config.save.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -21,7 +21,7 @@ else
                 when "memory" then  :memory_store
                 when "cache" then   :dalli_store
                 else
-                  raise "session_store, '#{evm_store}', invalid. Should be one of 'sql', 'memory', 'cache'"
+                  raise "session_store, '#{evm_store}', invalid. Should be one of 'sql', 'memory', 'cache'.  Source configuration: #{config_file}"
                 end
 
   if rails_store == :dalli_store

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -259,7 +259,7 @@ module VMDB
       config.store_path(keys, value)
     end
 
-    def save
+    def save(save_db_file = true)
       raise "configuration invalid, see errors for details" unless validate
 
       begin
@@ -272,10 +272,10 @@ module VMDB
       case configuration_source
       when :database
         @db_record = Configuration.create_or_update(svr, @config, @name)
-        save_file(@cfile_db)
+        save_file(@cfile_db) if save_db_file
         _log.info("Saved Config [#{@name}] from database in file: [#{@cfile_db}]")
       when :filesystem
-        save_file(@cfile_db)
+        save_file(@cfile_db) if save_db_file
         _log.info("Saved Config [#{@name}] in file: [#{@cfile_db}]")
       end
       update_cache_metadata

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -35,7 +35,7 @@ describe VMDB::Config do
     server        = EvmSpecHelper.create_guid_miq_server_zone[1]
     config        = VMDB::Config.new("vmdb")
     config.config = {:log_depot => {:uri => "smb://server/share", :username => "user", :password => password}}
-    config.save
+    config.save(false)
 
     expect(VMDB::Config.get_file("vmdb")).to eq(
       "---\nlog_depot:\n  uri: smb://server/share\n  username: user\n  password: #{enc_pass}\n"
@@ -47,8 +47,7 @@ describe VMDB::Config do
       EvmSpecHelper.create_guid_miq_server_zone
       config = VMDB::Config.new("vmdb")
       config.config = {:one => {:two => :three}}
-      expect(config).to receive(:save_file)
-      config.save
+      config.save(false)
       expect(Configuration.count).to eq(1)
       expect(Configuration.first).to have_attributes(:typ => 'vmdb', :settings => {:one => {:two => :three}})
     end


### PR DESCRIPTION
Instead of deleting any changes made by the test, just skip writing the file
via an optional flag.

If you ran the config_spec.rb locally, your vmdb.yml.db would be invalid,
containing only:

```
 # The header comment...
---
log_depot:
  uri: smb://server/share
  username: user
  password: v2:{...}
```

After you run this test and have this invalid vmdb.yml.db, the next time the
session_store initializer would load (rails console/server/etc), you'd get this
error:

`config/initializers/session_store.rb:24:in<top (required)>': session_store, '', invalid. Should be one of 'sql', 'memory', 'cache'`