### PR TITLE
BZ1305719 - Fix Importing of Reporting Widget via rake script

### DIFF
--- a/app/models/miq_widget/import_export.rb
+++ b/app/models/miq_widget/import_export.rb
@@ -5,50 +5,7 @@ module MiqWidget::ImportExport
     def import_from_hash(widget, options = {})
       raise "No Widget to Import" if widget.nil?
 
-      status = {:class => name, :description => widget["description"], :children => []}
-
-      if rep = widget.delete("MiqReportContent")
-        report_klass = Object.const_get(rep.first.keys.first)
-        report, status[:children] = report_klass.import_from_hash(rep.first, options)
-
-        if status[:children][:level] == "error"
-          status[:status] = :error
-          _log.error("Importing widget: [#{widget["description"]}] - Aborted. Status: #{status[:children][:message]}")
-          return nil, status
-        end
-      end
-
-      w = MiqWidget.find_by(:guid => widget["guid"])
-      if w.nil?
-        w = MiqWidget.new(widget)
-        status.merge!(:status => :add, :message => "Imported Widget: [#{widget["description"]}]")
-        msg = "Importing widget: [#{widget["description"]}]"
-      elsif options[:overwrite]
-        status[:old_description] = w.description
-        w.attributes = widget
-        status.merge!(:status => :update, :message => "Replaced Widget: [#{widget["description"]}]")
-        msg = "Overwriting widget: [#{widget["description"]}]"
-      else
-        status.merge!(:status => :keep, :message => "Skipping Widget (already in DB): [#{widget["description"]}]")
-        msg = "Skipping widget (already in DB): [#{widget["description"]}]"
-      end
-
-      unless w.valid?
-        status[:status]  = :conflict
-        status[:messages] << w.errors.full_messages
-      end
-
-      msg = "#{msg}"
-      msg << ", Messages: #{status[:messages].join(",")}" if status[:messages]
-      _log.info(msg)
-
-      if options[:save]
-        w.resource = report if report
-        w.save!
-        _log.info("- Completed.")
-      end
-
-      return w, status
+      WidgetImportService.new.import_widget_from_hash(widget)
     end
   end
 

--- a/spec/models/miq_widget/import_export_spec.rb
+++ b/spec/models/miq_widget/import_export_spec.rb
@@ -1,7 +1,8 @@
 describe MiqWidget::ImportExport do
-  before do
-    MiqReport.seed_report("Vendor and Guest OS")
-    @widget_report_vendor_and_guest_os = MiqWidget.sync_from_hash(YAML.load('
+  context "legacy tests" do
+    before do
+      MiqReport.seed_report("Vendor and Guest OS")
+      @widget_report_vendor_and_guest_os = MiqWidget.sync_from_hash(YAML.load('
       description: report_vendor_and_guest_os
       title: Vendor and Guest OS
       content_type: report
@@ -17,31 +18,56 @@ describe MiqWidget::ImportExport do
       resource_type: MiqReport
       enabled: true
       read_only: true
-    '))
+                                                                              '))
+    end
+
+    context "#export_to_array" do
+      subject { @widget_report_vendor_and_guest_os.export_to_array.first }
+
+      it "MiqWidget" do
+        expect(subject["MiqWidget"]).not_to be_empty
+      end
+
+      it "MiqReportContent" do
+        report = MiqReport.where(:name => "Vendor and Guest OS").first
+        expect(subject["MiqWidget"]["MiqReportContent"]).to eq(report.export_to_array)
+      end
+
+      it "no id" do
+        expect(subject["MiqWidget"]["id"]).to be_nil
+      end
+
+      it "no created_at" do
+        expect(subject["MiqWidget"]["created_at"]).to be_nil
+      end
+
+      it "no updated_at" do
+        expect(subject["MiqWidget"]["updated_at"]).to be_nil
+      end
+    end
   end
 
-  context "#export_to_array" do
-    subject { @widget_report_vendor_and_guest_os.export_to_array.first }
+  describe "#import_from_hash" do
+    context "when the widget given is nil" do
+      let(:widget) { nil }
 
-    it "MiqWidget" do
-      expect(subject["MiqWidget"]).not_to be_empty
+      it "raises an error" do
+        expect { MiqWidget.import_from_hash(widget) }.to raise_error("No Widget to Import")
+      end
     end
 
-    it "MiqReportContent" do
-      report = MiqReport.where(:name => "Vendor and Guest OS").first
-      expect(subject["MiqWidget"]["MiqReportContent"]).to eq(report.export_to_array)
-    end
+    context "when the widget given is not nil" do
+      let(:widget) { "a non nil widget" }
+      let(:widget_import_service) { double("WidgetImportService") }
 
-    it "no id" do
-      expect(subject["MiqWidget"]["id"]).to be_nil
-    end
+      before do
+        allow(WidgetImportService).to receive(:new).and_return(widget_import_service)
+      end
 
-    it "no created_at" do
-      expect(subject["MiqWidget"]["created_at"]).to be_nil
-    end
-
-    it "no updated_at" do
-      expect(subject["MiqWidget"]["updated_at"]).to be_nil
+      it "delegates to the widget import service" do
+        expect(widget_import_service).to receive(:import_widget_from_hash).with(widget)
+        MiqWidget.import_from_hash(widget)
+      end
     end
   end
 end

--- a/spec/models/miq_widget/import_from_hash_spec.rb
+++ b/spec/models/miq_widget/import_from_hash_spec.rb
@@ -37,12 +37,6 @@ describe MiqWidget do
           expect(MiqReport.count).to eq(0)
         end
 
-        it "preview" do
-          subject
-          expect(MiqWidget.count).to eq(0)
-          expect(MiqReport.count).to eq(0)
-        end
-
         it "import" do
           @options[:save] = true
           subject
@@ -59,52 +53,13 @@ describe MiqWidget do
           expect(MiqReport.count).to eq(1)
         end
 
-        context "overwrite" do
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
+        it "import" do
+          @options[:save] = true
+          subject
 
-            expect(MiqWidget.count).to eq(0)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:update)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("Eastern Time (US & Canada)")
-            expect(rep_status[:status]).to eq(:update)
-          end
-        end
-
-        context "not overwrite" do
-          before { @options[:overwrite] = false }
-
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(0)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:keep)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:keep)
-          end
+          expect(MiqWidget.count).to eq(1)
+          expect(MiqReport.count).to eq(1)
+          expect(MiqReport.first.tz).to eq("UTC")
         end
       end
     end
@@ -123,56 +78,13 @@ describe MiqWidget do
           expect(MiqReport.count).to eq(0)
         end
 
-        context "overwrite" do
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
+        it "import" do
+          @options[:save] = true
+          subject
 
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:update)
-            expect(MiqReport.count).to eq(0)
-            expect(rep_status[:status]).to eq(:add)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["_ALL_"]})
-            expect(status[:status]).to eq(:update)
-            expect(MiqReport.count).to eq(1)
-            expect(rep_status[:status]).to eq(:add)
-          end
-        end
-
-        context "no overwrite" do
-          before { @options[:overwrite] = false }
-
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:keep)
-            expect(MiqReport.count).to eq(0)
-            expect(rep_status[:status]).to eq(:add)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:keep)
-            expect(MiqReport.count).to eq(1)
-            expect(rep_status[:status]).to eq(:add)
-          end
+          expect(MiqWidget.count).to eq(1)
+          expect(MiqWidget.first.visibility).to eq(:roles => ["_ALL_"])
+          expect(MiqReport.count).to eq(1)
         end
       end
 
