### PR TITLE
add pod creation and deletion rate to hourly metric rollup

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -165,4 +165,13 @@ module Metric::Helper
 
     return start_time, end_time
   end
+
+  def self.get_time_interval(obj, timestamp)
+    timestamp = Time.parse(timestamp).utc if timestamp.kind_of?(String)
+
+    state = obj.vim_performance_state_for_ts(timestamp)
+    start_time = timestamp - state[:capture_interval]
+
+    start_time..timestamp
+  end
 end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -1,5 +1,6 @@
 module Metric::Rollup
-  ROLLUP_COLS  = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float || c[0, 7] == "derived" }.compact
+  ROLLUP_COLS  = Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float || c[0, 7] == "derived" }.compact +
+                 [:stat_containergroup_create_rate, :stat_containergroup_delete_rate]
   STORAGE_COLS = Metric.columns_hash.collect { |c, _h| c.to_sym if c.starts_with?("derived_storage_") }.compact
 
   AGGREGATE_COLS = {
@@ -151,6 +152,7 @@ module Metric::Rollup
 
     new_perf.reverse_merge!(orig_perf)
     new_perf.merge!(Metric::Processing.process_derived_columns(obj, new_perf, hour)) unless DERIVED_COLS_EXCLUDED_CLASSES.include?(obj.class.base_class.name)
+    new_perf.merge!(Metric::Statistic.calculate_stat_columns(obj, hour))
 
     new_perf
   end

--- a/app/models/metric/statistic.rb
+++ b/app/models/metric/statistic.rb
@@ -1,0 +1,13 @@
+module Metric::Statistic
+  def self.calculate_stat_columns(obj, timestamp)
+    return {} unless obj.respond_to?(:container_groups)
+
+    capture_interval = Metric::Helper.get_time_interval(obj, timestamp)
+    container_groups = ContainerGroup.where("ems_id = #{obj.id} OR old_ems_id = #{obj.id}")
+
+    {
+      :stat_containergroup_create_rate => container_groups.where(:created_on => capture_interval).count,
+      :stat_containergroup_delete_rate => container_groups.where(:deleted_on => capture_interval).count
+    }
+  end
+end

--- a/db/migrate/20160223085416_add_stat_containergroup_create_rate.rb
+++ b/db/migrate/20160223085416_add_stat_containergroup_create_rate.rb
@@ -1,0 +1,6 @@
+class AddStatContainergroupCreateRate < ActiveRecord::Migration[5.0]
+  def change
+    add_column :metric_rollups, :stat_containergroup_create_rate, :integer
+    add_column :metric_rollups, :stat_containergroup_delete_rate, :integer
+  end
+end

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -1,0 +1,34 @@
+describe Metric::Statistic do
+  context ".calculate_stat_columns" do
+    let(:ems_openshift) do
+      FactoryGirl.create(:ems_openshift, :hostname => 't', :port => 8443, :name => 't',
+                         :zone => Zone.first)
+    end
+
+    hour = Time.parse(Metric::Helper.nearest_hourly_timestamp(Time.now)).utc
+
+    let(:c1) { FactoryGirl.create(:container_group, :created_on => hour - 10.minutes) }
+    let(:c2) { FactoryGirl.create(:container_group, :created_on => hour - 50.minutes) }
+    let(:c3) { FactoryGirl.create(:container_group, :created_on => hour - 120.minutes) }
+    let(:c4) { FactoryGirl.create(:container_group, :created_on => hour + 1.minute) }
+
+    let(:c5) { FactoryGirl.create(:container_group, :deleted_on => hour - 10.minutes) }
+    let(:c6) { FactoryGirl.create(:container_group, :deleted_on => hour - 50.minutes) }
+    let(:c7) { FactoryGirl.create(:container_group, :deleted_on => hour - 120.minutes) }
+    let(:c8) { FactoryGirl.create(:container_group, :deleted_on => hour + 1.minute) }
+
+    it "count created container groups in a provider" do
+      ems_openshift.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
+      derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
+
+      expect(derived_columns[:stat_containergroup_create_rate]).to eq(2)
+    end
+
+    it "count deleted container groups in a provider" do
+      ems_openshift.container_groups << [c1, c2, c3, c4, c5, c6, c7, c8]
+      derived_columns = described_class.calculate_stat_columns(ems_openshift, hour)
+
+      expect(derived_columns[:stat_containergroup_delete_rate]).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Add a ContainerGroup creation and deletion rate column to MetricRollup.

- A column named :stat_containergroup_create_rate is added to table metric_rollups.
- A column named :stat_containergroup_delete_rate is added to table metric_rollups.
- Counts how many pods created in the last hour when calling Metric Rollup rollup_hourly.
- Counts how many pods deleted in the last hour when calling Metric Rollup rollup_hourly.
