### PR TITLE
Reset retirement_state

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -36,12 +36,16 @@ module RetirementMixin
   end
 
   def retires_on=(timestamp)
-    if retires_on != timestamp
-      self.retired              = false if timestamp.nil? || (timestamp.to_date > Date.today)
-      self.retirement_last_warn = nil # Reset so that a new warning can be sent out when the time is right
-      write_attribute(:retires_on, timestamp)
-      self.retirement_requester = nil
+    return if retires_on == timestamp
+
+    if timestamp.nil? || (timestamp.to_date > Date.today)
+      self.retired = false
+      _log.warn("Resetting retirement state from #{self.retirement_state}") unless self.retirement_state.nil?
+      self.retirement_state = nil
     end
+    self.retirement_last_warn = nil # Reset so that a new warning can be sent out when the time is right
+    write_attribute(:retires_on, timestamp)
+    self.retirement_requester = nil
   end
 
   def retires_on_date

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -38,13 +38,13 @@ module RetirementMixin
   def retires_on=(timestamp)
     return if retires_on == timestamp
 
-    if timestamp.nil? || (timestamp.to_date > Date.today)
+    if timestamp.nil? || (timestamp.to_date > Time.zone.today)
       self.retired = false
-      _log.warn("Resetting retirement state from #{self.retirement_state}") unless self.retirement_state.nil?
+      _log.warn("Resetting retirement state from #{retirement_state}") unless retirement_state.nil?
       self.retirement_state = nil
     end
     self.retirement_last_warn = nil # Reset so that a new warning can be sent out when the time is right
-    write_attribute(:retires_on, timestamp)
+    self[:retires_on] = timestamp
     self.retirement_requester = nil
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -160,17 +160,15 @@ describe "VM Retirement Management" do
 
   it "reset retirement state in future" do
     @vm.update_attributes(:retirement_state => 'retiring')
-    @vm.retire(:date => Date.today + 1.day)
+    @vm.retire(:date => Time.zone.today + 1.day)
 
     expect(@vm.reload.retirement_state).to be_nil
   end
 
   it "reset retirement state in past" do
     @vm.update_attributes(:retirement_state => 'retiring')
-    @vm.retire(:date => Date.today - 1.day)
+    @vm.retire(:date => Time.zone.today - 1.day)
 
     expect(@vm.reload.retirement_state).to eq('retiring')
   end
-
-
 end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -160,20 +160,16 @@ describe "VM Retirement Management" do
 
   it "reset retirement state in future" do
     @vm.update_attributes(:retirement_state => 'retiring')
-    options = { :date => Date.today + 1}
-    @vm.retire(options)
+    @vm.retire(:date => Date.today + 1.day)
 
-    @vm.reload
-    expect(@vm.retirement_state).to be_nil
+    expect(@vm.reload.retirement_state).to be_nil
   end
 
   it "reset retirement state in past" do
     @vm.update_attributes(:retirement_state => 'retiring')
-    options = { :date => Date.today - 1}
-    @vm.retire(options)
+    @vm.retire(:date => Date.today - 1.day)
 
-    @vm.reload
-    expect(@vm.retirement_state).to eq('retiring')
+    expect(@vm.reload.retirement_state).to eq('retiring')
   end
 
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -157,4 +157,24 @@ describe "VM Retirement Management" do
 
     vm.raise_audit_event(event_name, message)
   end
+
+  it "reset retirement state in future" do
+    @vm.update_attributes(:retirement_state => 'retiring')
+    options = { :date => Date.today + 1}
+    @vm.retire(options)
+
+    @vm.reload
+    expect(@vm.retirement_state).to be_nil
+  end
+
+  it "reset retirement state in past" do
+    @vm.update_attributes(:retirement_state => 'retiring')
+    options = { :date => Date.today - 1}
+    @vm.retire(options)
+
+    @vm.reload
+    expect(@vm.retirement_state).to eq('retiring')
+  end
+
+
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1306830

If the retirment date/time is changed, reset the retirment_state
to nil, log a warning message if someone changes the date/time
when a retirment is in progress.