### PR TITLE
miq_ujs - preventDefault & stopPropagation for click events handled by miqJqueryRequest

### DIFF
--- a/app/assets/javascripts/miq_ujs_bindings.js
+++ b/app/assets/javascripts/miq_ujs_bindings.js
@@ -22,6 +22,8 @@ $(document).ready(function () {
       miqJqueryRequest(url, {data: miqSerializeForm(submit)});
     else
       miqJqueryRequest(url, options);
+
+    return false;
   });
 
   // bind button click to call JS function to send up grid data
@@ -125,6 +127,8 @@ $(document).ready(function () {
       options.complete = true;
     }
     miqJqueryRequest(url, options);
+
+    return false;
   });
 
   ManageIQ.observeDate = function(el) {

--- a/app/views/report/_column_lists.html.haml
+++ b/app/views/report/_column_lists.html.haml
@@ -26,11 +26,9 @@
             %button.btn.btn-default.btn-disabled{:title => t, :disabled => true}
               %i.fa.fa-lg{:class => icon}
           - else
-            // button has attribute onclick='return false;' to not send a form
             %button.btn.btn-default{:title           => t,
                                     :alt             => t,
                                     :remote          => true,
-                                    :onclick         => 'return false;',
                                     "data-submit"    => 'column_lists',
                                     "data-method"    => :post,
                                     "data-click_url" => {:url => url_for(:action => 'form_field_changed',
@@ -62,11 +60,9 @@
               %button.btn.btn-default.btn-disabled{:title => t, :disabled => true}
                 %i.fa.fa-lg{:class => icon}
             - else
-              // button has attribute onclick='return false;' to not send a form
               %button.btn.btn-default{:title           => t,
                                       :alt             => t,
                                       :remote          => true,
-                                      :onclick         => 'return false;',
                                       "data-submit"    => 'column_lists',
                                       "data-method"    => :post,
                                       "data-click_url" => {:url => url_for(:action => 'form_field_changed',


### PR DESCRIPTION
Previously, code like

```haml
%a{ :href => "", :data-click_url => {:url => "whatever"}.to_json }
```

would still do the default browser behaviour (`a href=""` => trigger reload) and would usually not manage to perform the intended http request before that reload.

This stops the default handlers for any ujs `click` events that end up being
handled by miqJqueryRequest.