### PR TITLE
[api] DRY up API specs with shared context

### DIFF
--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -2,7 +2,6 @@
 # REST API Request Tests - /api authentication
 #
 describe ApiController do
-  include_context "api request specs"
   ENTRYPOINT_KEYS = %w(name description version versions identity collections)
 
   context "Basic Authentication" do

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -2,16 +2,7 @@
 # REST API Request Tests - /api authentication
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
-
+  include_context "api request specs"
   ENTRYPOINT_KEYS = %w(name description version versions identity collections)
 
   context "Basic Authentication" do

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -6,15 +6,7 @@
 # - Create multiple automation requests /api/automation_requests    action "create"
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   describe "Automation Requests" do
     let(:approver) { FactoryGirl.create(:user_miq_request_approver) }

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -6,8 +6,6 @@
 # - Create multiple automation requests /api/automation_requests    action "create"
 #
 describe ApiController do
-  include_context "api request specs"
-
   describe "Automation Requests" do
     let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
     let(:single_automation_request) do

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -1,11 +1,5 @@
 RSpec.describe "categories API" do
-  include Rack::Test::Methods
-
-  before { init_api_spec_env }
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   it "can list all the categories" do
     categories = FactoryGirl.create_list(:category, 2)

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "categories API" do
-  include_context "api request specs"
-
   it "can list all the categories" do
     categories = FactoryGirl.create_list(:category, 2)
     api_basic_authorize

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -1,11 +1,5 @@
 RSpec.describe "chargebacks API" do
-  include Rack::Test::Methods
-
-  def app
-    Vmdb::Application
-  end
-
-  before { init_api_spec_env }
+  include_context "api request specs"
 
   it "can fetch the list of all chargeback rates" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "chargebacks API" do
-  include_context "api request specs"
-
   it "can fetch the list of all chargeback rates" do
     chargeback_rate = FactoryGirl.create(:chargeback_rate)
 

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -2,20 +2,12 @@
 # Rest API Collections Tests
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
   let(:template) do
     FactoryGirl.create(:miq_template, :name => "template 1", :vendor => "vmware", :location => "template1.vmtx")
-  end
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
   end
 
   def test_collection_query(collection, collection_url, klass, attr = :id)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -2,8 +2,6 @@
 # Rest API Collections Tests
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
   let(:template) do

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -8,15 +8,7 @@
 #   /api/policies/:id/conditions
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   let(:condition_guid_list) { Condition.pluck(:guid) }
 

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -8,8 +8,6 @@
 #   /api/policies/:id/conditions
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:condition_guid_list) { Condition.pluck(:guid) }
 
   def create_conditions(count)

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -18,15 +18,7 @@
 #          { "action" : "<custom_action_button_name>" }
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   let(:template1) { FactoryGirl.create(:service_template, :name => "template1") }
   let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :service_template_id => template1.id) }

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -18,8 +18,6 @@
 #          { "action" : "<custom_action_button_name>" }
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:template1) { FactoryGirl.create(:service_template, :name => "template1") }
   let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :service_template_id => template1.id) }
 

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -1,13 +1,5 @@
 RSpec.describe "API entrypoint" do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   it "returns a :settings hash" do
     api_basic_authorize

--- a/spec/requests/api/entrypoint_spec.rb
+++ b/spec/requests/api/entrypoint_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "API entrypoint" do
-  include_context "api request specs"
-
   it "returns a :settings hash" do
     api_basic_authorize
 

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -8,15 +8,7 @@
 #   /api/policies/:id/events
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   let(:miq_event_guid_list) { MiqEventDefinition.pluck(:guid) }
 

