### PR TITLE
Group switcher - disable currently chosen group

### DIFF
--- a/app/views/layouts/_user_options.html.haml
+++ b/app/views/layouts/_user_options.html.haml
@@ -15,11 +15,18 @@
             = _('Change Group:')
             %ul.dropdown-menu.scrollable-menu
               - current_user.miq_groups.sort_by_desc.each do |group|
-                %li
-                  %a{:title => _("Select to change to another Group"), :href => "#",
-                        :onclick => "miqSparkle(true);miqToggleUserOptions(#{group.id})"}
-                    = group.description
-                    = "(#{_('Current Group')})" if group == current_group
+                - if group == current_group
+                  %li.disabled
+                    %a{:title   => _("Currently Selected Group"),
+                       :href    => "#"}
+                      = group.description
+                      = "(#{_('Current Group')})"
+                - else
+                  %li
+                    %a{:title   => _("Change to this Group"),
+                      :href     => "#",
+                      :onclick  => "miqSparkle(true); miqToggleUserOptions(#{group.id})"}
+                      = group.description
       - else
         %li.disabled
           %a{:href => "#"}


### PR DESCRIPTION
this changes the group switcher to show the currently chosen group disabled (non-clickable)

also the title was changed from "Select to change to another Group" to "Change to this Group" or "Currently Selected Group"

![grp_other](https://cloud.githubusercontent.com/assets/289743/13077247/77ac8842-d4af-11e5-8997-f273692e49ec.png)
