### PR TITLE
Change EMS total_storages method to use where

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -430,7 +430,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def total_storages
-    HostStorage.count(:conditions => {:host_id => host_ids}, :select => "DISTINCT storage_id")
+    HostStorage.where(:host_id => host_ids).count("DISTINCT storage_id")
   end
 
   def vm_count_by_state(state)

--- a/spec/controllers/ems_infra_controller_spec.rb
+++ b/spec/controllers/ems_infra_controller_spec.rb
@@ -178,6 +178,17 @@ describe EmsInfraController do
     end
   end
 
+  describe "#show_list" do
+    before(:each) do
+      session[:settings] = {:views => {}}
+      set_user_privileges
+      FactoryGirl.create(:ems_vmware)
+      get :show_list
+    end
+    it { expect(response.status).to eq(200) }
+
+  end
+
   describe "UI interactions in the form" do
     render_views
     context "#form_field_changed" do


### PR DESCRIPTION
After conversion to Rails 5, clicking on Infrastructure / Providers was blowing up in the UI with:

```
[----] F, [2016-02-16T14:18:41.673243 #29636:310b618] FATAL -- : Error caught: [PG::SyntaxError] ERROR:  syntax error at or near "{"
LINE 1: SELECT COUNT({:conditions=>{:host_id=>[360000000000015, 3600...
                     ^

/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:591:in `async_exec'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:591:in `block in exec_no_cache'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract_adapter.rb:528:in `block in log'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activesupport-5.0.0.beta2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract_adapter.rb:522:in `log'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:591:in `exec_no_cache'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/postgresql_adapter.rb:578:in `execute_and_clear'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/postgresql/database_statements.rb:103:in `exec_query'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/database_statements.rb:374:in `select'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/database_statements.rb:41:in `select_all'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `block in select_all'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/query_cache.rb:83:in `cache_sql'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/connection_adapters/abstract/query_cache.rb:68:in `select_all'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation/calculations.rb:258:in `execute_simple_calculation'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation/calculations.rb:217:in `perform_calculation'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation/calculations.rb:118:in `calculate'
/home/dclarizio/dev/manageiq/lib/extensions/ar_virtual.rb:315:in `calculate_with_virtual'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/relation/calculations.rb:40:in `count'
/home/dclarizio/.rvm/gems/ruby-2.2.3/gems/activerecord-5.0.0.beta2/lib/active_record/querying.rb:13:in `count'
/home/dclarizio/dev/manageiq/app/models/ext_management_system.rb:434:in `total_storages'
```

Changed to use where method vs count method with :conditions.

cc @matthewd @chessbyte 