### PR TITLE
Expose storage files to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -4,6 +4,8 @@ module MiqAeMethodService
     expose :hosts,                  :association => true
     expose :vms,                    :association => true
     expose :unregistered_vms,       :association => true
+    expose :storage_files,          :association => true
+    expose :files,                  :association => true
     expose :to_s
     expose :scan,                   :override_return => true
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage_file.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage_file.rb
@@ -1,0 +1,8 @@
+module MiqAeMethodService
+  class MiqAeServiceStorageFile < MiqAeServiceModelBase
+    expose :storage,                :association => true
+    expose :vm_or_template,         :association => true
+    expose :vm,                     :association => true
+    expose :miq_template,           :association => true
+  end
+end


### PR DESCRIPTION
Expose storage_files and files relationship from storage model
Add StorageFile service model.

Based on talk topic: http://talk.manageiq.org/t/how-to-access-references-to-files-on-a-vsphere-datastore/1213