### PR TITLE
Add Rbac search to tree for containers

### DIFF
--- a/app/presenters/tree_builder_containers.rb
+++ b/app/presenters/tree_builder_containers.rb
@@ -18,6 +18,6 @@ class TreeBuilderContainers < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only, Container.all, "name")
+    count_only_or_objects(count_only, rbac_filtered_objects(Container.all), "name")
   end
 end

--- a/spec/presenters/tree_builder_containers_spec.rb
+++ b/spec/presenters/tree_builder_containers_spec.rb
@@ -1,0 +1,35 @@
+describe TreeBuilderContainers do
+  let(:tag)   { FactoryGirl.create(:tag, :name => "/managed/department/accounting") }
+  let(:role)  { FactoryGirl.create(:miq_user_role, :name => "EvmRole-operator") }
+  let(:group) { FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Group 1") }
+  let(:user)  { FactoryGirl.create(:user, :userid => 'User 1', :miq_groups => [group]) }
+
+  before do
+    MiqRegion.seed
+    EvmSpecHelper.local_miq_server
+
+    @tagged_container = FactoryGirl.create(:container, :name => "Tagged Container", :tags => [tag])
+    @untagged_container = FactoryGirl.create(:container, :name => "Untagged Container")
+
+    login_as user
+  end
+
+  describe ".new" do
+    def get_tree_results(tree)
+      JSON.parse(tree.tree_nodes).first['children'].collect { |h| h['title'] }
+    end
+
+    it "returns all containers" do
+      tree = TreeBuilderContainers.new("containers_tree", "containers", {}, true)
+      results = get_tree_results(tree)
+      expect(results).to match_array(["Untagged Container", "Tagged Container"])
+    end
+
+    it "returns tagged containers, logged user with tag filter" do
+      user.current_group.set_managed_filters([tag.name])
+      @tree = TreeBuilderContainers.new("containers_tree", "containers", {}, true)
+      results = get_tree_results(@tree)
+      expect(results).to match_array(["Tagged Container"])
+    end
+  end
+end


### PR DESCRIPTION
scenario:
Add tag for any container
Add to user's group the tag and log in,
then Containers -> Containers
All containers are listed in tree, but only containers with the tag should be listed.

![screen shot 2016-02-16 at 09 52 10](https://cloud.githubusercontent.com/assets/14937244/13071557/a398489e-d494-11e5-8643-b839f49380c7.png)

cc @jrafanie 
