### PR TITLE
Fix EMS.supported_types_and_descriptions_hash

### DIFF
--- a/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
+++ b/app/models/manageiq/providers/ansible_tower/configuration_manager.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::AnsibleTower::ConfigurationManager < ManageIQ::Provid
            :to => :provider
 
   def self.ems_type
-    "ansible_tower_configuration".freeze
+    @ems_type ||= "ansible_tower_configuration".freeze
+  end
+
+  def self.description
+    @description ||= "Ansible Tower Configuration".freeze
   end
 end

--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -17,6 +17,10 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
            :to => :provider
 
   def self.ems_type
-    "foreman_configuration".freeze
+    @ems_type ||= "foreman_configuration".freeze
+  end
+
+  def self.description
+    @description ||= "Foreman Configuration".freeze
   end
 end

--- a/app/models/manageiq/providers/foreman/provisioning_manager.rb
+++ b/app/models/manageiq/providers/foreman/provisioning_manager.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::Foreman::ProvisioningManager < ManageIQ::Providers::P
   has_many :configuration_organizations, :foreign_key => :provisioning_manager_id
 
   def self.ems_type
-    "foreman_provisioning".freeze
+    @ems_type ||= "foreman_provisioning".freeze
+  end
+
+  def self.description
+    @description ||= "Foreman Provisioning".freeze
   end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -6,34 +6,38 @@ describe ExtManagementSystem do
     expect(described_class.model_name_from_emstype('foo')).to be_nil
   end
 
-  let(:all_types) do
-    %w(
-      ec2
-      foreman_configuration
-      foreman_provisioning
-      gce
-      hawkular
-      kubernetes
-      openshift
-      atomic
-      openshift_enterprise
-      atomic_enterprise
-      openstack
-      openstack_infra
-      rhevm
-      scvmm
-      vmwarews
-      azure
-      ansible_tower_configuration
-    )
+  let(:all_types_and_descriptions) do
+    {
+      "ansible_tower_configuration" => "Ansible Tower Configuration",
+      "atomic"                      => "Atomic",
+      "atomic_enterprise"           => "Atomic Enterprise",
+      "azure"                       => "Azure",
+      "ec2"                         => "Amazon EC2",
+      "foreman_configuration"       => "Foreman Configuration",
+      "foreman_provisioning"        => "Foreman Provisioning",
+      "gce"                         => "Google Compute Engine",
+      "hawkular"                    => "Hawkular",
+      "kubernetes"                  => "Kubernetes",
+      "openshift"                   => "OpenShift Origin",
+      "openshift_enterprise"        => "OpenShift Enterprise",
+      "openstack"                   => "OpenStack",
+      "openstack_infra"             => "OpenStack Platform Director",
+      "rhevm"                       => "Red Hat Enterprise Virtualization Manager",
+      "scvmm"                       => "Microsoft System Center VMM",
+      "vmwarews"                    => "VMware vCenter",
+    }
   end
 
   it ".types" do
-    expect(described_class.types).to match_array(all_types)
+    expect(described_class.types).to match_array(all_types_and_descriptions.keys)
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array(all_types)
+    expect(described_class.supported_types).to match_array(all_types_and_descriptions.keys)
+  end
+
+  it ".supported_types_and_descriptions_hash" do
+    expect(described_class.supported_types_and_descriptions_hash).to eq(all_types_and_descriptions)
   end
 
   it ".ems_infra_discovery_types" do


### PR DESCRIPTION
I added descriptions for the missing managers.  Without them, the method blows up with:
```ruby
NoMethodError: undefined method `description' for #<Class:0x0055965fe7a360>
	from /home/bdunne/.gem/ruby/2.2.4/gems/activerecord-5.0.0.beta2/lib/active_record/dynamic_matchers.rb:21:in `method_missing'
	from /home/bdunne/projects/redhat/manageiq/app/models/ext_management_system.rb:23:in `block in supported_types_and_descriptions_hash'
	from /home/bdunne/projects/redhat/manageiq/app/models/ext_management_system.rb:21:in `each'
	from /home/bdunne/projects/redhat/manageiq/app/models/ext_management_system.rb:21:in `each_with_object'
	from /home/bdunne/projects/redhat/manageiq/app/models/ext_management_system.rb:21:in `supported_types_and_descriptions_hash'
	from (irb):2
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/console.rb:65:in `start'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/console_helper.rb:9:in `start'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/command.rb:20:in `run'
	from /home/bdunne/.gem/ruby/2.2.4/gems/railties-5.0.0.beta2/lib/rails/commands.rb:19:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'

```