### PR TITLE
Clustered Datastores - Modeling/Inventory Refresh

### DIFF
--- a/app/controllers/application_controller/tree_support.rb
+++ b/app/controllers/application_controller/tree_support.rb
@@ -222,6 +222,11 @@ module ApplicationController::TreeSupport
         end
       end
 
+    # Handle folder named "datastore" under a Datacenter
+    elsif folder.kind_of?(EmsFolder) && folder.name == "datastore" &&
+          folder.parent.kind_of?(EmsFolder) && folder.parent.is_datacenter
+    # Skip showing the datastore folder and sub-folders
+
     # Handle folder named "Discovered Virtual Machine"
     # elsif folder.kind_of?(EmsFolder) && folder.name == "Discovered Virtual Machine"
     # Commented this out to handle like any other blue folder, for now

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -1,4 +1,6 @@
 class EmsFolder < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
   include ReportableMixin

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -20,7 +20,7 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :miq_templates,     :uses => :all_relationships
   virtual_has_many :hosts,             :uses => :all_relationships
 
-  NON_DISPLAY_FOLDERS = ['Datacenters', 'vm', 'host']
+  NON_DISPLAY_FOLDERS = %w(Datacenters vm host datastore).freeze
 
   def hidden?(overrides = {})
     ems = overrides[:ext_management_system] || ext_management_system
@@ -29,9 +29,9 @@ class EmsFolder < ApplicationRecord
     p = overrides[:parent] || parent if NON_DISPLAY_FOLDERS.include?(name)
 
     case name
-    when "Datacenters" then p.kind_of?(ExtManagementSystem)
-    when "vm", "host"  then p.kind_of?(EmsFolder) && p.is_datacenter?
-    else                    false
+    when "Datacenters"              then p.kind_of?(ExtManagementSystem)
+    when "vm", "host", "datastore"  then p.kind_of?(EmsFolder) && p.is_datacenter?
+    else                            false
     end
   end
 

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -118,6 +118,17 @@ class EmsFolder < ApplicationRecord
     remove_all_children(:of_type => 'Vm')
   end
 
+  def storages
+    children(:of_type => 'Storage').sort_by { |c| c.name.downcase }
+  end
+
+  alias add_storage set_child
+  alias remove_storage remove_child
+
+  def remove_all_storages
+    remove_all_children(:of_type => 'Storage')
+  end
+
   # Parent relationship methods
   def parent_datacenter
     detect_ancestor(:of_type => "EmsFolder", &:is_datacenter)

--- a/app/models/ems_refresh/link_inventory.rb
+++ b/app/models/ems_refresh/link_inventory.rb
@@ -60,6 +60,15 @@ module EmsRefresh::LinkInventory
        proc { |vs| folder.add_vm(instances_with_ids(VmOrTemplate, vs)) }]                      # Bulk connect proc
     end
 
+    # Do the Folders to Storages relationships
+    update_relats(:folders_to_storages, prev_relats, new_relats) do |f|
+      folder = instance_with_id(EmsFolder, f)
+      break if folder.nil?
+      [do_disconnect ? proc { |s| folder.remove_storage(instance_with_id(Storage, s)) } : nil, # Disconnect proc
+       proc { |s| folder.add_storage(instance_with_id(Storage, s)) },                          # Connect proc
+       proc { |ss| folder.add_storage(instances_with_ids(Storage, ss)) }]                      # Bulk connect proc
+    end
+
     # Do the Clusters to ResourcePools relationships
     update_relats(:clusters_to_resource_pools, prev_relats, new_relats) do |c|
       cluster = instance_with_id(EmsCluster, c)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -1075,16 +1075,18 @@ module ManageIQ::Providers
           mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
 
           child_mors = get_mors(data, 'childEntity')
+          name       = data.fetch_path('summary', 'name')
 
           new_result = {
             :type          => StorageCluster.name,
             :ems_ref       => mor,
             :ems_ref_obj   => mor,
             :uid_ems       => mor,
-            :name          => data["name"],
+            :name          => name,
             :is_datacenter => false,
             :child_uids    => child_mors
           }
+
           result << new_result
           result_uids[mor] = new_result
         end
@@ -1190,7 +1192,9 @@ module ManageIQ::Providers
       end
 
       def self.link_ems_metadata(data, inv)
-        inv_to_data_types = {:folder => :folders, :dc => :folders, :cluster => :clusters, :rp => :resource_pools, :host => :hosts, :vm => :vms}
+        inv_to_data_types = {:folder => :folders, :dc => :folders, :storage_pod => :folders,
+                             :cluster => :clusters, :rp => :resource_pools,
+                             :storage => :storages, :host => :hosts, :vm => :vms}
 
         [:folders, :clusters, :resource_pools, :hosts].each do |parent_type|
           data[parent_type].each do |parent_data|