--- a/spec/requests/api/events_spec.rb
+++ b/spec/requests/api/events_spec.rb
@@ -8,8 +8,6 @@
 #   /api/policies/:id/events
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:miq_event_guid_list) { MiqEventDefinition.pluck(:guid) }
 
   def create_events(count)

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -11,8 +11,6 @@
 # - Delete multiple groups                /api/groups                           action "delete"
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:expected_attributes) { %w(id guid description group_type tenant_id) }
 
   let(:sample_group1) { {:description => "sample_group_1"} }

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -11,7 +11,7 @@
 # - Delete multiple groups                /api/groups                           action "delete"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:expected_attributes) { %w(id guid description group_type tenant_id) }
 
@@ -22,14 +22,6 @@ describe ApiController do
 
   let(:role3)    { FactoryGirl.create(:miq_user_role) }
   let(:tenant3)  { FactoryGirl.create(:tenant, :name => "Tenant3") }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   describe "groups create" do
     it "rejects creation without appropriate role" do

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "hosts API" do
-  include_context "api request specs"
-
   describe "editing a host's password" do
     context "with an appropriate role" do
       it "can edit the password on a host" do

--- a/spec/requests/api/hosts_spec.rb
+++ b/spec/requests/api/hosts_spec.rb
@@ -1,11 +1,5 @@
 RSpec.describe "hosts API" do
-  include Rack::Test::Methods
-
-  before { init_api_spec_env }
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   describe "editing a host's password" do
     context "with an appropriate role" do

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "Instances API" do
-  include_context "api request specs"
-
   def update_raw_power_state(state, *instances)
     instances.each { |instance| instance.update_attributes!(:raw_power_state => state) }
   end

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -1,9 +1,5 @@
 RSpec.describe "Instances API" do
-  include Rack::Test::Methods
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   def update_raw_power_state(state, *instances)
     instances.each { |instance| instance.update_attributes!(:raw_power_state => state) }
@@ -20,7 +16,6 @@ RSpec.describe "Instances API" do
   let(:instance2_url) { instances_url(instance2.id) }
   let(:invalid_instance_url) { instances_url(999_999) }
   let(:instances_list) { [instance1_url, instance2_url] }
-  before(:each) { init_api_spec_env }
 
   context "Instance index" do
     it "lists only the cloud instances (no infrastructure vms)" do

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -6,8 +6,6 @@
 # - Query picture and image_href of service_requests   /api/service_requests/:id?attributes=picture,picture.image_href
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
   let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
   let(:picture)  { FactoryGirl.create(:picture, :extension => "jpg") }

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -6,7 +6,7 @@
 # - Query picture and image_href of service_requests   /api/service_requests/:id?attributes=picture,picture.image_href
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:dialog1)  { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
   let(:ra1)      { FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog1) }
@@ -25,14 +25,7 @@ describe ApiController do
                        :source_id   => template.id)
   end
 
-  before(:each) do
-    init_api_spec_env
-    api_basic_authorize
-  end
-
-  def app
-    Vmdb::Application
-  end
+  before { api_basic_authorize }
 
   def expect_result_to_include_picture_href(source_id)
     expect_result_to_match_hash(@result, "id" => source_id)

--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -16,7 +16,7 @@
 #   /api/:collection/:id/policy_profiles
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -38,19 +38,13 @@ describe ApiController do
   let(:ps1) { FactoryGirl.create(:miq_policy_set, :description => "Policy Set 1") }
   let(:ps2) { FactoryGirl.create(:miq_policy_set, :description => "Policy Set 2") }
 
-  before(:each) do
-    init_api_spec_env
-
+  before do
     # Creating:  policy_set_1 = [policy_1, policy_2]  and  policy_set_2 = [policy_3]
 
     ps1.add_member(p1)
     ps1.add_member(p2)
 
     ps2.add_member(p3)
-  end
-
-  def app
-    Vmdb::Application
   end
 
   def test_policy_assign_no_role(object_policies_url)

