### PR TITLE
Add winrm 1.7 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/matthewd/rubyrep.git", :branch => "rails5"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "winrm",                          "~>1.5.0",   :require => false
+gem "winrm",                          "~>1.7.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required


### PR DESCRIPTION
WinRM 1.7 fixes the issue addressed by closed PR
https://github.com/ManageIQ/manageiq/pull/6720
which required reopening the WinRM executor after
every 1500 commands on the same connection.
No code changes are necessary but this is needed to run
SSA on larger HyperV disks.

@Fryguy @roliveri @chessbyte @djberg96 Please review and merge when possible.