### PR TITLE
find_or_initialize_by_name is removed in rails 5

### DIFF
--- a/app/models/scan_item.rb
+++ b/app/models/scan_item.rb
@@ -54,15 +54,15 @@ class ScanItem < ApplicationRecord
 
   def self.preload_default_profile
     # Create sample VM scan profiles
-    vm_profile = ScanItemSet.find_or_initialize_by_name(SAMPLE_VM_PROFILE)
+    vm_profile = ScanItemSet.find_or_initialize_by(:name => SAMPLE_VM_PROFILE[:name])
     vm_profile.update_attributes(SAMPLE_VM_PROFILE)
 
     # Create sample Host scan profiles
-    host_profile = ScanItemSet.find_or_initialize_by_name(SAMPLE_HOST_PROFILE)
+    host_profile = ScanItemSet.find_or_initialize_by(:name => SAMPLE_HOST_PROFILE[:name])
     host_profile.update_attributes(SAMPLE_HOST_PROFILE)
 
     # Create default Host scan profiles
-    host_default = ScanItemSet.find_or_initialize_by_name(DEFAULT_HOST_PROFILE)
+    host_default = ScanItemSet.find_or_initialize_by(:name => DEFAULT_HOST_PROFILE[:name])
     load_host_default = host_default.new_record?
     host_default.update_attributes(DEFAULT_HOST_PROFILE)
 


### PR DESCRIPTION
The constants passed to find_or_initialize_by are condition hashes so pass them
directly.

Fixes an error during seeding:
```
NoMethodError: undefined method `find_or_initialize_by_name' for #<Class:0x007ffd96e35120>
/Users/joerafaniello/.gem/ruby/2.2.4/gems/activerecord-5.0.0.beta2/lib/active_record/dynamic_matchers.rb:21:in `method_missing'
/Users/joerafaniello/Code/manageiq/app/models/scan_item.rb:57:in `preload_default_profile'
/Users/joerafaniello/Code/manageiq/app/models/scan_item.rb:52:in `seed'
```