### PR TITLE
[api] Add service orders API

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -705,6 +705,7 @@
     :klass: Dialog
   :service_orders:
     :description: Service Orders
+    :identifier: svc_catalog_provision
     :options:
     - :collection
     :methods: *70174834084700
@@ -712,12 +713,20 @@
     :collection_actions:
       :post:
       - :name: create
+        :identifier: svc_catalog_provision
       - :name: edit
+        :identifier: svc_catalog_provision
       - :name: delete
+        :identifier: svc_catalog_provision
     :resource_actions:
       :post:
       - :name: edit
+        :identifier: svc_catalog_provision
       - :name: delete
+        :identifier: svc_catalog_provision
+      :delete:
+      - :name: delete
+        :identifier: svc_catalog_provision
   :service_requests:
     :description: Service Requests
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -703,6 +703,21 @@
     - :subcollection
     :methods: *70174834086080
     :klass: Dialog
+  :service_orders:
+    :description: Service Orders
+    :options:
+    - :collection
+    :methods: *70174834084700
+    :klass: ServiceOrder
+    :collection_actions:
+      :post:
+      - :name: create
+      - :name: edit
+      - :name: delete
+    :resource_actions:
+      :post:
+      - :name: edit
+      - :name: delete
   :service_requests:
     :description: Service Requests
     :options:

--- a/spec/factories/service_order.rb
+++ b/spec/factories/service_order.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory(:service_order) do
+    name "service order"
+    state "ordered"
+  end
+end

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe "service orders API" do
+  it "can list all service orders" do
+    service_order = FactoryGirl.create(:service_order)
+    api_basic_authorize
+
+    run_get service_orders_url
+
+    expect_request_success
+    expect_result_resources_to_include_hrefs("resources", [service_orders_url(service_order.id)])
+  end
+
+  it "can create a service order" do
+    api_basic_authorize
+
+    expect do
+      run_post service_orders_url, :name => "service order", :state => "wish"
+    end.to change(ServiceOrder, :count).by(1)
+
+    expect_request_success
+  end
+
+  it "can create multiple service orders" do
+    api_basic_authorize
+
+    expect do
+      run_post(service_orders_url,
+               :action => "create", :resources => [{:name => "service order 1", :state => "wish"},
+                                                   {:name => "service order 2", :state => "wish"}])
+    end.to change(ServiceOrder, :count).by(2)
+    expect_request_success
+  end
+
+  it "can read a service order" do
+    service_order = FactoryGirl.create(:service_order)
+    api_basic_authorize
+
+    run_get service_orders_url(service_order.id)
+
+    expect_result_to_match_hash(@result, "name" => service_order.name, "state" => service_order.state)
+    expect_request_success
+  end
+
+  it "can update a service order" do
+    service_order = FactoryGirl.create(:service_order, :name => "old name")
+    api_basic_authorize
+
+    run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
+
+    expect_result_to_match_hash(@result, "name" => "new name")
+    expect_request_success
+  end
+
+  it "can update multiple service orders" do
+    service_order_1 = FactoryGirl.create(:service_order, :name => "old name 1")
+    service_order_2 = FactoryGirl.create(:service_order, :name => "old name 2")
+    api_basic_authorize
+
+    run_post(service_orders_url,
+             :action => "edit", :resources => [{:id => service_order_1.id, :name => "new name 1"},
+                                               {:id => service_order_2.id, :name => "new name 2"}])
+
+    expect_results_to_match_hash("results", [{"name" => "new name 1"}, {"name" => "new name 2"}])
+    expect_request_success
+  end
+
+  it "can delete a service order" do
+    service_order = FactoryGirl.create(:service_order)
+    api_basic_authorize
+
+    expect do
+      run_delete service_orders_url(service_order.id)
+    end.to change(ServiceOrder, :count).by(-1)
+    expect_request_success_with_no_content
+  end
+
+  it "can delete a service order through POST" do
+    service_order = FactoryGirl.create(:service_order)
+    api_basic_authorize
+
+    expect do
+      run_post service_orders_url(service_order.id), :action => "delete"
+    end.to change(ServiceOrder, :count).by(-1)
+    expect_request_success
+  end
+
+  it "can delete multiple service orders" do
+    service_order_1 = FactoryGirl.create(:service_order, :name => "old name")
+    service_order_2 = FactoryGirl.create(:service_order, :name => "old name")
+    api_basic_authorize
+
+    expect do
+      run_post(service_orders_url,
+               :action => "delete", :resources => [{:id => service_order_1.id},
+                                                   {:id => service_order_2.id}])
+    end.to change(ServiceOrder, :count).by(-2)
+    expect_request_success
+  end
+end

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can create a service order" do
-    api_basic_authorize
+    api_basic_authorize collection_action_identifier(:service_orders, :create)
 
     expect do
       run_post service_orders_url, :name => "service order", :state => "wish"
