### PR TITLE
Remove deprecation warning about top level constant

### DIFF
--- a/app/services/container_topology_service.rb
+++ b/app/services/container_topology_service.rb
@@ -63,7 +63,7 @@ class ContainerTopologyService < TopologyService
   def entity_display_type(entity)
     if entity.kind_of?(ManageIQ::Providers::ContainerManager)
       entity.type.split('::')[2]
-    elsif entity.kind_of?(ManageIQ::Providers::ContainerManager::ContainerGroup)
+    elsif entity.kind_of?(ContainerGroup)
       "Pod"
     else
       name = entity.class.name.demodulize


### PR DESCRIPTION
Fixes #6612 

ContainerGroup is a top-level constant and should be accessed that way instead of through a different namespace.

@simon3z @abonas Please review.