### PR TITLE
Allow over 1500 commands to be run per WinRM connection

### DIFF
--- a/gems/pending/Scvmm/miq_hyperv_disk.rb
+++ b/gems/pending/Scvmm/miq_hyperv_disk.rb
@@ -52,7 +52,7 @@ STAT_EOL
   def close
     hit_or_miss if DEBUG_CACHE_STATS
     @file_offset = 0
-    @winrm.executor.close
+    @winrm.close
     @winrm = nil
   end
 


### PR DESCRIPTION
WinRM Gem version 1.5 and beyond allow a single connection
to the Windows server to be used for multiple commands.
We now take advantage of this performance gain, but there
is per-user QUOTA which defaults to 1500 commands per connection.
During SSA, this limit is sometimes reached.

This modification keeps track of the commands per connection.  When
1500 have been issued, the "executor" object in the connection is closed and
reopened to allow for the next 1500.

@djberg96 @roliveri @Fryguy @jrafanie @chessbyte Please review and merge when appropriate.  Thanks.