### PR TITLE
Use the built-in memcache session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -19,24 +19,17 @@ else
   rails_store = case evm_store
                 when "sql" then     :active_record_store
                 when "memory" then  :memory_store
-                when "cache" then   :dalli_store
+                when "cache" then   :mem_cache_store
                 else
                   raise "session_store, '#{evm_store}', invalid. Should be one of 'sql', 'memory', 'cache'.  Source configuration: #{config_file}"
                 end
 
-  if rails_store == :dalli_store
-    require "action_dispatch/middleware/session/dalli_store"
+  if rails_store == :mem_cache_store
     memcached_server = config.fetch_path("session", "memcache_server") || "127.0.0.1:11211"
     session_options = session_options.merge(
-      :cache         => Dalli::Client.new(memcached_server, :namespace => "MIQ:VMDB"),
-      :expires_after => 24.hours,
-      # :compress       => true,
-      :key           => "_vmdb_session",
-    # :readonly       => false,
-    # :urlencode      => false,
-    # :logger         => $log,
-    # :socket_timeout => 5,
-    # :failover       => false
+      :cache        => Dalli::Client.new(memcached_server, :namespace => "MIQ:VMDB"),
+      :expire_after => 24.hours,
+      :key          => "_vmdb_session",
     )
   end
 


### PR DESCRIPTION
Since Rails 4.0, it's used Dalli internally anyway.

And the one that comes with the Dalli gem isn't compatible with Rails 5.