@@ -1372,13 +1376,15 @@ module ManageIQ::Providers
       end
 
       VC_MOR_FILTERS = [
-        [:host_res, 'domain'],
-        [:cluster,  'domain'],
-        [:dc,       'datacenter'],
-        [:folder,   'group'],
-        [:rp,       'resgroup'],
-        [:host,     'host'],
-        [:vm,       'vm']
+        [:host_res,    'domain'],
+        [:cluster,     'domain'],
+        [:dc,          'datacenter'],
+        [:folder,      'group'],
+        [:rp,          'resgroup'],
+        [:storage,     'datastore'],
+        [:storage_pod, 'group'],
+        [:host,        'host'],
+        [:vm,          'vm']
       ]
 
       def self.inv_target_by_mor(mor, inv)

--- a/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/refresh_parser.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers
         result[:hosts], uids[:hosts], uids[:clusters_by_host], uids[:lans], uids[:switches], uids[:guest_devices], uids[:scsi_luns] = host_inv_to_hashes(inv[:host], inv, uids[:storages], uids[:clusters])
         result[:vms], uids[:vms] = vm_inv_to_hashes(inv[:vm], inv[:storage], uids[:storages], uids[:hosts], uids[:clusters_by_host], uids[:lans])
 
-        result[:folders], uids[:folders] = folder_dc_sp_inv_to_hashes(inv[:folder], inv[:dc], inv[:storage_pod])
+        result[:folders], uids[:folders] = inv_to_ems_folder_hashes(inv)
         result[:resource_pools], uids[:resource_pools] = rp_inv_to_hashes(inv[:rp])
 
         result[:customization_specs] = customization_spec_inv_to_hashes(inv[:customization_specs]) if inv.key?(:customization_specs)
@@ -1011,38 +1011,78 @@ module ManageIQ::Providers
         result
       end
 
-      def self.folder_dc_sp_inv_to_hashes(folder_inv, dc_inv, sp_inv)
-        folder_result, folder_uids = folder_inv_to_hashes(folder_inv, false, EmsFolder.name)
-        dc_result, dc_uids = folder_inv_to_hashes(dc_inv, true, Datacenter.name)
-        sp_result, sp_uids = folder_inv_to_hashes(sp_inv, false, StorageCluster.name)
+      def self.inv_to_ems_folder_hashes(inv)
+        result = []
+        result_uids = {}
 
-        result = folder_result + dc_result + sp_result
-        result_uids = folder_uids.merge(dc_uids).merge(sp_uids)
+        folder_inv_to_hashes(inv[:folder], result, result_uids)
+        datacenter_inv_to_hashes(inv[:dc], result, result_uids)
+        storage_pod_inv_to_hashes(inv[:storage_pod], result, result_uids)
+
         return result, result_uids
       end
 
-      def self.folder_inv_to_hashes(inv, is_dc, type)
-        result = []
-        result_uids = {}
+      def self.folder_inv_to_hashes(inv, result, result_uids)
         return result, result_uids if inv.nil?
 
         inv.each do |mor, data|
           mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
 
-          child_mors = if is_dc
-                         get_mors(data, 'hostFolder') + get_mors(data, 'vmFolder') + get_mors(data, 'datastoreFolder')
-                       else
-                         get_mors(data, 'childEntity')
-                       end
+          child_mors = get_mors(data, 'childEntity')
 
           new_result = {
-            :type          => type,
+            :type          => EmsFolder.name,
             :ems_ref       => mor,
             :ems_ref_obj   => mor,
             :uid_ems       => mor,
             :name          => data["name"],
-            :is_datacenter => is_dc,
+            :is_datacenter => false,
+            :child_uids    => child_mors
+          }
+          result << new_result
+          result_uids[mor] = new_result
+        end
+        return result, result_uids
+      end
 
+      def self.datacenter_inv_to_hashes(inv, result, result_uids)
+        return result, result_uids if inv.nil?
+
+        inv.each do |mor, data|
+          mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
+
+          child_mors = get_mors(data, 'hostFolder') + get_mors(data, 'vmFolder') + get_mors(data, 'datastoreFolder')
+
+          new_result = {
+            :type          => Datacenter.name,
+            :ems_ref       => mor,
+            :ems_ref_obj   => mor,
+            :uid_ems       => mor,
+            :name          => data["name"],
+            :is_datacenter => true,
+            :child_uids    => child_mors
+          }
+          result << new_result
+          result_uids[mor] = new_result
+        end
+        return result, result_uids
+      end
+
+      def self.storage_pod_inv_to_hashes(inv, result, result_uids)
+        return result, result_uids if inv.nil?
+
+        inv.each do |mor, data|
+          mor = data['MOR'] # Use the MOR directly from the data since the mor as a key may be corrupt
+
+          child_mors = get_mors(data, 'childEntity')
+
+          new_result = {
+            :type          => StorageCluster.name,
+            :ems_ref       => mor,
+            :ems_ref_obj   => mor,
+            :uid_ems       => mor,
+            :name          => data["name"],
+            :is_datacenter => false,
             :child_uids    => child_mors
           }
           result << new_result

