### PR TITLE
Fix VmOrTemplate.find_all_by_id_and_ems_created_on call

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1203,7 +1203,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def self.assign_ems_created_on(vm_ids)
-    vms_to_update = VmOrTemplate.find_all_by_id_and_ems_created_on(vm_ids, nil)
+    vms_to_update = VmOrTemplate.where(:id => vm_ids, :ems_created_on => nil)
     return if vms_to_update.empty?
 
     # Of the VMs without a VM create time, filter out the ones for which we


### PR DESCRIPTION
Addresses 1 issue in https://github.com/ManageIQ/manageiq/issues/6754