### PR TITLE
Remove some secureheaders deprecations.

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,11 +11,11 @@ SecureHeaders::Configuration.configure do |config|
   }
   config.csp = {
     :enforce     => true,
-    :default_src => "'self'",
-    :frame_src   => "'self'",
-    :connect_src => "'self'",
-    :style_src   => "'unsafe-inline' 'self'",
-    :script_src  => "'unsafe-eval' 'unsafe-inline' 'self'",
-    :report_uri  => "/dashboard/csp_report"
+    :default_src => ["'self'"],
+    :frame_src   => ["'self'"],
+    :connect_src => ["'self'"],
+    :style_src   => ["'unsafe-inline'", "'self'"],
+    :script_src  => ["'unsafe-eval'", "'unsafe-inline'", "'self'"],
+    :report_uri  => ["/dashboard/csp_report"]
   }
 end


### PR DESCRIPTION
This removes 6 lines of deprecations on every request.  In v2 both Arrays and a single string are supported, but on v3 only Arrays are supported, so this removes the deprecation warning.  See https://github.com/twitter/secureheaders/blob/master/upgrading-to-3-0.md

Note that there is still at least 1 one deprecation warning, but it can't be fixed without going to v3.

@chrisarcand @martinpovolny Please review