### PR TITLE
Introduce new table cloud_databases and model

### DIFF
--- a/app/models/cloud_database.rb
+++ b/app/models/cloud_database.rb
@@ -1,0 +1,11 @@
+class CloudDatabase < ApplicationRecord
+  include NewWithTypeStiMixin
+  include ReportableMixin
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
+  belongs_to :cloud_tenant
+  belongs_to :cloud_database_flavor
+  belongs_to :resource_group
+
+  serialize :extra_attributes
+end

--- a/app/models/cloud_database_flavor.rb
+++ b/app/models/cloud_database_flavor.rb
@@ -1,0 +1,17 @@
+class CloudDatabaseFlavor < ApplicationRecord
+  include NewWithTypeStiMixin
+  include ReportableMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"
+  has_many   :cloud_databases
+
+  virtual_column :total_cloud_databases, :type => :integer, :uses => :cloud_databases
+
+  default_value_for :enabled, true
+
+  def total_cloud_databases
+    cloud_databases.size
+  end
+end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -14,12 +14,14 @@ module ManageIQ::Providers
 
     has_many :availability_zones,            :foreign_key => :ems_id, :dependent => :destroy
     has_many :flavors,                       :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_database_flavors,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_tenants,                 :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_resource_quotas,         :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volumes,                 :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
     has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
 
     validates_presence_of :zone

--- a/db/migrate/20160211113430_create_cloud_databases.rb
+++ b/db/migrate/20160211113430_create_cloud_databases.rb
@@ -1,0 +1,39 @@
+class CreateCloudDatabases < ActiveRecord::Migration
+  def change
+    create_table :cloud_database_flavors do |t|
+      t.string  :name
+      t.string  :type
+      t.string  :ems_ref
+      t.integer :cpus
+      t.bigint  :memory
+      t.bigint  :max_size
+      t.integer :max_connections
+      t.string  :performance
+      t.boolean :enabled
+
+      t.belongs_to :ems, :type => :bigint
+    end
+
+    add_index :cloud_database_flavors, :ems_id
+
+    create_table :cloud_databases do |t|
+      t.string :name
+      t.string :type
+      t.string :ems_ref
+      t.string :db_engine
+      t.string :status
+      t.string :status_reason
+      t.bigint :used_storage
+      t.bigint :max_storage
+      t.text   :extra_attributes
+
+      t.belongs_to :ems, :type => :bigint
+      t.belongs_to :resource_group, :type => :bigint
+      t.belongs_to :cloud_database_flavor, :type => :bigint
+      t.belongs_to :cloud_tenant, :type => :bigint
+    end
+
+    add_index :cloud_databases, :ems_id
+    add_index :cloud_databases, :cloud_database_flavor_id
+  end
+end


### PR DESCRIPTION
Now all major cloud providers support DBaaS. This work introduce a new VMDB table named `cloud_databases` and its model `CloudDatabase` to store cloud database instances collected from cloud providers.

The fields are mostly related to SQL databases. NoSQL databases have fewer information. TBD whether they need a separate table.

More fields such as cloud network for a DB can be added in the future.

Like cloud instances, each cloud database instance is created based on some predefined size, i.e. flavor. 
These flavors are stored in table `cloud_db_flavors` with model `CloudDbFlavor`