@@ -20,7 +20,7 @@ RSpec.describe "service orders API" do
   end
 
   it "can create multiple service orders" do
-    api_basic_authorize
+    api_basic_authorize collection_action_identifier(:service_orders, :create)
 
     expect do
       run_post(service_orders_url,
@@ -42,7 +42,7 @@ RSpec.describe "service orders API" do
 
   it "can update a service order" do
     service_order = FactoryGirl.create(:service_order, :name => "old name")
-    api_basic_authorize
+    api_basic_authorize action_identifier(:service_orders, :edit)
 
     run_post service_orders_url(service_order.id), :action => "edit", :resource => {:name => "new name"}
 
@@ -53,7 +53,7 @@ RSpec.describe "service orders API" do
   it "can update multiple service orders" do
     service_order_1 = FactoryGirl.create(:service_order, :name => "old name 1")
     service_order_2 = FactoryGirl.create(:service_order, :name => "old name 2")
-    api_basic_authorize
+    api_basic_authorize collection_action_identifier(:service_orders, :edit)
 
     run_post(service_orders_url,
              :action => "edit", :resources => [{:id => service_order_1.id, :name => "new name 1"},
@@ -65,7 +65,7 @@ RSpec.describe "service orders API" do
 
   it "can delete a service order" do
     service_order = FactoryGirl.create(:service_order)
-    api_basic_authorize
+    api_basic_authorize action_identifier(:service_orders, :delete, :resource_actions, :delete)
 
     expect do
       run_delete service_orders_url(service_order.id)
@@ -75,7 +75,7 @@ RSpec.describe "service orders API" do
 
   it "can delete a service order through POST" do
     service_order = FactoryGirl.create(:service_order)
-    api_basic_authorize
+    api_basic_authorize action_identifier(:service_orders, :delete)
 
     expect do
       run_post service_orders_url(service_order.id), :action => "delete"
@@ -86,7 +86,7 @@ RSpec.describe "service orders API" do
   it "can delete multiple service orders" do
     service_order_1 = FactoryGirl.create(:service_order, :name => "old name")
     service_order_2 = FactoryGirl.create(:service_order, :name => "old name")
-    api_basic_authorize
+    api_basic_authorize collection_action_identifier(:service_orders, :delete)
 
     expect do
       run_post(service_orders_url,

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -103,8 +103,8 @@ module ApiSpecHelper
                      data_stores events features flavors groups hosts instances pictures policies policy_actions
                      policy_profiles providers provision_dialogs provision_requests rates
                      reports request_tasks requests resource_pools results roles security_groups
-                     servers service_dialogs service_catalogs service_requests service_templates
-                     services tags tasks templates tenants users vms zones)
+                     servers service_dialogs service_catalogs service_orders service_requests
+                     service_templates services tags tasks templates tenants users vms zones)
 
     define_entrypoint_url_methods
     define_url_methods(collections)


### PR DESCRIPTION
Adds the basic CRUD actions for service orders.

Resolves https://trello.com/c/P9fUtvuW

***

@abellotti please review
@miq-bot add-label api, enhancement