### PR TITLE
Allow region change or database reconfiguration from the console

### DIFF
--- a/gems/pending/appliance_console/locales/en.yml
+++ b/gems/pending/appliance_console/locales/en.yml
@@ -10,6 +10,8 @@ en:
     - hostname
     - datetime
     - dbrestore
+    - dbregion_setup
+    - db_config
     - httpdauth
     - key_gen
     - evmstop
@@ -24,6 +26,8 @@ en:
     hostname: Set Hostname
     datetime: Set Timezone, Date, and Time
     dbrestore: Restore Database From Backup
+    dbregion_setup: Setup Database Region
+    db_config: Configure Database
     httpdauth: Configure External Authentication (httpd)
     evmstop: Stop EVM Server Processes
     key_gen: Generate Custom Encryption Key


### PR DESCRIPTION
This will allow a region different from the default and make
replication much easier to configure.  Also users will be able
to configure an external database from the appliance console.

@Fryguy @kbrock please review