### PR TITLE
Remove class variables from MiqExpression and MiqAlert

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -12,7 +12,7 @@ class MiqAlert < ApplicationRecord
 
   attr_accessor :reserved
 
-  @@base_tables = %w(
+  BASE_TABLES = %w(
     Vm
     Host
     Storage
@@ -20,7 +20,10 @@ class MiqAlert < ApplicationRecord
     ExtManagementSystem
     MiqServer
   )
-  cattr_accessor :base_tables
+
+  def self.base_tables
+    BASE_TABLES
+  end
 
   include ReportableMixin
 
@@ -362,7 +365,7 @@ class MiqAlert < ApplicationRecord
 
   def self.automate_expressions
     @automate_expressions ||= [
-      {:name => "nothing", :description => " Nothing", :db => @@base_tables, :options => []},
+      {:name => "nothing", :description => " Nothing", :db => BASE_TABLES, :options => []},
       {:name => "ems_alarm", :description => "VMware Alarm", :db => ["Vm", "Host", "EmsCluster"], :responds_to_events => 'AlarmStatusChangedEvent_#{expression[:options][:ems_id]}_#{expression[:options][:ems_alarm_mor]}',
         :options => [
           {:name => :ems_id, :description => "Management System"},

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -2,7 +2,7 @@ class MiqExpression
   include Vmdb::Logging
   attr_accessor :exp, :context_type, :preprocess_options
 
-  @@base_tables = %w(
+  BASE_TABLES = %w(
     AuditEvent
     AvailabilityZone
     BottleneckEvent
@@ -61,7 +61,7 @@ class MiqExpression
     Zone
   )
 
-  @@include_tables = %w(
+  INCLUDE_TABLES = %w(
     advanced_settings
     audit_events
     availability_zones
@@ -1396,7 +1396,7 @@ class MiqExpression
   end
 
   def self.base_tables
-    @@base_tables
+    BASE_TABLES
   end
 
   def self.model_details(model, opts = {:typ => "all", :include_model => true, :include_tags => false, :include_my_tags => false})
@@ -1522,7 +1522,7 @@ class MiqExpression
     end
 
     refs.each do |assoc, ref|
-      next unless @@include_tables.include?(assoc.to_s.pluralize)
+      next unless INCLUDE_TABLES.include?(assoc.to_s.pluralize)
       next if     assoc.to_s.pluralize == "event_logs" && parent[:root] == "Host" && !proto?
       next if     assoc.to_s.pluralize == "processes" && parent[:root] == "Host" # Process data not available yet for Host
 

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -2,7 +2,6 @@ class MiqExpression
   include Vmdb::Logging
   attr_accessor :exp, :context_type, :preprocess_options
 
-  @@proto = VMDB::Config.new("vmdb").config[:product][:proto]
   @@base_tables = %w(
     AuditEvent
     AvailabilityZone
@@ -329,6 +328,11 @@ class MiqExpression
   def initialize(exp, ctype = nil)
     @exp = exp
     @context_type = ctype
+  end
+
+  def self.proto?
+    return @proto if defined?(@proto)
+    @proto = VMDB::Config.new("vmdb").config.fetch_path(:product, :proto)
   end
 
   def self.to_human(exp)
@@ -1519,7 +1523,7 @@ class MiqExpression
 
     refs.each do |assoc, ref|
       next unless @@include_tables.include?(assoc.to_s.pluralize)
-      next if     assoc.to_s.pluralize == "event_logs" && parent[:root] == "Host" && !@@proto
+      next if     assoc.to_s.pluralize == "event_logs" && parent[:root] == "Host" && !proto?
       next if     assoc.to_s.pluralize == "processes" && parent[:root] == "Host" # Process data not available yet for Host
 
       next if ref.macro == :belongs_to && model.name != parent[:root]

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -1,7 +1,7 @@
 module Rbac
   # This list is used to detemine whether RBAC, based on assigned tags, should be applied for a class in a search that is based on the class.
   # Classes should be added to this list ONLY after:
-  # 1. It has been added to the MiqExpression.@@base_tables list
+  # 1. It has been added to the MiqExpression::BASE_TABLES list
   # 2. Tagging has been enabled in the UI
   # 3. Class contains acts_as_miq_taggable
   CLASSES_THAT_PARTICIPATE_IN_RBAC = %w(


### PR DESCRIPTION
The first commit was killing me in the config revamp, but the mix of constants and class variables made no sense anyway, so I cleaned it up.

@jrafanie or @gtanzillo Please review.