### PR TITLE
Without requiring Dalli, starting rails server would blow up

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -25,6 +25,7 @@ else
                 end
 
   if rails_store == :mem_cache_store
+    require 'dalli'
     memcached_server = config.fetch_path("session", "memcache_server") || "127.0.0.1:11211"
     session_options = session_options.merge(
       :cache        => Dalli::Client.new(memcached_server, :namespace => "MIQ:VMDB"),


### PR DESCRIPTION
```
$ bundle exec rails s
=> Booting Puma
=> Rails 5.0.0.beta2 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:Preloader> at /home/bdunne/projects/redhat/manageiq/lib/extensions/ar_virtual.rb:283)
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:FinderMethods> at /home/bdunne/projects/redhat/manageiq/lib/extensions/ar_virtual.rb:310)
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:Calculations> at /home/bdunne/projects/redhat/manageiq/lib/extensions/ar_virtual.rb:317)
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from singleton class at /home/bdunne/projects/redhat/manageiq/lib/extensions/ar_process.rb:6)
** EVM vmaster; Database: adapter=postgresql, name=vmdb_development, host=
Exiting
/home/bdunne/projects/redhat/manageiq/config/initializers/session_store.rb:30:in `<top (required)>': uninitialized constant Dalli (NameError)
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/engine.rb:648:in `block in load_config_initializer'
	from /home/bdunne/.gem/ruby/2.2.4/gems/activesupport-5.0.0.beta2/lib/active_support/notifications.rb:166:in `instrument'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/engine.rb:647:in `load_config_initializer'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/engine.rb:612:in `block (2 levels) in <class:Engine>'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/engine.rb:611:in `each'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/engine.rb:611:in `block in <class:Engine>'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:30:in `instance_exec'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:30:in `run'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:420:in `block (2 levels) in each_strongly_connected_component_from'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:419:in `block in each_strongly_connected_component_from'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:44:in `each'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:44:in `tsort_each_child'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:413:in `call'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:413:in `each_strongly_connected_component_from'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `each'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `call'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
	from /home/bdunne/.rubies/ruby-2.2.4/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/initializable.rb:54:in `run_initializers'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/application.rb:350:in `initialize!'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/railtie.rb:194:in `public_send'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/railtie.rb:194:in `method_missing'
	from /home/bdunne/projects/redhat/manageiq/config/environment.rb:5:in `<top (required)>'
	from /home/bdunne/projects/redhat/manageiq/config.ru:3:in `block in <main>'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/builder.rb:55:in `instance_eval'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/builder.rb:55:in `initialize'
	from /home/bdunne/projects/redhat/manageiq/config.ru:in `new'
	from /home/bdunne/projects/redhat/manageiq/config.ru:in `<main>'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/builder.rb:49:in `eval'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/builder.rb:49:in `new_from_string'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/builder.rb:40:in `parse_file'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/server.rb:318:in `build_app_and_options_from_config'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/server.rb:218:in `app'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:58:in `app'
	from /home/bdunne/.gem/ruby/2.2.4/gems/rack-2.0.0.alpha/lib/rack/server.rb:353:in `wrapped_app'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:136:in `log_to_stdout'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:76:in `start'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:90:in `block in server'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `tap'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `server'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/command.rb:20:in `run'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands.rb:19:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```