### PR TITLE
Use find_by method instead of find_by_name in seeding MiqWidgets

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -36,7 +36,7 @@ class MiqWidgetSet < ApplicationRecord
   def self.sync_from_file(filename)
     attrs = YAML.load_file(filename)
 
-    ws = find_by_name(attrs["name"])
+    ws = find_by(:name => attrs["name"])
 
     if ws.nil? || ws.updated_on.utc < File.mtime(filename).utc
       # Convert widget descriptions to ids in set_data


### PR DESCRIPTION
getting error after rails s

	from /Users/liborpichler/manageiq/app/models/miq_widget_set.rb:40:in `sync_from_file'
	from /Users/liborpichler/manageiq/app/models/miq_widget_set.rb:33:in `block in sync_from_dir'
	from /Users/liborpichler/manageiq/app/models/miq_widget_set.rb:33:in `each'
	from /Users/liborpichler/manageiq/app/models/miq_widget_set.rb:33:in `sync_from_dir'
	from /Users/liborpichler/manageiq/app/models/miq_widget_set.rb:71:in `seed'
	from /Users/liborpichler/manageiq/app/models/miq_widget.rb:589:in `seed'

cc @jrafanie 