--- a/spec/requests/api/policies_assignment_spec.rb
+++ b/spec/requests/api/policies_assignment_spec.rb
@@ -16,8 +16,6 @@
 #   /api/:collection/:id/policy_profiles
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:provider)   { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -23,8 +23,6 @@
 #   /api/templates/:id/policy_profiles
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)        { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)  { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)         { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -23,7 +23,7 @@
 #   /api/templates/:id/policy_profiles
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)        { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)  { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -40,18 +40,12 @@ describe ApiController do
   let(:p_guids)     { [p1.guid, p2.guid] }
   let(:p_all_guids) { [p1.guid, p2.guid, p3.guid] }
 
-  before(:each) do
-    init_api_spec_env
-
+  before do
     # Creating:  policy_set_1 = [policy_1, policy_2]  and  policy_set_2 = [policy_3]
     ps1.add_member(p1)
     ps1.add_member(p2)
 
     ps2.add_member(p3)
-  end
-
-  def app
-    Vmdb::Application
   end
 
   def test_no_policy_query(object_policies_url)

--- a/spec/requests/api/policy_actions_spec.rb
+++ b/spec/requests/api/policy_actions_spec.rb
@@ -8,8 +8,6 @@
 #   /api/policies/:id/policy_actions
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:miq_action_guid_list) { MiqAction.pluck(:guid) }
 
   def create_actions(count)

--- a/spec/requests/api/policy_actions_spec.rb
+++ b/spec/requests/api/policy_actions_spec.rb
@@ -8,15 +8,7 @@
 #   /api/policies/:id/policy_actions
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   let(:miq_action_guid_list) { MiqAction.pluck(:guid) }
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -14,8 +14,6 @@
 # - Refresh multiple providers            /api/providers                        action "refresh"
 #
 describe ApiController do
-  include_context "api request specs"
-
   ENDPOINT_ATTRS = ApiController::Providers::ENDPOINT_ATTRS
 
   let(:default_credentials) { {"userid" => "admin1", "password" => "password1"} }

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -14,7 +14,7 @@
 # - Refresh multiple providers            /api/providers                        action "refresh"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   ENDPOINT_ATTRS = ApiController::Providers::ENDPOINT_ATTRS
 
@@ -52,14 +52,6 @@ describe ApiController do
       "hostname"  => "sample_openshift.provider.com",
       "ipaddress" => "100.200.300.3",
     }