--- a/app/models/storage_cluster.rb
+++ b/app/models/storage_cluster.rb
@@ -1,0 +1,2 @@
+class StorageCluster < EmsFolder
+end

--- a/db/migrate/20160219190002_add_type_to_ems_folders.rb
+++ b/db/migrate/20160219190002_add_type_to_ems_folders.rb
@@ -1,0 +1,5 @@
+class AddTypeToEmsFolders < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ems_folders, :type, :string
+  end
+end

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -469,7 +469,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
   def assert_relationship_tree
     expect(@ems.descendants_arranged).to match_relationship_tree(
       [EmsFolder, "Datacenters", {:is_datacenter => false}] => {
-        [EmsFolder, "Dev", {:is_datacenter => true}]            => {
+        [Datacenter, "Dev", {:is_datacenter => true}]            => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
             [ManageIQ::Providers::Vmware::InfraManager::HostEsx, "vi4esxm3.manageiq.com"] => {
               [ResourcePool, "Default for Host / Node vi4esxm3.manageiq.com", {:is_default => true}] => {
@@ -564,11 +564,11 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
             [ManageIQ::Providers::Vmware::InfraManager::Vm, "test3"]                                => {}
           }
         },
-        [EmsFolder, "New Datacenter", {:is_datacenter => true}] => {
+        [Datacenter, "New Datacenter", {:is_datacenter => true}] => {
           [EmsFolder, "host", {:is_datacenter => false}] => {},
           [EmsFolder, "vm", {:is_datacenter => false}]   => {}
         },
-        [EmsFolder, "Prod", {:is_datacenter => true}]           => {
+        [Datacenter, "Prod", {:is_datacenter => true}]           => {
           [EmsFolder, "host", {:is_datacenter => false}] => {
             [EmsCluster, "Testing-Production Cluster"]     => {
               [ResourcePool, "Default for Cluster / Deployment Role Testing-Production Cluster",

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -178,6 +178,9 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :name        => "TestDatastoreCluster",
       :type        => "StorageCluster",
     )
+
+    @child_storage = Storage.find_by_ems_ref("datastore-12281")
+    expect(@storage_cluster.children).to include(@child_storage)
   end
 
   def assert_specific_host

--- a/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/refresher_spec.rb
@@ -25,6 +25,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     assert_ems
     assert_specific_cluster
     assert_specific_storage
+    assert_specific_storage_cluster
     assert_specific_host
     assert_specific_vm
     assert_cpu_layout
@@ -33,7 +34,8 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
 
   def assert_table_counts
     expect(ExtManagementSystem.count).to eq(1)
-    expect(EmsFolder.count).to eq(30)
+    expect(Datacenter.count).to eq(3)
+    expect(EmsFolder.count).to eq(31)
     expect(EmsCluster.count).to eq(1)
     expect(Host.count).to eq(4)
     expect(ResourcePool.count).to eq(17)
@@ -56,7 +58,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
     expect(Switch.count).to eq(8)
     expect(SystemService.count).to eq(29)
 
-    expect(Relationship.count).to eq(244)
+    expect(Relationship.count).to eq(246)
     expect(MiqQueue.count).to eq(101)
   end
 
@@ -66,7 +68,7 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :uid_ems     => "EF53782F-6F1A-4471-B338-72B27774AFDD"
     )
 
-    expect(@ems.ems_folders.size).to eq(30)
+    expect(@ems.ems_folders.size).to eq(31)
     expect(@ems.ems_clusters.size).to eq(1)
     expect(@ems.resource_pools.size).to eq(17)
     expect(@ems.storages.size).to eq(47)
@@ -164,6 +166,17 @@ describe ManageIQ::Providers::Vmware::InfraManager::Refresher do
       :directory_hierarchy_supported => true,
       :thin_provisioning_supported   => true,
       :raw_disk_mappings_supported   => true
+    )
+  end
+
+  def assert_specific_storage_cluster
+    @storage_cluster = StorageCluster.find_by_name("TestDatastoreCluster")
+    expect(@storage_cluster).to have_attributes(
+      :ems_ref     => "group-p81",
+      :ems_ref_obj => VimString.new("group-p81", :StorageCluster, :ManagedObjectReference),
+      :uid_ems     => "group-p81",
+      :name        => "TestDatastoreCluster",
+      :type        => "StorageCluster",
     )
   end
 


### PR DESCRIPTION
Return storage pods from the VMwareWebService gem and add to storage inventory.  Also link up hosts to clustered datastores through the datastore.parent property.

ems_folders table now contains the 'datastore' folder with a StorageCluster folder below that:

<img width="1111" alt="screen shot 2016-03-01 at 5 11 57 pm" src="https://cloud.githubusercontent.com/assets/19339/13443802/c9eac2d2-dfd0-11e5-8302-9cd496e1033e.png">