### PR TITLE
Bump pool size to 5 since puma + miq seems to use more connections

### DIFF
--- a/config/database.pg.yml
+++ b/config/database.pg.yml
@@ -15,7 +15,7 @@ base: &base
   adapter: postgresql
   encoding: utf8
   username: root
-  pool: 1
+  pool: 5
   wait_timeout: 5
   min_messages: warning
 


### PR DESCRIPTION
Fixes some sporadic errors seen locally:

ActiveRecord::ConnectionTimeoutError (could not obtain a connection from the pool within 5.000 seconds).

We'll have to circle back to this and figure out why this is happening.
https://github.com/ManageIQ/manageiq/issues/3415