@@ -182,59 +94,14 @@ describe MiqWidget do
           expect(MiqReport.count).to eq(1)
         end
 
-        context "overwrite" do
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
+        it "import" do
+          @options[:save] = true
+          subject
 
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:update)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:update)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["_ALL_"]})
-            expect(status[:status]).to eq(:update)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("Eastern Time (US & Canada)")
-            expect(rep_status[:status]).to eq(:update)
-          end
-        end
-
-        context "no overwrite" do
-          before { @options[:overwrite] = false }
-          it "preview" do
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:keep)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:keep)
-          end
-
-          it "import" do
-            @options[:save] = true
-            w, status = subject
-            rep_status = status[:children]
-
-            expect(MiqWidget.count).to eq(1)
-            expect(MiqWidget.first.visibility).to eq({:roles => ["EvmRole-support"]})
-            expect(status[:status]).to eq(:keep)
-            expect(MiqReport.count).to eq(1)
-            expect(MiqReport.first.tz).to eq("UTC")
-            expect(rep_status[:status]).to eq(:keep)
-          end
+          expect(MiqWidget.count).to eq(1)
+          expect(MiqWidget.first.visibility).to eq(:roles => ["_ALL_"])
+          expect(MiqReport.count).to eq(1)
+          expect(MiqReport.first.tz).to eq("UTC")
         end
       end
     end
@@ -259,12 +126,6 @@ describe MiqWidget do
 
         context "with new rss feed" do
           it "init status" do
-            expect(MiqWidget.count).to eq(1)
-            expect(RssFeed.count).to eq(0)
-          end
-
-          it "preview" do
-            subject
             expect(MiqWidget.count).to eq(1)
             expect(RssFeed.count).to eq(0)
           end
@@ -295,12 +156,6 @@ describe MiqWidget do
 
         context "with new rss feed" do
           it "init status" do
-            expect(MiqWidget.count).to eq(1)
-            expect(RssFeed.count).to eq(0)
-          end
-
-          it "preview" do
-            subject
             expect(MiqWidget.count).to eq(1)
             expect(RssFeed.count).to eq(0)
           end

--- a/spec/services/widget_import_service_spec.rb
+++ b/spec/services/widget_import_service_spec.rb
@@ -32,6 +32,21 @@ describe WidgetImportService do
     end
   end
 
+  describe "#import_widget_from_hash" do
+    let(:widget_to_import) do
+      {
+        "description" => "Test2",
+        "title"       => "potato"
+      }
+    end
+
+    it "builds a new widget" do
+      expect(MiqWidget.first).to be_nil
+      widget_import_service.import_widget_from_hash(widget_to_import)
+      expect(MiqWidget.first).not_to be_nil
+    end
+  end
+
   describe "#import_widgets" do
     let(:miq_queue) { double("MiqQueue") }
     let(:yaml_data) { "the yaml" }


### PR DESCRIPTION
This fix changes the old MiqWidget.import_from_hash class method to use the WidgetImportService so that we only need to worry about widget import code changes in one place.

https://bugzilla.redhat.com/show_bug.cgi?id=1305719

Note that the test I added looks sparse, but the `import_widgets` method calls the new `import_widget_from_hash` method and is testing all of the different combinations of widget data.