### PR TITLE
Bump secure_headers to 2.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>2.13"
 gem "recursive-open-struct",          "~>0.6.1"
 gem "responders",                     "~>2.0"
-gem "secure_headers",                 "~>2.4.4"
+gem "secure_headers",                 "~>2.5.2"
 gem "spice-html5-rails"
 #gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 


### PR DESCRIPTION
Removes some Rails 5 deprecations. Fixes #6763.