### PR TITLE
Add environment variable option to use memory store.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-if !Rails.env.development? && !Rails.env.production?
+if ENV['RAILS_USE_MEMORY_STORE'] || (!Rails.env.development? && !Rails.env.production?)
   Vmdb::Application.config.session_store :memory_store
 else
   session_options = {}


### PR DESCRIPTION
For rails 5, we switched to rails' MemCacheStore [1], a subclass of rack's
store that tries to connect to memcached when loading rails. The prior store,
DalliStore, did not connect on initialize. We need to allow specific
environments that do not have memcached running, such as the nightly build's
anaconda setup, to bypass using memcached.

See also [2].

[1] ManageIQ/manageiq#6704
[2] petergoldstein/dalli#423