-  end
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
   end
 
   describe "Providers actions on Provider class" do

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -6,8 +6,6 @@
 # - Create multiple provision requests /api/provision_requests    action "create"
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -6,21 +6,13 @@
 # - Create multiple provision requests /api/provision_requests    action "create"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }
   let(:host)       { FactoryGirl.create(:host, :ext_management_system => ems) }
   let(:dialog)     { FactoryGirl.create(:miq_dialog_provision) }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   describe "Provision Requests" do
     let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 1024) }

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - Queries
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -13,14 +13,6 @@ describe ApiController do
   let(:vm1_url)    { vms_url(vm1.id) }
 
   let(:vm_href_pattern) { %r{^http://.*/api/vms/[0-9]+$} }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   def create_vms(count)
     count.times { FactoryGirl.create(:vm_vmware) }

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - Queries
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -9,15 +9,7 @@
 #   - Resource actions
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   def create_vms_by_name(names)
     names.each.collect { |name| FactoryGirl.create(:vm_vmware, :name => name) }

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -9,8 +9,6 @@
 #   - Resource actions
 #
 describe ApiController do
-  include_context "api request specs"
-
   def create_vms_by_name(names)
     names.each.collect { |name| FactoryGirl.create(:vm_vmware, :name => name) }
   end

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -1,11 +1,5 @@
 RSpec.describe "reports API" do
-  include Rack::Test::Methods
-
-  def app
-    Vmdb::Application
-  end
-
-  before { init_api_spec_env }
+  include_context "api request specs"
 
   it "can fetch all the reports" do
     report_1 = FactoryGirl.create(:miq_report_with_results)

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "reports API" do
-  include_context "api request specs"
-
   it "can fetch all the reports" do
     report_1 = FactoryGirl.create(:miq_report_with_results)
     report_2 = FactoryGirl.create(:miq_report_with_results)

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -16,8 +16,6 @@
 # - Delete multiple roles                 /api/roles                            action "delete"
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:feature_identifiers) do
     %w(vm_explorer ems_infra_tag my_settings_time_profiles
        miq_request_view miq_report_run storage_manager_show_list)

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -16,7 +16,7 @@
 # - Delete multiple roles                 /api/roles                            action "delete"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:feature_identifiers) do
     %w(vm_explorer ems_infra_tag my_settings_time_profiles
@@ -56,15 +56,9 @@ describe ApiController do
   end
 
   before(:each) do
-    init_api_spec_env
-
     @product_features = feature_identifiers.collect do |identifier|
       FactoryGirl.create(:miq_product_feature, :identifier => identifier)
     end
-  end
-
-  def app
-    Vmdb::Application
   end
 
   def test_features_query(role, role_url, klass, attr = :id)

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -19,19 +19,11 @@
 # - Refresh dialog fields       /api/service_catalogs/:id/service_templates/:id action "refresh_dialog_fields"
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
+  include_context "api request specs"
 
   def sc_templates_url(id, st_id = nil)
     st_base = "#{service_catalogs_url(id)}/service_templates"
     st_id ? "#{st_base}/#{st_id}" : st_base
-  end
-
-  def app
-    Vmdb::Application
   end
 
   describe "Service Catalogs create" do

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -19,8 +19,6 @@
 # - Refresh dialog fields       /api/service_catalogs/:id/service_templates/:id action "refresh_dialog_fields"
 #
 describe ApiController do
-  include_context "api request specs"
-
   def sc_templates_url(id, st_id = nil)
     st_base = "#{service_catalogs_url(id)}/service_templates"
     st_id ? "#{st_base}/#{st_id}" : st_base

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - Service Dialogs specs
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -17,14 +17,6 @@ describe ApiController do
 
   let(:template)   { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
   let(:service)    { FactoryGirl.create(:service, :name => "Service1") }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   context "Service Dialogs collection" do
     before do

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - Service Dialogs specs
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -8,8 +8,6 @@
 #     GET /api/services/:id?attributes=provision_dialog
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:provision_dialog1)    { FactoryGirl.create(:dialog, :label => "ProvisionDialog1") }
   let(:retirement_dialog2)   { FactoryGirl.create(:dialog, :label => "RetirementDialog2") }
 

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -8,7 +8,7 @@
 #     GET /api/services/:id?attributes=provision_dialog
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:provision_dialog1)    { FactoryGirl.create(:dialog, :label => "ProvisionDialog1") }
   let(:retirement_dialog2)   { FactoryGirl.create(:dialog, :label => "RetirementDialog2") }
@@ -26,14 +26,6 @@ describe ApiController do
 
   let(:request_task) { FactoryGirl.create(:miq_request_task, :miq_request => service_request) }
   let(:service) { FactoryGirl.create(:service, :name => "Service", :miq_request_task => request_task) }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   def expect_result_to_have_provision_dialog
     expect_result_to_have_keys(%w(id href provision_dialog))

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -7,7 +7,7 @@
 # - Delete multiple service templates   /api/service_templates        action "delete"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:dialog1)    { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
   let(:dialog2)    { FactoryGirl.create(:dialog, :label => "ServiceDialog2") }
@@ -17,14 +17,6 @@ describe ApiController do
 
   let(:picture)    { FactoryGirl.create(:picture, :extension => "jpg") }
   let(:template)   { FactoryGirl.create(:service_template, :name => "ServiceTemplate") }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   describe "Service Templates query" do
     before do

--- a/spec/requests/api/service_templates_spec.rb
+++ b/spec/requests/api/service_templates_spec.rb
@@ -7,8 +7,6 @@
 # - Delete multiple service templates   /api/service_templates        action "delete"
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:dialog1)    { FactoryGirl.create(:dialog, :label => "ServiceDialog1") }
   let(:dialog2)    { FactoryGirl.create(:dialog, :label => "ServiceDialog2") }
 

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -14,8 +14,6 @@
 # - Retire multiple services    /api/services         action "retire"
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:svc)  { FactoryGirl.create(:service, :name => "svc",  :description => "svc description")  }
   let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :description => "svc1 description") }
   let(:svc2) { FactoryGirl.create(:service, :name => "svc2", :description => "svc2 description") }

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -14,19 +14,11 @@
 # - Retire multiple services    /api/services         action "retire"
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:svc)  { FactoryGirl.create(:service, :name => "svc",  :description => "svc description")  }
   let(:svc1) { FactoryGirl.create(:service, :name => "svc1", :description => "svc1 description") }
   let(:svc2) { FactoryGirl.create(:service, :name => "svc2", :description => "svc2 description") }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   describe "Services edit" do
     it "rejects requests without appropriate role" do

--- a/spec/requests/api/set_ownership_spec.rb
+++ b/spec/requests/api/set_ownership_spec.rb
@@ -7,8 +7,6 @@
 # - Templates               /api/templates/:id
 #
 describe ApiController do
-  include_context "api request specs"
-
   def expect_set_ownership_success(object, href, user = nil, group = nil)
     expect_single_action_result(:success => true, :message => "setting ownership", :href => href)
     expect(object.reload.evm_owner).to eq(user)  if user

--- a/spec/requests/api/set_ownership_spec.rb
+++ b/spec/requests/api/set_ownership_spec.rb
@@ -7,15 +7,7 @@
 # - Templates               /api/templates/:id
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   def expect_set_ownership_success(object, href, user = nil, group = nil)
     expect_single_action_result(:success => true, :message => "setting ownership", :href => href)

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - Tags subcollection specs for Non-Vm collections
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)          { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/tag_collections_spec.rb
+++ b/spec/requests/api/tag_collections_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - Tags subcollection specs for Non-Vm collections
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -29,15 +29,9 @@ describe ApiController do
     expect(resource.tags.map(&:name).sort).to eq(tag_names.sort)
   end
 
-  before(:each) do
-    init_api_spec_env
-
+  before do
     FactoryGirl.create(:classification_department_with_tags)
     FactoryGirl.create(:classification_cost_center_with_tags)
-  end
-
-  def app
-    Vmdb::Application
   end
 
   context "Provider Tag subcollection" do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - /api/tags
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -25,17 +25,11 @@ describe ApiController do
   let(:tag_count)    { Tag.count }
 
   before(:each) do
-    init_api_spec_env
-
     FactoryGirl.create(:classification_department_with_tags)
     FactoryGirl.create(:classification_cost_center_with_tags)
 
     Classification.classify(vm2, tag1[:category], tag1[:name])
     Classification.classify(vm2, tag2[:category], tag2[:name])
-  end
-
-  def app
-    Vmdb::Application
   end
 
   context "Tag collection" do

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - /api/tags
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)         { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server)   { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)          { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -1,11 +1,6 @@
 RSpec.describe "tenants API" do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
-  def app
-    Vmdb::Application
-  end
-
-  before { init_api_spec_env }
   let!(:root_tenant) { Tenant.seed }
 
   it "can list all the tenants" do

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "tenants API" do
-  include_context "api request specs"
-
   let!(:root_tenant) { Tenant.seed }
 
   it "can list all the tenants" do

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -10,8 +10,6 @@
 # - Delete multiple users                /api/users                           action "delete"
 #
 RSpec.describe "users API" do
-  include_context "api request specs"
-
   let(:expected_attributes) { %w(id name userid current_group_id) }
 
   let(:tenant1)  { FactoryGirl.create(:tenant, :name => "Tenant1") }

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -10,11 +10,7 @@
 # - Delete multiple users                /api/users                           action "delete"
 #
 RSpec.describe "users API" do
-  include Rack::Test::Methods
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   let(:expected_attributes) { %w(id name userid current_group_id) }
 
@@ -30,8 +26,6 @@ RSpec.describe "users API" do
 
   let(:user1) { FactoryGirl.create(:user, sample_user1.except(:group).merge(:miq_groups => [group1])) }
   let(:user2) { FactoryGirl.create(:user, sample_user2.except(:group).merge(:miq_groups => [group2])) }
-
-  before { init_api_spec_env }
 
   context "with an appropriate role" do
     it "can change the user's password" do

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -2,15 +2,7 @@
 # REST API Request Tests - /api versioning
 #
 describe ApiController do
-  include Rack::Test::Methods
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
+  include_context "api request specs"
 
   context "Versioning Queries" do
     it "test versioning query" do

--- a/spec/requests/api/versioning_spec.rb
+++ b/spec/requests/api/versioning_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - /api versioning
 #
 describe ApiController do
-  include_context "api request specs"
-
   context "Versioning Queries" do
     it "test versioning query" do
       api_basic_authorize

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -2,8 +2,6 @@
 # REST API Request Tests - /api/vms
 #
 describe ApiController do
-  include_context "api request specs"
-
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
   let(:ems)        { FactoryGirl.create(:ems_vmware, :zone => zone) }

--- a/spec/requests/api/vms_spec.rb
+++ b/spec/requests/api/vms_spec.rb
@@ -2,7 +2,7 @@
 # REST API Request Tests - /api/vms
 #
 describe ApiController do
-  include Rack::Test::Methods
+  include_context "api request specs"
 
   let(:zone)       { FactoryGirl.create(:zone, :name => "api_zone") }
   let(:miq_server) { FactoryGirl.create(:miq_server, :guid => miq_server_guid, :zone => zone) }
@@ -26,14 +26,6 @@ describe ApiController do
   let(:vm_url)             { vms_url(vm.id) }
 
   let(:invalid_vm_url) { vms_url(999_999) }
-
-  before(:each) do
-    init_api_spec_env
-  end
-
-  def app
-    Vmdb::Application
-  end
 
   def update_raw_power_state(state, *vms)
     vms.each { |vm| vm.update_attributes!(:raw_power_state => state) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,10 +65,10 @@ RSpec.configure do |config|
   config.include MigrationSpecHelper, :migrations => :up
   config.include MigrationSpecHelper, :migrations => :down
 
-  config.include ApiSpecHelper,     :type => :request, :rest_api => true
+  config.include ApiSpecHelper,     :rest_api => true
   config.include AuthRequestHelper, :type => :request
   config.define_derived_metadata(:file_path => /spec\/requests\/api/) do |metadata|
-    metadata[:type] ||= :request
+    metadata[:rest_api] = true
   end
 
   config.include AuthHelper,  :type => :helper

--- a/spec/support/api_spec_setup.rb
+++ b/spec/support/api_spec_setup.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "api request specs" do
+RSpec.shared_context "api request specs", :type => :request do
   include Rack::Test::Methods
   before { init_api_spec_env }
   def app

--- a/spec/support/api_spec_setup.rb
+++ b/spec/support/api_spec_setup.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context "api request specs", :type => :request do
+RSpec.shared_context "api request specs", :rest_api => true do
   include Rack::Test::Methods
   before { init_api_spec_env }
   def app

--- a/spec/support/api_spec_setup.rb
+++ b/spec/support/api_spec_setup.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context "api request specs" do
+  include Rack::Test::Methods
+  before { init_api_spec_env }
+  def app
+    Vmdb::Application
+  end
+end


### PR DESCRIPTION
All of the API request specs:

* include the `Rack::Test::Methods` module
* define `app` as required by rack-test
* invoke `init_api_spec_env` before each example

This change moves all that into a shared context

***

/cc @jrafanie :scissors: 

I'm open to different approaches to this, but went with a shared context because it seemed like a low :sparkles: solution.

@miq-bot add-label api, refactoring