### PR TITLE
i18n: use standard gettext in ui_lookup()

### DIFF
--- a/app/controllers/application_controller/ci_processing.rb
+++ b/app/controllers/application_controller/ci_processing.rb
@@ -1052,7 +1052,7 @@ module ApplicationController::CiProcessing
   end
 
   def breadcrumb_name(_model)
-    ui_lookup_for_model(self.class.model.name).pluralize
+    ui_lookup(:models => self.class.model.name)
   end
 
   # Reconfigure selected VMs

--- a/app/controllers/mixins/vm_show_mixin.rb
+++ b/app/controllers/mixins/vm_show_mixin.rb
@@ -167,6 +167,6 @@ module VmShowMixin
   end
 
   def breadcrumb_name(model)
-    ui_lookup_for_model(model || self.class.model.name).pluralize
+    ui_lookup(:models => model || self.class.model.name)
   end
 end

--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1093,8 +1093,8 @@ class ApplicationHelper::ToolbarBuilder
     when "MiqServer"
       case id
       when "collect_logs", "collect_current_logs"
-        return "Cannot collect current logs unless the #{ui_lookup(:table => "miq_servers")} is started" unless @record.started?
-        return "Log collection is already in progress for this #{ui_lookup(:table => "miq_servers")}" if @record.log_collection_active_recently?
+        return "Cannot collect current logs unless the #{ui_lookup(:table => "miq_server")} is started" unless @record.started?
+        return "Log collection is already in progress for this #{ui_lookup(:table => "miq_server")}" if @record.log_collection_active_recently?
         return "Log collection requires the Log Depot settings to be configured" unless @record.log_file_depot
       when "delete_server"
         return "Server #{@record.name} [#{@record.id}] can only be deleted if it is stopped or has not responded for a while" unless @record.is_deleteable?
@@ -1146,9 +1146,9 @@ class ApplicationHelper::ToolbarBuilder
     when "Storage"
       case id
       when "storage_perf"
-        return "No Capacity & Utilization data has been collected for this #{ui_lookup(:table => "storages")}" unless @record.has_perf_data?
+        return "No Capacity & Utilization data has been collected for this #{ui_lookup(:table => "storage")}" unless @record.has_perf_data?
       when "storage_delete"
-        return "Only #{ui_lookup(:table => "storages")} without VMs and Hosts can be removed" if @record.vms_and_templates.length > 0 || @record.hosts.length > 0
+        return "Only #{ui_lookup(:table => "storage")} without VMs and Hosts can be removed" if @record.vms_and_templates.length > 0 || @record.hosts.length > 0
       when "storage_scan"
         return @record.is_available_now_error_message(:smartstate_analysis) unless @record.is_available?(:smartstate_analysis)
       end

--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -1,10 +1,13 @@
 class Dictionary
   def self.gettext(text, opts = {})
     opts[:type] ||= :column
+    opts[:plural] ||= false
 
     key, suffix = text.split("__")  # HACK: Sometimes we need to add a suffix to report columns, this should probably be moved into the presenter.
-    result      = i18n_lookup(opts[:type], key)
-    result ||= i18n_lookup(opts[:type], key.split(".").last)
+
+    i18n_result = i18n_lookup(opts[:type], key)
+    i18n_result ||= i18n_lookup(opts[:type], key.split(".").last)
+    result = _(opts[:plural] ? i18n_result.pluralize : i18n_result) if i18n_result
     result << " (#{suffix.titleize})" if result && suffix  # HACK: continued.  i.e. Adding (Min) or (Max) to a column name.
 
     return result if result
@@ -15,7 +18,7 @@ class Dictionary
     # HACK: Strip off the 'v_' for virtual columns if titleizing
     col = col[2..-1] if col.starts_with?("v_") && opts[:notfound].to_sym == :titleize
 
-    col.send(opts[:notfound])
+    opts[:plural] ? col.send(opts[:notfound]).send(:pluralize) : col.send(opts[:notfound])
   end
 
   def self.i18n_lookup(type, text)

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair/operations.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair/operations.rb
@@ -43,7 +43,7 @@ module ManageIQ::Providers::CloudManager::AuthKeyPair::Operations
       if ext_management_system.nil?
         return {:available => false,
                 :message   => "The Keypair is not connected to an active #{ui_lookup(
-                  :table => "ext_management_systems")}"}
+                  :table => "ext_management_system")}"}
       end
       {:available => true, :message => nil}
     end

--- a/config/dictionary_strings.rb
+++ b/config/dictionary_strings.rb
@@ -1,0 +1,2137 @@
+# Strings extracted from en.yml for gettext to find
+# TRANSLATORS: en.yml key: dictionary.column.User.name
+_("Full Name")
+# TRANSLATORS: en.yml key: dictionary.column.userid
+_("Username")
+# TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+_("Total Instances")
+# TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+_("Total Images")
+# TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+_("Total Instances")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+_("CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+_("CPU - Total Installed - Sum of Child Hosts (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+_("Disk I/O - Aggregate of Avg for Child Hosts (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+_("CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+_("Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+_("Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+_("Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+_("Memory - Avg Usage of Total Allocated for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+_("CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+_("CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+_("Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+_("Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+_("Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+_("Network I/O - Aggregate of Avg for Child Hosts (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+_("Total Instances")
+# TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+_("CPU - Total Installed - from Host Analysis (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+_("Disk Space Max Total")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+_("CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+_("CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+_("CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+_("Memory - Avg Used for Collected Intervals 30 Day Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+_("Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+_("Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+_("CPU - Time Spent In Ready State (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+_("CPU - Time Spent in System State (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+_("CPU - Usage Rate for Collected Intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+_("CPU - Time Used (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+_("CPU - Time Spent in Wait State (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+_("CPU - Total - from VM Analysis (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+_("CPU - Reserved (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+_("Memory - Total Allocated (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+_("Memory - Reserved (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+_("Memory - Avg Used for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+_("CPU Max Reserved MHz")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+_("Memory Max Allocated")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+_("Memory Max Reserved")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+_("Memory - Peak Avg Used for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+_("Memory - Minimum Avg Used for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+_("CPU - Reserved (%)")
+# TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+_("Memory - Reserved (%)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+_("CPU - Absolute Max Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+_("CPU - Absolute Max Usage Rate (%)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+_("Disk I/O - Absolute Max Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+_("Disk I/O - Absolute Max Usage Rate (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+_("Memory - Absolute Max Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+_("Memory - Absolute Max Usage Rate (%)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+_("Network I/O - Absolute Max Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+_("Network I/O - Absolute Max Usage Rate (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+_("CPU - Absolute Min Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+_("CPU - Absolute Min Usage Rate (%)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+_("Disk I/O - Absolute Min Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+_("Disk I/O - Absolute Min Usage Rate (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+_("Memory - Absolute Min Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+_("Memory - Absolute Min Usage Rate (%)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+_("Network I/O - Absolute Min Usage Rate (Timestamp)")
+# TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+_("Network I/O - Absolute Min Usage Rate (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.acctid
+_("Account ID")
+# TRANSLATORS: en.yml key: dictionary.column.accttype
+_("Account Type")
+# TRANSLATORS: en.yml key: dictionary.column.action_type_description
+_("Type")
+# TRANSLATORS: en.yml key: dictionary.column.active
+_("Active")
+# TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+_("Lockdown Mode")
+# TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+_("Total CPU Speed")
+# TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+_("Total Number of Logical CPUs")
+# TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+_("Total Memory")
+# TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+_("Total Number of Physical CPUs")
+# TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+_("Allocated Memory")
+# TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+_("Allocated Storage")
+# TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+_("Allocated vCPU")
+# TRANSLATORS: en.yml key: dictionary.column.avg_latency
+_("Usage (All) - Latency in MicroSeconds for All Operations Avg")
+# TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+_("Usage (All) - Latency in MicroSeconds for All Operations Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+_("Usage (All) - Latency in MicroSeconds for All Operations Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.bios
+_("BIOS")
+# TRANSLATORS: en.yml key: dictionary.column.bios_location
+_("BIOS Location")
+# TRANSLATORS: en.yml key: dictionary.column.chain_id
+_("Chain ID")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+_("Usage (CIFS) - Time for Other Operations Avg")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+_("Usage (CIFS) - Time for Other Operations Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+_("Usage (CIFS) - Time for Other Operations Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+_("Usage (CIFS) - Number of Other Operations per Second")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+_("Usage (CIFS) - Number of Other Operations per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+_("Usage (CIFS) - Number of Other Operations per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+_("Usage (CIFS) - Bytes Read per Second")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+_("Usage (CIFS) - Bytes Read per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+_("Usage (CIFS) - Bytes Read per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+_("Usage (CIFS) - Time for Reads Avg")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+_("Usage (CIFS) - Time for Reads Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+_("Usage (CIFS) - Time for Reads Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+_("Usage (CIFS) - Number of Reads per Second")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+_("Usage (CIFS) - Number of Reads per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+_("Usage (CIFS) - Number of Reads per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+_("Usage (CIFS) - Bytes Written per Second")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+_("Usage (CIFS) - Bytes Written per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+_("Usage (CIFS) - Bytes Written per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+_("Usage (CIFS) - Time for Writes Avg")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+_("Usage (CIFS) - Time for Writes Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+_("Usage (CIFS) - Time for Writes Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+_("Usage (CIFS) - Number of Writes per Second")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+_("Usage (CIFS) - Number of Writes per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+_("Usage (CIFS) - Number of Writes per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.config_xml
+_("Configuration XML")
+# TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+_("Data Points")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+_("CPU Affinity")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_limit
+_("CPU Limit")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+_("CPU - Aggregate Time Child VMs Spent in Ready State (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
+_("CPU Reserve")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
+_("CPU Reserve Expand")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_shares
+_("CPU Shares")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
+_("CPU Shares Level")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_speed
+_("CPU Speed")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+_("CPU - Aggregate Time Child VMs Spent in System State (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_time
+_("CPU Time")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_type
+_("CPU Type")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+_("CPU - Usage Rate for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+_("CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+_("CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+_("CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+_("CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Avg (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+_("CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+_("CPU - Aggregate Time Used for Child VMs (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+_("CPU - Aggregate Time Spent in Wait State for Child VMs (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.created_at
+_("Date Created")
+# TRANSLATORS: en.yml key: dictionary.column.created_on
+_("Date Created")
+# TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+_("Depends on Group")
+# TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+_("Depends on Service")
+# TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+_("CPU Total Installed")
+# TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+_("CPU - Available (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+_("State - Number of Hosts Powered Off  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+_("State - Number of Hosts Powered On  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+_("Memory - Total Allocated for Child VMs (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+_("Memory - Available (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+_("Memory - Aggregate Used for Child VMs for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+_("Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+_("Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+_("Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+_("Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+_("Content - Avg of Total Size of Managed VMs Disk Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+_("Content - Avg of Total Size of Registered VMs Disk Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+_("Content - Avg of Total Size of Unmanaged VMs Disk Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+_("Content - Avg of Total Size of Unregistered VMs Disk Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+_("Capacity - Avg Free Space for Collected Intervals (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+_("Content - Avg of Total Size of Managed VMs Memory Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+_("Content - Avg of Total Size of Registered VMs Memory Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+_("Content - Avg of Total Size of Unmanaged VMs Memory Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+_("Content - Avg of Total Size of Unregistered VMs Memory Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+_("Content - Avg of Total Size of Managed VMs Snapshot Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+_("Content - Avg of Total Size of Registered VMs Snapshot Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+_("Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+_("Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+_("Capacity - Total Space (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+_("Content - Avg Space Used by Managed VMs for Collected Intervals (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+_("Content - Avg Space Used by Registered VMs for Collected Intervals (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+_("Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+_("Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+_("Content - Avg Count of Managed VMs")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+_("Content - Avg Count of Registered VMs")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+_("Content - Avg Count of Unmanaged VMs")
+# TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+_("Content - Avg Count of Unregistered VMs")
+# TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+_("State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+_("State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+_("Destination Host Name")
+# TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+_("Destination VM Location")
+# TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+_("Destination VM Name")
+# TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
+_("DHCP Enabled")
+# TRANSLATORS: en.yml key: dictionary.column.dhcp_server
+_("DHCP Server")
+# TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+_("Trend")
+# TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+_("Disk Latency - Avg (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+_("Disk Kernel Latency - Avg (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+_("Disk Queue Latency - Avg (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+_("Disk I/O - Avg (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+_("Disks Aligned")
+# TRANSLATORS: en.yml key: dictionary.column.dns_server
+_("DNS Server")
+# TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+_("CPU - Effective")
+# TRANSLATORS: en.yml key: dictionary.column.effective_memory
+_("Memory - Effective")
+# TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
+_("Cluster")
+# TRANSLATORS: en.yml key: dictionary.column.emstype_description
+_("Type")
+# TRANSLATORS: en.yml key: dictionary.column.enabled
+_("Active")
+# TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+_("End")
+# TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+_("What is evaluated")
+# TRANSLATORS: en.yml key: dictionary.column.event_src
+_("Event Source")
+# TRANSLATORS: en.yml key: dictionary.column.filename
+_("File Name")
+# TRANSLATORS: en.yml key: dictionary.column.fqname
+_("Fully Qualified Name")
+# TRANSLATORS: en.yml key: dictionary.column.guest_os
+_("Guest OS")
+# TRANSLATORS: en.yml key: dictionary.column.guid
+_("EVM Unique ID (Guid)")
+# TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+_("Has an RDM Disk?")
+# TRANSLATORS: en.yml key: dictionary.column.health_state
+_("Health State Code")
+# TRANSLATORS: en.yml key: dictionary.column.health_state_str
+_("Health State")
+# TRANSLATORS: en.yml key: dictionary.column.homedir
+_("Home Directory")
+# TRANSLATORS: en.yml key: dictionary.column.host_name
+_("Parent Host")
+# TRANSLATORS: en.yml key: dictionary.column.hostnames
+_("Host Names")
+# TRANSLATORS: en.yml key: dictionary.column.ip_address
+_("IP Address")
+# TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+_("IP Addresses")
+# TRANSLATORS: en.yml key: dictionary.column.ipaddress
+_("IP Address")
+# TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+_("IP Addresses")
+# TRANSLATORS: en.yml key: dictionary.column.ipmi_address
+_("IPMI IP Address")
+# TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+_("IPMI Enabled")
+# TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+_("Is an EVM Appliance?")
+# TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+_("Last Analysis Attempt On")
+# TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+_("Last Analysis Time")
+# TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+_("Last Sync Time")
+# TRANSLATORS: en.yml key: dictionary.column.last_update_status
+_("Last Update Status Code")
+# TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+_("Last Update Status")
+# TRANSLATORS: en.yml key: dictionary.column.ldap_group
+_("LDAP Group")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+_("Number of CPU Cores")
+# TRANSLATORS: en.yml key: dictionary.column.mac_address
+_("MAC Address")
+# TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+_("MAC Addresses")
+# TRANSLATORS: en.yml key: dictionary.column.macaddress
+_("MAC Address")
+# TRANSLATORS: en.yml key: dictionary.column.macaddresses
+_("MAC Addresses")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+_("CPU - Peak Usage Rate Avg for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+_("CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+_("CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+_("CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+_("CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+_("CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+_("CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+_("CPU - Peak Usage Rate for Collected Intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+_("CPU Max Total MHz")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+_("CPU Max Available MHz")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+_("State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+_("State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+_("Memory Max Total")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+_("Memory Max Available")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+_("Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+_("Disk Space Max Free")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+_("Disk Space Max Total")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+_("State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+_("State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+_("Disk I/O - Peak Avg for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+_("Memory - Swap In Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+_("Memory - Swap Out Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+_("Memory - Swapped Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+_("Memory - Swap Target Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+_("Memory - Peak Usage of Allocated for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+_("Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+_("Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+_("Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+_("Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day High Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+_("Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+_("Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Low Avg (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+_("Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+_("Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Max (%)")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+_("Memory - Balloon Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+_("Memory - Balloon Target Max Average")
+# TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+_("Network I/O - Peak Avg for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+_("Uptime - Peak Uptime for Collected Intervals (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.max_trend_value
+_("Max")
+# TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+_("Disk Space Max Used")
+# TRANSLATORS: en.yml key: dictionary.column.mem_cpu
+_("Memory")
+# TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+_("Memory - Swap In Average")
+# TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+_("Memory - Swap Out Average")
+# TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+_("Memory - Swapped Average")
+# TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+_("Memory - Swap Target Average")
+# TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+_("Memory - Usage of Total Allocated (%)")
+# TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+_("Memory - Balloon Average")
+# TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+_("Memory - Balloon Target Average")
+# TRANSLATORS: en.yml key: dictionary.column.memory_mb
+_("RAM")
+# TRANSLATORS: en.yml key: dictionary.column.memory_size
+_("Memory Usage")
+# TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+_("CPU - Min Usage Rate for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+_("CPU - Min Usage for Collected Intervals (MHz)")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+_("State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+_("State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+_("Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+_("Disk Space Min Free")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+_("State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+_("State - Min Number of VMs Powered On  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+_("Disk I/O - Min Avg for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+_("Memory - Swap In Min Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+_("Memory - Swap Out Min Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+_("Memory - Swapped Min Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+_("Memory - Swap Min Target Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+_("Memory - Min Usage of Allocated for Collected Intervals (%)")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+_("Memory - Balloon Min Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+_("Memory - Balloon Target Min Average")
+# TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+_("Network I/O - Min Avg for Collected Intervals (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+_("Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.min_trend_value
+_("Min")
+# TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+_("Disk Space Min Used")
+# TRANSLATORS: en.yml key: dictionary.column.mode
+_("Type")
+# TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+_("Multiple Host Access")
+# TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+_("Network I/O - Avg (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+_("Usage (NFS) - Time for Other Operations Avg")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+_("Usage (NFS) - Time for Other Operations Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+_("Usage (NFS) - Time for Other Operations Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+_("Usage (NFS) - Number of Other Operations per Second")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+_("Usage (NFS) - Number of Other Operations per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+_("Usage (NFS) - Number of Other Operations per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+_("Usage (NFS) - Bytes Read per Second")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+_("Usage (NFS) - Bytes Read per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+_("Usage (NFS) - Bytes Read per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+_("Usage (NFS) - Time for Reads Avg")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+_("Usage (NFS) - Time for Reads Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+_("Usage (NFS) - Time for Reads Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+_("Usage (NFS) - Number of Reads per Second")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+_("Usage (NFS) - Number of Reads per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+_("Usage (NFS) - Number of Reads per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+_("Usage (NFS) - Bytes Written per Second")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+_("Usage (NFS) - Bytes Written per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+_("Usage (NFS) - Bytes Written per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+_("Usage (NFS) - Time for Writes Avg")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+_("Usage (NFS) - Time for Writes Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+_("Usage (NFS) - Time for Writes Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+_("Usage (NFS) - Number of Writes per Second")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+_("Usage (NFS) - Number of Writes per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+_("Usage (NFS) - Number of Writes per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.notify_automate
+_("Management Event Raised")
+# TRANSLATORS: en.yml key: dictionary.column.notify_email
+_("Email")
+# TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+_("Event on Timeline")
+# TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+_("SNMP")
+# TRANSLATORS: en.yml key: dictionary.column.num_cpu
+_("Number of CPUs")
+# TRANSLATORS: en.yml key: dictionary.column.num_disks
+_("Number of Disks")
+# TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+_("Number of Hard Disks")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+_("Number of CPUs")
+# TRANSLATORS: en.yml key: dictionary.column.operational_status
+_("Operational Status Code")
+# TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+_("Operational Status")
+# TRANSLATORS: en.yml key: dictionary.column.os_image_name
+_("OS Name")
+# TRANSLATORS: en.yml key: dictionary.column.other_latency
+_("Usage (Other) - Time for Other Operations Avg")
+# TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+_("Usage (Other) - Time for Other Operations Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+_("Usage (Other) - Time for Other Operations Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.other_ops
+_("Usage (Other) - Number of Other Operations per Second")
+# TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+_("Usage (Other) - Number of Other Operations per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+_("Usage (Other) - Number of Other Operations per Second Miin")
+# TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+_("Memory - % Overallocated")
+# TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+_("CPU - % Overallocated")
+# TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+_("In My LDAP Group?")
+# TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+_("Owned by Me?")
+# TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+_("LDAP Group")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+_("Folder Name (VMs & Templates) 1")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+_("Folder Name (VMs & Templates) 2")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+_("Folder Name (VMs & Templates) 3")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+_("Folder Name (VMs & Templates) 4")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+_("Folder Name (VMs & Templates) 5")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+_("Folder Name (VMs & Templates) 6")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+_("Folder Name (VMs & Templates) 7")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+_("Folder Name (VMs & Templates) 8")
+# TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+_("Folder Name (VMs & Templates) 9")
+# TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
+_("Partitions Aligned")
+# TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+_("CPU %")
+# TRANSLATORS: en.yml key: dictionary.column.percent_memory
+_("Memory %")
+# TRANSLATORS: en.yml key: dictionary.column.pid
+_("PID")
+# TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+_("Total Provisioned Space")
+# TRANSLATORS: en.yml key: dictionary.column.ram_size
+_("RAM Size (MB)")
+# TRANSLATORS: en.yml key: dictionary.column.read_data
+_("Usage (Other) - Bytes Read per Second")
+# TRANSLATORS: en.yml key: dictionary.column.read_data_max
+_("Usage (Other) - Bytes Read per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.read_data_min
+_("Usage (Other) - Bytes Read per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.read_latency
+_("Usage (Other) - Time for Reads Avg")
+# TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+_("Usage (Other) - Time for Reads Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+_("Usage (Other) - Time for Reads Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.read_ops
+_("Usage (Other) - Number of Reads per Second")
+# TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+_("Usage (Other) - Number of Reads per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+_("Usage (Other) - Number of Reads per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.resource_name
+_("Asset Name")
+# TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+_("Total VMs Powered Never")
+# TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+_("Total VMs Powered Off")
+# TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+_("Total VMs Powered On")
+# TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+_("Total VMs Power Suspended")
+# TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+_("Total VMs Powered Unknown")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+_("CPU - Available (%)")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+_("State - Number of Hosts  - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+_("Memory - Available (%)")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+_("State - Peak Avg VMs - Hourly Count / Daily Avg")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+_("CPU - Usage Rate for Collected Intervals (Number of Cores)")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+_("Memory - Aggressive Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+_("Memory - Aggressive Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+_("Memory - Aggressive Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+_("CPU - Aggressive Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+_("CPU - Aggressive Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+_("CPU - Aggressive Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+_("Capacity - Profile 1 - Total Memory with HA")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+_("Capacity - Profile 1 - Total CPU with HA")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+_("Capacity - Profile 1 - Memory Commitment Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+_("Capacity - Profile 1 - Maximum Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+_("Capacity - Profile 1 - Memory Calculation Method")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+_("Capacity - Profile 1 - Minimum Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+_("Capacity - Profile 1 - Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+_("Capacity - Profile 1 - Memory per VM Used in Calculation")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+_("Capacity - Profile 1 - VM Count (combined)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+_("Capacity - Profile 1 - VM Count based on Memory")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+_("Capacity - Profile 1 - VM Count based on vCPU")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+_("Capacity - Profile 1 - Available Memory for New VMs")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+_("Capacity - Profile 1 - Available vCPUs for New VMs")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+_("Capacity - Profile 1 - Available VM Count (combined)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+_("Capacity - Profile 1 - Available VM Count based on Memory")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+_("Capacity - Profile 1 - Available VM Count based on vCPU")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+_("Capacity - Profile 1 - vCPU Commitment Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+_("Capacity - Profile 1 - Maximum vCPU per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+_("Capacity - Profile 1 - vCPU Calculation Method")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+_("Capacity - Profile 1 - Minimum vCPU per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+_("Capacity - Profile 1 - Number of vCPUs per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+_("Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+_("Capacity - Profile 2 - Memory Effective with HA")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+_("Capacity - Profile 2 - CPU Effective with HA (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+_("Capacity - Profile 2 - Memory Commitment Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+_("Capacity - Profile 2 - Maximum Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+_("Capacity - Profile 2 - Memory Calculation Method")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+_("Capacity - Profile 2 - Minimum Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+_("Capacity - Profile 2 - Memory per VM")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+_("Capacity - Profile 2 - Memory per VM Used in Calculation")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+_("Capacity - Profile 2 - VM Count (combined)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+_("Capacity - Profile 2 - VM Count based on Memory")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+_("Capacity - Profile 2 - VM Count based on vCPU")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+_("Capacity - Profile 2 - Available Memory for New VMs")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+_("Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+_("Capacity - Profile 2 - Available VM Count (combined)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+_("Capacity - Profile 2 - Available VM Count based on Memory")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+_("Capacity - Profile 2 - Available VM Count based on vCPU")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+_("Capacity - Profile 2 - vCPU Commitment Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+_("Capacity - Profile 2 - Maximum vCPU per VM (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+_("Capacity - Profile 2 - vCPU Calculation Method")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+_("Capacity - Profile 2 - Minimum vCPU per VM (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+_("Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+_("Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+_("Memory - Conservative Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+_("Memory - Conservative Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+_("Memory - Conservative Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+_("CPU - Conservative Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+_("CPU - Conservative Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+_("CPU - Conservative Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+_("Created on Time")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+_("Memory - Moderate Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+_("Memory - Moderate Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+_("Memory - Moderate Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+_("CPU - Moderate Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+_("CPU - Moderate Recommendation Savings")
+# TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+_("CPU - Moderate Recommendation Savings (%)")
+# TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+_("Memory - Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+_("CPU - Recommendation")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+_("Usage (Other) - Time for Other Block Protocol Operations Avg")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+_("Usage (Other) - Time for Other Block Protocol Operations Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+_("Usage (Other) - Time for Other Block Protocol Operations Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+_("Usage (Block Protocol) - Number of Other Operations per Second")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+_("Usage (Block Protocol) - Number of Other Operations per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+_("Usage (Block Protocol) - Number of Other Operations per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_data
+_("Usage (Block Protocol) - Bytes Read per Second")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+_("Usage (Block Protocol) - Bytes Read per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+_("Usage (Block Protocol) - Bytes Read per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+_("Usage (Block Protocol) - Time for Reads Avg")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+_("Usage (Block Protocol) - Time for Reads Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+_("Usage (Block Protocol) - Time for Reads Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+_("Usage (Block Protocol) - Number of Reads per Second")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+_("Usage (Block Protocol) - Number of Reads per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+_("Usage (Block Protocol) - Number of Reads per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_data
+_("Usage (Block Protocol) - Bytes Written per Second")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+_("Usage (Block Protocol) - Bytes Written per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+_("Usage (Block Protocol) - Bytes Written per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+_("Usage (Block Protocol) - Time for Writes Avg")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+_("Usage (Block Protocol) - Time for Writes Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+_("Usage (Block Protocol) - Time for Writes Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+_("Usage (Block Protocol) - Number of Writes per Second")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+_("Usage (Block Protocol) - Number of Writes per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+_("Usage (Block Protocol) - Number of Writes per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.slope
+_("Slope")
+# TRANSLATORS: en.yml key: dictionary.column.src_host_name
+_("Source Host Name")
+# TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+_("Source VM Location")
+# TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+_("Source VM Name")
+# TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+_("SSH Root Access")
+# TRANSLATORS: en.yml key: dictionary.column.start_trend_value
+_("Start")
+# TRANSLATORS: en.yml key: dictionary.column.svc_type
+_("Service Type")
+# TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+_("Asset - Uptime (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+_("Thin Provisioned")
+# TRANSLATORS: en.yml key: dictionary.column.timestamp
+_("Activity Sample - Timestamp (Day/Time)")
+# TRANSLATORS: en.yml key: dictionary.column.total_ops
+_("Usage (All) - Number of Operations per Second")
+# TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+_("Usage (All) - Number of Operations per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+_("Usage (All) - Number of Operations per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+_("CPU Average Used MHz Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+_("Memory Average Used Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+_("CPU Max Used MHz Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+_("Memory Max Used Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+_("Disk I/O Max Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+_("Network I/O Max Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+_("Disk Space Max Trend")
+# TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+_("Disk Space Average Trend")
+# TRANSLATORS: en.yml key: dictionary.column.typename
+_("Type Name")
+# TRANSLATORS: en.yml key: dictionary.column.uid
+_("UID")
+# TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+_("Uncommitted Space")
+# TRANSLATORS: en.yml key: dictionary.column.updated_at
+_("Date Updated")
+# TRANSLATORS: en.yml key: dictionary.column.updated_on
+_("Date Updated")
+# TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+_("Total Used Disk Space")
+# TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+_("Percent Used Provisioned Space")
+# TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+_("Currently Used Space")
+# TRANSLATORS: en.yml key: dictionary.column.v_arch
+_("Architecture")
+# TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+_("CPU Cores Virtual to Real Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+_("Datastore Path")
+# TRANSLATORS: en.yml key: dictionary.column.v_date
+_("Activity Sample - Day (MM DD YY)")
+# TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+_("Non-VM Files Percent of Used")
+# TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+_("Capacity - Used Space (B)")
+# TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
+_("Direct VMs")
+# TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+_("Disk Files Percent of Used")
+# TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+_("Free Space Percent of Total")
+# TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+_("Parent Host Platform")
+# TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+_("Is a Template")
+# TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+_("VM Memory Files Percent of Used")
+# TRANSLATORS: en.yml key: dictionary.column.v_message
+_("Message")
+# TRANSLATORS: en.yml key: dictionary.column.v_month
+_("Activity Sample - Month (YYYY/MM)")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+_("Parent Folder (VMs & Templates)")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+_("Parent Folder Path (VMs & Templates)")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+_("Parent Cluster")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+_("Parent Datacenter")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+_("Parent Folder (Hosts & Clusters)")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+_("Parent Folder Path (Hosts & Clusters)")
+# TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+_("Parent Resource Pool")
+# TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+_("Parent Cluster")
+# TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+_("Parent Datacenter")
+# TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+_("Parent Folder")
+# TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+_("Parent Host")
+# TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+_("Parent Resource Pool")
+# TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+_("CPU - % Ready")
+# TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+_("CPU - % Used")
+# TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+_("CPU - % Wait")
+# TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+_("Pct Free Disk")
+# TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+_("Provisioned Space Percent of Total")
+# TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+_("Cluster in Datacenter")
+# TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+_("Memory Virtual to Real Ratio")
+# TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
+_("Size")
+# TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+_("Snapshot Files Percent of Used")
+# TRANSLATORS: en.yml key: dictionary.column.v_time
+_("Activity Sample - Time (HH MM SS)")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+_("Size of Non-VM Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+_("Size of VM Provisioned Disk Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+_("Total Hosts")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+_("Size of VM Memory Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+_("Total Provisioned Space")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+_("Size of VM Snapshot Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+_("Total Snapshots")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+_("Total Datastores")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+_("Size of Other VM Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+_("Size of VM Memory Files")
+# TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+_("Total VMs")
+# TRANSLATORS: en.yml key: dictionary.column.v_used_space
+_("Used Space")
+# TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+_("Used Space Percent of Total")
+# TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+_("Other VM Files Percent of Used")
+# TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+_("Virtual Hardware Version")
+# TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+_("VMM Build Number")
+# TRANSLATORS: en.yml key: dictionary.column.vmm_product
+_("VMM Platform")
+# TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+_("VMM Vendor")
+# TRANSLATORS: en.yml key: dictionary.column.vmm_version
+_("VMM Version")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+_("VMsafe Agent Address")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+_("VMsafe Agent Port")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+_("VMsafe Enable")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+_("VMsafe Fail Open")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+_("VMsafe Immutable VM")
+# TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+_("VMsafe Timeout (ms)")
+# TRANSLATORS: en.yml key: dictionary.column.write_data
+_("Usage (All) - Bytes Written per Second")
+# TRANSLATORS: en.yml key: dictionary.column.write_data_max
+_("Usage (All) - Bytes Written per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.write_data_min
+_("Usage (All) - Bytes Written per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.write_latency
+_("Usage (All) - Time for Writes Avg")
+# TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+_("Usage (All) - Time for Writes Avg Max")
+# TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+_("Usage (All) - Time for Writes Avg Min")
+# TRANSLATORS: en.yml key: dictionary.column.write_ops
+_("Usage (All) - Number of Writes per Second")
+# TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+_("Usage (All) - Number of Writes per Second Max")
+# TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+_("Usage (All) - Number of Writes per Second Min")
+# TRANSLATORS: en.yml key: dictionary.column.ws_port
+_("Web Services Port")
+# TRANSLATORS: en.yml key: dictionary.column.zone_name
+_("EVM Zone")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+_("vCPUs Allocated Cost")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+_("vCPUs Allocated over Time Period")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+_("CPU Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+_("CPU Total")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+_("CPU Used Cost")
+# TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+_("CPU Used")
+# TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+_("Disk I/O Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+_("Disk I/O Total")
+# TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+_("Disk I/O Used Cost")
+# TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+_("Disk I/O Used")
+# TRANSLATORS: en.yml key: dictionary.column.display_range
+_("Date Range")
+# TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+_("Fixed Compute Cost 1")
+# TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+_("Fixed Compute Cost 2")
+# TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+_("Fixed Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+_("Fixed Storage Cost 1")
+# TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+_("Fixed Storage Cost 2")
+# TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+_("Memory Allocated Cost")
+# TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+_("Memory Allocated over Time Period")
+# TRANSLATORS: en.yml key: dictionary.column.memory_cost
+_("Memory Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.memory_metric
+_("Memory Total")
+# TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+_("Memory Used Cost")
+# TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+_("Memory Used")
+# TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+_("Network I/O Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+_("Network I/O Total")
+# TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+_("Network I/O Used Cost")
+# TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+_("Network I/O Used")
+# TRANSLATORS: en.yml key: dictionary.column.owner_name
+_("Owner")
+# TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+_("Storage Allocated Cost")
+# TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+_("Storage Allocated")
+# TRANSLATORS: en.yml key: dictionary.column.storage_cost
+_("Storage Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.storage_metric
+_("Storage Total")
+# TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+_("Storage Used Cost")
+# TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+_("Storage Used")
+# TRANSLATORS: en.yml key: dictionary.column.total_cost
+_("Total Cost")
+# TRANSLATORS: en.yml key: dictionary.column.vm_name
+_("VM Name")
+# TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+_("Average Read Size")
+# TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+_("Average Write Size")
+# TRANSLATORS: en.yml key: dictionary.column.interval
+_("Interval")
+# TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+_("Read (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+_("Transferred (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+_("Written (KBps)")
+# TRANSLATORS: en.yml key: dictionary.column.pct_hit
+_("Hit %")
+# TRANSLATORS: en.yml key: dictionary.column.pct_read
+_("Read %")
+# TRANSLATORS: en.yml key: dictionary.column.pct_write
+_("Write %")
+# TRANSLATORS: en.yml key: dictionary.column.queue_depth
+_("Queue Depth")
+# TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+_("Read Hit (IOPS)")
+# TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+_("Read (IOPS)")
+# TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+_("Response Time (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+_("Service Time (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.statistic_time
+_("Activity Sample - Timestamp (Day/Time)")
+# TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+_("Total (IOPS)")
+# TRANSLATORS: en.yml key: dictionary.column.utilization
+_("Utilization %")
+# TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+_("Activity Sample - Day (MM DD YY)")
+# TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+_("Activity Sample - Time (HH MM SS)")
+# TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+_("Wait Time (Seconds)")
+# TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+_("Write Hit (IOPS)")
+# TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+_("Write (IOPS)")
+# TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+_("EVM Audit Event")
+# TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+_("EVM Audit Events")
+# TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+_("Availability Zone")
+# TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+_("Availability Zones")
+# TRANSLATORS: en.yml key: dictionary.model.Chargeback
+_("Chargeback")
+# TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+_("Chargebacks")
+# TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+_("Chargeback Rate")
+# TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+_("Chargeback Rates")
+# TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+_("Storage - Extent")
+# TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+_("Storage - Extents")
+# TRANSLATORS: en.yml key: dictionary.model.Classification
+_("Category")
+# TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
+_("Categories")
+# TRANSLATORS: en.yml key: dictionary.model.Compliance
+_("Compliance History")
+# TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+_("Compliance Histories")
+# TRANSLATORS: en.yml key: dictionary.model.Compliances
+_("Compliance History")
+# TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+_("Compliance Histories")
+# TRANSLATORS: en.yml key: dictionary.model.Condition
+_("Condition")
+# TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
+_("Conditions")
+# TRANSLATORS: en.yml key: dictionary.model.CustomButton
+_("Button")
+# TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+_("Buttons")
+# TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+_("Buttons Group")
+# TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+_("Buttons Groups")
+# TRANSLATORS: en.yml key: dictionary.model.Container
+_("Container")
+# TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+_("Containers")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+_("Pod")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+_("Pods")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+_("Image Registry")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+_("Image Registries")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+_("Image")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+_("Images")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+_("Node")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+_("Nodes")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+_("Project")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+_("Projects")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+_("Route")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+_("Routes")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+_("Replicator")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+_("Replicators")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerService
+_("Service")
+# TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+_("Services")
+# TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+_("Cluster / Deployment Role")
+# TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+_("Cluster / Deployment Roles")
+# TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+_("Performance - Cluster")
+# TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+_("Performance - Clusters")
+# TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+_("Management Event")
+# TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+_("Management Events")
+# TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+_("Folder")
+# TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+_("Folders")
+# TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+_("Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+_("Providers")
+# TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+_("Performance - Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+_("Performance - Providers")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+_("FTP")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+_("FTPs")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+_("Anonymous FTP")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+_("Anonymous FTPs")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+_("NFS")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+_("Samba")
+# TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+_("Sambas")
+# TRANSLATORS: en.yml key: dictionary.model.Filesystem
+_("File")
+# TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+_("Files")
+# TRANSLATORS: en.yml key: dictionary.model.Flavor
+_("Flavor")
+# TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+_("Flavors")
+# TRANSLATORS: en.yml key: dictionary.model.Host
+_("Host / Node")
+# TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+_("Host / Nodes")
+# TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+_("Performance - Host")
+# TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+_("Performance - Hosts")
+# TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+_("ISO Datastore")
+# TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+_("ISO Datastores")
+# TRANSLATORS: en.yml key: dictionary.model.IsoImage
+_("ISO Image")
+# TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+_("ISO Images")
+# TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+_("LDAP Domain")
+# TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+_("LDAP Domains")
+# TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+_("LDAP Region")
+# TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+_("LDAP Regions")
+# TRANSLATORS: en.yml key: dictionary.model.LdapServer
+_("LDAP Server")
+# TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+_("LDAP Servers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
+_("Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
+_("Providers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+_("Configuration Manager")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+_("Configuration Managers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+_("Foreman Configured System")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+_("Foreman Configured Systems")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+_("Cloud Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+_("Cloud Providers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+_("Instance")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+_("Instances")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+_("Image")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+_("Images")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+_("Containers Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+_("Containers Providers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+_("Infrastructure Provider")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+_("Infrastructure Providers")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+_("Virtual Machine")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+_("Virtual Machines")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+_("Template")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+_("Templates")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+_("Infrastructure Provider (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+_("Infrastructure Providers (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+_("Infrastructure Provider (Microsoft)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+_("Infrastructure Providers (Microsoft)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+_("Infrastructure Provider (Redhat)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+_("Infrastructure Providers (Redhat)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+_("Infrastructure Provider (Vmware)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+_("Infrastructure Providers (Vmware)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+_("Cloud Provider (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+_("Cloud Providers (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+_("Cloud Provider (Amazon)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+_("Cloud Providers (Amazon)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+_("Cloud Provider (Microsoft Azure)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+_("Cloud Providers (Microsoft Azure)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+_("Container Provider (Atomic)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+_("Container Providers (Atomic)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+_("Container Provider (Kubernetes)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+_("Container Providers (Kubernetes)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+_("Container Provider (Openshift)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+_("Container Providers (Openshift)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+_("Container Provider (Openshift Enterprise)")
+# TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+_("Container Providers (Openshift Enterprise)")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAction
+_("Action")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
+_("Actions")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+_("Automate Class")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+_("Automate Classes")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+_("Automate Domain")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+_("Automate Domains")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+_("Automate Instance")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+_("Automate Instances")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+_("Automate Method")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+_("Automate Methods")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+_("Automate Namespace")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+_("Automate Namespaces")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+_("Alert")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
+_("Alerts")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+_("Alert Profile")
+# TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
+_("Alert Profiles")
+# TRANSLATORS: en.yml key: dictionary.model.MiqDialog
+_("Dialog")
+# TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+_("Dialogs")
+# TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
+_("Enterprise")
+# TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+_("Enterprises")
+# TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+_("Event")
+# TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+_("Events")
+# TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+_("EVM Group")
+# TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+_("EVM Groups")
+# TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
+_("Policy")
+# TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
+_("Policies")
+# TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+_("Policy Profile")
+# TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
+_("Policy Profiles")
+# TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+_("Provision")
+# TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+_("Provisions")
+# TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+_("SmartProxy")
+# TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+_("SmartProxies")
+# TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+_("Region")
+# TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+_("Regions")
+# TRANSLATORS: en.yml key: dictionary.model.MiqReport
+_("Report")
+# TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
+_("Reports")
+# TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+_("Request")
+# TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+_("Requests")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+_("Schedule")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+_("Schedules")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+_("Search")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+_("Searches")
+# TRANSLATORS: en.yml key: dictionary.model.MiqServer
+_("Server")
+# TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+_("Servers")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+_("SMI-S Agent")
+# TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+_("SMI-S Agents")
+# TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+_("VM Template and Image")
+# TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+_("VM Template and Images")
+# TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
+_("Role")
+# TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+_("Roles")
+# TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+_("Widget")
+# TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
+_("Widgets")
+# TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+_("EVM Worker")
+# TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+_("EVM Workers")
+# TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+_("NetApp Remote Service")
+# TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+_("NetApp Remote Services")
+# TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+_("Storage - Aggregate")
+# TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+_("Storage - Aggregates")
+# TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+_("Storage - File Share")
+# TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+_("Storage - File Shares")
+# TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+_("Storage - Volume")
+# TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+_("Storage - Volumes")
+# TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+_("Storage - Plex")
+# TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+_("Storage - Plexes")
+# TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+_("Storage - Raid Group")
+# TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+_("Storage - Raid Groups")
+# TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+_("Storage - Filer")
+# TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+_("Storage - Filers")
+# TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+_("Storage - LUN")
+# TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+_("Storage - LUNs")
+# TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+_("Storage Performance - Volumes")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+_("Orchestration Template")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+_("Orchestration Templates")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+_("CloudFormation Template")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+_("CloudFormation Templates")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+_("Heat Template")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+_("Heat Templates")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+_("Azure Template")
+# TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+_("Azure Templates")
+# TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+_("Product Update")
+# TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+_("Product Updates")
+# TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+_("Customization Template")
+# TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+_("Customization Templates")
+# TRANSLATORS: en.yml key: dictionary.model.PxeImage
+_("PXE Image")
+# TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
+_("PXE Images")
+# TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+_("System Image Type")
+# TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+_("System Image Types")
+# TRANSLATORS: en.yml key: dictionary.model.PxeServer
+_("PXE Server")
+# TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+_("PXE Servers")
+# TRANSLATORS: en.yml key: dictionary.model.ResourcePool
+_("Resource Pool")
+# TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+_("Resource Pools")
+# TRANSLATORS: en.yml key: dictionary.model.ScanItem
+_("Scan Item")
+# TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+_("Scan Items")
+# TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
+_("Analysis Profile")
+# TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
+_("Analysis Profiles")
+# TRANSLATORS: en.yml key: dictionary.model.Service
+_("Service")
+# TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+_("Services")
+# TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+_("Service Catalog Item")
+# TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+_("Service Catalog Items")
+# TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+_("Catalog")
+# TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+_("Catalogs")
+# TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+_("Storage - Local File System")
+# TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+_("Storage - Local File Systems")
+# TRANSLATORS: en.yml key: dictionary.model.Storage
+_("Datastore")
+# TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+_("Datastores")
+# TRANSLATORS: en.yml key: dictionary.model.StorageFile
+_("Datastore File")
+# TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+_("Datastore Files")
+# TRANSLATORS: en.yml key: dictionary.model.StorageManager
+_("Storage Manager")
+# TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
+_("Storage Managers")
+# TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+_("Performance - Datastore")
+# TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+_("Performance - Datastores")
+# TRANSLATORS: en.yml key: dictionary.model.TimeProfile
+_("Time Profile")
+# TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
+_("Time Profiles")
+# TRANSLATORS: en.yml key: dictionary.model.User
+_("EVM User")
+# TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+_("EVM Users")
+# TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+_("Performance Trend")
+# TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+_("Performance Trends")
+# TRANSLATORS: en.yml key: dictionary.model.Vm
+_("VM and Instance")
+# TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+_("VM and Instances")
+# TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+_("VMDB Table")
+# TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+_("VMDB Tables")
+# TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+_("VM or Template")
+# TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+_("VM or Templates")
+# TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+_("Performance - VM")
+# TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+_("Performance - VMs")
+# TRANSLATORS: en.yml key: dictionary.model.Zone
+_("Zone")
+# TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+_("Zones")
+# TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
+_("Key Pair")
+# TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+_("Key Pairs")
+# TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
+_("Key Pairs")
+# TRANSLATORS: en.yml key: dictionary.table.availability_zone
+_("Availability Zone")
+# TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
+_("Availability Zones")
+# TRANSLATORS: en.yml key: dictionary.table.cdroms
+_("CD/DVD Drives")
+# TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+_("Base Extents")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+_("Cloud Volume")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+_("Cloud Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+_("Cloud Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.compliance_details
+_("Details")
+# TRANSLATORS: en.yml key: dictionary.table.compliances
+_("Compliance History")
+# TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+_("Compliance Histories")
+# TRANSLATORS: en.yml key: dictionary.table.container
+_("Container")
+# TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+_("Containers")
+# TRANSLATORS: en.yml key: dictionary.table.containers
+_("Containers")
+# TRANSLATORS: en.yml key: dictionary.table.container_group
+_("Pod")
+# TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+_("Pods")
+# TRANSLATORS: en.yml key: dictionary.table.container_groups
+_("Pods")
+# TRANSLATORS: en.yml key: dictionary.table.container_replicator
+_("Replicator")
+# TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+_("Replicators")
+# TRANSLATORS: en.yml key: dictionary.table.container_replicators
+_("Replicators")
+# TRANSLATORS: en.yml key: dictionary.table.container_image
+_("Image")
+# TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+_("Images")
+# TRANSLATORS: en.yml key: dictionary.table.container_images
+_("Images")
+# TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+_("Image Registry")
+# TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+_("Image Registries")
+# TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+_("Image Registries")
+# TRANSLATORS: en.yml key: dictionary.table.container_node
+_("Node")
+# TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+_("Nodes")
+# TRANSLATORS: en.yml key: dictionary.table.container_nodes
+_("Nodes")
+# TRANSLATORS: en.yml key: dictionary.table.container_service
+_("Service")
+# TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+_("Services")
+# TRANSLATORS: en.yml key: dictionary.table.container_services
+_("Services")
+# TRANSLATORS: en.yml key: dictionary.table.container_route
+_("Route")
+# TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+_("Routes")
+# TRANSLATORS: en.yml key: dictionary.table.container_routes
+_("Routes")
+# TRANSLATORS: en.yml key: dictionary.table.container_project
+_("Project")
+# TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+_("Projects")
+# TRANSLATORS: en.yml key: dictionary.table.container_projects
+_("Projects")
+# TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+_("Volume")
+# TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+_("Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+_("Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.custom_button
+_("Button")
+# TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
+_("Buttons")
+# TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+_("Buttons Group")
+# TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+_("Buttons Groups")
+# TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+_("Cloud Provider")
+# TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+_("Cloud Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+_("Cloud Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_cluster
+_("Cluster / Deployment Role")
+# TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+_("Cluster / Deployment Roles")
+# TRANSLATORS: en.yml key: dictionary.table.ems_clusters
+_("Clusters / Deployment Roles")
+# TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+_("VC Custom Attribute")
+# TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+_("VC Custom Attributes")
+# TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
+_("VC Custom Attributes")
+# TRANSLATORS: en.yml key: dictionary.table.ems_event
+_("Management Event")
+# TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+_("Management Events")
+# TRANSLATORS: en.yml key: dictionary.table.ems_events
+_("Management Events")
+# TRANSLATORS: en.yml key: dictionary.table.ems_folder
+_("Folder")
+# TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+_("Folders")
+# TRANSLATORS: en.yml key: dictionary.table.ems_folders
+_("Folders")
+# TRANSLATORS: en.yml key: dictionary.table.ems_infra
+_("Infrastructure Provider")
+# TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+_("Infrastructure Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_infras
+_("Infrastructure Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_container
+_("Containers Provider")
+# TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+_("Containers Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_containers
+_("Containers Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+_("Middleware Provider")
+# TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+_("Middleware Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+_("Middleware Providers")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_server
+_("Middleware Server")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+_("Middleware Servers")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_servers
+_("Middleware Servers")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+_("Middleware Deployment")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+_("Middleware Deployments")
+# TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+_("Middleware Deployments")
+# TRANSLATORS: en.yml key: dictionary.table.evm_owner
+_("EVM Owner")
+# TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+_("EVM Owners")
+# TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+_("Cloud/Infrastructure Provider")
+# TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+_("Cloud/Infrastructure Providers")
+# TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+_("Cloud/Infrastructure Providers")
+# TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+_("File System Drivers")
+# TRANSLATORS: en.yml key: dictionary.table.filesystems
+_("Files")
+# TRANSLATORS: en.yml key: dictionary.table.flavor
+_("Flavor")
+# TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+_("Flavors")
+# TRANSLATORS: en.yml key: dictionary.table.flavors
+_("Flavors")
+# TRANSLATORS: en.yml key: dictionary.table.floppies
+_("Floppy Drives")
+# TRANSLATORS: en.yml key: dictionary.table.guest_devices
+_("Devices")
+# TRANSLATORS: en.yml key: dictionary.table.host
+_("Host / Node")
+# TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+_("Host / Nodes")
+# TRANSLATORS: en.yml key: dictionary.table.hosts
+_("Hosts / Nodes")
+# TRANSLATORS: en.yml key: dictionary.table.host_services
+_("Services")
+# TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+_("ISO Datastore")
+# TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+_("ISO Datastores")
+# TRANSLATORS: en.yml key: dictionary.table.iso_image
+_("ISO Image")
+# TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
+_("ISO Images")
+# TRANSLATORS: en.yml key: dictionary.table.lans
+_("vLANs")
+# TRANSLATORS: en.yml key: dictionary.table.last_compliance
+_("Last Compliance History")
+# TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+_("Last Compliance Histories")
+# TRANSLATORS: en.yml key: dictionary.table.ldap
+_("LDAP")
+# TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+_("LDAPs")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+_("LDAP Domain")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
+_("LDAP Domains")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_region
+_("LDAP Region")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
+_("LDAP Regions")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_server
+_("LDAP Server")
+# TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
+_("LDAP Servers")
+# TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+_("Linux Init Processes")
+# TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+_("Stamped Approvals")
+# TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+_("Approvals")
+# TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+_("EVM Custom Attribute")
+# TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+_("EVM Custom Attributes")
+# TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+_("EVM Custom Attributes")
+# TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+_("Event")
+# TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
+_("Events")
+# TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+_("Configuration Profile (Foreman)")
+# TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+_("Configuration Profiles (Foreman)")
+# TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+_("Cloud Networks (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+_("Cloud Tenants (Openstack)")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provision
+_("Provision")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+_("Provisions")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+_("Provisioned From Template")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+_("Provisioned From Templates")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
+_("Provisioned VMs")
+# TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+_("Provisions")
+# TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+_("SmartProxy Builds")
+# TRANSLATORS: en.yml key: dictionary.table.miq_region
+_("Region")
+# TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+_("Regions")
+# TRANSLATORS: en.yml key: dictionary.table.miq_regions
+_("Regions")
+# TRANSLATORS: en.yml key: dictionary.table.miq_request
+_("Request")
+# TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+_("Requests")
+# TRANSLATORS: en.yml key: dictionary.table.miq_requests
+_("Requests")
+# TRANSLATORS: en.yml key: dictionary.table.miq_schedules
+_("Schedules")
+# TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+_("SCSI LUNs")
+# TRANSLATORS: en.yml key: dictionary.table.miq_server
+_("Server")
+# TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+_("Servers")
+# TRANSLATORS: en.yml key: dictionary.table.miq_servers
+_("Servers")
+# TRANSLATORS: en.yml key: dictionary.table.miq_task
+_("Task")
+# TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
+_("Tasks")
+# TRANSLATORS: en.yml key: dictionary.table.miq_template
+_("VM Template")
+# TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+_("VM Templates")
+# TRANSLATORS: en.yml key: dictionary.table.miq_worker
+_("EVM Worker")
+# TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+_("EVM Workers")
+# TRANSLATORS: en.yml key: dictionary.table.miq_workers
+_("EVM Workers")
+# TRANSLATORS: en.yml key: dictionary.table.nics
+_("Network Adapters")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+_("Storage - Aggregates")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+_("File Shares")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+_("Storage - File Shares")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
+_("Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+_("Storage - Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+_("Storage - Plexes")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+_("Storage - Raid Groups")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+_("Filers")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+_("Storage - Filers")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+_("LUNs")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+_("Storage - LUNs")
+# TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+_("Storage Performance - Volumes")
+# TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+_("Stack")
+# TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
+_("Stacks")
+# TRANSLATORS: en.yml key: dictionary.table.orchestration_template
+_("Orchestration Template")
+# TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
+_("Orchestration Templates")
+# TRANSLATORS: en.yml key: dictionary.table.operating_system
+_("OS")
+# TRANSLATORS: en.yml key: dictionary.table.registry_items
+_("Registry")
+# TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
+_("Registries")
+# TRANSLATORS: en.yml key: dictionary.table.resource_pools
+_("Resource Pools")
+# TRANSLATORS: en.yml key: dictionary.table.server_builds
+_("EVM Builds")
+# TRANSLATORS: en.yml key: dictionary.table.service_template
+_("Catalog Item")
+# TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
+_("Catalog Items")
+# TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
+_("Catalog")
+# TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
+_("Catalogs")
+# TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+_("Storage - Local File Systems")
+# TRANSLATORS: en.yml key: dictionary.table.storage
+_("Datastore")
+# TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+_("Datastores")
+# TRANSLATORS: en.yml key: dictionary.table.storage_file
+_("Datastore File")
+# TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+_("Datastore Files")
+# TRANSLATORS: en.yml key: dictionary.table.storage_files
+_("Datastore Files")
+# TRANSLATORS: en.yml key: dictionary.table.storages
+_("Datastores")
+# TRANSLATORS: en.yml key: dictionary.table.switches
+_("vSwitches")
+# TRANSLATORS: en.yml key: dictionary.table.template_cloud
+_("Image")
+# TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
+_("Images")
+# TRANSLATORS: en.yml key: dictionary.table.template_infra
+_("Template")
+# TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
+_("Templates")
+# TRANSLATORS: en.yml key: dictionary.table.vm
+_("VM and Instance")
+# TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+_("VM and Instances")
+# TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+_("Instance")
+# TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+_("Instances")
+# TRANSLATORS: en.yml key: dictionary.table.vm_clouds
+_("Instances")
+# TRANSLATORS: en.yml key: dictionary.table.vm_infra
+_("Virtual Machine")
+# TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+_("Virtual Machines")
+# TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+_("Virtual Machine")
+# TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
+_("Virtual Machines")
+# TRANSLATORS: en.yml key: dictionary.table.vms
+_("VMs")
+# TRANSLATORS: en.yml key: dictionary.table.zone
+_("Zone")
+# TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+_("Zones")
+# TRANSLATORS: en.yml key: dictionary.table.zones
+_("Zones")

--- a/config/locales/en/manageiq.po
+++ b/config/locales/en/manageiq.po
@@ -19,6 +19,7 @@ msgstr ""
 msgid "CPU"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
 msgid "Memory"
 msgstr ""
 
@@ -46,30 +47,58 @@ msgstr ""
 msgid "Network Utilization Trends"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
 msgid "Providers"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_nodes
 msgid "Nodes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.containers
 msgid "Containers"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
 msgid "Registries"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_projects
 msgid "Projects"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_groups
 msgid "Pods"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_services
+#. TRANSLATORS: en.yml key: dictionary.table.host_services
 msgid "Services"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_images
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
 msgid "Images"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_routes
 msgid "Routes"
 msgstr ""
 
@@ -214,9 +243,11 @@ msgstr ""
 msgid "Second"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.compliance_details
 msgid "Details"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_message
 msgid "Message"
 msgstr ""
 
@@ -475,6 +506,7 @@ msgstr ""
 msgid "%{model}: %{task} successfully initiated"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.hosts
 msgid "Hosts / Nodes"
 msgstr ""
 
@@ -741,6 +773,7 @@ msgstr ""
 msgid "* You are not authorized to view %{children} on this %{model}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
 msgid "Key Pair"
 msgstr ""
 
@@ -968,6 +1001,7 @@ msgstr ""
 msgid "Default Filters"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
 msgid "Time Profiles"
 msgstr ""
 
@@ -1074,6 +1108,8 @@ msgstr ""
 msgid "%s (All cloud tenants present on this host)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.filesystems
 msgid "Files"
 msgstr ""
 
@@ -1095,6 +1131,8 @@ msgstr ""
 msgid "Credentials/Settings saved successfully"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
 msgid "Middleware Servers"
 msgstr ""
 
@@ -1205,9 +1243,13 @@ msgstr ""
 msgid "%{typ} Button Group \"Unassigned Buttons\""
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Host
+#. TRANSLATORS: en.yml key: dictionary.table.host
 msgid "Host / Node"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
 msgid "Cluster / Deployment Role"
 msgstr ""
 
@@ -1294,6 +1336,9 @@ msgstr ""
 msgid "%{val} missing for %{field}"
 msgstr ""
 
+msgid "At least one VM Option must be selected"
+msgstr ""
+
 msgid "No Utilization data available to generate planning results"
 msgstr ""
 
@@ -1303,13 +1348,25 @@ msgstr ""
 msgid "Planning options have been reset by the user"
 msgstr ""
 
-msgid "Best Fit %s"
+msgid "Best Fit Hosts"
 msgstr ""
 
-msgid "%s cancelled by user"
+msgid "Best Fit Clusters"
 msgstr ""
 
-msgid "At least %{num} %{model} must be selected for %{action}"
+msgid "Export cancelled by user"
+msgstr ""
+
+msgid "Error during export: %{error_message}"
+msgstr ""
+
+msgid "Error during 'Policy Import': %{messages}"
+msgstr ""
+
+msgid "Error during upload: %{messages}"
+msgstr ""
+
+msgid "Import cancelled by user"
 msgstr ""
 
 msgid "Import not available due to conflicts"
@@ -1318,67 +1375,158 @@ msgstr ""
 msgid "Press commit to Import"
 msgstr ""
 
-msgid "%s no longer exists"
+msgid "All %{items}"
+msgstr ""
+
+msgid "All %{models}"
+msgstr ""
+
+msgid "Adding a new %{record}"
 msgstr ""
 
 msgid "All %{typ} %{model}"
 msgstr ""
 
-msgid " %s Assignments"
+msgid "Adding a new %{model_name} %{mode} Policy"
 msgstr ""
 
-msgid "Select only one or consecutive %s to move up"
+msgid "Adding a new %{model_name} Policy"
 msgstr ""
 
-msgid "Select only one or consecutive %s to move down"
+msgid " %{model} Assignments"
 msgstr ""
 
-msgid "No %s selected to set to Synchronous"
+msgid "Adding a new %{model}"
 msgstr ""
 
-msgid "No %s selected to set to Asynchronous"
+msgid "Editing %{model} Condition \"%{name}\""
 msgstr ""
 
+msgid "%{model} Condition \"%{name}\""
+msgstr ""
+
+msgid "Adding a new %{alerts}"
+msgstr ""
+
+msgid "No %{member} were selected to move right"
+msgstr ""
+
+msgid "No %{member} were selected to move left"
+msgstr ""
+
+msgid "Select only one or consecutive %{member} to move up"
+msgstr ""
+
+msgid "Select only one or consecutive %{member} to move down"
+msgstr ""
+
+msgid "No %{member} selected to set to Synchronous"
+msgstr ""
+
+msgid "No %{member} selected to set to Asynchronous"
+msgstr ""
+
+msgid "Host is required"
+msgstr ""
+
+msgid "Trap Number is required"
+msgstr ""
+
+msgid "Trap Object ID is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
 msgid "Policy Profiles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
 msgid "Policies"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
 msgid "Events"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
 msgid "Conditions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
 msgid "Actions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
 msgid "Alert Profiles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
 msgid "Alerts"
 msgstr ""
 
 msgid "%{model} must contain at least one %{field}"
 msgstr ""
 
+msgid "Error during 'Alert Profile %{params}': "
+msgstr ""
+
+msgid "Edit %{model} assignments cancelled by user"
+msgstr ""
+
+msgid "A Tag Category must be selected"
+msgstr ""
+
 msgid "At least one Selection must be checked"
 msgstr ""
 
-msgid "Alert Profile \"%s\" assignments succesfully saved"
+msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
 msgstr ""
 
-msgid "The selected %s was deleted"
+msgid "%{model} no longer exists"
+msgstr ""
+
+msgid "The selected %{model} was deleted"
+msgstr ""
+
+msgid "All %{records}"
+msgstr ""
+
+msgid "Add of new %{models} was cancelled by the user"
+msgstr ""
+
+msgid "%{models} no longer exists"
+msgstr ""
+
+msgid "The selected %{models} was deleted"
+msgstr ""
+
+msgid "Error during alarms: %{messages}"
 msgstr ""
 
 msgid "A valid expression must be present"
 msgstr ""
 
-msgid "%s must be an integer"
+msgid "A Driving Event must be selected"
 msgstr ""
 
-msgid "At least one %s must be configured"
+msgid "Event name is required"
+msgstr ""
+
+msgid "Event to Check is required"
+msgstr ""
+
+msgid "Value Threshold must be an integer"
+msgstr ""
+
+msgid "Trend Steepness must be an integer"
+msgstr ""
+
+msgid ""
+"At least one of E-mail, SNMP Trap, Timeline Event, or Management Event must be"
+" configured"
+msgstr ""
+
+msgid "At least one E-mail recipient must be configured"
 msgstr ""
 
 msgid ""
@@ -1389,13 +1537,55 @@ msgstr ""
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr ""
 
-msgid "Actions for Policy Event \"%s\" were saved"
+msgid "Edit Event cancelled by user"
 msgstr ""
 
-msgid "E-mail address '%s' is not valid"
+msgid "Actions for Policy Event \"%{events}\" were saved"
+msgstr ""
+
+msgid "All %{tables}"
+msgstr ""
+
+msgid "No %{members} were selected to move left"
+msgstr ""
+
+msgid "No %{members} were selected to move right"
+msgstr ""
+
+msgid "Action Type must be selected"
+msgstr ""
+
+msgid "Analysis Profile is required"
+msgstr ""
+
+msgid "Attribute Name is required"
+msgstr ""
+
+msgid "At least one Alert must be selected"
+msgstr ""
+
+msgid "Parent Type must be selected"
+msgstr ""
+
+msgid "At least one Category must be selected"
+msgstr ""
+
+msgid "Snapshot Age must be selected"
+msgstr ""
+
+msgid "E-mail address 'From' is not valid"
+msgstr ""
+
+msgid "E-mail address 'To' is not valid"
+msgstr ""
+
+msgid "At least one Tag must be selected"
 msgstr ""
 
 msgid "%{model} \"%{name}\" already exists"
+msgstr ""
+
+msgid "Error during 'Policy Profile %{params}': %{messages}"
 msgstr ""
 
 msgid "No VMs match the selection criteria"
@@ -1404,7 +1594,10 @@ msgstr ""
 msgid "Policy Simulation generation returned: %{error_message}"
 msgstr ""
 
-msgid "Request %s was cancelled by the user"
+msgid "Request approval was cancelled by the user"
+msgstr ""
+
+msgid "Request denial was cancelled by the user"
 msgstr ""
 
 msgid "Request \"%{name}\" was %{task}"
@@ -1413,7 +1606,16 @@ msgstr ""
 msgid "Error retrieving LDAP info: %{error_message}"
 msgstr ""
 
-msgid "The selected %s were deleted"
+msgid "At least one status must be selected"
+msgstr ""
+
+msgid "The selected %{tables} were deleted"
+msgstr ""
+
+msgid "%{table} no longer exists"
+msgstr ""
+
+msgid "The selected %{table} was deleted"
 msgstr ""
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
@@ -1428,10 +1630,34 @@ msgstr ""
 msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr ""
 
+msgid "%s no longer exists"
+msgstr ""
+
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
 msgid "\"%{record}\": Analysis successfully initiated"
+msgstr ""
+
+msgid "Create Datastore was cancelled by the user"
+msgstr ""
+
+msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
+msgstr ""
+
+msgid "Create Logical Disk was cancelled by the user"
+msgstr ""
+
+msgid "Aggregate is required"
+msgstr ""
+
+msgid "Size is required"
+msgstr ""
+
+msgid "Size must be an integer"
+msgstr ""
+
+msgid "Adding a new Category"
 msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\""
@@ -1443,34 +1669,49 @@ msgstr ""
 msgid "Export generation returned: Status [%{status}] Message [%{message}]"
 msgstr ""
 
-msgid "%s Summary"
+msgid "VMDB Summary"
 msgstr ""
 
-msgid "%s Utilization"
+msgid "VMDB Utilization"
 msgstr ""
 
-msgid "%s Client Connections"
+msgid "VMDB Client Connections"
 msgstr ""
 
-msgid "All %s Indexes"
+msgid "All VMDB Indexes"
 msgstr ""
 
-msgid "%s Settings"
+msgid "VMDB Settings"
 msgstr ""
 
 msgid "Indexes for %{model} \"%{name}\""
 msgstr ""
 
+msgid "VMDB \"%{name}\" Table Utilization"
+msgstr ""
+
+msgid "Error during 'Appliance restart': %{message}"
+msgstr ""
+
 msgid "CFME Appliance restart initiated successfully"
 msgstr ""
 
-msgid "'%s' Worker restart initiated successfully"
+msgid "Error during 'workers restart': %{message}"
+msgstr ""
+
+msgid "'%{type}' Worker restart initiated successfully"
 msgstr ""
 
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr ""
 
+msgid "Error during 'Save': %{message}"
+msgstr ""
+
 msgid "Log Depot Settings were saved"
+msgstr ""
+
+msgid "Error during 'Validate': %{message}"
 msgstr ""
 
 msgid "Log Depot Settings were validated"
@@ -1479,13 +1720,34 @@ msgstr ""
 msgid "End Date cannot be greater than Start Date"
 msgstr ""
 
-msgid "%s successfully initiated"
+msgid "Error during 'C & U Gap Collection': %{message}"
 msgstr ""
 
-msgid "Error during Orphaned Records delete for user %s: "
+msgid "C & U Gap Collection successfully initiated"
 msgstr ""
 
-msgid "Orphaned Records for userid %s were successfully deleted"
+msgid "Error during 'Reset/synchronization process': %{message}"
+msgstr ""
+
+msgid "Reset/synchronization process successfully initiated"
+msgstr ""
+
+msgid "Database Backup successfully initiated"
+msgstr ""
+
+msgid "Error during 'Database Garbage Collection': %{message}"
+msgstr ""
+
+msgid "Database Garbage Collection successfully initiated"
+msgstr ""
+
+msgid "Error during Orphaned Records delete for user %{id}: %{message}"
+msgstr ""
+
+msgid "Orphaned Records for userid %{id} were successfully deleted"
+msgstr ""
+
+msgid "Error during 'Clear Connection Broker cache': %{message}"
 msgstr ""
 
 msgid "Connection Broker cache cleared successfully"
@@ -1505,7 +1767,16 @@ msgstr ""
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr ""
 
-msgid "%s is not allowed for the selected item"
+msgid "Start is not allowed for the selected item"
+msgstr ""
+
+msgid "Start successfully initiated"
+msgstr ""
+
+msgid "Suspend is not allowed for the selected item"
+msgstr ""
+
+msgid "Suspend successfully initiated"
 msgstr ""
 
 msgid "Setting priority is not allowed for the selected item"
@@ -1514,19 +1785,37 @@ msgstr ""
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr ""
 
-msgid "Error when adding a new tenant: "
+msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr ""
+
+msgid "Diagnostics %{model} \"%{name}\""
+msgstr ""
+
+msgid "Error when adding a new tenant: %{message}"
 msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
-msgid "Error when saving tenant quota: "
+msgid "Error when saving tenant quota: %{message}"
 msgstr ""
 
 msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
+msgid "User no longer exists"
+msgstr ""
+
+msgid "Role no longer exists"
+msgstr ""
+
 msgid "Default %{model} \"%{name}\" can not be deleted"
+msgstr ""
+
+msgid "Tenant no longer exists"
+msgstr ""
+
+msgid "MiqGroup no longer exists"
 msgstr ""
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
@@ -1535,25 +1824,43 @@ msgstr ""
 msgid "User Group Sequence was saved"
 msgstr ""
 
-msgid "No %s were selected to move up"
+msgid "User must be entered to perform LDAP Group Look Up"
 msgstr ""
 
-msgid "No %s were selected to move down"
+msgid "Username must be entered to perform LDAP Group Look Up"
 msgstr ""
 
-msgid "%s must be entered to perform LDAP Group Look Up"
+msgid "User Password must be entered to perform LDAP Group Look Up"
+msgstr ""
+
+msgid "Error during 'LDAP Group Look Up': %{message}"
 msgstr ""
 
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
-msgid "Edit of %s was cancelled by the user"
+msgid "Edit of %{name} was cancelled by the user"
+msgstr ""
+
+msgid "Add of new %{name} was cancelled by the user"
 msgstr ""
 
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr ""
 
+msgid "Adding a new %{name}"
+msgstr ""
+
+msgid "Access Control %{model}"
+msgstr ""
+
+msgid "Access Control %{model} \"%{name}\""
+msgstr ""
+
 msgid "A User must be assigned to a Group"
+msgstr ""
+
+msgid "At least one Product Feature must be selected"
 msgstr ""
 
 msgid "A User Group must be assigned a Role"
@@ -1562,22 +1869,43 @@ msgstr ""
 msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
+msgid "Error during 'apply': %{error}"
+msgstr ""
+
 msgid "Records were successfully imported"
 msgstr ""
 
-msgid "Use the Browse button to locate %s file"
+msgid "Use the Browse button to locate CSV file"
 msgstr ""
 
-msgid "%s should be unique"
+msgid "LDAP Host is required"
 msgstr ""
 
-msgid "%s Credentials validated successfully"
+msgid "LDAP Host should be unique"
+msgstr ""
+
+msgid "Replication Worker Credentials validated successfully"
+msgstr ""
+
+msgid "Settings %{model} \"%{name}\""
+msgstr ""
+
+msgid "Region description is required"
 msgstr ""
 
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr ""
 
 msgid "Sample %{model} \"%{name}\" can not be edited"
+msgstr ""
+
+msgid "File Entry is required"
+msgstr ""
+
+msgid "Registry Entry is required"
+msgstr ""
+
+msgid "Event log name is required"
 msgstr ""
 
 msgid "Capacity and Utilization Collection settings saved"
@@ -1595,7 +1923,9 @@ msgstr ""
 msgid "Error during sending test email: %{class_name}, %{error_message}"
 msgstr ""
 
-msgid "The test email is being delivered, check \"%s\" to verify it was successful"
+msgid ""
+"The test email is being delivered, check \"%{email}\" to verify it was successfu"
+"l"
 msgstr ""
 
 msgid "CFME Database settings validation was successful"
@@ -1606,18 +1936,26 @@ msgid ""
 "estart"
 msgstr ""
 
-msgid "Error during %s: "
+msgid "Error during Server restart: %{message}"
 msgstr ""
 
-msgid "%s file saved"
+msgid "%{model}: Restart successfully initiated"
 msgstr ""
 
-msgid "Error when saving new server name: "
+msgid "%{name} file saved"
+msgstr ""
+
+msgid "Error when saving new server name: %{message}"
 msgstr ""
 
 msgid ""
-"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone"
-"}\""
+"Configuration settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone "
+"\"%{zone}\""
+msgstr ""
+
+msgid ""
+"Authentication settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone"
+" \"%{zone}\""
 msgstr ""
 
 msgid "Edit of Customer Information was cancelled"
@@ -1626,10 +1964,19 @@ msgstr ""
 msgid "Custom Support URL and Description both must be entered."
 msgstr ""
 
+msgid "VNC Proxy Port must be numeric"
+msgstr ""
+
 msgid "When configuring a VNC Proxy, both Address and Port are required"
 msgstr ""
 
+msgid "Error during Analysis Affinity save: %{message}"
+msgstr ""
+
 msgid "Analysis Affinity was saved"
+msgstr ""
+
+msgid "Settings %{model} \"%{name}\" (current)"
 msgstr ""
 
 msgid "Locate and upload a file to start the import process"
@@ -1638,10 +1985,19 @@ msgstr ""
 msgid "Choose the type of custom variables to be imported"
 msgstr ""
 
+msgid "Settings %{model}"
+msgstr ""
+
+msgid "Hostname is required"
+msgstr ""
+
 msgid "Customer Information successfully saved"
 msgstr ""
 
-msgid "Credential validation returned: %s"
+msgid "Credential validation returned: %{message}"
+msgstr ""
+
+msgid "%{name} is required"
 msgstr ""
 
 msgid "No Server was selected"
@@ -1656,27 +2012,36 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-msgid "%s has been initiated for the selected Servers"
+msgid "%{item} has been initiated for the selected Servers"
 msgstr ""
 
-msgid "Error occured when queuing action: %s"
+msgid "Error occured when queuing action: %{message}"
 msgstr ""
 
-msgid "Error when adding a new schedule: "
+msgid "Error when adding a new schedule: %{message}"
 msgstr ""
 
-msgid "The selected %s were enabled"
+msgid "The selected Schedules were enabled"
 msgstr ""
 
-msgid "The selected %s were disabled"
+msgid "The selected Schedules were disabled"
 msgstr ""
 
 msgid "Depot Settings successfuly validated"
 msgstr ""
 
+msgid "Filter must be selected"
+msgstr ""
+
+msgid "Filter value must be selected"
+msgstr ""
+
 msgid ""
 "Warning: This 'Run Once' timer is in the past and will never run as currently "
 "configured"
+msgstr ""
+
+msgid "Long Description is required"
 msgstr ""
 
 msgid "Custom logo image must be a .png file"
@@ -1685,10 +2050,13 @@ msgstr ""
 msgid "Custom login image must be a .png file"
 msgstr ""
 
-msgid "Custom Logo file \"%s\" uploaded"
+msgid "Custom Logo file \"%{name}\" uploaded"
 msgstr ""
 
-msgid "Custom login file \"%s\" uploaded"
+msgid "Custom login file \"%{name}\" uploaded"
+msgstr ""
+
+msgid "Use the Browse button to locate .png image file"
 msgstr ""
 
 msgid "Import validation complete: %{good_record}, %{bad_record}"
@@ -1698,6 +2066,15 @@ msgid "No valid import records were found, please upload another file"
 msgstr ""
 
 msgid "Press the Apply button to import the good records into the CFME database"
+msgstr ""
+
+msgid "Add of new %{table} was cancelled by the user"
+msgstr ""
+
+msgid "Zone name is required"
+msgstr ""
+
+msgid "%{task} initiated for %{count_model}"
 msgstr ""
 
 msgid "No common configuration profiles available for the selected configured %s"
@@ -1753,6 +2130,9 @@ msgstr ""
 msgid "Import file cannot be empty"
 msgstr ""
 
+msgid "At least %{num} %{model} must be selected for %{action}"
+msgstr ""
+
 msgid "Error: the file uploaded contains no widgets"
 msgstr ""
 
@@ -1771,9 +2151,12 @@ msgstr ""
 msgid "Saved Reports"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
 msgid "Reports"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
 msgid "Schedules"
 msgstr ""
 
@@ -1801,6 +2184,9 @@ msgstr ""
 msgid "Dashboard Sequence was saved"
 msgstr ""
 
+msgid "The selected %s was deleted"
+msgstr ""
+
 msgid "%{model} for \"%{name}\""
 msgstr ""
 
@@ -1808,6 +2194,18 @@ msgid "%{field} cannot contain \"%{character}\""
 msgstr ""
 
 msgid "%s must be unique for this group"
+msgstr ""
+
+msgid "No %s were selected to move up"
+msgstr ""
+
+msgid "Select only one or consecutive %s to move up"
+msgstr ""
+
+msgid "No %s were selected to move down"
+msgstr ""
+
+msgid "Select only one or consecutive %s to move down"
 msgstr ""
 
 msgid ""
@@ -1895,6 +2293,9 @@ msgstr ""
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr ""
 
+msgid "The selected %s were deleted"
+msgstr ""
+
 msgid "No Report Schedules were selected to be Run now"
 msgstr ""
 
@@ -1907,7 +2308,16 @@ msgstr ""
 msgid "No %s were selected to be enabled"
 msgstr ""
 
+msgid "The selected %s were enabled"
+msgstr ""
+
 msgid "No %s were selected to be disabled"
+msgstr ""
+
+msgid "The selected %s were disabled"
+msgstr ""
+
+msgid "At least one %s must be configured"
 msgstr ""
 
 msgid "Widget content generation error: "
@@ -2021,6 +2431,8 @@ msgid_plural "Guest Applications"
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container
+#. TRANSLATORS: en.yml key: dictionary.table.container
 #, fuzzy
 msgid "Container"
 msgid_plural "Container"
@@ -2158,9 +2570,12 @@ msgstr ""
 msgid "Hosts"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+#. TRANSLATORS: en.yml key: dictionary.table.container_node
 msgid "Node"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
 msgid "Cluster"
 msgstr ""
 
@@ -2173,6 +2588,7 @@ msgstr ""
 msgid "Deployment Roles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
 msgid "Clusters / Deployment Roles"
 msgstr ""
 
@@ -2248,6 +2664,7 @@ msgstr ""
 msgid "Analysis"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
 msgid "Policy"
 msgstr ""
 
@@ -3328,6 +3745,56 @@ msgstr ""
 msgid "Edit Tags for the selected #{ui_lookup(:tables=>\"ems_infras\")}"
 msgstr ""
 
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}"
+msgstr ""
+
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}?"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"ems_middleware\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"ems_middleware\")} and ALL of its components"
+" will be permanently removed from the Virtual Management Database.  Are you su"
+"re you want to remove this #{ui_lookup(:table=>\"ems_middleware\")}?"
+msgstr ""
+
+msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"ems_middleware\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of thei"
+"r components will be permanently removed from the Virtual Management Database."
+"  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_middl"
+"ewares\")}?"
+msgstr ""
+
 msgid "Edit Tags for this Flavor"
 msgstr ""
 
@@ -3620,6 +4087,46 @@ msgid "Reload the #{@msg_title} Log Display"
 msgstr ""
 
 msgid "Download the Entire #{@msg_title} Log File"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"middleware_server\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"middleware_server\")} and ALL of its compone"
+"nts will be permanently removed from the Virtual Management Database.  Are you"
+" sure you want to remove this #{ui_lookup(:table=>\"middleware_server\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"middleware_server\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"middleware_servers\")} and ALL of t"
+"heir components will be permanently removed from the Virtual Management Databa"
+"se.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"middle"
+"ware_servers\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_servers\")}"
 msgstr ""
 
 msgid "Edit this Action"
@@ -5328,6 +5835,7 @@ msgstr ""
 msgid "Start the selected items"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
 msgid "Start"
 msgstr ""
 
@@ -5454,6 +5962,8 @@ msgstr ""
 msgid "Request to Provision"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision
 msgid "Provision"
 msgstr ""
 
@@ -5761,6 +6271,9 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.action_type_description
+#. TRANSLATORS: en.yml key: dictionary.column.emstype_description
+#. TRANSLATORS: en.yml key: dictionary.column.mode
 msgid "Type"
 msgstr ""
 
@@ -5782,9 +6295,11 @@ msgstr ""
 msgid "Default Limit"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.max_trend_value
 msgid "Max"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_trend_value
 msgid "Min"
 msgstr ""
 
@@ -5866,15 +6381,21 @@ msgstr ""
 msgid "IPMI Present"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ip_address
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddress
 msgid "IP Address"
 msgstr ""
 
 msgid "Mac address"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
 msgid "Provider"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone
+#. TRANSLATORS: en.yml key: dictionary.table.zone
 msgid "Zone"
 msgstr ""
 
@@ -5893,6 +6414,7 @@ msgstr ""
 msgid "Compute Profile"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_arch
 msgid "Architecture"
 msgstr ""
 
@@ -5911,6 +6433,7 @@ msgstr ""
 msgid "Configuration Organization"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.operating_system
 msgid "OS"
 msgstr ""
 
@@ -5968,6 +6491,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback
 msgid "Chargeback"
 msgstr ""
 
@@ -5977,48 +6501,72 @@ msgstr ""
 msgid "My Services"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
 msgid "Catalogs"
 msgstr ""
 
 msgid "Workloads"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_requests
 msgid "Requests"
 msgstr ""
 
 msgid "Clouds"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
 msgid "Availability Zones"
 msgstr ""
 
 msgid "Tenants"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
 msgid "Volumes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavors
 msgid "Flavors"
 msgstr ""
 
 msgid "Security Groups"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
 msgid "Instances"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
 msgid "Stacks"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
 msgid "Key Pairs"
 msgstr ""
 
 msgid "Infrastructure"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
 msgid "Virtual Machines"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.resource_pools
 msgid "Resource Pools"
 msgstr ""
 
@@ -6046,6 +6594,7 @@ msgstr ""
 msgid "Middleware"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
 msgid "Storage Managers"
 msgstr ""
 
@@ -6082,6 +6631,7 @@ msgstr ""
 msgid "My Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
 msgid "Tasks"
 msgstr ""
 
@@ -6091,9 +6641,12 @@ msgstr ""
 msgid "Object Types"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Storage
+#. TRANSLATORS: en.yml key: dictionary.table.storage
 msgid "Datastore"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
 msgid "Enterprise"
 msgstr ""
 
@@ -6450,12 +7003,15 @@ msgstr ""
 msgid "Display in Catalog"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
 msgid "Catalog"
 msgstr ""
 
 msgid "Unassigned"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
 msgid "Dialog"
 msgstr ""
 
@@ -6465,6 +7021,8 @@ msgstr ""
 msgid "Choose"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
 msgid "Orchestration Template"
 msgstr ""
 
@@ -6519,6 +7077,7 @@ msgstr ""
 msgid "Selected Resources"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction
 msgid "Action"
 msgstr ""
 
@@ -6603,6 +7162,7 @@ msgstr ""
 msgid "No Catalog Items found."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
 msgid "Catalog Items"
 msgstr ""
 
@@ -6744,6 +7304,8 @@ msgstr ""
 msgid "Grid/Tile Icons"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra
 msgid "Template"
 msgstr ""
 
@@ -6807,6 +7369,8 @@ msgstr ""
 msgid "Tagging"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
 msgid "Orchestration Templates"
 msgstr ""
 
@@ -6819,9 +7383,12 @@ msgstr ""
 msgid "VMs & Instances"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.vms
 msgid "VMs"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
 msgid "Templates"
 msgstr ""
 
@@ -6843,6 +7410,7 @@ msgstr ""
 msgid "Roll Up Performance"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.userid
 msgid "Username"
 msgstr ""
 
@@ -7037,9 +7605,12 @@ msgstr ""
 msgid "Custom Identifier"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
 msgid "IPMI IP Address"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.mac_address
+#. TRANSLATORS: en.yml key: dictionary.column.macaddress
 msgid "MAC Address"
 msgstr ""
 
@@ -7061,6 +7632,8 @@ msgstr ""
 msgid "Custom Attributes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
 msgid "VC Custom Attributes"
 msgstr ""
 
@@ -7148,6 +7721,8 @@ msgstr ""
 msgid "System/Process"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request
 msgid "Request"
 msgstr ""
 
@@ -7190,6 +7765,7 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification
 msgid "Category"
 msgstr ""
 
@@ -7448,6 +8024,7 @@ msgstr ""
 msgid "Options %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.interval
 msgid "Interval"
 msgstr ""
 
@@ -7466,6 +8043,7 @@ msgstr ""
 msgid "Show VM Types"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
 msgid "Time Profile"
 msgstr ""
 
@@ -7836,6 +8414,7 @@ msgstr ""
 msgid "Show %{host_title}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
 msgid "Direct VMs"
 msgstr ""
 
@@ -7896,6 +8475,7 @@ msgstr ""
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.guest_devices
 msgid "Devices"
 msgstr ""
 
@@ -8381,6 +8961,8 @@ msgstr ""
 msgid "Dialog Information"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
 msgid "Buttons"
 msgstr ""
 
@@ -8527,6 +9109,7 @@ msgstr ""
 msgid "Select a node on the left to view Bottlenecks timeline."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport
 msgid "Report"
 msgstr ""
 
@@ -8583,6 +9166,7 @@ msgstr ""
 msgid "VM Options"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_speed
 msgid "CPU Speed"
 msgstr ""
 
@@ -8765,6 +9349,7 @@ msgstr ""
 msgid "Object ID"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
 msgid "Analysis Profile"
 msgstr ""
 
@@ -8786,6 +9371,7 @@ msgstr ""
 msgid "Parent Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
 msgid "Categories"
 msgstr ""
 
@@ -8843,6 +9429,7 @@ msgstr ""
 msgid "SNMP Trap Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
 msgid "Analysis Profiles"
 msgstr ""
 
@@ -8882,6 +9469,8 @@ msgstr ""
 msgid "Choose a %s first"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.active
+#. TRANSLATORS: en.yml key: dictionary.column.enabled
 msgid "Active"
 msgstr ""
 
@@ -8966,6 +9555,8 @@ msgstr ""
 msgid "No Alerts are defined %s."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event
 msgid "Management Event"
 msgstr ""
 
@@ -9390,6 +9981,7 @@ msgstr ""
 msgid "Datacenter"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
 msgid "Resource Pool"
 msgstr ""
 
@@ -9441,6 +10033,7 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
 msgid "Provisioned VMs"
 msgstr ""
 
@@ -9507,6 +10100,8 @@ msgstr ""
 msgid "SmartProxy Affinity"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server
 msgid "Server"
 msgstr ""
 
@@ -9540,6 +10135,9 @@ msgstr ""
 msgid "Servers by Roles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_servers
 msgid "Servers"
 msgstr ""
 
@@ -9576,9 +10174,11 @@ msgstr ""
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem
 msgid "File"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items
 msgid "Registry"
 msgstr ""
 
@@ -9654,6 +10254,7 @@ msgstr ""
 msgid "Rows"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
 msgid "Size"
 msgstr ""
 
@@ -9773,12 +10374,15 @@ msgstr ""
 msgid "LDAP Groups for User"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
 msgid "LDAP Servers"
 msgstr ""
 
 msgid "Mode"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ldap
 msgid "LDAP"
 msgstr ""
 
@@ -9815,6 +10419,8 @@ msgstr ""
 msgid "Click to edit this forest"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
 msgid "LDAP Domains"
 msgstr ""
 
@@ -9895,6 +10501,7 @@ msgstr ""
 msgid "(Look Up LDAP Groups)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
 msgid "Role"
 msgstr ""
 
@@ -9997,6 +10604,7 @@ msgstr ""
 msgid "User Information"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.User.name
 msgid "Full Name"
 msgstr ""
 
@@ -10063,9 +10671,11 @@ msgstr ""
 msgid "Stopped On"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.memory_size
 msgid "Memory Usage"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_time
 msgid "CPU Time"
 msgstr ""
 
@@ -10228,6 +10838,9 @@ msgstr ""
 msgid "View Zones"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zones
 msgid "Zones"
 msgstr ""
 
@@ -10237,6 +10850,8 @@ msgstr ""
 msgid "View LDAP Regions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
 msgid "LDAP Regions"
 msgstr ""
 
@@ -10471,6 +11086,9 @@ msgstr ""
 msgid "Appliances in this region can be registered with:"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService
+#. TRANSLATORS: en.yml key: dictionary.model.Service
+#. TRANSLATORS: en.yml key: dictionary.table.container_service
 msgid "Service"
 msgstr ""
 
@@ -10552,6 +11170,8 @@ msgstr ""
 msgid "Tenancy"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
 msgid "ISO Images"
 msgstr ""
 
@@ -10590,6 +11210,7 @@ msgid ""
 " PXE Server"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
 msgid "PXE Images"
 msgstr ""
 
@@ -10635,13 +11256,22 @@ msgstr ""
 msgid "Available Fields:"
 msgstr ""
 
+msgid "down"
+msgstr ""
+
+msgid "up"
+msgstr ""
+
+msgid "Move selected fields %{where}"
+msgstr ""
+
 msgid "Selected Fields:"
 msgstr ""
 
-msgid "Move selected fields to top"
+msgid "to bottom"
 msgstr ""
 
-msgid "Move selected fields to bottom"
+msgid "to top"
 msgstr ""
 
 msgid "Tab Title"
@@ -10701,6 +11331,7 @@ msgstr ""
 msgid "Commit Changes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
 msgid "Widgets"
 msgstr ""
 
@@ -10843,6 +11474,7 @@ msgstr ""
 msgid "Show Costs by"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.owner_name
 msgid "Owner"
 msgstr ""
 
@@ -11334,6 +11966,10 @@ msgstr ""
 msgid "Hover Text"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.container_image
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud
 msgid "Image"
 msgstr ""
 
@@ -11356,6 +11992,12 @@ msgid "Move selected fields right"
 msgstr ""
 
 msgid "Move selected fields left"
+msgstr ""
+
+msgid "Move selected fields to top"
+msgstr ""
+
+msgid "Move selected fields to bottom"
 msgstr ""
 
 msgid "Button Group Text"
@@ -11415,6 +12057,8 @@ msgstr ""
 msgid "Placement"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder
 msgid "Folder"
 msgstr ""
 
@@ -11523,9 +12167,13 @@ msgstr ""
 msgid "Add this %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region
 msgid "Region"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+#. TRANSLATORS: en.yml key: dictionary.table.container_project
 msgid "Project"
 msgstr ""
 
@@ -11618,18 +12266,22 @@ msgstr ""
 msgid "Network Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.nics
 msgid "Network Adapters"
 msgstr ""
 
 msgid "%s has no network adapters"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
 msgid "DHCP Enabled"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
 msgid "DHCP Server"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dns_server
 msgid "DNS Server"
 msgstr ""
 
@@ -11642,18 +12294,23 @@ msgstr ""
 msgid "Subnet Mask"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
 msgid "CPU Limit"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
 msgid "CPU Reserve"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
 msgid "CPU Reserve Expand"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
 msgid "CPU Shares"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
 msgid "CPU Shares Level"
 msgstr ""
 
@@ -11675,6 +12332,7 @@ msgstr ""
 msgid "Device Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
 msgid "Partitions Aligned"
 msgstr ""
 
@@ -11874,6 +12532,3286 @@ msgstr ""
 #. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
 msgid "locale_name"
 msgstr "English"
+
+#. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+msgid "Total Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+msgid "Total Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+msgid "CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+msgid "CPU - Total Installed - Sum of Child Hosts (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+msgid "Disk I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg ("
+"%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High "
+"Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low A"
+"vg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+msgid "Memory - Avg Usage of Total Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+msgid ""
+"Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Interv"
+"als (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+msgid "Network I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+msgid "CPU - Total Installed - from Host Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+msgid "Disk Space Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+msgid "CPU - Time Spent In Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+msgid "CPU - Time Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+msgid "CPU - Time Used (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+msgid "CPU - Time Spent in Wait State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+msgid "CPU - Total - from VM Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+msgid "CPU - Reserved (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+msgid "Memory - Total Allocated (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+msgid "Memory - Reserved (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+msgid "Memory - Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+msgid "CPU Max Reserved MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+msgid "Memory Max Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+msgid "Memory Max Reserved"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+msgid "Memory - Peak Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+msgid "Memory - Minimum Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+msgid "CPU - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+msgid "Memory - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+msgid "CPU - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+msgid "Memory - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+msgid "Network I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+msgid "CPU - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+msgid "Memory - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+msgid "Network I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.acctid
+msgid "Account ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.accttype
+msgid "Account Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+msgid "Lockdown Mode"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+msgid "Total Number of Logical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+msgid "Total Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+msgid "Total Number of Physical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+msgid "Allocated Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+msgid "Allocated Storage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+msgid "Allocated vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios
+msgid "BIOS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios_location
+msgid "BIOS Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.chain_id
+msgid "Chain ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+msgid "Usage (CIFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+msgid "Usage (CIFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+msgid "Usage (CIFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+msgid "Usage (CIFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+msgid "Usage (CIFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+msgid "Usage (CIFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+msgid "Usage (CIFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+msgid "Usage (CIFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+msgid "Usage (CIFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+msgid "Usage (CIFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+msgid "Usage (CIFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+msgid "Usage (CIFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+msgid "Usage (CIFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+msgid "Usage (CIFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+msgid "Usage (CIFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+msgid "Usage (CIFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+msgid "Usage (CIFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+msgid "Usage (CIFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+msgid "Usage (CIFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+msgid "Usage (CIFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+msgid "Usage (CIFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+msgid "Usage (CIFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+msgid "Usage (CIFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+msgid "Usage (CIFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.config_xml
+msgid "Configuration XML"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+msgid "Data Points"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+msgid "CPU Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_type
+msgid "CPU Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High A"
+"vg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Av"
+"g (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+msgid "CPU - Aggregate Time Used for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+msgid "CPU - Aggregate Time Spent in Wait State for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.created_at
+#. TRANSLATORS: en.yml key: dictionary.column.created_on
+msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+msgid "Depends on Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+msgid "Depends on Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+msgid "CPU Total Installed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+msgid "CPU - Available (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+msgid "State - Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+msgid "State - Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+msgid "Memory - Total Allocated for Child VMs (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+msgid "Memory - Available (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg "
+"(MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg ("
+"MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+msgid "Content - Avg of Total Size of Managed VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+msgid "Content - Avg of Total Size of Registered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+msgid "Capacity - Avg Free Space for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+msgid "Content - Avg of Total Size of Managed VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+msgid "Content - Avg of Total Size of Registered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+msgid "Content - Avg of Total Size of Managed VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+msgid "Content - Avg of Total Size of Registered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+msgid "Capacity - Total Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+msgid "Content - Avg Space Used by Managed VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+msgid "Content - Avg Space Used by Registered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+msgid "Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+msgid "Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+msgid "Content - Avg Count of Managed VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+msgid "Content - Avg Count of Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+msgid "Content - Avg Count of Unmanaged VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+msgid "Content - Avg Count of Unregistered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+msgid "State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+msgid "State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+msgid "Destination Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+msgid "Destination VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+msgid "Destination VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+msgid "Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+msgid "Disk Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+msgid "Disk Kernel Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+msgid "Disk Queue Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+msgid "Disk I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+msgid "Disks Aligned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+msgid "CPU - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_memory
+msgid "Memory - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+msgid "End"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+msgid "What is evaluated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.event_src
+msgid "Event Source"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.filename
+msgid "File Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fqname
+msgid "Fully Qualified Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guest_os
+msgid "Guest OS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guid
+msgid "EVM Unique ID (Guid)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+msgid "Has an RDM Disk?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state
+msgid "Health State Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state_str
+msgid "Health State"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.homedir
+msgid "Home Directory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.host_name
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+msgid "Parent Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.hostnames
+msgid "Host Names"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+msgid "IP Addresses"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+msgid "IPMI Enabled"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+msgid "Is an EVM Appliance?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+msgid "Last Analysis Attempt On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+msgid "Last Analysis Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+msgid "Last Sync Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status
+msgid "Last Update Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+msgid "Last Update Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ldap_group
+#. TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+msgid "LDAP Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+msgid "Number of CPU Cores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.macaddresses
+msgid "MAC Addresses"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+msgid "CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max"
+" (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+msgid "CPU Max Total MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+msgid "CPU Max Available MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+msgid "State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+msgid "State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+msgid "Memory Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+msgid "Memory Max Available"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+msgid "Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+msgid "Disk Space Max Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+msgid "State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+msgid "Memory - Swap In Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+msgid "Memory - Swap Out Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+msgid "Memory - Swapped Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+msgid "Memory - Peak Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+msgid "Uptime - Peak Uptime for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+msgid "Disk Space Max Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+msgid "Memory - Swap In Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+msgid "Memory - Swap Out Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+msgid "Memory - Swapped Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+msgid "Memory - Usage of Total Allocated (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_mb
+msgid "RAM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+msgid "State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+msgid "State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+msgid "Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+msgid "Disk Space Min Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+msgid "State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+msgid "State - Min Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+msgid "Memory - Swap In Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+msgid "Memory - Swap Out Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+msgid "Memory - Swapped Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+msgid "Memory - Swap Min Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+msgid "Memory - Min Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+msgid "Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+msgid "Disk Space Min Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+msgid "Multiple Host Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+msgid "Network I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+msgid "Usage (NFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+msgid "Usage (NFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+msgid "Usage (NFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+msgid "Usage (NFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+msgid "Usage (NFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+msgid "Usage (NFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+msgid "Usage (NFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+msgid "Usage (NFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+msgid "Usage (NFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+msgid "Usage (NFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+msgid "Usage (NFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+msgid "Usage (NFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+msgid "Usage (NFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+msgid "Usage (NFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+msgid "Usage (NFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+msgid "Usage (NFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+msgid "Usage (NFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+msgid "Usage (NFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+msgid "Usage (NFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+msgid "Usage (NFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+msgid "Usage (NFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+msgid "Usage (NFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+msgid "Usage (NFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+msgid "Usage (NFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_automate
+msgid "Management Event Raised"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_email
+msgid "Email"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+msgid "Event on Timeline"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+msgid "SNMP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_cpu
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+msgid "Number of CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_disks
+msgid "Number of Disks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+msgid "Number of Hard Disks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status
+msgid "Operational Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+msgid "Operational Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.os_image_name
+msgid "OS Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency
+msgid "Usage (Other) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+msgid "Usage (Other) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+msgid "Usage (Other) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops
+msgid "Usage (Other) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+msgid "Usage (Other) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+msgid "Usage (Other) - Number of Other Operations per Second Miin"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+msgid "Memory - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+msgid "CPU - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+msgid "In My LDAP Group?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+msgid "Owned by Me?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+msgid "Folder Name (VMs & Templates) 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+msgid "Folder Name (VMs & Templates) 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+msgid "Folder Name (VMs & Templates) 3"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+msgid "Folder Name (VMs & Templates) 4"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+msgid "Folder Name (VMs & Templates) 5"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+msgid "Folder Name (VMs & Templates) 6"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+msgid "Folder Name (VMs & Templates) 7"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+msgid "Folder Name (VMs & Templates) 8"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+msgid "Folder Name (VMs & Templates) 9"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+msgid "CPU %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_memory
+msgid "Memory %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pid
+msgid "PID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+msgid "Total Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ram_size
+msgid "RAM Size (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data
+msgid "Usage (Other) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_max
+msgid "Usage (Other) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_min
+msgid "Usage (Other) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency
+msgid "Usage (Other) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+msgid "Usage (Other) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+msgid "Usage (Other) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops
+msgid "Usage (Other) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+msgid "Usage (Other) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+msgid "Usage (Other) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.resource_name
+msgid "Asset Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+msgid "Total VMs Powered Never"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+msgid "Total VMs Powered Off"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+msgid "Total VMs Powered On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+msgid "Total VMs Power Suspended"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+msgid "Total VMs Powered Unknown"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+msgid "CPU - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+msgid "State - Number of Hosts  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+msgid "Memory - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+msgid "State - Peak Avg VMs - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+msgid "CPU - Usage Rate for Collected Intervals (Number of Cores)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+msgid "Memory - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+msgid "Memory - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+msgid "Memory - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+msgid "CPU - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+msgid "CPU - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+msgid "CPU - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+msgid "Capacity - Profile 1 - Total Memory with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+msgid "Capacity - Profile 1 - Total CPU with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+msgid "Capacity - Profile 1 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+msgid "Capacity - Profile 1 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+msgid "Capacity - Profile 1 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+msgid "Capacity - Profile 1 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+msgid "Capacity - Profile 1 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+msgid "Capacity - Profile 1 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+msgid "Capacity - Profile 1 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+msgid "Capacity - Profile 1 - Available vCPUs for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 1 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+msgid "Capacity - Profile 1 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+msgid "Capacity - Profile 1 - Maximum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+msgid "Capacity - Profile 1 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+msgid "Capacity - Profile 1 - Minimum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+msgid "Capacity - Profile 1 - Number of vCPUs per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+msgid "Capacity - Profile 2 - Memory Effective with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+msgid "Capacity - Profile 2 - CPU Effective with HA (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+msgid "Capacity - Profile 2 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+msgid "Capacity - Profile 2 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+msgid "Capacity - Profile 2 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+msgid "Capacity - Profile 2 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+msgid "Capacity - Profile 2 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+msgid "Capacity - Profile 2 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+msgid "Capacity - Profile 2 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+msgid "Capacity - Profile 2 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+msgid "Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 2 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+msgid "Capacity - Profile 2 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+msgid "Capacity - Profile 2 - Maximum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+msgid "Capacity - Profile 2 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+msgid "Capacity - Profile 2 - Minimum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+msgid "Memory - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+msgid "Memory - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+msgid "Memory - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+msgid "CPU - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+msgid "CPU - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+msgid "CPU - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+msgid "Created on Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+msgid "Memory - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+msgid "Memory - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+msgid "Memory - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+msgid "CPU - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+msgid "CPU - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+msgid "CPU - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+msgid "Memory - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+msgid "CPU - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+msgid "Usage (Block Protocol) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data
+msgid "Usage (Block Protocol) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+msgid "Usage (Block Protocol) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+msgid "Usage (Block Protocol) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+msgid "Usage (Block Protocol) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+msgid "Usage (Block Protocol) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+msgid "Usage (Block Protocol) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+msgid "Usage (Block Protocol) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+msgid "Usage (Block Protocol) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+msgid "Usage (Block Protocol) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data
+msgid "Usage (Block Protocol) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+msgid "Usage (Block Protocol) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+msgid "Usage (Block Protocol) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+msgid "Usage (Block Protocol) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+msgid "Usage (Block Protocol) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+msgid "Usage (Block Protocol) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+msgid "Usage (Block Protocol) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+msgid "Usage (Block Protocol) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+msgid "Usage (Block Protocol) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.slope
+msgid "Slope"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_host_name
+msgid "Source Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+msgid "Source VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+msgid "Source VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+msgid "SSH Root Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.svc_type
+msgid "Service Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+msgid "Asset - Uptime (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+msgid "Thin Provisioned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.timestamp
+#. TRANSLATORS: en.yml key: dictionary.column.statistic_time
+msgid "Activity Sample - Timestamp (Day/Time)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops
+msgid "Usage (All) - Number of Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+msgid "Usage (All) - Number of Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+msgid "Usage (All) - Number of Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+msgid "CPU Average Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+msgid "Memory Average Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+msgid "CPU Max Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+msgid "Memory Max Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+msgid "Disk I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+msgid "Network I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+msgid "Disk Space Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+msgid "Disk Space Average Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.typename
+msgid "Type Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uid
+msgid "UID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+msgid "Uncommitted Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.updated_at
+#. TRANSLATORS: en.yml key: dictionary.column.updated_on
+msgid "Date Updated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+msgid "Total Used Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+msgid "Percent Used Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+msgid "Currently Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+msgid "CPU Cores Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+msgid "Datastore Path"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_date
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+msgid "Activity Sample - Day (MM DD YY)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+msgid "Non-VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+msgid "Capacity - Used Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+msgid "Disk Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+msgid "Free Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+msgid "Parent Host Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+msgid "Is a Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+msgid "VM Memory Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_month
+msgid "Activity Sample - Month (YYYY/MM)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+msgid "Parent Folder (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+msgid "Parent Folder Path (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+msgid "Parent Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+msgid "Parent Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+msgid "Parent Folder (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+msgid "Parent Folder Path (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+msgid "Parent Resource Pool"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+msgid "Parent Folder"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+msgid "CPU - % Ready"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+msgid "CPU - % Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+msgid "CPU - % Wait"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+msgid "Pct Free Disk"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+msgid "Provisioned Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+msgid "Cluster in Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+msgid "Memory Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+msgid "Snapshot Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_time
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+msgid "Activity Sample - Time (HH MM SS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+msgid "Size of Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+msgid "Size of VM Provisioned Disk Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+msgid "Total Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+msgid "Size of VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+msgid "Size of VM Snapshot Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+msgid "Total Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+msgid "Size of Other VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+msgid "Total VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space
+msgid "Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+msgid "Used Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+msgid "Other VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+msgid "Virtual Hardware Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+msgid "VMM Build Number"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_product
+msgid "VMM Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+msgid "VMM Vendor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_version
+msgid "VMM Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+msgid "VMsafe Agent Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+msgid "VMsafe Agent Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+msgid "VMsafe Enable"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+msgid "VMsafe Fail Open"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+msgid "VMsafe Immutable VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+msgid "VMsafe Timeout (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data
+msgid "Usage (All) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_max
+msgid "Usage (All) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_min
+msgid "Usage (All) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency
+msgid "Usage (All) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+msgid "Usage (All) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+msgid "Usage (All) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops
+msgid "Usage (All) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+msgid "Usage (All) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+msgid "Usage (All) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ws_port
+msgid "Web Services Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.zone_name
+msgid "EVM Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+msgid "vCPUs Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+msgid "vCPUs Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+msgid "CPU Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+msgid "CPU Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+msgid "CPU Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+msgid "CPU Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+msgid "Disk I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+msgid "Disk I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+msgid "Disk I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+msgid "Disk I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.display_range
+msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+msgid "Fixed Compute Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+msgid "Fixed Compute Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+msgid "Fixed Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+msgid "Fixed Storage Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+msgid "Fixed Storage Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+msgid "Memory Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+msgid "Memory Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_cost
+msgid "Memory Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_metric
+msgid "Memory Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+msgid "Memory Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+msgid "Memory Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+msgid "Network I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+msgid "Network I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+msgid "Network I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+msgid "Network I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+msgid "Storage Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+msgid "Storage Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_cost
+msgid "Storage Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_metric
+msgid "Storage Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+msgid "Storage Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+msgid "Storage Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_cost
+msgid "Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vm_name
+msgid "VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+msgid "Average Read Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+msgid "Average Write Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+msgid "Read (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+msgid "Transferred (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+msgid "Written (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_hit
+msgid "Hit %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_read
+msgid "Read %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_write
+msgid "Write %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.queue_depth
+msgid "Queue Depth"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+msgid "Read Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+msgid "Read (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+msgid "Response Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+msgid "Service Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+msgid "Total (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.utilization
+msgid "Utilization %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+msgid "Wait Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+msgid "Write Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+msgid "Write (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+msgid "EVM Audit Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+msgid "EVM Audit Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone
+msgid "Availability Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+msgid "Chargebacks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+msgid "Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+msgid "Chargeback Rates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+msgid "Storage - Extent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+msgid "Storage - Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances
+#. TRANSLATORS: en.yml key: dictionary.table.compliances
+msgid "Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+msgid "Compliance Histories"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Condition
+msgid "Condition"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button
+msgid "Button"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+msgid "Buttons Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+msgid "Buttons Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+#. TRANSLATORS: en.yml key: dictionary.table.container_group
+msgid "Pod"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+msgid "Image Registry"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+msgid "Image Registries"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+#. TRANSLATORS: en.yml key: dictionary.table.container_route
+msgid "Route"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator
+msgid "Replicator"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicators
+msgid "Replicators"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+msgid "Cluster / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+msgid "Performance - Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+msgid "Performance - Clusters"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_events
+msgid "Management Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folders
+msgid "Folders"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+msgid "Performance - Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+msgid "Performance - Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+msgid "FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+msgid "FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+msgid "Anonymous FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+msgid "Anonymous FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+msgid "NFS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+msgid "Samba"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+msgid "Sambas"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor
+#. TRANSLATORS: en.yml key: dictionary.table.flavor
+msgid "Flavor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+msgid "Host / Nodes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+msgid "Performance - Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+msgid "Performance - Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+msgid "ISO Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+msgid "ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image
+msgid "ISO Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+msgid "LDAP Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region
+msgid "LDAP Region"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server
+msgid "LDAP Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+msgid "Configuration Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+msgid "Configuration Managers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+msgid "Foreman Configured System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+msgid "Foreman Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+msgid "Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+msgid "Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+msgid "Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container
+msgid "Containers Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_containers
+msgid "Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra
+msgid "Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infras
+msgid "Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+msgid "Virtual Machine"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+msgid "Infrastructure Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+msgid "Infrastructure Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+msgid "Infrastructure Provider (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+msgid "Infrastructure Providers (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+msgid "Infrastructure Provider (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+msgid "Infrastructure Providers (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+msgid "Infrastructure Provider (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+msgid "Infrastructure Providers (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+msgid "Cloud Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+msgid "Cloud Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+msgid "Cloud Provider (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+msgid "Cloud Providers (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+msgid "Cloud Provider (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+msgid "Cloud Providers (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+msgid "Container Provider (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+msgid "Container Providers (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+msgid "Container Provider (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+msgid "Container Providers (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+msgid "Container Provider (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+msgid "Container Providers (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+msgid "Container Provider (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+msgid "Container Providers (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+msgid "Automate Class"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+msgid "Automate Classes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+msgid "Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+msgid "Automate Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+msgid "Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+msgid "Automate Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+msgid "Automate Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+msgid "Automate Methods"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+msgid "Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+msgid "Automate Namespaces"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+msgid "Alert"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+msgid "Alert Profile"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+msgid "Dialogs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+msgid "Enterprises"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+msgid "Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+msgid "EVM Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+msgid "EVM Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+msgid "Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+msgid "Provisions"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+msgid "SmartProxy"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+msgid "SmartProxies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_regions
+msgid "Regions"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+msgid "Schedule"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+msgid "Search"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+msgid "Searches"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+msgid "SMI-S Agent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+msgid "SMI-S Agents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+msgid "VM Template and Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+msgid "VM Template and Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+msgid "Roles"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+msgid "Widget"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker
+msgid "EVM Worker"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_workers
+msgid "EVM Workers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+msgid "NetApp Remote Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+msgid "NetApp Remote Services"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+msgid "Storage - Aggregate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+msgid "Storage - Aggregates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+msgid "Storage - File Share"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+msgid "Storage - File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+msgid "Storage - Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+msgid "Storage - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+msgid "Storage - Plex"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+msgid "Storage - Plexes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+msgid "Storage - Raid Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+msgid "Storage - Raid Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+msgid "Storage - Filer"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+msgid "Storage - Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+msgid "Storage - LUN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+msgid "Storage - LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+msgid "Storage Performance - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+msgid "CloudFormation Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+msgid "CloudFormation Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+msgid "Heat Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+msgid "Heat Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+msgid "Azure Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+msgid "Azure Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+msgid "Product Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+msgid "Product Updates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+msgid "Customization Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+msgid "Customization Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage
+msgid "PXE Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+msgid "System Image Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+msgid "System Image Types"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer
+msgid "PXE Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+msgid "PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem
+msgid "Scan Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+msgid "Scan Items"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+msgid "Service Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+msgid "Service Catalog Items"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+msgid "Storage - Local File System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+msgid "Storage - Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storages
+msgid "Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file
+msgid "Datastore File"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_files
+msgid "Datastore Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager
+msgid "Storage Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+msgid "Performance - Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+msgid "Performance - Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User
+msgid "EVM User"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+msgid "EVM Users"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+msgid "Performance Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+msgid "Performance Trends"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm
+msgid "VM and Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+msgid "VM and Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+msgid "VMDB Table"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+msgid "VMDB Tables"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+msgid "VM or Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+msgid "VM or Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+msgid "Performance - VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+msgid "Performance - VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cdroms
+msgid "CD/DVD Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+msgid "Base Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+msgid "Cloud Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+msgid "Cloud Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+msgid "Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+msgid "VC Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+msgid "Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+msgid "Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server
+msgid "Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+msgid "Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+msgid "Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner
+msgid "EVM Owner"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+msgid "EVM Owners"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+msgid "Cloud/Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+msgid "Cloud/Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+msgid "File System Drivers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.floppies
+msgid "Floppy Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.lans
+msgid "vLANs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance
+msgid "Last Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+msgid "Last Compliance Histories"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+msgid "LDAPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+msgid "Linux Init Processes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+msgid "Stamped Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+msgid "Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+msgid "EVM Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+msgid "EVM Custom Attributes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+msgid "Configuration Profile (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+msgid "Configuration Profiles (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+msgid "Cloud Networks (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+msgid "Cloud Tenants (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+msgid "Provisioned From Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+msgid "Provisioned From Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+msgid "SmartProxy Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+msgid "SCSI LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task
+msgid "Task"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template
+msgid "VM Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+msgid "VM Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+msgid "File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+msgid "Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+msgid "LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+msgid "Stack"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.server_builds
+msgid "EVM Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.service_template
+msgid "Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.switches
+msgid "vSwitches"
+msgstr ""
 
 msgid "Account|Acctid"
 msgstr ""
@@ -12395,9 +16333,6 @@ msgid "Computer system"
 msgstr ""
 
 msgid "ComputerSystem|Managed entity type"
-msgstr ""
-
-msgid "Condition"
 msgstr ""
 
 msgid "Condition|Applies to exp"
@@ -13522,9 +17457,6 @@ msgid "FirewallRule|Source ip range"
 msgstr ""
 
 msgid "FirewallRule|Updated on"
-msgstr ""
-
-msgid "Flavor"
 msgstr ""
 
 msgid "Flavor|Block storage based only"
@@ -18757,9 +22689,6 @@ msgid "VmdbTable|Name"
 msgstr ""
 
 msgid "VmdbTable|Prior raw metrics"
-msgstr ""
-
-msgid "Volume"
 msgstr ""
 
 msgid "Volume|Created on"

--- a/config/locales/ja/manageiq.po
+++ b/config/locales/ja/manageiq.po
@@ -21,6 +21,7 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
+#. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
 msgid "Memory"
 msgstr "メモリー"
 
@@ -50,32 +51,60 @@ msgstr ""
 msgid "Network Utilization Trends"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
 msgid "Providers"
 msgstr "プロバイダー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_nodes
 msgid "Nodes"
 msgstr "ノード"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.containers
 msgid "Containers"
 msgstr "コンテナー"
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
 #, fuzzy
 msgid "Registries"
 msgstr "レジストリー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_projects
 msgid "Projects"
 msgstr "プロジェクト"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_groups
 #, fuzzy
 msgid "Pods"
 msgstr "ノード"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_services
+#. TRANSLATORS: en.yml key: dictionary.table.host_services
 msgid "Services"
 msgstr "サービス"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_images
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
 msgid "Images"
 msgstr "イメージ"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_routes
 #, fuzzy
 msgid "Routes"
 msgstr "レート"
@@ -236,9 +265,11 @@ msgstr ""
 msgid "Second"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.compliance_details
 msgid "Details"
 msgstr "詳細"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_message
 msgid "Message"
 msgstr "メッセージ"
 
@@ -522,6 +553,7 @@ msgstr ""
 msgid "%{model}: %{task} successfully initiated"
 msgstr "%{model}: %{task} が正常に実行されました"
 
+#. TRANSLATORS: en.yml key: dictionary.table.hosts
 msgid "Hosts / Nodes"
 msgstr "ホスト / ノード"
 
@@ -823,6 +855,7 @@ msgstr "このタイムラインの記録が見つかりませんでした"
 msgid "* You are not authorized to view %{children} on this %{model}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
 msgid "Key Pair"
 msgstr ""
 
@@ -1071,6 +1104,7 @@ msgstr "デフォルトビュー"
 msgid "Default Filters"
 msgstr "デフォルトフィルター"
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
 msgid "Time Profiles"
 msgstr "タイムプロファイル"
 
@@ -1184,6 +1218,8 @@ msgstr "値を変更する必要があります。プロバイダーのサイズ
 msgid "%s (All cloud tenants present on this host)"
 msgstr "%s (このホストにあるすべてのクラウドテナント)"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.filesystems
 msgid "Files"
 msgstr "ファイル"
 
@@ -1205,6 +1241,8 @@ msgstr "選択した %s の認証情報の編集がユーザーによりキャ�
 msgid "Credentials/Settings saved successfully"
 msgstr "認証情報/設定が正常に保存されました"
 
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
 msgid "Middleware Servers"
 msgstr ""
 
@@ -1323,10 +1361,14 @@ msgstr ""
 msgid "%{typ} Button Group \"Unassigned Buttons\""
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Host
+#. TRANSLATORS: en.yml key: dictionary.table.host
 #, fuzzy
 msgid "Host / Node"
 msgstr "ホスト / ノード"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
 #, fuzzy
 msgid "Cluster / Deployment Role"
 msgstr "クラスター / デプロイメントルール"
@@ -1422,6 +1464,10 @@ msgstr "カスタマイズしたクラスとインスタンスのすべてがデ
 msgid "%{val} missing for %{field}"
 msgstr "%{val} が %{field} に設定されていません"
 
+#, fuzzy
+msgid "At least one VM Option must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
+
 msgid "No Utilization data available to generate planning results"
 msgstr "計画している結果を生成するための利用可能な使用率データがありません"
 
@@ -1431,14 +1477,29 @@ msgstr "%{model} \"%{name}\" %{typ}"
 msgid "Planning options have been reset by the user"
 msgstr "計画オプションがユーザーによりリセットされました"
 
-msgid "Best Fit %s"
+#, fuzzy
+msgid "Best Fit Hosts"
 msgstr "Best Fit %s"
 
-msgid "%s cancelled by user"
+msgid "Best Fit Clusters"
+msgstr ""
+
+#, fuzzy
+msgid "Export cancelled by user"
 msgstr "%s はユーザーによりキャンセルされました"
 
-msgid "At least %{num} %{model} must be selected for %{action}"
-msgstr "少なくとも %{num} %{model} が %{action} 用に選択されている必要があります"
+msgid "Error during export: %{error_message}"
+msgstr ""
+
+msgid "Error during 'Policy Import': %{messages}"
+msgstr ""
+
+msgid "Error during upload: %{messages}"
+msgstr ""
+
+#, fuzzy
+msgid "Import cancelled by user"
+msgstr "%s はユーザーによりキャンセルされました"
 
 msgid "Import not available due to conflicts"
 msgstr "競合によりインポートができません"
@@ -1446,68 +1507,181 @@ msgstr "競合によりインポートができません"
 msgid "Press commit to Import"
 msgstr "インポートするには「コミット」を押してください"
 
-msgid "%s no longer exists"
-msgstr "%s は存在しません"
+#, fuzzy
+msgid "All %{items}"
+msgstr "すべてのダイアログ"
+
+msgid "All %{models}"
+msgstr ""
+
+#, fuzzy
+msgid "Adding a new %{record}"
+msgstr "新規 %s の追加"
 
 msgid "All %{typ} %{model}"
 msgstr "すべての %{typ} %{model}"
 
-msgid " %s Assignments"
+msgid "Adding a new %{model_name} %{mode} Policy"
+msgstr ""
+
+msgid "Adding a new %{model_name} Policy"
+msgstr ""
+
+#, fuzzy
+msgid " %{model} Assignments"
 msgstr "%s の割り当て"
 
-msgid "Select only one or consecutive %s to move up"
+#, fuzzy
+msgid "Adding a new %{model}"
+msgstr "新規 %s の追加"
+
+#, fuzzy
+msgid "Editing %{model} Condition \"%{name}\""
+msgstr "\"%{name}\" の %{model} を編集"
+
+#, fuzzy
+msgid "%{model} Condition \"%{name}\""
+msgstr "\"%{name}\" の %{model}"
+
+#, fuzzy
+msgid "Adding a new %{alerts}"
+msgstr "新規 %s の追加"
+
+#, fuzzy
+msgid "No %{member} were selected to move right"
+msgstr "右に移動するために選択された %s はありません"
+
+#, fuzzy
+msgid "No %{member} were selected to move left"
+msgstr "左に移動するために選択された %s はありません"
+
+#, fuzzy
+msgid "Select only one or consecutive %{member} to move up"
 msgstr "上に移動する連続した %s を 1 つだけ選択する"
 
-msgid "Select only one or consecutive %s to move down"
+#, fuzzy
+msgid "Select only one or consecutive %{member} to move down"
 msgstr "下に移動する連続した %s を 1 つだけ選択する"
 
-msgid "No %s selected to set to Synchronous"
+#, fuzzy
+msgid "No %{member} selected to set to Synchronous"
 msgstr "同期に設定するために選択された %s はありません"
 
-msgid "No %s selected to set to Asynchronous"
+#, fuzzy
+msgid "No %{member} selected to set to Asynchronous"
 msgstr "非同期に設定するために選択された %s はありません"
 
+#, fuzzy
+msgid "Host is required"
+msgstr "%s が必要です"
+
+msgid "Trap Number is required"
+msgstr ""
+
+msgid "Trap Object ID is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
 msgid "Policy Profiles"
 msgstr "ポリシープロファイル"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
 msgid "Policies"
 msgstr "ポリシー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
 msgid "Events"
 msgstr "イベント"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
 msgid "Conditions"
 msgstr "条件"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
 msgid "Actions"
 msgstr "アクション"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
 msgid "Alert Profiles"
 msgstr "アラートプロファイル"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
 msgid "Alerts"
 msgstr "アラート"
 
 msgid "%{model} must contain at least one %{field}"
 msgstr "%{model} は最低 1 つの %{field} を含む必要があります"
 
+msgid "Error during 'Alert Profile %{params}': "
+msgstr ""
+
+#, fuzzy
+msgid "Edit %{model} assignments cancelled by user"
+msgstr "ポリシー割り当ての編集がユーザーによりキャンセルされました"
+
+msgid "A Tag Category must be selected"
+msgstr ""
+
 msgid "At least one Selection must be checked"
 msgstr "少なくとも 1 つの選択にチェックされている必要があります"
 
-msgid "Alert Profile \"%s\" assignments succesfully saved"
+#, fuzzy
+msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
 msgstr "アラートプロファイル \"%s\" 割り当てが正常に保存されました"
 
-msgid "The selected %s was deleted"
+#, fuzzy
+msgid "%{model} no longer exists"
+msgstr "%s 記録は存在しません"
+
+#, fuzzy
+msgid "The selected %{model} was deleted"
 msgstr "選択した %s は削除されました "
+
+msgid "All %{records}"
+msgstr ""
+
+#, fuzzy
+msgid "Add of new %{models} was cancelled by the user"
+msgstr "%{model} の追加がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "%{models} no longer exists"
+msgstr "%s 記録は存在しません"
+
+#, fuzzy
+msgid "The selected %{models} was deleted"
+msgstr "選択した %s は削除されました "
+
+msgid "Error during alarms: %{messages}"
+msgstr ""
 
 msgid "A valid expression must be present"
 msgstr "有効な式がなければなりません"
 
-msgid "%s must be an integer"
-msgstr "%s には整数を指定する必要があります"
+msgid "A Driving Event must be selected"
+msgstr ""
 
-msgid "At least one %s must be configured"
-msgstr "少なくとも 1 つの %s が設定されている必要があります"
+#, fuzzy
+msgid "Event name is required"
+msgstr "%s が必要です"
+
+msgid "Event to Check is required"
+msgstr ""
+
+msgid "Value Threshold must be an integer"
+msgstr ""
+
+msgid "Trend Steepness must be an integer"
+msgstr ""
+
+msgid ""
+"At least one of E-mail, SNMP Trap, Timeline Event, or Management Event must be"
+" configured"
+msgstr ""
+
+msgid "At least one E-mail recipient must be configured"
+msgstr ""
 
 msgid ""
 "Ruby scripts are no longer supported in expressions, please change or remove t"
@@ -1517,14 +1691,68 @@ msgstr "Ruby スクリプトは式でサポートされなくなりました。�
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr "条件 \"%{cond_name}\" がポリシーから削除されました\"%{pol_name}\""
 
-msgid "Actions for Policy Event \"%s\" were saved"
+msgid "Edit Event cancelled by user"
+msgstr ""
+
+#, fuzzy
+msgid "Actions for Policy Event \"%{events}\" were saved"
 msgstr "ポリシーイベント \"%s\" に関するアクションが保存されました"
 
-msgid "E-mail address '%s' is not valid"
+#, fuzzy
+msgid "All %{tables}"
+msgstr "すべてのダイアログ"
+
+#, fuzzy
+msgid "No %{members} were selected to move left"
+msgstr "左に移動するために選択された %s はありません"
+
+#, fuzzy
+msgid "No %{members} were selected to move right"
+msgstr "右に移動するために選択された %s はありません"
+
+#, fuzzy
+msgid "Action Type must be selected"
+msgstr "%s の選択が必要です"
+
+msgid "Analysis Profile is required"
+msgstr ""
+
+msgid "Attribute Name is required"
+msgstr ""
+
+#, fuzzy
+msgid "At least one Alert must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
+
+#, fuzzy
+msgid "Parent Type must be selected"
+msgstr "%s の選択が必要です"
+
+#, fuzzy
+msgid "At least one Category must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
+
+#, fuzzy
+msgid "Snapshot Age must be selected"
+msgstr "%s の選択が必要です"
+
+#, fuzzy
+msgid "E-mail address 'From' is not valid"
 msgstr "メールアドレス '%s' は無効です"
+
+#, fuzzy
+msgid "E-mail address 'To' is not valid"
+msgstr "メールアドレス '%s' は無効です"
+
+#, fuzzy
+msgid "At least one Tag must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
 
 msgid "%{model} \"%{name}\" already exists"
 msgstr "%{model} \"%{name}\" はすでに存在しています"
+
+msgid "Error during 'Policy Profile %{params}': %{messages}"
+msgstr ""
 
 msgid "No VMs match the selection criteria"
 msgstr "選択基準に一致する VM はありません"
@@ -1533,7 +1761,12 @@ msgstr "選択基準に一致する VM はありません"
 msgid "Policy Simulation generation returned: %{error_message}"
 msgstr "ポリシーシミュレーション生成が返されました: "
 
-msgid "Request %s was cancelled by the user"
+#, fuzzy
+msgid "Request approval was cancelled by the user"
+msgstr "要求 %s がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "Request denial was cancelled by the user"
 msgstr "要求 %s がユーザーによりキャンセルされました"
 
 msgid "Request \"%{name}\" was %{task}"
@@ -1542,8 +1775,21 @@ msgstr "リクエスト\"%{name}\" は %{task}"
 msgid "Error retrieving LDAP info: %{error_message}"
 msgstr ""
 
-msgid "The selected %s were deleted"
-msgstr "選択した %s は削除されました"
+#, fuzzy
+msgid "At least one status must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
+
+#, fuzzy
+msgid "The selected %{tables} were deleted"
+msgstr "選択した %s は削除されました "
+
+#, fuzzy
+msgid "%{table} no longer exists"
+msgstr "%s 記録は存在しません"
+
+#, fuzzy
+msgid "The selected %{table} was deleted"
+msgstr "選択した %s は削除されました "
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
 msgstr "%{model} \"%{name}\": '%{task}' の実行中にエラーが発生しました: "
@@ -1557,11 +1803,41 @@ msgstr "選択したタスクがキャンセルされました"
 msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr "選択したジョブは存在しなくなりました。古いタスクすべての削除は完了していません"
 
+msgid "%s no longer exists"
+msgstr "%s は存在しません"
+
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr "%{model} \"%{name}\": '分析' の実行中にエラーが発生しました: "
 
 msgid "\"%{record}\": Analysis successfully initiated"
 msgstr "\"%{record}\": 分析が正常に開始されました"
+
+#, fuzzy
+msgid "Create Datastore was cancelled by the user"
+msgstr "%s の編集がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
+msgstr "%{model} \"%{name}\": %{task} が正常に実行されました"
+
+#, fuzzy
+msgid "Create Logical Disk was cancelled by the user"
+msgstr "%s の編集がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "Aggregate is required"
+msgstr "%s が必要です"
+
+#, fuzzy
+msgid "Size is required"
+msgstr "%s が必要です"
+
+#, fuzzy
+msgid "Size must be an integer"
+msgstr "%s には整数を指定する必要があります"
+
+msgid "Adding a new Category"
+msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\""
 msgstr "%{model} \"%{name}\" のクォータの管理"
@@ -1572,35 +1848,56 @@ msgstr "%{typ} %{model} \"%{name}\" (current)"
 msgid "Export generation returned: Status [%{status}] Message [%{message}]"
 msgstr "エクスポート生成が返されました: ステータス [%{status}] メッセージ [%{message}]"
 
-msgid "%s Summary"
+#, fuzzy
+msgid "VMDB Summary"
 msgstr "%s 概要"
 
-msgid "%s Utilization"
+#, fuzzy
+msgid "VMDB Utilization"
 msgstr "%s 使用率"
 
-msgid "%s Client Connections"
+#, fuzzy
+msgid "VMDB Client Connections"
 msgstr "%s クライアント接続"
 
-msgid "All %s Indexes"
+#, fuzzy
+msgid "All VMDB Indexes"
 msgstr "すべての %s インデックス"
 
-msgid "%s Settings"
-msgstr "%s 設定"
+#, fuzzy
+msgid "VMDB Settings"
+msgstr "マイ設定"
 
 msgid "Indexes for %{model} \"%{name}\""
 msgstr "%{model} のインデックス\"%{name}\""
 
+msgid "VMDB \"%{name}\" Table Utilization"
+msgstr ""
+
+msgid "Error during 'Appliance restart': %{message}"
+msgstr ""
+
 msgid "CFME Appliance restart initiated successfully"
 msgstr "CFME アプライアンスの再起動が正常に実行されました"
 
-msgid "'%s' Worker restart initiated successfully"
+msgid "Error during 'workers restart': %{message}"
+msgstr ""
+
+#, fuzzy
+msgid "'%{type}' Worker restart initiated successfully"
 msgstr "'%s' ワーカーの再起動が正常に実行されました"
 
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr "ログデポ設定の編集がユーザーによりキャンセルされました"
 
+msgid "Error during 'Save': %{message}"
+msgstr ""
+
 msgid "Log Depot Settings were saved"
 msgstr "ログデポ設定が保存されました"
+
+msgid "Error during 'Validate': %{message}"
+msgstr ""
 
 msgid "Log Depot Settings were validated"
 msgstr "ログデポ設定が検証されました"
@@ -1608,14 +1905,37 @@ msgstr "ログデポ設定が検証されました"
 msgid "End Date cannot be greater than Start Date"
 msgstr "終了日を開始日より前の日付にすることはできません"
 
-msgid "%s successfully initiated"
-msgstr "%s が正常に実行されました"
+msgid "Error during 'C & U Gap Collection': %{message}"
+msgstr ""
 
-msgid "Error during Orphaned Records delete for user %s: "
+msgid "C & U Gap Collection successfully initiated"
+msgstr ""
+
+msgid "Error during 'Reset/synchronization process': %{message}"
+msgstr ""
+
+msgid "Reset/synchronization process successfully initiated"
+msgstr ""
+
+msgid "Database Backup successfully initiated"
+msgstr ""
+
+msgid "Error during 'Database Garbage Collection': %{message}"
+msgstr ""
+
+msgid "Database Garbage Collection successfully initiated"
+msgstr ""
+
+#, fuzzy
+msgid "Error during Orphaned Records delete for user %{id}: %{message}"
 msgstr "ユーザー %s 用の単独記録の削除時のエラー: "
 
-msgid "Orphaned Records for userid %s were successfully deleted"
+#, fuzzy
+msgid "Orphaned Records for userid %{id} were successfully deleted"
 msgstr "ユーザーID %s の単独の記録が正常に削除されました"
+
+msgid "Error during 'Clear Connection Broker cache': %{message}"
+msgstr ""
 
 msgid "Connection Broker cache cleared successfully"
 msgstr "接続ブローカーのキャッシュが正常にクリアされました"
@@ -1634,8 +1954,21 @@ msgstr ""
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr "CFME %{object_type} %{name} のログ収集が実行されました"
 
-msgid "%s is not allowed for the selected item"
+#, fuzzy
+msgid "Start is not allowed for the selected item"
 msgstr "%s は選択した項目では許可されていません"
+
+#, fuzzy
+msgid "Start successfully initiated"
+msgstr "%s が正常に実行されました"
+
+#, fuzzy
+msgid "Suspend is not allowed for the selected item"
+msgstr "%s は選択した項目では許可されていません"
+
+#, fuzzy
+msgid "Suspend successfully initiated"
+msgstr "%s が正常に実行されました"
 
 msgid "Setting priority is not allowed for the selected item"
 msgstr "選択した項目は優先順位の設定が許可されていません"
@@ -1643,20 +1976,46 @@ msgstr "選択した項目は優先順位の設定が許可されていません
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr "CFME サーバー \"%{name}\" をロール \"%{role_description}\" の %{priority} に設定する"
 
-msgid "Error when adding a new tenant: "
+#, fuzzy
+msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr "%{typ} %{model} \"%{name}\" (current)"
+
+#, fuzzy
+msgid "Diagnostics %{model} \"%{name}\""
+msgstr "%{model} \"%{name}\" を編集"
+
+#, fuzzy
+msgid "Error when adding a new tenant: %{message}"
 msgstr "新規テナント追加時のエラー: "
 
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr "%{model} \"%{name}\" のクォータ管理はユーザーによってキャンセルされました。"
 
-msgid "Error when saving tenant quota: "
+#, fuzzy
+msgid "Error when saving tenant quota: %{message}"
 msgstr "テナントクォータの保存時のエラー:"
 
 msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr "%{model} \"%{name}\" のクォータが保存されました"
 
+#, fuzzy
+msgid "User no longer exists"
+msgstr "%s は存在しません"
+
+#, fuzzy
+msgid "Role no longer exists"
+msgstr "レポートは存在しません"
+
 msgid "Default %{model} \"%{name}\" can not be deleted"
 msgstr "デフォルト %{model} \"%{name}\" は削除することができません"
+
+#, fuzzy
+msgid "Tenant no longer exists"
+msgstr "レポートは存在しません"
+
+#, fuzzy
+msgid "MiqGroup no longer exists"
+msgstr "レポートは存在しません"
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr "ユーザーグループシーケンスの編集がユーザーによりキャンセルされました"
@@ -1664,26 +2023,52 @@ msgstr "ユーザーグループシーケンスの編集がユーザーにより
 msgid "User Group Sequence was saved"
 msgstr "ユーザーグループシーケンスが保存されました"
 
-msgid "No %s were selected to move up"
-msgstr "上に移動するために選択された %s はありません"
-
-msgid "No %s were selected to move down"
-msgstr "下に移動するために選択された %s はありません"
-
-msgid "%s must be entered to perform LDAP Group Look Up"
+#, fuzzy
+msgid "User must be entered to perform LDAP Group Look Up"
 msgstr "LDAP グループ検索を実行するためには %s の入力が必要です"
+
+#, fuzzy
+msgid "Username must be entered to perform LDAP Group Look Up"
+msgstr "LDAP グループ検索を実行するためには %s の入力が必要です"
+
+#, fuzzy
+msgid "User Password must be entered to perform LDAP Group Look Up"
+msgstr "LDAP グループ検索を実行するためには %s の入力が必要です"
+
+msgid "Error during 'LDAP Group Look Up': %{message}"
+msgstr ""
 
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr "現在の %{model} \"%{name}\" を削除することができません"
 
-msgid "Edit of %s was cancelled by the user"
+#, fuzzy
+msgid "Edit of %{name} was cancelled by the user"
 msgstr "%s の編集がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "Add of new %{name} was cancelled by the user"
+msgstr "%{model} の追加がユーザーによりキャンセルされました"
 
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr "読み取り専用 %{model} \"%{name}\" は編集することができません"
 
+#, fuzzy
+msgid "Adding a new %{name}"
+msgstr "新規 %s の追加"
+
+msgid "Access Control %{model}"
+msgstr ""
+
+#, fuzzy
+msgid "Access Control %{model} \"%{name}\""
+msgstr "%{model} のインデックス\"%{name}\""
+
 msgid "A User must be assigned to a Group"
 msgstr "ユーザーをグループに割り当てる必要があります"
+
+#, fuzzy
+msgid "At least one Product Feature must be selected"
+msgstr "少なくとも %s が選択されている必要があります"
 
 msgid "A User Group must be assigned a Role"
 msgstr "ユーザーグループにロールを割り当てる必要があります"
@@ -1691,23 +2076,48 @@ msgstr "ユーザーグループにロールを割り当てる必要がありま
 msgid "Access Rules for all Virtual Machines"
 msgstr "すべての仮想マシンのアクセスルール"
 
+msgid "Error during 'apply': %{error}"
+msgstr ""
+
 msgid "Records were successfully imported"
 msgstr "記録が正常にインポートされました"
 
-msgid "Use the Browse button to locate %s file"
+#, fuzzy
+msgid "Use the Browse button to locate CSV file"
 msgstr "参照ボタンを使って %s ファイルを検索します。"
 
-msgid "%s should be unique"
+#, fuzzy
+msgid "LDAP Host is required"
+msgstr "%s が必要です"
+
+#, fuzzy
+msgid "LDAP Host should be unique"
 msgstr "%s は固有でなければなりません"
 
-msgid "%s Credentials validated successfully"
-msgstr "%s 認証情報が正常に検証されました"
+msgid "Replication Worker Credentials validated successfully"
+msgstr ""
+
+#, fuzzy
+msgid "Settings %{model} \"%{name}\""
+msgstr "%{model} \"%{name}\" を編集"
+
+msgid "Region description is required"
+msgstr ""
 
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr "分析プロファイルを作成するには、少なくとも 1 つの項目が入力されている必要があります"
 
 msgid "Sample %{model} \"%{name}\" can not be edited"
 msgstr "サンプル %{model} \"%{name}\" は編集することができません"
+
+msgid "File Entry is required"
+msgstr ""
+
+msgid "Registry Entry is required"
+msgstr ""
+
+msgid "Event log name is required"
+msgstr ""
 
 msgid "Capacity and Utilization Collection settings saved"
 msgstr "容量と使用率収集設定が保存されました"
@@ -1724,7 +2134,10 @@ msgstr "Amazon 設定が正常に検証されました"
 msgid "Error during sending test email: %{class_name}, %{error_message}"
 msgstr ""
 
-msgid "The test email is being delivered, check \"%s\" to verify it was successful"
+#, fuzzy
+msgid ""
+"The test email is being delivered, check \"%{email}\" to verify it was successfu"
+"l"
 msgstr "テストメールが送信されています。正常に送信されたかを確認するために \"%s\" をチェックしてください"
 
 msgid "CFME Database settings validation was successful"
@@ -1735,18 +2148,31 @@ msgid ""
 "estart"
 msgstr "データベースの設定が正常に保存されました。この設定は CFME サーバーが再起動した時点で有効になります"
 
-msgid "Error during %s: "
-msgstr "%s 中のエラー: "
+msgid "Error during Server restart: %{message}"
+msgstr ""
 
-msgid "%s file saved"
+#, fuzzy
+msgid "%{model}: Restart successfully initiated"
+msgstr "%{model}: %{task} が正常に実行されました"
+
+#, fuzzy
+msgid "%{name} file saved"
 msgstr "%s ファイルが保存されました"
 
-msgid "Error when saving new server name: "
+#, fuzzy
+msgid "Error when saving new server name: %{message}"
 msgstr "新規サーバー名の追加時のエラー:"
 
+#, fuzzy
 msgid ""
-"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone"
-"}\""
+"Configuration settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone "
+"\"%{zone}\""
+msgstr "%{typ} 設定が CFME サーバー \"%{name} [%{server_id}]\" のゾーン \"%{zone}\" に保存されました"
+
+#, fuzzy
+msgid ""
+"Authentication settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone"
+" \"%{zone}\""
 msgstr "%{typ} 設定が CFME サーバー \"%{name} [%{server_id}]\" のゾーン \"%{zone}\" に保存されました"
 
 msgid "Edit of Customer Information was cancelled"
@@ -1755,11 +2181,21 @@ msgstr "カスタマー情報の編集がキャンセルされました"
 msgid "Custom Support URL and Description both must be entered."
 msgstr "カスタムサポート URL と内容の両方の入力が必要です。"
 
+msgid "VNC Proxy Port must be numeric"
+msgstr ""
+
 msgid "When configuring a VNC Proxy, both Address and Port are required"
 msgstr "VNC プロキシーを設定する際、アドレスとポートの両方が必要です"
 
+msgid "Error during Analysis Affinity save: %{message}"
+msgstr ""
+
 msgid "Analysis Affinity was saved"
 msgstr "分析アフィニティーが保存されました"
+
+#, fuzzy
+msgid "Settings %{model} \"%{name}\" (current)"
+msgstr "%{typ} %{model} \"%{name}\" (current)"
 
 msgid "Locate and upload a file to start the import process"
 msgstr "ファイルを検索してアップロードし、インポートプロセスを開始します"
@@ -1767,11 +2203,23 @@ msgstr "ファイルを検索してアップロードし、インポートプロ
 msgid "Choose the type of custom variables to be imported"
 msgstr "インポートするカスタム変数のタイプを選択"
 
+msgid "Settings %{model}"
+msgstr ""
+
+#, fuzzy
+msgid "Hostname is required"
+msgstr "%s が必要です"
+
 msgid "Customer Information successfully saved"
 msgstr "カスタム情報が正常に保存されました"
 
-msgid "Credential validation returned: %s"
+#, fuzzy
+msgid "Credential validation returned: %{message}"
 msgstr "認証情報の検証が返されました: %s"
+
+#, fuzzy
+msgid "%{name} is required"
+msgstr "%s が必要です"
 
 msgid "No Server was selected"
 msgstr "サーバーが選択されていません"
@@ -1785,28 +2233,43 @@ msgstr "更新をチェック"
 msgid "Update"
 msgstr "更新"
 
-msgid "%s has been initiated for the selected Servers"
+#, fuzzy
+msgid "%{item} has been initiated for the selected Servers"
 msgstr "選択したサーバー用に %s が開始されました"
 
-msgid "Error occured when queuing action: %s"
+#, fuzzy
+msgid "Error occured when queuing action: %{message}"
 msgstr "アクションをキューに追加する際にエラーが発生しました: %s"
 
-msgid "Error when adding a new schedule: "
+#, fuzzy
+msgid "Error when adding a new schedule: %{message}"
 msgstr "新規スケジュール追加時のエラー: "
 
-msgid "The selected %s were enabled"
+#, fuzzy
+msgid "The selected Schedules were enabled"
 msgstr "選択された %s は有効にされました"
 
-msgid "The selected %s were disabled"
+#, fuzzy
+msgid "The selected Schedules were disabled"
 msgstr "選択した %s は無効にされました"
 
 msgid "Depot Settings successfuly validated"
 msgstr "デポ設定が正常に検証されました"
 
+#, fuzzy
+msgid "Filter must be selected"
+msgstr "%s の選択が必要です"
+
+msgid "Filter value must be selected"
+msgstr ""
+
 msgid ""
 "Warning: This 'Run Once' timer is in the past and will never run as currently "
 "configured"
 msgstr "警告：この '一度実行' タイマーは過去の時間に設定されているため、現在の設定では実行されることはありません "
+
+msgid "Long Description is required"
+msgstr ""
 
 msgid "Custom logo image must be a .png file"
 msgstr "カスタムロゴイメージは .png ファイルである必要があります"
@@ -1814,11 +2277,17 @@ msgstr "カスタムロゴイメージは .png ファイルである必要があ
 msgid "Custom login image must be a .png file"
 msgstr "カスタムログインイメージは .png ファイルである必要があります"
 
-msgid "Custom Logo file \"%s\" uploaded"
+#, fuzzy
+msgid "Custom Logo file \"%{name}\" uploaded"
 msgstr "カスタムロゴファイル \"%s\" がアップロードされました"
 
-msgid "Custom login file \"%s\" uploaded"
+#, fuzzy
+msgid "Custom login file \"%{name}\" uploaded"
 msgstr "カスタムログインファイル \"%s\" がアップロードされました"
+
+#, fuzzy
+msgid "Use the Browse button to locate .png image file"
+msgstr "参照ボタンを使って %s イメージファイルを検索します。"
 
 msgid "Import validation complete: %{good_record}, %{bad_record}"
 msgstr "インポート検証完了: %{good_record}, %{bad_record}"
@@ -1828,6 +2297,17 @@ msgstr "有効なインポート記録が見つかりませんでした。別の
 
 msgid "Press the Apply button to import the good records into the CFME database"
 msgstr "適正な記録を CFME データベースにインポートするには「適用」ボタンを押してください "
+
+#, fuzzy
+msgid "Add of new %{table} was cancelled by the user"
+msgstr "%{model} の追加がユーザーによりキャンセルされました"
+
+#, fuzzy
+msgid "Zone name is required"
+msgstr "%s が必要です"
+
+msgid "%{task} initiated for %{count_model}"
+msgstr ""
 
 msgid "No common configuration profiles available for the selected configured %s"
 msgstr "選択された設定済みの %s に利用可能な共通設定プロファイルがありません。"
@@ -1883,6 +2363,9 @@ msgstr "%{group} \"%{name}\" の %{model}"
 msgid "Import file cannot be empty"
 msgstr "インポートファイルは空にすることができません"
 
+msgid "At least %{num} %{model} must be selected for %{action}"
+msgstr "少なくとも %{num} %{model} が %{action} 用に選択されている必要があります"
+
 msgid "Error: the file uploaded contains no widgets"
 msgstr "エラー: アップロードしたファイルにはウィジェットがありません"
 
@@ -1901,9 +2384,12 @@ msgstr "ウィジェットのインポートがキャンセルされました"
 msgid "Saved Reports"
 msgstr "保存されたレポート"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
 msgid "Reports"
 msgstr "レポート"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
 msgid "Schedules"
 msgstr "スケジュール"
 
@@ -1934,6 +2420,9 @@ msgstr "ダッシュボードシーケンスの編集がユーザーによりキ
 msgid "Dashboard Sequence was saved"
 msgstr "ダッシュボードシーケンスが保存されました"
 
+msgid "The selected %s was deleted"
+msgstr "選択した %s は削除されました "
+
 msgid "%{model} for \"%{name}\""
 msgstr "\"%{name}\" の %{model}"
 
@@ -1942,6 +2431,18 @@ msgstr "%{field} には \"%{character}\" を含めることができません"
 
 msgid "%s must be unique for this group"
 msgstr "%s はこのグループ内で一意なものである必要があります"
+
+msgid "No %s were selected to move up"
+msgstr "上に移動するために選択された %s はありません"
+
+msgid "Select only one or consecutive %s to move up"
+msgstr "上に移動する連続した %s を 1 つだけ選択する"
+
+msgid "No %s were selected to move down"
+msgstr "下に移動するために選択された %s はありません"
+
+msgid "Select only one or consecutive %s to move down"
+msgstr "下に移動する連続した %s を 1 つだけ選択する"
 
 msgid ""
 "Can not delete folder, one or more reports in the selected folder are not owne"
@@ -2028,6 +2529,9 @@ msgstr "一番下に移動する連続した %s を 1 つだけ選択する"
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr "保存されたレポート \"%s\" が見つかりませんでした。スケジュールが失敗した可能性があります"
 
+msgid "The selected %s were deleted"
+msgstr "選択した %s は削除されました"
+
 msgid "No Report Schedules were selected to be Run now"
 msgstr "現在実行するために選択されたレポートスケジュールはありません"
 
@@ -2040,8 +2544,17 @@ msgstr "選択したスケジュールが実行のキューに追加されまし
 msgid "No %s were selected to be enabled"
 msgstr "有効にするために選択された %s はありません"
 
+msgid "The selected %s were enabled"
+msgstr "選択された %s は有効にされました"
+
 msgid "No %s were selected to be disabled"
 msgstr "無効にするために選択された %s はありません"
+
+msgid "The selected %s were disabled"
+msgstr "選択した %s は無効にされました"
+
+msgid "At least one %s must be configured"
+msgstr "少なくとも 1 つの %s が設定されている必要があります"
 
 msgid "Widget content generation error: "
 msgstr "ウィジェットコンテンツ生成エラー: "
@@ -2151,6 +2664,8 @@ msgid "Guest Application"
 msgid_plural "Guest Applications"
 msgstr[0] "ゲストアプリケーション"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container
+#. TRANSLATORS: en.yml key: dictionary.table.container
 #, fuzzy
 msgid "Container"
 msgid_plural "Container"
@@ -2281,10 +2796,13 @@ msgstr "ホスト"
 msgid "Hosts"
 msgstr "ホスト"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+#. TRANSLATORS: en.yml key: dictionary.table.container_node
 #, fuzzy
 msgid "Node"
 msgstr "ノード"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
 #, fuzzy
 msgid "Cluster"
 msgstr "クラスター"
@@ -2299,6 +2817,7 @@ msgstr "デプロイメントロール"
 msgid "Deployment Roles"
 msgstr "デプロイメントロール"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
 msgid "Clusters / Deployment Roles"
 msgstr "クラスター / デプロイメントルール"
 
@@ -2377,6 +2896,7 @@ msgstr ""
 msgid "Analysis"
 msgstr "分析"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
 #, fuzzy
 msgid "Policy"
 msgstr "ポリシー"
@@ -3528,6 +4048,56 @@ msgstr ""
 msgid "Edit Tags for the selected #{ui_lookup(:tables=>\"ems_infras\")}"
 msgstr ""
 
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}"
+msgstr ""
+
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}?"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"ems_middleware\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"ems_middleware\")} and ALL of its components"
+" will be permanently removed from the Virtual Management Database.  Are you su"
+"re you want to remove this #{ui_lookup(:table=>\"ems_middleware\")}?"
+msgstr ""
+
+msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"ems_middleware\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of thei"
+"r components will be permanently removed from the Virtual Management Database."
+"  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_middl"
+"ewares\")}?"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Tags for this Flavor"
 msgstr "%s のタグを編集"
@@ -3859,6 +4429,46 @@ msgid "Reload the #{@msg_title} Log Display"
 msgstr ""
 
 msgid "Download the Entire #{@msg_title} Log File"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"middleware_server\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"middleware_server\")} and ALL of its compone"
+"nts will be permanently removed from the Virtual Management Database.  Are you"
+" sure you want to remove this #{ui_lookup(:table=>\"middleware_server\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"middleware_server\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"middleware_servers\")} and ALL of t"
+"heir components will be permanently removed from the Virtual Management Databa"
+"se.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"middle"
+"ware_servers\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_servers\")}"
 msgstr ""
 
 #, fuzzy
@@ -5839,6 +6449,7 @@ msgstr "選択したフィルターを適用"
 msgid "Start the selected items"
 msgstr "選択したフィルターを適用"
 
+#. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
 msgid "Start"
 msgstr "開始"
 
@@ -5997,6 +6608,8 @@ msgstr ""
 msgid "Request to Provision"
 msgstr "要求情報"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision
 #, fuzzy
 msgid "Provision"
 msgstr "%s のプロビジョニング "
@@ -6336,6 +6949,9 @@ msgstr "プロパティー"
 msgid "Value"
 msgstr "値"
 
+#. TRANSLATORS: en.yml key: dictionary.column.action_type_description
+#. TRANSLATORS: en.yml key: dictionary.column.emstype_description
+#. TRANSLATORS: en.yml key: dictionary.column.mode
 msgid "Type"
 msgstr "タイプ"
 
@@ -6357,9 +6973,11 @@ msgstr "反映済み"
 msgid "Default Limit"
 msgstr "デフォルト制限"
 
+#. TRANSLATORS: en.yml key: dictionary.column.max_trend_value
 msgid "Max"
 msgstr "最大"
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_trend_value
 msgid "Min"
 msgstr "最小値"
 
@@ -6441,15 +7059,21 @@ msgstr "ホスト名"
 msgid "IPMI Present"
 msgstr "IPMI 有"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ip_address
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddress
 msgid "IP Address"
 msgstr "IP アドレス"
 
 msgid "Mac address"
 msgstr "MAC アドレス"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
 msgid "Provider"
 msgstr "プロバイダー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone
+#. TRANSLATORS: en.yml key: dictionary.table.zone
 msgid "Zone"
 msgstr "ゾーン"
 
@@ -6468,6 +7092,7 @@ msgstr "レルム"
 msgid "Compute Profile"
 msgstr "コンピュートプロファイル"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_arch
 msgid "Architecture"
 msgstr "アーキテクチャー"
 
@@ -6486,6 +7111,7 @@ msgstr "設定場所"
 msgid "Configuration Organization"
 msgstr "設定組織"
 
+#. TRANSLATORS: en.yml key: dictionary.table.operating_system
 msgid "OS"
 msgstr "OS"
 
@@ -6546,6 +7172,7 @@ msgstr "クラウドインテリジェンス"
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback
 msgid "Chargeback"
 msgstr "チャージバック"
 
@@ -6555,48 +7182,72 @@ msgstr "RSS"
 msgid "My Services"
 msgstr "マイサービス"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
 msgid "Catalogs"
 msgstr "カタログ"
 
 msgid "Workloads"
 msgstr "ワークロード"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_requests
 msgid "Requests"
 msgstr "要求"
 
 msgid "Clouds"
 msgstr "クラウド"
 
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
 msgid "Availability Zones"
 msgstr "アベイラビリティーゾーン"
 
 msgid "Tenants"
 msgstr "テナント"
 
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
 msgid "Volumes"
 msgstr "ボリューム"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavors
 msgid "Flavors"
 msgstr "フレーバー"
 
 msgid "Security Groups"
 msgstr "セキュリティーグループ"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
 msgid "Instances"
 msgstr "インスタンス"
 
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
 msgid "Stacks"
 msgstr "スタック"
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
 msgid "Key Pairs"
 msgstr ""
 
 msgid "Infrastructure"
 msgstr "インフラストラクチャー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
 msgid "Virtual Machines"
 msgstr "仮想マシン"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.resource_pools
 msgid "Resource Pools"
 msgstr "リソースプール"
 
@@ -6624,6 +7275,7 @@ msgstr "コンテナーイメージ"
 msgid "Middleware"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
 msgid "Storage Managers"
 msgstr "ストレージマネジャー"
 
@@ -6660,6 +7312,7 @@ msgstr "設定"
 msgid "My Settings"
 msgstr "マイ設定"
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
 msgid "Tasks"
 msgstr "タスク"
 
@@ -6669,9 +7322,12 @@ msgstr "情報"
 msgid "Object Types"
 msgstr "オブジェクトタイプ"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Storage
+#. TRANSLATORS: en.yml key: dictionary.table.storage
 msgid "Datastore"
 msgstr "データストア"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
 msgid "Enterprise"
 msgstr "エンタープライズ"
 
@@ -7028,12 +7684,15 @@ msgstr "名前 / 説明"
 msgid "Display in Catalog"
 msgstr "カタログ内の表示"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
 msgid "Catalog"
 msgstr "カタログ"
 
 msgid "Unassigned"
 msgstr "未割り当て"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
 msgid "Dialog"
 msgstr "ダイアログ"
 
@@ -7043,6 +7702,8 @@ msgstr "ダイアログなし"
 msgid "Choose"
 msgstr "選択"
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
 msgid "Orchestration Template"
 msgstr "オーケストレーションテンプレート"
 
@@ -7097,6 +7758,7 @@ msgstr "リソースの追加"
 msgid "Selected Resources"
 msgstr "選択したリソース"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction
 msgid "Action"
 msgstr "アクション"
 
@@ -7181,6 +7843,7 @@ msgstr "カタログ項目の割り当て"
 msgid "No Catalog Items found."
 msgstr "カタログ項目が見つかりませんでした。"
 
+#. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
 msgid "Catalog Items"
 msgstr "カタログ項目"
 
@@ -7322,6 +7985,8 @@ msgstr "レポートが現在このタイムプロファイルを使用中です
 msgid "Grid/Tile Icons"
 msgstr "グリッド/タイトルアイコン"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra
 msgid "Template"
 msgstr "テンプレート"
 
@@ -7385,6 +8050,8 @@ msgstr "ドリフトモード"
 msgid "Tagging"
 msgstr "タグ付け"
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
 msgid "Orchestration Templates"
 msgstr "オーケストレーションテンプレート"
 
@@ -7397,9 +8064,12 @@ msgstr "テンプレート & イメージ"
 msgid "VMs & Instances"
 msgstr "VM & インスタンス"
 
+#. TRANSLATORS: en.yml key: dictionary.table.vms
 msgid "VMs"
 msgstr "VM"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
 msgid "Templates"
 msgstr "テンプレート"
 
@@ -7422,6 +8092,7 @@ msgstr "記録が見つかりませんでした。"
 msgid "Roll Up Performance"
 msgstr "パフォーマンスのロールアップ"
 
+#. TRANSLATORS: en.yml key: dictionary.column.userid
 msgid "Username"
 msgstr "ユーザー名"
 
@@ -7621,9 +8292,12 @@ msgstr "ホストプラットフォーム"
 msgid "Custom Identifier"
 msgstr "カスタム識別子"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
 msgid "IPMI IP Address"
 msgstr "IPMI IP アドレス"
 
+#. TRANSLATORS: en.yml key: dictionary.column.mac_address
+#. TRANSLATORS: en.yml key: dictionary.column.macaddress
 msgid "MAC Address"
 msgstr "MAC アドレス"
 
@@ -7645,6 +8319,8 @@ msgstr "診断法"
 msgid "Custom Attributes"
 msgstr "カスタム属性"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
 msgid "VC Custom Attributes"
 msgstr "VC カスタム属性"
 
@@ -7732,6 +8408,8 @@ msgstr "オブジェクト詳細"
 msgid "System/Process"
 msgstr "システム/プロセス"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request
 msgid "Request"
 msgstr "要求"
 
@@ -7774,6 +8452,7 @@ msgstr "%s の確認"
 msgid "Private Key"
 msgstr "プライベートキー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification
 msgid "Category"
 msgstr "カテゴリー"
 
@@ -8033,6 +8712,7 @@ msgstr "VM \"%{name}\""
 msgid "Options %s"
 msgstr "オプション %s"
 
+#. TRANSLATORS: en.yml key: dictionary.column.interval
 msgid "Interval"
 msgstr "間隔"
 
@@ -8051,6 +8731,7 @@ msgstr "グループ化"
 msgid "Show VM Types"
 msgstr "VM タイプの表示"
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
 msgid "Time Profile"
 msgstr "タイムプロファイル"
 
@@ -8424,6 +9105,7 @@ msgstr "設定の表示"
 msgid "Show %{host_title}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
 #, fuzzy
 msgid "Direct VMs"
 msgstr "ダイレクト VM: 0"
@@ -8489,6 +9171,7 @@ msgstr "すべてのテンプレートの表示"
 msgid "Show this Flavor's parent %s"
 msgstr "このフレーバーの親 %s を表示"
 
+#. TRANSLATORS: en.yml key: dictionary.table.guest_devices
 msgid "Devices"
 msgstr "デバイス"
 
@@ -8993,6 +9676,8 @@ msgstr "サービスダイアログのインポート"
 msgid "Dialog Information"
 msgstr "ダイアログ情報"
 
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
 msgid "Buttons"
 msgstr "ボタン"
 
@@ -9141,6 +9826,7 @@ msgstr "ボトルネックイベント詳細"
 msgid "Select a node on the left to view Bottlenecks timeline."
 msgstr "左側のノードを選択してボトルネックタイムラインを表示します。"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport
 msgid "Report"
 msgstr "レポート"
 
@@ -9197,6 +9883,7 @@ msgstr "VM の選択"
 msgid "VM Options"
 msgstr "VM オプション"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_speed
 msgid "CPU Speed"
 msgstr "CPU スピード"
 
@@ -9379,6 +10066,7 @@ msgstr "変数が設定されていません。"
 msgid "Object ID"
 msgstr "オブジェクト ID"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
 msgid "Analysis Profile"
 msgstr "分析プロファイル"
 
@@ -9400,6 +10088,7 @@ msgstr "継承タグ"
 msgid "Parent Type"
 msgstr "親タイプ"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
 msgid "Categories"
 msgstr "カテゴリー"
 
@@ -9457,6 +10146,7 @@ msgstr "このアクションから選択したアラートを削除"
 msgid "SNMP Trap Settings"
 msgstr "SNMP トラップ設定"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
 msgid "Analysis Profiles"
 msgstr "分析プロファイル"
 
@@ -9496,6 +10186,8 @@ msgstr "選択された %s のアラームが見つかりませんでした"
 msgid "Choose a %s first"
 msgstr "最初に %s を選択"
 
+#. TRANSLATORS: en.yml key: dictionary.column.active
+#. TRANSLATORS: en.yml key: dictionary.column.enabled
 msgid "Active"
 msgstr "アクティブ"
 
@@ -9580,6 +10272,8 @@ msgstr "このアクションを表示"
 msgid "No Alerts are defined %s."
 msgstr "%s と定義されたアラートはありません。"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event
 msgid "Management Event"
 msgstr "管理イベント"
 
@@ -10004,6 +10698,7 @@ msgstr "フィルター変更のリセット"
 msgid "Datacenter"
 msgstr "データセンター"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
 msgid "Resource Pool"
 msgstr "リソースプール"
 
@@ -10055,6 +10750,7 @@ msgstr "承認/否認"
 msgid "Approved/Denied on"
 msgstr "承認/否認日"
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
 msgid "Provisioned VMs"
 msgstr "プロビジョニングされた VM"
 
@@ -10121,6 +10817,8 @@ msgstr "この論理ディスク作成要求を送信"
 msgid "SmartProxy Affinity"
 msgstr "SmartProxy アフィニティー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server
 msgid "Server"
 msgstr "サーバー"
 
@@ -10154,6 +10852,9 @@ msgstr "サーバー別ロール"
 msgid "Servers by Roles"
 msgstr "ロール別サーバー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_servers
 msgid "Servers"
 msgstr "サーバー"
 
@@ -10190,9 +10891,11 @@ msgstr "Amazon 設定の検証"
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr "Amazon アクセスキーおよび秘密キーは Amazon 設定を検証するために必要です"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem
 msgid "File"
 msgstr "ファイル"
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items
 msgid "Registry"
 msgstr "レジストリー"
 
@@ -10268,6 +10971,7 @@ msgstr "メトリック"
 msgid "Rows"
 msgstr "行"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
 msgid "Size"
 msgstr "サイズ"
 
@@ -10387,12 +11091,15 @@ msgstr "テストメールを送信するには、SMTP メールサーバー設�
 msgid "LDAP Groups for User"
 msgstr "ユーザーの LDAP グループ"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
 msgid "LDAP Servers"
 msgstr "LDAP サーバー"
 
 msgid "Mode"
 msgstr "モード"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ldap
 msgid "LDAP"
 msgstr "LDAP"
 
@@ -10429,6 +11136,8 @@ msgstr "クリックしてこのフォレストを削除する"
 msgid "Click to edit this forest"
 msgstr "クリックしてこのフォレストを編集する"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
 msgid "LDAP Domains"
 msgstr "LDAP ドメイン"
 
@@ -10509,6 +11218,7 @@ msgstr "グループ情報"
 msgid "(Look Up LDAP Groups)"
 msgstr "(LDAP グループ検索)"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
 msgid "Role"
 msgstr "ロール"
 
@@ -10613,6 +11323,7 @@ msgstr ""
 msgid "User Information"
 msgstr "ユーザー情報"
 
+#. TRANSLATORS: en.yml key: dictionary.column.User.name
 msgid "Full Name"
 msgstr "氏名"
 
@@ -10679,9 +11390,11 @@ msgstr "開始日"
 msgid "Stopped On"
 msgstr "停止日"
 
+#. TRANSLATORS: en.yml key: dictionary.column.memory_size
 msgid "Memory Usage"
 msgstr "メモリー使用量"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_time
 msgid "CPU Time"
 msgstr "CPU 時間"
 
@@ -10848,6 +11561,9 @@ msgstr "分析プロファイルの表示"
 msgid "View Zones"
 msgstr "ゾーンの表示"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zones
 msgid "Zones"
 msgstr "ゾーン"
 
@@ -10857,6 +11573,8 @@ msgstr "スケジュールの表示"
 msgid "View LDAP Regions"
 msgstr "LDAP 領域の表示"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
 msgid "LDAP Regions"
 msgstr "LDAP 領域"
 
@@ -11091,6 +11809,9 @@ msgstr "グレー表示"
 msgid "Appliances in this region can be registered with:"
 msgstr "このリージョンのアプライアンスは以下を使って登録できます:"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService
+#. TRANSLATORS: en.yml key: dictionary.model.Service
+#. TRANSLATORS: en.yml key: dictionary.table.container_service
 msgid "Service"
 msgstr "サービス"
 
@@ -11174,6 +11895,8 @@ msgstr "オペレーティングシステム"
 msgid "Tenancy"
 msgstr "テナンシー"
 
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
 msgid "ISO Images"
 msgstr "ISO イメージ"
 
@@ -11212,6 +11935,7 @@ msgid ""
 " PXE Server"
 msgstr "* このボックスをチェックすると、この PXE サーバーにある他のすべての PXE イメージからこの設定が削除されます"
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
 msgid "PXE Images"
 msgstr "PXE イメージ"
 
@@ -11257,14 +11981,24 @@ msgstr "Sysprep"
 msgid "Available Fields:"
 msgstr "選択可能なフィールド:"
 
+msgid "down"
+msgstr ""
+
+msgid "up"
+msgstr ""
+
+#, fuzzy
+msgid "Move selected fields %{where}"
+msgstr "選択したフィールドを下に移動する"
+
 msgid "Selected Fields:"
 msgstr " 選択フィールド:"
 
-msgid "Move selected fields to top"
-msgstr "選択したフィールドを先頭に移動する"
+msgid "to bottom"
+msgstr ""
 
-msgid "Move selected fields to bottom"
-msgstr "選択したフィールドを一番下に移動する"
+msgid "to top"
+msgstr ""
 
 msgid "Tab Title"
 msgstr "タブタイトル"
@@ -11323,6 +12057,7 @@ msgstr ""
 msgid "Commit Changes"
 msgstr "変更のコミット"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
 msgid "Widgets"
 msgstr "ウィジェット"
 
@@ -11465,6 +12200,7 @@ msgstr "チャージバックフィルター"
 msgid "Show Costs by"
 msgstr "コストの表示"
 
+#. TRANSLATORS: en.yml key: dictionary.column.owner_name
 msgid "Owner"
 msgstr "所有者"
 
@@ -11956,6 +12692,10 @@ msgstr "項目が見つかりませんでした。"
 msgid "Hover Text"
 msgstr "ホバーテキスト"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.container_image
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud
 msgid "Image"
 msgstr "イメージ"
 
@@ -11979,6 +12719,12 @@ msgstr "選択したフィールドを右に移動する"
 
 msgid "Move selected fields left"
 msgstr "選択したフィールドを左に移動する"
+
+msgid "Move selected fields to top"
+msgstr "選択したフィールドを先頭に移動する"
+
+msgid "Move selected fields to bottom"
+msgstr "選択したフィールドを一番下に移動する"
 
 msgid "Button Group Text"
 msgstr "ボタングループテキスト"
@@ -12037,6 +12783,8 @@ msgstr "名前"
 msgid "Placement"
 msgstr "配置"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder
 msgid "Folder"
 msgstr "フォルダー"
 
@@ -12145,9 +12893,13 @@ msgstr "ホストのデフォルト VNC ポート範囲"
 msgid "Add this %s"
 msgstr "この %s を追加"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region
 msgid "Region"
 msgstr "リージョン"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+#. TRANSLATORS: en.yml key: dictionary.table.container_project
 #, fuzzy
 msgid "Project"
 msgstr "プロジェクト"
@@ -12241,18 +12993,22 @@ msgstr "アカウントポリシー"
 msgid "Network Type"
 msgstr "ネットワークタイプ"
 
+#. TRANSLATORS: en.yml key: dictionary.table.nics
 msgid "Network Adapters"
 msgstr "ネットワークアダプター"
 
 msgid "%s has no network adapters"
 msgstr "%s にはネットワークアダプターがありません"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
 msgid "DHCP Enabled"
 msgstr "DHCP 有効化"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
 msgid "DHCP Server"
 msgstr "DHCP サーバー"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dns_server
 msgid "DNS Server"
 msgstr "DNS サーバー"
 
@@ -12265,18 +13021,23 @@ msgstr "IPアドレス"
 msgid "Subnet Mask"
 msgstr "サブネットマスク"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
 msgid "CPU Limit"
 msgstr "CPU 上限"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
 msgid "CPU Reserve"
 msgstr "CPU 予約"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
 msgid "CPU Reserve Expand"
 msgstr "CPU 予約拡張"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
 msgid "CPU Shares"
 msgstr "CPU 共有"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
 msgid "CPU Shares Level"
 msgstr "CPU 共有レベル"
 
@@ -12298,6 +13059,7 @@ msgstr "メモリー共有レベル"
 msgid "Device Type"
 msgstr "デバイスタイプ"
 
+#. TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
 msgid "Partitions Aligned"
 msgstr "パーティションの配置"
 
@@ -12499,6 +13261,3441 @@ msgstr "無効なチャート定義"
 #. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
 msgid "locale_name"
 msgstr "日本語"
+
+#. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+#, fuzzy
+msgid "Total Instances"
+msgstr "すべてのインスタンス"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+#, fuzzy
+msgid "Total Images"
+msgstr "すべてのイメージ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+msgid "CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+msgid "CPU - Total Installed - Sum of Child Hosts (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+msgid "Disk I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg ("
+"%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High "
+"Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low A"
+"vg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+msgid "Memory - Avg Usage of Total Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+msgid ""
+"Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Interv"
+"als (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+msgid "Network I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+msgid "CPU - Total Installed - from Host Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+msgid "Disk Space Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+msgid "CPU - Time Spent In Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+msgid "CPU - Time Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+msgid "CPU - Time Used (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+msgid "CPU - Time Spent in Wait State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+msgid "CPU - Total - from VM Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+msgid "CPU - Reserved (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+msgid "Memory - Total Allocated (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+msgid "Memory - Reserved (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+msgid "Memory - Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+msgid "CPU Max Reserved MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+msgid "Memory Max Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+#, fuzzy
+msgid "Memory Max Reserved"
+msgstr "メモリー予約"
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+msgid "Memory - Peak Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+msgid "Memory - Minimum Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+msgid "CPU - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+#, fuzzy
+msgid "Memory - Reserved (%)"
+msgstr "メモリー予約"
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+msgid "CPU - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+msgid "Memory - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+msgid "Network I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+msgid "CPU - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+msgid "Memory - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+msgid "Network I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.acctid
+#, fuzzy
+msgid "Account ID"
+msgstr "アカウント"
+
+#. TRANSLATORS: en.yml key: dictionary.column.accttype
+#, fuzzy
+msgid "Account Type"
+msgstr "アクションタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+msgid "Lockdown Mode"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+msgid "Total Number of Logical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+msgid "Total Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+msgid "Total Number of Physical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+msgid "Allocated Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+msgid "Allocated Storage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+msgid "Allocated vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios
+msgid "BIOS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios_location
+msgid "BIOS Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.chain_id
+msgid "Chain ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+msgid "Usage (CIFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+msgid "Usage (CIFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+msgid "Usage (CIFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+msgid "Usage (CIFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+msgid "Usage (CIFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+msgid "Usage (CIFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+msgid "Usage (CIFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+msgid "Usage (CIFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+msgid "Usage (CIFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+msgid "Usage (CIFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+msgid "Usage (CIFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+msgid "Usage (CIFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+msgid "Usage (CIFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+msgid "Usage (CIFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+msgid "Usage (CIFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+msgid "Usage (CIFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+msgid "Usage (CIFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+msgid "Usage (CIFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+msgid "Usage (CIFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+msgid "Usage (CIFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+msgid "Usage (CIFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+msgid "Usage (CIFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+msgid "Usage (CIFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+msgid "Usage (CIFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.config_xml
+#, fuzzy
+msgid "Configuration XML"
+msgstr "設定タグ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+msgid "Data Points"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+msgid "CPU Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_type
+#, fuzzy
+msgid "CPU Type"
+msgstr "CPU 時間"
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High A"
+"vg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Av"
+"g (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+msgid "CPU - Aggregate Time Used for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+msgid "CPU - Aggregate Time Spent in Wait State for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.created_at
+#. TRANSLATORS: en.yml key: dictionary.column.created_on
+msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+msgid "Depends on Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+msgid "Depends on Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+msgid "CPU Total Installed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+msgid "CPU - Available (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+msgid "State - Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+msgid "State - Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+msgid "Memory - Total Allocated for Child VMs (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+msgid "Memory - Available (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg "
+"(MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg ("
+"MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+msgid "Content - Avg of Total Size of Managed VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+msgid "Content - Avg of Total Size of Registered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+msgid "Capacity - Avg Free Space for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+msgid "Content - Avg of Total Size of Managed VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+msgid "Content - Avg of Total Size of Registered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+msgid "Content - Avg of Total Size of Managed VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+msgid "Content - Avg of Total Size of Registered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+msgid "Capacity - Total Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+msgid "Content - Avg Space Used by Managed VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+msgid "Content - Avg Space Used by Registered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+msgid "Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+msgid "Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+msgid "Content - Avg Count of Managed VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+msgid "Content - Avg Count of Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+msgid "Content - Avg Count of Unmanaged VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+msgid "Content - Avg Count of Unregistered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+msgid "State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+msgid "State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+msgid "Destination Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+msgid "Destination VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+msgid "Destination VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+msgid "Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+msgid "Disk Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+msgid "Disk Kernel Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+msgid "Disk Queue Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+msgid "Disk I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+msgid "Disks Aligned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+msgid "CPU - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_memory
+msgid "Memory - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+msgid "End"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+#, fuzzy
+msgid "What is evaluated"
+msgstr "評価対象"
+
+#. TRANSLATORS: en.yml key: dictionary.column.event_src
+#, fuzzy
+msgid "Event Source"
+msgstr "ソース"
+
+#. TRANSLATORS: en.yml key: dictionary.column.filename
+#, fuzzy
+msgid "File Name"
+msgstr "氏名"
+
+#. TRANSLATORS: en.yml key: dictionary.column.fqname
+msgid "Fully Qualified Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guest_os
+msgid "Guest OS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guid
+msgid "EVM Unique ID (Guid)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+msgid "Has an RDM Disk?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state
+msgid "Health State Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state_str
+msgid "Health State"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.homedir
+#, fuzzy
+msgid "Home Directory"
+msgstr "PXE ディレクトリー"
+
+#. TRANSLATORS: en.yml key: dictionary.column.host_name
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+#, fuzzy
+msgid "Parent Host"
+msgstr "親 VM"
+
+#. TRANSLATORS: en.yml key: dictionary.column.hostnames
+#, fuzzy
+msgid "Host Names"
+msgstr "名前"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+#, fuzzy
+msgid "IP Addresses"
+msgstr "IP アドレス"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+#, fuzzy
+msgid "IPMI Enabled"
+msgstr "DHCP 有効化"
+
+#. TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+msgid "Is an EVM Appliance?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+msgid "Last Analysis Attempt On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+msgid "Last Analysis Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+#, fuzzy
+msgid "Last Sync Time"
+msgstr "最終実行時間"
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status
+msgid "Last Update Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+#, fuzzy
+msgid "Last Update Status"
+msgstr "ステータスの更新"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ldap_group
+#. TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+msgid "LDAP Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+#, fuzzy
+msgid "Number of CPU Cores"
+msgstr "CPU の数"
+
+#. TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.macaddresses
+#, fuzzy
+msgid "MAC Addresses"
+msgstr "MAC アドレス"
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+msgid "CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max"
+" (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+msgid "CPU Max Total MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+msgid "CPU Max Available MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+msgid "State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+msgid "State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+msgid "Memory Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+msgid "Memory Max Available"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+msgid "Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+msgid "Disk Space Max Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+msgid "State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+msgid "Memory - Swap In Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+msgid "Memory - Swap Out Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+msgid "Memory - Swapped Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+msgid "Memory - Peak Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+msgid "Uptime - Peak Uptime for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+msgid "Disk Space Max Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+msgid "Memory - Swap In Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+msgid "Memory - Swap Out Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+msgid "Memory - Swapped Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+msgid "Memory - Usage of Total Allocated (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_mb
+msgid "RAM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+msgid "State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+msgid "State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+msgid "Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+msgid "Disk Space Min Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+msgid "State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+msgid "State - Min Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+msgid "Memory - Swap In Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+msgid "Memory - Swap Out Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+msgid "Memory - Swapped Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+msgid "Memory - Swap Min Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+msgid "Memory - Min Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+msgid "Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+msgid "Disk Space Min Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+msgid "Multiple Host Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+msgid "Network I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+msgid "Usage (NFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+msgid "Usage (NFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+msgid "Usage (NFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+msgid "Usage (NFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+msgid "Usage (NFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+msgid "Usage (NFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+msgid "Usage (NFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+msgid "Usage (NFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+msgid "Usage (NFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+msgid "Usage (NFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+msgid "Usage (NFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+msgid "Usage (NFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+msgid "Usage (NFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+msgid "Usage (NFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+msgid "Usage (NFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+msgid "Usage (NFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+msgid "Usage (NFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+msgid "Usage (NFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+msgid "Usage (NFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+msgid "Usage (NFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+msgid "Usage (NFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+msgid "Usage (NFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+msgid "Usage (NFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+msgid "Usage (NFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_automate
+#, fuzzy
+msgid "Management Event Raised"
+msgstr "管理イベント"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_email
+#, fuzzy
+msgid "Email"
+msgstr "メール"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+#, fuzzy
+msgid "Event on Timeline"
+msgstr "タイムラインに表示"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+msgid "SNMP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_cpu
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+#, fuzzy
+msgid "Number of CPUs"
+msgstr "CPU の数"
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_disks
+#, fuzzy
+msgid "Number of Disks"
+msgstr "VMの数"
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+#, fuzzy
+msgid "Number of Hard Disks"
+msgstr "VMの数"
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status
+msgid "Operational Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+msgid "Operational Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.os_image_name
+#, fuzzy
+msgid "OS Name"
+msgstr "新規名前"
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency
+msgid "Usage (Other) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+msgid "Usage (Other) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+msgid "Usage (Other) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops
+msgid "Usage (Other) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+msgid "Usage (Other) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+msgid "Usage (Other) - Number of Other Operations per Second Miin"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+msgid "Memory - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+msgid "CPU - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+msgid "In My LDAP Group?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+msgid "Owned by Me?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+msgid "Folder Name (VMs & Templates) 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+msgid "Folder Name (VMs & Templates) 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+msgid "Folder Name (VMs & Templates) 3"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+msgid "Folder Name (VMs & Templates) 4"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+msgid "Folder Name (VMs & Templates) 5"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+msgid "Folder Name (VMs & Templates) 6"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+msgid "Folder Name (VMs & Templates) 7"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+msgid "Folder Name (VMs & Templates) 8"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+msgid "Folder Name (VMs & Templates) 9"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+#, fuzzy
+msgid "CPU %"
+msgstr "CPU"
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_memory
+#, fuzzy
+msgid "Memory %"
+msgstr "メモリー"
+
+#. TRANSLATORS: en.yml key: dictionary.column.pid
+msgid "PID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+msgid "Total Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ram_size
+msgid "RAM Size (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data
+msgid "Usage (Other) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_max
+msgid "Usage (Other) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_min
+msgid "Usage (Other) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency
+msgid "Usage (Other) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+msgid "Usage (Other) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+msgid "Usage (Other) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops
+msgid "Usage (Other) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+msgid "Usage (Other) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+msgid "Usage (Other) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.resource_name
+#, fuzzy
+msgid "Asset Name"
+msgstr "ユーザー名"
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+msgid "Total VMs Powered Never"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+msgid "Total VMs Powered Off"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+msgid "Total VMs Powered On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+msgid "Total VMs Power Suspended"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+msgid "Total VMs Powered Unknown"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+msgid "CPU - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+msgid "State - Number of Hosts  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+msgid "Memory - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+msgid "State - Peak Avg VMs - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+msgid "CPU - Usage Rate for Collected Intervals (Number of Cores)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+msgid "Memory - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+msgid "Memory - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+msgid "Memory - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+msgid "CPU - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+msgid "CPU - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+msgid "CPU - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+msgid "Capacity - Profile 1 - Total Memory with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+msgid "Capacity - Profile 1 - Total CPU with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+msgid "Capacity - Profile 1 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+msgid "Capacity - Profile 1 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+msgid "Capacity - Profile 1 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+msgid "Capacity - Profile 1 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+msgid "Capacity - Profile 1 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+msgid "Capacity - Profile 1 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+msgid "Capacity - Profile 1 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+msgid "Capacity - Profile 1 - Available vCPUs for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 1 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+msgid "Capacity - Profile 1 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+msgid "Capacity - Profile 1 - Maximum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+msgid "Capacity - Profile 1 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+msgid "Capacity - Profile 1 - Minimum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+msgid "Capacity - Profile 1 - Number of vCPUs per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+msgid "Capacity - Profile 2 - Memory Effective with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+msgid "Capacity - Profile 2 - CPU Effective with HA (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+msgid "Capacity - Profile 2 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+msgid "Capacity - Profile 2 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+msgid "Capacity - Profile 2 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+msgid "Capacity - Profile 2 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+msgid "Capacity - Profile 2 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+msgid "Capacity - Profile 2 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+msgid "Capacity - Profile 2 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+msgid "Capacity - Profile 2 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+msgid "Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 2 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+msgid "Capacity - Profile 2 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+msgid "Capacity - Profile 2 - Maximum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+msgid "Capacity - Profile 2 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+msgid "Capacity - Profile 2 - Minimum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+msgid "Memory - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+msgid "Memory - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+msgid "Memory - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+msgid "CPU - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+msgid "CPU - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+msgid "CPU - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+msgid "Created on Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+msgid "Memory - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+msgid "Memory - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+msgid "Memory - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+msgid "CPU - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+msgid "CPU - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+msgid "CPU - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+msgid "Memory - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+msgid "CPU - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+msgid "Usage (Block Protocol) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data
+msgid "Usage (Block Protocol) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+msgid "Usage (Block Protocol) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+msgid "Usage (Block Protocol) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+msgid "Usage (Block Protocol) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+msgid "Usage (Block Protocol) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+msgid "Usage (Block Protocol) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+msgid "Usage (Block Protocol) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+msgid "Usage (Block Protocol) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+msgid "Usage (Block Protocol) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data
+msgid "Usage (Block Protocol) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+msgid "Usage (Block Protocol) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+msgid "Usage (Block Protocol) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+msgid "Usage (Block Protocol) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+msgid "Usage (Block Protocol) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+msgid "Usage (Block Protocol) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+msgid "Usage (Block Protocol) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+msgid "Usage (Block Protocol) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+msgid "Usage (Block Protocol) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.slope
+#, fuzzy
+msgid "Slope"
+msgstr "範囲"
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_host_name
+msgid "Source Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+msgid "Source VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+msgid "Source VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+msgid "SSH Root Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.svc_type
+#, fuzzy
+msgid "Service Type"
+msgstr "デバイスタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+msgid "Asset - Uptime (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+msgid "Thin Provisioned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.timestamp
+#. TRANSLATORS: en.yml key: dictionary.column.statistic_time
+msgid "Activity Sample - Timestamp (Day/Time)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops
+msgid "Usage (All) - Number of Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+msgid "Usage (All) - Number of Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+msgid "Usage (All) - Number of Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+msgid "CPU Average Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+msgid "Memory Average Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+msgid "CPU Max Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+msgid "Memory Max Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+msgid "Disk I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+msgid "Network I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+msgid "Disk Space Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+msgid "Disk Space Average Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.typename
+msgid "Type Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uid
+msgid "UID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+msgid "Uncommitted Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.updated_at
+#. TRANSLATORS: en.yml key: dictionary.column.updated_on
+#, fuzzy
+msgid "Date Updated"
+msgstr "最終更新日"
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+msgid "Total Used Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+#, fuzzy
+msgid "Percent Used Provisioned Space"
+msgstr "プロビジョニングされたサイズの使用率"
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+msgid "Currently Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+msgid "CPU Cores Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+#, fuzzy
+msgid "Datastore Path"
+msgstr "データストアスペース"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_date
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+msgid "Activity Sample - Day (MM DD YY)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+msgid "Non-VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+msgid "Capacity - Used Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+msgid "Disk Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+msgid "Free Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+msgid "Parent Host Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+#, fuzzy
+msgid "Is a Template"
+msgstr "VM & テンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+msgid "VM Memory Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_month
+msgid "Activity Sample - Month (YYYY/MM)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+msgid "Parent Folder (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+msgid "Parent Folder Path (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+msgid "Parent Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+msgid "Parent Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+msgid "Parent Folder (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+msgid "Parent Folder Path (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+msgid "Parent Resource Pool"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+#, fuzzy
+msgid "Parent Folder"
+msgstr "フォルダーを開く"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+msgid "CPU - % Ready"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+msgid "CPU - % Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+msgid "CPU - % Wait"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+msgid "Pct Free Disk"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+msgid "Provisioned Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+msgid "Cluster in Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+msgid "Memory Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+msgid "Snapshot Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_time
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+msgid "Activity Sample - Time (HH MM SS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+msgid "Size of Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+#, fuzzy
+msgid "Size of VM Provisioned Disk Files"
+msgstr "VM のプロビジョニングされたディスクファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+msgid "Total Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+msgid "Size of VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+#, fuzzy
+msgid "Size of VM Snapshot Files"
+msgstr "VM スナップショットファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+msgid "Total Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+msgid "Size of Other VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+#, fuzzy
+msgid "Total VMs"
+msgstr "VM の合計"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space
+#, fuzzy
+msgid "Used Space"
+msgstr "使用サイズ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+msgid "Used Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+msgid "Other VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+msgid "Virtual Hardware Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+msgid "VMM Build Number"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_product
+msgid "VMM Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+msgid "VMM Vendor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_version
+#, fuzzy
+msgid "VMM Version"
+msgstr "CFME バージョン"
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+msgid "VMsafe Agent Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+msgid "VMsafe Agent Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+msgid "VMsafe Enable"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+msgid "VMsafe Fail Open"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+msgid "VMsafe Immutable VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+msgid "VMsafe Timeout (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data
+msgid "Usage (All) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_max
+msgid "Usage (All) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_min
+msgid "Usage (All) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency
+msgid "Usage (All) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+msgid "Usage (All) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+msgid "Usage (All) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops
+msgid "Usage (All) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+msgid "Usage (All) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+msgid "Usage (All) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ws_port
+#, fuzzy
+msgid "Web Services Port"
+msgstr "Web サービス"
+
+#. TRANSLATORS: en.yml key: dictionary.column.zone_name
+msgid "EVM Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+msgid "vCPUs Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+msgid "vCPUs Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+msgid "CPU Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+msgid "CPU Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+msgid "CPU Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+#, fuzzy
+msgid "CPU Used"
+msgstr "CPU スピード"
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+msgid "Disk I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+msgid "Disk I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+msgid "Disk I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+msgid "Disk I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.display_range
+msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+msgid "Fixed Compute Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+msgid "Fixed Compute Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+msgid "Fixed Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+msgid "Fixed Storage Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+msgid "Fixed Storage Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+msgid "Memory Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+msgid "Memory Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_cost
+msgid "Memory Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_metric
+msgid "Memory Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+msgid "Memory Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+#, fuzzy
+msgid "Memory Used"
+msgstr "メモリー使用量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+msgid "Network I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+#, fuzzy
+msgid "Network I/O Total"
+msgstr "ネットワークタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+msgid "Network I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+#, fuzzy
+msgid "Network I/O Used"
+msgstr "ネットワークタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+msgid "Storage Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+msgid "Storage Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_cost
+#, fuzzy
+msgid "Storage Total Cost"
+msgstr "合計容量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_metric
+msgid "Storage Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+msgid "Storage Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+#, fuzzy
+msgid "Storage Used"
+msgstr "ストレージファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_cost
+msgid "Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vm_name
+#, fuzzy
+msgid "VM Name"
+msgstr "VM 番号"
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+msgid "Average Read Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+msgid "Average Write Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+msgid "Read (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+msgid "Transferred (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+msgid "Written (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_hit
+msgid "Hit %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_read
+msgid "Read %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_write
+msgid "Write %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.queue_depth
+msgid "Queue Depth"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+msgid "Read Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+msgid "Read (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+msgid "Response Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+msgid "Service Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+msgid "Total (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.utilization
+#, fuzzy
+msgid "Utilization %"
+msgstr "使用率"
+
+#. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+msgid "Wait Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+msgid "Write Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+msgid "Write (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+#, fuzzy
+msgid "EVM Audit Event"
+msgstr "イベント監査"
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+msgid "EVM Audit Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone
+#, fuzzy
+msgid "Availability Zone"
+msgstr "アベイラビリティーゾーン"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+#, fuzzy
+msgid "Chargebacks"
+msgstr "チャージバック"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+#, fuzzy
+msgid "Chargeback Rate"
+msgstr "チャージバックレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+#, fuzzy
+msgid "Chargeback Rates"
+msgstr "チャージバックレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+msgid "Storage - Extent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+#, fuzzy
+msgid "Storage - Extents"
+msgstr "ストレージアダプター"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances
+#. TRANSLATORS: en.yml key: dictionary.table.compliances
+#, fuzzy
+msgid "Compliance History"
+msgstr "コンプライアンス詳細"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+#, fuzzy
+msgid "Compliance Histories"
+msgstr "コンプライアンスポリシー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Condition
+msgid "Condition"
+msgstr "条件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button
+#, fuzzy
+msgid "Button"
+msgstr "ボタン"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+#, fuzzy
+msgid "Buttons Group"
+msgstr "ボタングループテキスト"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+#, fuzzy
+msgid "Buttons Groups"
+msgstr "ボタングループテキスト"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+#. TRANSLATORS: en.yml key: dictionary.table.container_group
+#, fuzzy
+msgid "Pod"
+msgstr "ノード"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+msgid "Image Registry"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+msgid "Image Registries"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+#. TRANSLATORS: en.yml key: dictionary.table.container_route
+#, fuzzy
+msgid "Route"
+msgstr "レート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator
+#, fuzzy
+msgid "Replicator"
+msgstr "複製"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicators
+#, fuzzy
+msgid "Replicators"
+msgstr "複製"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+#, fuzzy
+msgid "Cluster / Deployment Roles"
+msgstr "クラスター / デプロイメントルール"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+msgid "Performance - Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+msgid "Performance - Clusters"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_events
+#, fuzzy
+msgid "Management Events"
+msgstr "管理イベント"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folders
+#, fuzzy
+msgid "Folders"
+msgstr "フォルダー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+msgid "Performance - Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+msgid "Performance - Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+msgid "FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+msgid "FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+msgid "Anonymous FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+msgid "Anonymous FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+msgid "NFS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+msgid "Samba"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+msgid "Sambas"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor
+#. TRANSLATORS: en.yml key: dictionary.table.flavor
+msgid "Flavor"
+msgstr "フレーバー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+#, fuzzy
+msgid "Host / Nodes"
+msgstr "ホスト / ノード"
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+msgid "Performance - Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+msgid "Performance - Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+#, fuzzy
+msgid "ISO Datastore"
+msgstr "ISO データストア"
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+#, fuzzy
+msgid "ISO Datastores"
+msgstr "すべての ISO データストア"
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image
+#, fuzzy
+msgid "ISO Image"
+msgstr "ISO イメージ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+#, fuzzy
+msgid "LDAP Domain"
+msgstr "LDAP ドメイン"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region
+#, fuzzy
+msgid "LDAP Region"
+msgstr "LDAP 領域"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server
+#, fuzzy
+msgid "LDAP Server"
+msgstr "LDAP サーバー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+#, fuzzy
+msgid "Configuration Manager"
+msgstr "設定管理"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+#, fuzzy
+msgid "Configuration Managers"
+msgstr "設定管理"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+#, fuzzy
+msgid "Foreman Configured System"
+msgstr "すべての %s 設定済みシステム"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+#, fuzzy
+msgid "Foreman Configured Systems"
+msgstr "すべての %s 設定済みシステム"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+msgid "Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+#, fuzzy
+msgid "Cloud Providers"
+msgstr "すべての %s プロバイダー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+#, fuzzy
+msgid "Instance"
+msgstr "インスタンス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container
+#, fuzzy
+msgid "Containers Provider"
+msgstr "コンテナーサービス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_containers
+#, fuzzy
+msgid "Containers Providers"
+msgstr "コンテナーサービス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra
+#, fuzzy
+msgid "Infrastructure Provider"
+msgstr "インフラストラクチャープロバイダーのサイズ調整"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infras
+#, fuzzy
+msgid "Infrastructure Providers"
+msgstr "インフラストラクチャープロバイダーのサイズ調整"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+#, fuzzy
+msgid "Virtual Machine"
+msgstr "仮想マシン"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+msgid "Infrastructure Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+msgid "Infrastructure Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+msgid "Infrastructure Provider (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+msgid "Infrastructure Providers (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+msgid "Infrastructure Provider (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+msgid "Infrastructure Providers (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+msgid "Infrastructure Provider (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+msgid "Infrastructure Providers (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+msgid "Cloud Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+msgid "Cloud Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+msgid "Cloud Provider (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+msgid "Cloud Providers (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+msgid "Cloud Provider (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+msgid "Cloud Providers (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+msgid "Container Provider (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+msgid "Container Providers (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+msgid "Container Provider (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+msgid "Container Providers (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+msgid "Container Provider (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+msgid "Container Providers (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+msgid "Container Provider (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+msgid "Container Providers (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+msgid "Automate Class"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+msgid "Automate Classes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+msgid "Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+msgid "Automate Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+msgid "Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+#, fuzzy
+msgid "Automate Instances"
+msgstr "アーカイブされたインスタンス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+msgid "Automate Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+msgid "Automate Methods"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+msgid "Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+#, fuzzy
+msgid "Automate Namespaces"
+msgstr "名前空間"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+#, fuzzy
+msgid "Alert"
+msgstr "アラート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+#, fuzzy
+msgid "Alert Profile"
+msgstr "アラートプロファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+#, fuzzy
+msgid "Dialogs"
+msgstr "ダイアログ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+#, fuzzy
+msgid "Enterprises"
+msgstr "エンタープライズ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+#, fuzzy
+msgid "Event"
+msgstr "イベント"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+#, fuzzy
+msgid "EVM Group"
+msgstr "グループなし"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+#, fuzzy
+msgid "EVM Groups"
+msgstr "イベントグループ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+#, fuzzy
+msgid "Policy Profile"
+msgstr "ポリシープロファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+#, fuzzy
+msgid "Provisions"
+msgstr "%s のプロビジョニング "
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+msgid "SmartProxy"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+msgid "SmartProxies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_regions
+#, fuzzy
+msgid "Regions"
+msgstr "リージョン:"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+#, fuzzy
+msgid "Schedule"
+msgstr "スケジュール"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+msgid "Search"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+#, fuzzy
+msgid "Searches"
+msgstr "パッチ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+msgid "SMI-S Agent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+msgid "SMI-S Agents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+msgid "VM Template and Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+#, fuzzy
+msgid "VM Template and Images"
+msgstr "すべてのテンプレート & イメージ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+#, fuzzy
+msgid "Roles"
+msgstr "ロール"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+#, fuzzy
+msgid "Widget"
+msgstr "ウィジェット"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker
+#, fuzzy
+msgid "EVM Worker"
+msgstr "UI ワーカー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_workers
+#, fuzzy
+msgid "EVM Workers"
+msgstr "ワーカー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+msgid "NetApp Remote Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+msgid "NetApp Remote Services"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+msgid "Storage - Aggregate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+msgid "Storage - Aggregates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+msgid "Storage - File Share"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+msgid "Storage - File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+msgid "Storage - Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+msgid "Storage - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+#, fuzzy
+msgid "Storage - Plex"
+msgstr "ストレージファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+msgid "Storage - Plexes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+msgid "Storage - Raid Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+msgid "Storage - Raid Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+#, fuzzy
+msgid "Storage - Filer"
+msgstr "ストレージファイル"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+#, fuzzy
+msgid "Storage - Filers"
+msgstr "ストレージマネジャー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+msgid "Storage - LUN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+msgid "Storage - LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+msgid "Storage Performance - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+msgid "CloudFormation Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+#, fuzzy
+msgid "CloudFormation Templates"
+msgstr "オーケストレーションテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+msgid "Heat Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+#, fuzzy
+msgid "Heat Templates"
+msgstr "すべてのテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+#, fuzzy
+msgid "Azure Template"
+msgstr "すべてのテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+#, fuzzy
+msgid "Azure Templates"
+msgstr "すべてのテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+msgid "Product Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+msgid "Product Updates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+#, fuzzy
+msgid "Customization Template"
+msgstr "カスタマイズテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+#, fuzzy
+msgid "Customization Templates"
+msgstr "カスタマイズテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage
+#, fuzzy
+msgid "PXE Image"
+msgstr "PXE イメージ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+#, fuzzy
+msgid "System Image Type"
+msgstr "すべてのシステムイメージタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+#, fuzzy
+msgid "System Image Types"
+msgstr "すべてのシステムイメージタイプ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer
+#, fuzzy
+msgid "PXE Server"
+msgstr "NFS サーバー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+#, fuzzy
+msgid "PXE Servers"
+msgstr "すべての PXE サーバー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem
+#, fuzzy
+msgid "Scan Item"
+msgstr "スキャン項目"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+#, fuzzy
+msgid "Scan Items"
+msgstr "スキャン項目"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+#, fuzzy
+msgid "Service Catalog Item"
+msgstr "サービスカタログ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+#, fuzzy
+msgid "Service Catalog Items"
+msgstr "サービスカタログ"
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+msgid "Storage - Local File System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+msgid "Storage - Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storages
+#, fuzzy
+msgid "Datastores"
+msgstr "データストア"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file
+#, fuzzy
+msgid "Datastore File"
+msgstr "データストアスペース"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_files
+#, fuzzy
+msgid "Datastore Files"
+msgstr "データストアスペース"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager
+#, fuzzy
+msgid "Storage Manager"
+msgstr "ストレージマネジャー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+msgid "Performance - Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+msgid "Performance - Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User
+msgid "EVM User"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+#, fuzzy
+msgid "EVM Users"
+msgstr "すべてのユーザー"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+#, fuzzy
+msgid "Performance Trend"
+msgstr "パフォーマンス時間枠"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+#, fuzzy
+msgid "Performance Trends"
+msgstr "パフォーマンス時間枠"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm
+#, fuzzy
+msgid "VM and Instance"
+msgstr "単独インスタンス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+#, fuzzy
+msgid "VM and Instances"
+msgstr "VM & インスタンス"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+msgid "VMDB Table"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+msgid "VMDB Tables"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+#, fuzzy
+msgid "VM or Template"
+msgstr "VM またはテンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+#, fuzzy
+msgid "VM or Templates"
+msgstr "VM & テンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+msgid "Performance - VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+msgid "Performance - VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cdroms
+msgid "CD/DVD Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+msgid "Base Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+#, fuzzy
+msgid "Cloud Volume"
+msgstr "クラウドボリューム"
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+#, fuzzy
+msgid "Cloud Volumes"
+msgstr "クラウドボリューム"
+
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+msgid "Volume"
+msgstr "ボリューム"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+#, fuzzy
+msgid "VC Custom Attribute"
+msgstr "VC カスタム属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+msgid "Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+msgid "Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server
+msgid "Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+msgid "Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+msgid "Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner
+#, fuzzy
+msgid "EVM Owner"
+msgstr "所有者なし"
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+msgid "EVM Owners"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+#, fuzzy
+msgid "Cloud/Infrastructure Provider"
+msgstr "インフラストラクチャープロバイダーのサイズ調整"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+#, fuzzy
+msgid "Cloud/Infrastructure Providers"
+msgstr "インフラストラクチャープロバイダーのサイズ調整"
+
+#. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+#, fuzzy
+msgid "File System Drivers"
+msgstr "アクセス時間"
+
+#. TRANSLATORS: en.yml key: dictionary.table.floppies
+msgid "Floppy Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.lans
+msgid "vLANs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance
+msgid "Last Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+#, fuzzy
+msgid "Last Compliance Histories"
+msgstr "ホストコンプライアンスポリシー"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+#, fuzzy
+msgid "LDAPs"
+msgstr "LDAP"
+
+#. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+msgid "Linux Init Processes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+msgid "Stamped Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+msgid "Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+#, fuzzy
+msgid "EVM Custom Attribute"
+msgstr "VC カスタム属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+#, fuzzy
+msgid "EVM Custom Attributes"
+msgstr "VC カスタム属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+#, fuzzy
+msgid "Configuration Profile (Foreman)"
+msgstr "設定プロファイルの説明"
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+msgid "Configuration Profiles (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+msgid "Cloud Networks (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+msgid "Cloud Tenants (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+msgid "Provisioned From Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+msgid "Provisioned From Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+msgid "SmartProxy Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+msgid "SCSI LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task
+#, fuzzy
+msgid "Task"
+msgstr "タスク"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template
+#, fuzzy
+msgid "VM Template"
+msgstr "VM & テンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+#, fuzzy
+msgid "VM Templates"
+msgstr "VM & テンプレート"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+#, fuzzy
+msgid "File Shares"
+msgstr "CPU 共有"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+#, fuzzy
+msgid "Filers"
+msgstr "フィルター"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+msgid "LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+#, fuzzy
+msgid "Stack"
+msgstr "スタック"
+
+#. TRANSLATORS: en.yml key: dictionary.table.server_builds
+msgid "EVM Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.service_template
+#, fuzzy
+msgid "Catalog Item"
+msgstr "カタログ項目"
+
+#. TRANSLATORS: en.yml key: dictionary.table.switches
+#, fuzzy
+msgid "vSwitches"
+msgstr "スイッチ"
 
 msgid "Account|Acctid"
 msgstr "アカウント ID"
@@ -13021,9 +17218,6 @@ msgstr "コンピュートシステム"
 
 msgid "ComputerSystem|Managed entity type"
 msgstr "管理対象のエンティティータイプ"
-
-msgid "Condition"
-msgstr "条件"
 
 msgid "Condition|Applies to exp"
 msgstr "有効期限に適用"
@@ -14140,9 +18334,6 @@ msgstr "ソース IP 範囲"
 
 msgid "FirewallRule|Updated on"
 msgstr "更新日"
-
-msgid "Flavor"
-msgstr "フレーバー"
 
 msgid "Flavor|Block storage based only"
 msgstr "ブロックストレージベースのみ"
@@ -19375,9 +23566,6 @@ msgstr "名前"
 
 msgid "VmdbTable|Prior raw metrics"
 msgstr "従前の生メトリック"
-
-msgid "Volume"
-msgstr "ボリューム"
 
 msgid "Volume|Created on"
 msgstr "作成日"

--- a/config/locales/manageiq.pot
+++ b/config/locales/manageiq.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: manageiq 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-17 13:50+0100\n"
-"PO-Revision-Date: 2016-02-17 13:50+0100\n"
+"POT-Creation-Date: 2016-02-19 14:51+0100\n"
+"PO-Revision-Date: 2016-02-19 14:51+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -22,8 +22,8 @@ msgstr ""
 msgid " # of Days"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:639 ../../app/controllers/miq_policy_controller.rb:640
-msgid " %s Assignments"
+#: ../../app/controllers/miq_policy_controller.rb:646 ../../app/controllers/miq_policy_controller.rb:649
+msgid " %{model} Assignments"
 msgstr ""
 
 #: ../../app/controllers/ems_infra_controller.rb:54
@@ -154,16 +154,8 @@ msgstr ""
 msgid "%s Being Tagged"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/db.rb:187
-msgid "%s Client Connections"
-msgstr ""
-
 #: ../../app/views/miq_policy/_condition_folders.html.haml:20
 msgid "%s Conditions"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/settings.rb:136
-msgid "%s Credentials validated successfully"
 msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:194
@@ -212,18 +204,6 @@ msgstr ""
 msgid "%s Policy Simulation"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/db.rb:193
-msgid "%s Settings"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/db.rb:177
-msgid "%s Summary"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/db.rb:183 ../../app/controllers/ops_controller/db.rb:218
-msgid "%s Utilization"
-msgstr ""
-
 #: ../../app/views/report/_form_filter_chargeback.html.haml:194 ../../app/views/report/_form_filter_chargeback.html.haml:196
 msgid "%s Week"
 msgid_plural "%s Weeks"
@@ -234,20 +214,8 @@ msgstr[1] ""
 msgid "%s bytes"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/events.rb:9 ../../app/controllers/miq_policy_controller/alert_profiles.rb:80 ../../app/controllers/miq_policy_controller.rb:28 ../../app/controllers/miq_policy_controller.rb:203
-msgid "%s cancelled by user"
-msgstr ""
-
 #: ../../app/controllers/miq_ae_class_controller.rb:206
 msgid "%s domain: Current version - %s, Available version - %s"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/settings/common.rb:383
-msgid "%s file saved"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/settings/rhn.rb:299
-msgid "%s has been initiated for the selected Servers"
 msgstr ""
 
 #: ../../app/views/vm_common/_config.html.haml:202
@@ -262,31 +230,19 @@ msgstr ""
 msgid "%s is currently being used in the Display Filter"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:658 ../../app/controllers/ops_controller/diagnostics.rb:675
-msgid "%s is not allowed for the selected item"
-msgstr ""
-
-#: ../../app/controllers/miq_ae_customization_controller.rb:500 ../../app/controllers/miq_ae_tools_controller.rb:357 ../../app/controllers/miq_ae_tools_controller.rb:358 ../../app/controllers/report_controller/widgets.rb:741 ../../app/controllers/report_controller/menus.rb:73 ../../app/controllers/report_controller/reports.rb:226 ../../app/controllers/miq_policy_controller/miq_actions.rb:379 ../../app/controllers/miq_policy_controller/miq_actions.rb:382 ../../app/controllers/miq_policy_controller/miq_actions.rb:385 ../../app/controllers/miq_policy_controller/alerts.rb:535 ../../app/controllers/miq_policy_controller/alerts.rb:538 ../../app/controllers/vm_common.rb:567 ../../app/controllers/storage_manager_controller.rb:83 ../../app/controllers/storage_manager_controller.rb:90 ../../app/controllers/storage_manager_controller.rb:119 ../../app/controllers/ontap_file_share_controller.rb:117 ../../app/controllers/ontap_file_share_controller.rb:118 ../../app/controllers/ops_controller/settings/rhn.rb:221 ../../app/controllers/ops_controller/settings/tags.rb:53 ../../app/controllers/ops_controller/settings/tags.rb:56 ../../app/controllers/ops_controller/settings/tags.rb:59 ../../app/controllers/ops_controller/settings/ldap.rb:49 ../../app/controllers/ops_controller/settings/ldap.rb:175 ../../app/controllers/ops_controller/settings/ldap.rb:218 ../../app/controllers/ops_controller/settings/zones.rb:19 ../../app/controllers/ops_controller/settings/zones.rb:22 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:578 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:612 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:670 ../../app/controllers/ops_controller/settings.rb:99 ../../app/controllers/ops_controller/settings.rb:157 ../../app/controllers/ontap_storage_system_controller.rb:124 ../../app/controllers/ontap_storage_system_controller.rb:125 ../../app/controllers/ontap_storage_system_controller.rb:126 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:112 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:115 ../../app/controllers/pxe_controller/iso_datastores.rb:49 ../../app/controllers/pxe_controller/pxe_image_types.rb:166 ../../app/controllers/pxe_controller/pxe_servers.rb:296 ../../app/controllers/pxe_controller/pxe_servers.rb:299 ../../app/controllers/pxe_controller/pxe_servers.rb:302 ../../app/controllers/pxe_controller/pxe_servers.rb:306 ../../app/controllers/pxe_controller/pxe_servers.rb:309 ../../app/controllers/pxe_controller/pxe_servers.rb:312 ../../app/controllers/miq_policy_controller.rb:1000 ../../app/controllers/miq_policy_controller.rb:1004 ../../app/controllers/application_controller/buttons.rb:323 ../../app/controllers/application_controller/buttons.rb:327
+#: ../../app/controllers/miq_ae_customization_controller.rb:500 ../../app/controllers/miq_ae_tools_controller.rb:357 ../../app/controllers/miq_ae_tools_controller.rb:358 ../../app/controllers/report_controller/widgets.rb:741 ../../app/controllers/report_controller/menus.rb:73 ../../app/controllers/report_controller/reports.rb:226 ../../app/controllers/vm_common.rb:567 ../../app/controllers/storage_manager_controller.rb:83 ../../app/controllers/storage_manager_controller.rb:90 ../../app/controllers/storage_manager_controller.rb:119 ../../app/controllers/ops_controller/settings/ldap.rb:175 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:112 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:115 ../../app/controllers/pxe_controller/iso_datastores.rb:49 ../../app/controllers/pxe_controller/pxe_image_types.rb:166 ../../app/controllers/pxe_controller/pxe_servers.rb:296 ../../app/controllers/pxe_controller/pxe_servers.rb:299 ../../app/controllers/pxe_controller/pxe_servers.rb:302 ../../app/controllers/pxe_controller/pxe_servers.rb:306 ../../app/controllers/pxe_controller/pxe_servers.rb:309 ../../app/controllers/pxe_controller/pxe_servers.rb:312 ../../app/controllers/application_controller/buttons.rb:323 ../../app/controllers/application_controller/buttons.rb:327
 msgid "%s is required"
-msgstr ""
-
-#: ../../app/controllers/miq_policy_controller/alerts.rb:544 ../../app/controllers/miq_policy_controller/alerts.rb:549 ../../app/controllers/ontap_storage_system_controller.rb:127
-msgid "%s must be an integer"
 msgstr ""
 
 #: ../../app/controllers/report_controller/reports.rb:229
 msgid "%s must be configured"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:530 ../../app/controllers/ops_controller/ops_rbac.rb:534 ../../app/controllers/ops_controller/ops_rbac.rb:537
-msgid "%s must be entered to perform LDAP Group Look Up"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:232 ../../app/controllers/report_controller/reports.rb:323 ../../app/controllers/report_controller/reports.rb:365 ../../app/controllers/ops_controller/settings/common.rb:523 ../../app/controllers/ems_common.rb:532 ../../app/controllers/ems_common.rb:535
+#: ../../app/controllers/report_controller/reports.rb:232 ../../app/controllers/report_controller/reports.rb:323 ../../app/controllers/report_controller/reports.rb:365 ../../app/controllers/ems_common.rb:532 ../../app/controllers/ems_common.rb:535
 msgid "%s must be numeric"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:356 ../../app/controllers/report_controller/dashboards.rb:349 ../../app/controllers/report_controller/widgets.rb:724 ../../app/controllers/report_controller/widgets.rb:733 ../../app/controllers/report_controller/widgets.rb:737 ../../app/controllers/report_controller/schedules.rb:231 ../../app/controllers/report_controller/reports.rb:242 ../../app/controllers/report_controller/reports.rb:247 ../../app/controllers/report_controller/reports.rb:252 ../../app/controllers/report_controller/reports.rb:256 ../../app/controllers/miq_policy_controller/miq_actions.rb:380 ../../app/controllers/miq_policy_controller/miq_actions.rb:392 ../../app/controllers/miq_policy_controller/miq_actions.rb:395 ../../app/controllers/miq_policy_controller/miq_actions.rb:398 ../../app/controllers/miq_policy_controller/miq_actions.rb:401 ../../app/controllers/miq_policy_controller/miq_actions.rb:414 ../../app/controllers/miq_policy_controller/alerts.rb:532 ../../app/controllers/miq_policy_controller/alert_profiles.rb:85 ../../app/controllers/ops_controller/settings/schedules.rb:402 ../../app/controllers/ops_controller/settings/schedules.rb:406 ../../app/controllers/application_controller/buttons.rb:331
+#: ../../app/controllers/miq_ae_tools_controller.rb:356 ../../app/controllers/report_controller/dashboards.rb:349 ../../app/controllers/report_controller/widgets.rb:724 ../../app/controllers/report_controller/widgets.rb:733 ../../app/controllers/report_controller/widgets.rb:737 ../../app/controllers/report_controller/schedules.rb:231 ../../app/controllers/report_controller/reports.rb:242 ../../app/controllers/report_controller/reports.rb:247 ../../app/controllers/report_controller/reports.rb:252 ../../app/controllers/report_controller/reports.rb:256 ../../app/controllers/application_controller/buttons.rb:331
 msgid "%s must be selected"
 msgstr ""
 
@@ -294,7 +250,7 @@ msgstr ""
 msgid "%s must be unique for this group"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:295 ../../app/controllers/repository_controller.rb:322 ../../app/controllers/report_controller/widgets.rb:100 ../../app/controllers/report_controller/saved_reports.rb:94 ../../app/controllers/report_controller/schedules.rb:83 ../../app/controllers/report_controller/schedules.rb:108 ../../app/controllers/miq_policy_controller/policies.rb:122 ../../app/controllers/miq_policy_controller/miq_actions.rb:74 ../../app/controllers/miq_policy_controller/alerts.rb:54 ../../app/controllers/miq_policy_controller/alert_profiles.rb:110 ../../app/controllers/miq_policy_controller/conditions.rb:125 ../../app/controllers/miq_policy_controller/policy_profiles.rb:77 ../../app/controllers/miq_request_controller.rb:531 ../../app/controllers/storage_manager_controller.rb:425 ../../app/controllers/ops_controller/settings/ldap.rb:121 ../../app/controllers/ops_controller/settings/ldap.rb:297 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:412 ../../app/controllers/ops_controller/settings/schedules.rb:183 ../../app/controllers/ops_controller/ops_rbac.rb:290 ../../app/controllers/ops_controller/ops_rbac.rb:321 ../../app/controllers/ops_controller/ops_rbac.rb:362 ../../app/controllers/ops_controller/ops_rbac.rb:385 ../../app/controllers/ops_controller/diagnostics.rb:693 ../../app/controllers/mixins/containers_common_mixin.rb:162 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:225 ../../app/controllers/pxe_controller/iso_datastores.rb:117 ../../app/controllers/pxe_controller/pxe_image_types.rb:110 ../../app/controllers/pxe_controller/pxe_servers.rb:137 ../../app/controllers/miq_policy_controller.rb:264 ../../app/helpers/application_helper.rb:1058
+#: ../../app/controllers/repository_controller.rb:295 ../../app/controllers/repository_controller.rb:322 ../../app/controllers/report_controller/widgets.rb:100 ../../app/controllers/report_controller/saved_reports.rb:94 ../../app/controllers/report_controller/schedules.rb:83 ../../app/controllers/report_controller/schedules.rb:108 ../../app/controllers/storage_manager_controller.rb:425 ../../app/controllers/mixins/containers_common_mixin.rb:162 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:225 ../../app/controllers/pxe_controller/iso_datastores.rb:117 ../../app/controllers/pxe_controller/pxe_image_types.rb:110 ../../app/controllers/pxe_controller/pxe_servers.rb:137 ../../app/helpers/application_helper.rb:1058
 msgid "%s no longer exists"
 msgstr ""
 
@@ -314,14 +270,6 @@ msgstr ""
 msgid "%s set to default"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings.rb:107
-msgid "%s should be unique"
-msgstr ""
-
-#: ../../app/controllers/ops_controller/diagnostics.rb:257 ../../app/controllers/ops_controller/diagnostics.rb:279 ../../app/controllers/ops_controller/diagnostics.rb:333 ../../app/controllers/ops_controller/diagnostics.rb:406 ../../app/controllers/ops_controller/diagnostics.rb:666 ../../app/controllers/ops_controller/diagnostics.rb:683
-msgid "%s successfully initiated"
-msgstr ""
-
 #: ../../app/controllers/report_controller/reports.rb:338
 msgid "%s tab is not available unless a sort field has been selected"
 msgstr ""
@@ -338,7 +286,7 @@ msgstr ""
 msgid "%s to validate against, Username and matching password fields are needed to perform verification of credentials"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:555 ../../app/controllers/vm_common.rb:877 ../../app/controllers/ontap_file_share_controller.rb:99 ../../app/controllers/ops_controller/ops_rbac.rb:627 ../../app/controllers/ontap_storage_system_controller.rb:105 ../../app/controllers/application_controller/ci_processing.rb:756 ../../app/controllers/application_controller/dialog_runner.rb:22
+#: ../../app/controllers/vm_common.rb:555 ../../app/controllers/vm_common.rb:877 ../../app/controllers/application_controller/ci_processing.rb:756 ../../app/controllers/application_controller/dialog_runner.rb:22
 msgid "%s was cancelled by the user"
 msgstr ""
 
@@ -350,7 +298,7 @@ msgstr ""
 msgid "%{action} \"%{item_name}\" for %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:206
+#: ../../app/controllers/provider_foreman_controller.rb:187
 msgid "%{action} %{model} was cancelled by the user"
 msgstr ""
 
@@ -374,6 +322,10 @@ msgstr ""
 msgid "%{hosts} & %{clusters}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:299
+msgid "%{item} has been initiated for the selected Servers"
+msgstr ""
+
 #: ../../app/controllers/application_controller.rb:1621
 msgid "%{labels} are not in the current region and will be skipped"
 msgstr ""
@@ -390,15 +342,19 @@ msgstr ""
 msgid "%{model_name} Group Reorder saved"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:1004
+#: ../../app/controllers/miq_policy_controller/policies.rb:122 ../../app/controllers/miq_policy_controller/miq_actions.rb:74 ../../app/controllers/miq_policy_controller/alerts.rb:54 ../../app/controllers/miq_policy_controller/conditions.rb:126 ../../app/controllers/miq_policy_controller/policy_profiles.rb:79
+msgid "%{models} no longer exists"
+msgstr ""
+
+#: ../../app/controllers/provider_foreman_controller.rb:985
 msgid "%{model}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:551 ../../app/controllers/ops_controller.rb:570 ../../app/controllers/ops_controller.rb:584 ../../app/controllers/ops_controller.rb:595 ../../app/controllers/ops_controller.rb:606 ../../app/controllers/ops_controller.rb:652 ../../app/controllers/ops_controller.rb:660 ../../app/controllers/chargeback_controller.rb:473 ../../app/controllers/chargeback_controller.rb:487 ../../app/controllers/chargeback_controller.rb:522 ../../app/controllers/report_controller/dashboards.rb:260 ../../app/controllers/report_controller/saved_reports.rb:23 ../../app/controllers/report_controller/schedules.rb:523 ../../app/controllers/report_controller/reports.rb:32 ../../app/controllers/report_controller/reports.rb:196 ../../app/controllers/miq_policy_controller/events.rb:116 ../../app/controllers/miq_policy_controller/policies.rb:239 ../../app/controllers/miq_policy_controller/miq_actions.rb:422 ../../app/controllers/miq_policy_controller/alerts.rb:589 ../../app/controllers/miq_policy_controller/alert_profiles.rb:342 ../../app/controllers/miq_policy_controller/conditions.rb:241 ../../app/controllers/miq_policy_controller/policy_profiles.rb:151 ../../app/controllers/vm_common.rb:1362 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:114 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1375 ../../app/controllers/service_controller.rb:238 ../../app/controllers/service_controller.rb:251 ../../app/controllers/container_controller.rb:211 ../../app/controllers/catalog_controller.rb:1629 ../../app/controllers/catalog_controller.rb:1656 ../../app/controllers/catalog_controller.rb:1659 ../../app/controllers/catalog_controller.rb:1707 ../../app/controllers/ops_controller/db.rb:210 ../../app/controllers/ops_controller/db.rb:224 ../../app/controllers/ops_controller/ops_rbac.rb:878 ../../app/controllers/ops_controller/ops_rbac.rb:881 ../../app/controllers/ops_controller/ops_rbac.rb:884 ../../app/controllers/ops_controller/ops_rbac.rb:888 ../../app/controllers/ops_controller/analytics.rb:43 ../../app/controllers/pxe_controller.rb:169 ../../app/controllers/pxe_controller.rb:173 ../../app/controllers/pxe_controller.rb:175 ../../app/controllers/pxe_controller.rb:187 ../../app/controllers/pxe_controller.rb:191 ../../app/controllers/pxe_controller.rb:202 ../../app/controllers/pxe_controller.rb:216 ../../app/controllers/report_controller.rb:429 ../../app/controllers/report_controller.rb:454 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:257 ../../app/controllers/pxe_controller/iso_datastores.rb:315 ../../app/controllers/pxe_controller/iso_datastores.rb:318 ../../app/controllers/pxe_controller/pxe_image_types.rb:222 ../../app/controllers/pxe_controller/pxe_servers.rb:490 ../../app/controllers/pxe_controller/pxe_servers.rb:493 ../../app/controllers/pxe_controller/pxe_servers.rb:496 ../../app/controllers/provider_foreman_controller.rb:589 ../../app/controllers/provider_foreman_controller.rb:593 ../../app/controllers/provider_foreman_controller.rb:631 ../../app/controllers/provider_foreman_controller.rb:658 ../../app/controllers/provider_foreman_controller.rb:998 ../../app/controllers/miq_policy_controller.rb:612 ../../app/controllers/miq_policy_controller.rb:638 ../../app/controllers/miq_policy_controller.rb:661 ../../app/controllers/miq_policy_controller.rb:666 ../../app/controllers/miq_policy_controller.rb:677 ../../app/controllers/miq_policy_controller.rb:688 ../../app/controllers/miq_policy_controller.rb:696 ../../app/controllers/application_controller/buttons.rb:948 ../../app/controllers/application_controller/buttons.rb:990
+#: ../../app/controllers/ops_controller.rb:551 ../../app/controllers/ops_controller.rb:570 ../../app/controllers/ops_controller.rb:584 ../../app/controllers/ops_controller.rb:595 ../../app/controllers/ops_controller.rb:606 ../../app/controllers/ops_controller.rb:652 ../../app/controllers/ops_controller.rb:660 ../../app/controllers/chargeback_controller.rb:473 ../../app/controllers/chargeback_controller.rb:487 ../../app/controllers/chargeback_controller.rb:522 ../../app/controllers/report_controller/dashboards.rb:260 ../../app/controllers/report_controller/saved_reports.rb:23 ../../app/controllers/report_controller/schedules.rb:523 ../../app/controllers/report_controller/reports.rb:32 ../../app/controllers/report_controller/reports.rb:196 ../../app/controllers/miq_policy_controller/events.rb:116 ../../app/controllers/miq_policy_controller/policies.rb:240 ../../app/controllers/miq_policy_controller/miq_actions.rb:426 ../../app/controllers/miq_policy_controller/alerts.rb:592 ../../app/controllers/miq_policy_controller/alert_profiles.rb:345 ../../app/controllers/miq_policy_controller/conditions.rb:243 ../../app/controllers/miq_policy_controller/policy_profiles.rb:154 ../../app/controllers/vm_common.rb:1362 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:114 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1375 ../../app/controllers/service_controller.rb:238 ../../app/controllers/service_controller.rb:251 ../../app/controllers/container_controller.rb:211 ../../app/controllers/catalog_controller.rb:1629 ../../app/controllers/catalog_controller.rb:1656 ../../app/controllers/catalog_controller.rb:1659 ../../app/controllers/catalog_controller.rb:1707 ../../app/controllers/ops_controller/db.rb:210 ../../app/controllers/ops_controller/db.rb:224 ../../app/controllers/ops_controller/ops_rbac.rb:882 ../../app/controllers/ops_controller/ops_rbac.rb:885 ../../app/controllers/ops_controller/ops_rbac.rb:888 ../../app/controllers/ops_controller/ops_rbac.rb:892 ../../app/controllers/ops_controller/analytics.rb:43 ../../app/controllers/pxe_controller.rb:169 ../../app/controllers/pxe_controller.rb:173 ../../app/controllers/pxe_controller.rb:175 ../../app/controllers/pxe_controller.rb:187 ../../app/controllers/pxe_controller.rb:191 ../../app/controllers/pxe_controller.rb:202 ../../app/controllers/pxe_controller.rb:216 ../../app/controllers/report_controller.rb:429 ../../app/controllers/report_controller.rb:454 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:257 ../../app/controllers/pxe_controller/iso_datastores.rb:315 ../../app/controllers/pxe_controller/iso_datastores.rb:318 ../../app/controllers/pxe_controller/pxe_image_types.rb:222 ../../app/controllers/pxe_controller/pxe_servers.rb:490 ../../app/controllers/pxe_controller/pxe_servers.rb:493 ../../app/controllers/pxe_controller/pxe_servers.rb:496 ../../app/controllers/provider_foreman_controller.rb:570 ../../app/controllers/provider_foreman_controller.rb:574 ../../app/controllers/provider_foreman_controller.rb:612 ../../app/controllers/provider_foreman_controller.rb:639 ../../app/controllers/provider_foreman_controller.rb:979 ../../app/controllers/miq_policy_controller.rb:613 ../../app/controllers/miq_policy_controller.rb:644 ../../app/controllers/miq_policy_controller.rb:682 ../../app/controllers/miq_policy_controller.rb:693 ../../app/controllers/miq_policy_controller.rb:704 ../../app/controllers/miq_policy_controller.rb:712 ../../app/controllers/application_controller/buttons.rb:948 ../../app/controllers/application_controller/buttons.rb:990
 msgid "%{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:412 ../../app/controllers/miq_capacity_controller.rb:644
+#: ../../app/controllers/miq_capacity_controller.rb:412 ../../app/controllers/miq_capacity_controller.rb:648
 msgid "%{model} \"%{name}\" %{typ}"
 msgstr ""
 
@@ -410,27 +366,31 @@ msgstr ""
 msgid "%{model} \"%{name}\" successfully added to Service \"%{to_name}\""
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:185
+#: ../../app/controllers/provider_foreman_controller.rb:166
 msgid "%{model} \"%{name}\" was %{action}"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:72 ../../app/controllers/chargeback_controller.rb:163 ../../app/controllers/report_controller/reports/editor.rb:62 ../../app/controllers/report_controller/schedules.rb:239 ../../app/controllers/miq_policy_controller/policies.rb:63 ../../app/controllers/miq_policy_controller/policies.rb:109 ../../app/controllers/miq_policy_controller/miq_actions.rb:46 ../../app/controllers/miq_policy_controller/alerts.rb:26 ../../app/controllers/miq_policy_controller/alert_profiles.rb:53 ../../app/controllers/miq_policy_controller/conditions.rb:60 ../../app/controllers/miq_policy_controller/policy_profiles.rb:52 ../../app/controllers/miq_ae_class_controller.rb:683 ../../app/controllers/miq_ae_class_controller.rb:1232 ../../app/controllers/miq_ae_class_controller.rb:1270 ../../app/controllers/miq_ae_class_controller.rb:1299 ../../app/controllers/storage_manager_controller.rb:101 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:279 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:226 ../../app/controllers/catalog_controller.rb:390 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/ops_controller/settings/tags.rb:83 ../../app/controllers/ops_controller/settings/zones.rb:35 ../../app/controllers/host_controller.rb:255 ../../app/controllers/configuration_controller.rb:518 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:59 ../../app/controllers/pxe_controller/pxe_image_types.rb:54 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/application_controller/buttons.rb:387 ../../app/controllers/application_controller/buttons.rb:474
+#: ../../app/controllers/repository_controller.rb:72 ../../app/controllers/chargeback_controller.rb:163 ../../app/controllers/report_controller/reports/editor.rb:62 ../../app/controllers/report_controller/schedules.rb:239 ../../app/controllers/miq_policy_controller/policies.rb:63 ../../app/controllers/miq_policy_controller/policies.rb:109 ../../app/controllers/miq_policy_controller/miq_actions.rb:46 ../../app/controllers/miq_policy_controller/alerts.rb:26 ../../app/controllers/miq_policy_controller/alert_profiles.rb:54 ../../app/controllers/miq_policy_controller/conditions.rb:61 ../../app/controllers/miq_policy_controller/policy_profiles.rb:54 ../../app/controllers/miq_ae_class_controller.rb:683 ../../app/controllers/miq_ae_class_controller.rb:1232 ../../app/controllers/miq_ae_class_controller.rb:1270 ../../app/controllers/miq_ae_class_controller.rb:1299 ../../app/controllers/storage_manager_controller.rb:101 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:279 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:226 ../../app/controllers/catalog_controller.rb:390 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/ops_controller/settings/tags.rb:84 ../../app/controllers/ops_controller/settings/zones.rb:35 ../../app/controllers/host_controller.rb:255 ../../app/controllers/configuration_controller.rb:518 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:59 ../../app/controllers/pxe_controller/pxe_image_types.rb:54 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/application_controller/buttons.rb:387 ../../app/controllers/application_controller/buttons.rb:474
 msgid "%{model} \"%{name}\" was added"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:125 ../../app/controllers/chargeback_controller.rb:187 ../../app/controllers/report_controller/dashboards.rb:82 ../../app/controllers/report_controller/widgets.rb:63 ../../app/controllers/report_controller/reports/editor.rb:61 ../../app/controllers/report_controller/schedules.rb:238 ../../app/controllers/report_controller/reports.rb:33 ../../app/controllers/miq_policy_controller/policies.rb:62 ../../app/controllers/miq_policy_controller/miq_actions.rb:45 ../../app/controllers/miq_policy_controller/alerts.rb:25 ../../app/controllers/miq_policy_controller/alert_profiles.rb:52 ../../app/controllers/miq_policy_controller/conditions.rb:59 ../../app/controllers/miq_policy_controller/policy_profiles.rb:51 ../../app/controllers/vm_common.rb:1075 ../../app/controllers/miq_ae_class_controller.rb:632 ../../app/controllers/miq_ae_class_controller.rb:1016 ../../app/controllers/miq_ae_class_controller.rb:1110 ../../app/controllers/miq_ae_class_controller.rb:1163 ../../app/controllers/storage_manager_controller.rb:192 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:281 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:228 ../../app/controllers/service_controller.rb:161 ../../app/controllers/catalog_controller.rb:389 ../../app/controllers/catalog_controller.rb:631 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/catalog_controller.rb:1009 ../../app/controllers/catalog_controller.rb:1063 ../../app/controllers/catalog_controller.rb:1110 ../../app/controllers/ops_controller/settings/tags.rb:104 ../../app/controllers/ops_controller/settings/ldap.rb:62 ../../app/controllers/ops_controller/settings/ldap.rb:192 ../../app/controllers/ops_controller/settings/zones.rb:34 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:269 ../../app/controllers/ops_controller/settings/schedules.rb:75 ../../app/controllers/ops_controller/ops_rbac.rb:131 ../../app/controllers/ops_controller/ops_rbac.rb:727 ../../app/controllers/ops_controller/settings.rb:178 ../../app/controllers/host_controller.rb:346 ../../app/controllers/configuration_controller.rb:579 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:182 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:202 ../../app/controllers/pxe_controller/pxe_servers.rb:254 ../../app/controllers/ems_common.rb:153 ../../app/controllers/ems_common.rb:260 ../../app/controllers/ems_cloud_controller.rb:53 ../../app/controllers/ems_cloud_controller.rb:105 ../../app/controllers/application_controller/buttons.rb:352 ../../app/controllers/application_controller/buttons.rb:530
+#: ../../app/controllers/repository_controller.rb:125 ../../app/controllers/chargeback_controller.rb:187 ../../app/controllers/report_controller/dashboards.rb:82 ../../app/controllers/report_controller/widgets.rb:63 ../../app/controllers/report_controller/reports/editor.rb:61 ../../app/controllers/report_controller/schedules.rb:238 ../../app/controllers/report_controller/reports.rb:33 ../../app/controllers/miq_policy_controller/policies.rb:62 ../../app/controllers/miq_policy_controller/miq_actions.rb:45 ../../app/controllers/miq_policy_controller/alerts.rb:25 ../../app/controllers/miq_policy_controller/alert_profiles.rb:53 ../../app/controllers/miq_policy_controller/conditions.rb:60 ../../app/controllers/miq_policy_controller/policy_profiles.rb:53 ../../app/controllers/vm_common.rb:1075 ../../app/controllers/miq_ae_class_controller.rb:632 ../../app/controllers/miq_ae_class_controller.rb:1016 ../../app/controllers/miq_ae_class_controller.rb:1110 ../../app/controllers/miq_ae_class_controller.rb:1163 ../../app/controllers/storage_manager_controller.rb:192 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:281 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:228 ../../app/controllers/service_controller.rb:161 ../../app/controllers/catalog_controller.rb:389 ../../app/controllers/catalog_controller.rb:631 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/catalog_controller.rb:1009 ../../app/controllers/catalog_controller.rb:1063 ../../app/controllers/catalog_controller.rb:1110 ../../app/controllers/ops_controller/settings/tags.rb:105 ../../app/controllers/ops_controller/settings/ldap.rb:62 ../../app/controllers/ops_controller/settings/ldap.rb:192 ../../app/controllers/ops_controller/settings/zones.rb:34 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:269 ../../app/controllers/ops_controller/settings/schedules.rb:75 ../../app/controllers/ops_controller/ops_rbac.rb:132 ../../app/controllers/ops_controller/ops_rbac.rb:732 ../../app/controllers/ops_controller/settings.rb:180 ../../app/controllers/host_controller.rb:346 ../../app/controllers/configuration_controller.rb:579 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:182 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:202 ../../app/controllers/pxe_controller/pxe_servers.rb:254 ../../app/controllers/ems_common.rb:153 ../../app/controllers/ems_common.rb:260 ../../app/controllers/ems_cloud_controller.rb:53 ../../app/controllers/ems_cloud_controller.rb:105 ../../app/controllers/application_controller/buttons.rb:352 ../../app/controllers/application_controller/buttons.rb:530
 msgid "%{model} \"%{name}\" was saved"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:561 ../../app/controllers/storage_manager_controller.rb:483 ../../app/controllers/ontap_file_share_controller.rb:81 ../../app/controllers/ontap_storage_system_controller.rb:87 ../../app/controllers/ems_common.rb:835 ../../app/controllers/application_controller/ci_processing.rb:981 ../../app/controllers/application_controller/ci_processing.rb:1579
+#: ../../app/controllers/miq_request_controller.rb:567 ../../app/controllers/storage_manager_controller.rb:483 ../../app/controllers/ontap_file_share_controller.rb:81 ../../app/controllers/ems_common.rb:835 ../../app/controllers/application_controller/ci_processing.rb:981 ../../app/controllers/application_controller/ci_processing.rb:1579
 msgid "%{model} \"%{name}\": %{task} successfully initiated"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:273 ../../app/controllers/report_controller/reports.rb:104 ../../app/controllers/miq_request_controller.rb:559 ../../app/controllers/storage_manager_controller.rb:478 ../../app/controllers/ops_controller/settings/tags.rb:22 ../../app/controllers/ops_controller/settings/zones.rb:73 ../../app/controllers/ops_controller/diagnostics.rb:715 ../../app/controllers/ems_common.rb:830 ../../app/controllers/miq_task_controller.rb:254 ../../app/controllers/application_controller/ci_processing.rb:979 ../../app/controllers/application_controller/buttons.rb:161 ../../app/controllers/application_controller/buttons.rb:239
+#: ../../app/controllers/ontap_storage_system_controller.rb:87
+msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:273 ../../app/controllers/report_controller/reports.rb:104 ../../app/controllers/miq_request_controller.rb:565 ../../app/controllers/storage_manager_controller.rb:478 ../../app/controllers/ops_controller/settings/tags.rb:22 ../../app/controllers/ops_controller/settings/zones.rb:73 ../../app/controllers/ops_controller/diagnostics.rb:718 ../../app/controllers/ems_common.rb:830 ../../app/controllers/miq_task_controller.rb:254 ../../app/controllers/application_controller/ci_processing.rb:979 ../../app/controllers/application_controller/buttons.rb:161 ../../app/controllers/application_controller/buttons.rb:239
 msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:269 ../../app/controllers/report_controller/reports.rb:97 ../../app/controllers/miq_request_controller.rb:554 ../../app/controllers/storage_manager_controller.rb:470 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:512 ../../app/controllers/ops_controller/diagnostics.rb:705 ../../app/controllers/miq_task_controller.rb:248
+#: ../../app/controllers/repository_controller.rb:269 ../../app/controllers/report_controller/reports.rb:97 ../../app/controllers/miq_request_controller.rb:560 ../../app/controllers/storage_manager_controller.rb:470 ../../app/controllers/ops_controller/diagnostics.rb:708 ../../app/controllers/miq_task_controller.rb:248
 msgid "%{model} \"%{name}\": Error during '%{task}': "
 msgstr ""
 
@@ -438,7 +398,7 @@ msgstr ""
 msgid "%{model} \"%{name}\": Error during '%{task}': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1639
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:514 ../../app/controllers/application_controller/ci_processing.rb:1639
 msgid "%{model} \"%{name}\": Error during '%{task}': %{message}"
 msgstr ""
 
@@ -452,6 +412,10 @@ msgstr ""
 
 #: ../../app/controllers/configuration_controller.rb:570
 msgid "%{model} \"%{name}\": Error during 'save': %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:674
+msgid "%{model} Condition \"%{name}\""
 msgstr ""
 
 #: ../../app/controllers/report_controller/dashboards.rb:240
@@ -470,8 +434,12 @@ msgstr ""
 msgid "%{model} for role \"%{role}\" was saved"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:36 ../../app/controllers/miq_policy_controller/policy_profiles.rb:35
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:36 ../../app/controllers/miq_policy_controller/policy_profiles.rb:36
 msgid "%{model} must contain at least one %{field}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:112 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:412
+msgid "%{model} no longer exists"
 msgstr ""
 
 #: ../../app/controllers/application_controller/filter.rb:642
@@ -486,8 +454,20 @@ msgstr ""
 msgid "%{model} search \"%{name}\": Delete successful"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:364 ../../app/controllers/application_controller/ci_processing.rb:874 ../../app/controllers/application_controller/ci_processing.rb:1548
+#: ../../app/controllers/application_controller/ci_processing.rb:874 ../../app/controllers/application_controller/ci_processing.rb:1548
 msgid "%{model}: %{task} successfully initiated"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:366
+msgid "%{model}: Restart successfully initiated"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:385
+msgid "%{name} file saved"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:221
+msgid "%{name} is required"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:2547
@@ -498,12 +478,16 @@ msgstr ""
 msgid "%{record} - \"%{button_text}\""
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:315 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:83 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1345 ../../app/controllers/ems_common.rb:859 ../../app/controllers/ems_common.rb:890 ../../app/controllers/ems_common.rb:923 ../../app/controllers/application_controller/ci_processing.rb:1211 ../../app/controllers/application_controller/ci_processing.rb:1279 ../../app/controllers/application_controller/ci_processing.rb:1604 ../../app/controllers/application_controller/ci_processing.rb:1767 ../../app/controllers/application_controller/ci_processing.rb:1855 ../../app/controllers/application_controller/ci_processing.rb:1919 ../../app/controllers/application_controller/ci_processing.rb:1947
+#: ../../app/controllers/chargeback_controller.rb:315 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:83 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1345 ../../app/controllers/ems_common.rb:859 ../../app/controllers/ems_common.rb:890 ../../app/controllers/ems_common.rb:923 ../../app/controllers/miq_policy_controller.rb:265 ../../app/controllers/application_controller/ci_processing.rb:1211 ../../app/controllers/application_controller/ci_processing.rb:1279 ../../app/controllers/application_controller/ci_processing.rb:1604 ../../app/controllers/application_controller/ci_processing.rb:1767 ../../app/controllers/application_controller/ci_processing.rb:1855 ../../app/controllers/application_controller/ci_processing.rb:1919 ../../app/controllers/application_controller/ci_processing.rb:1947
 msgid "%{record} no longer exists"
 msgstr ""
 
 #: ../../app/views/ops/_selected_by_servers.html.haml:172
 msgid "%{role} on %{model}: %{name} [%{id}]"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:536 ../../app/controllers/ops_controller/settings/ldap.rb:121 ../../app/controllers/ops_controller/settings/ldap.rb:297 ../../app/controllers/ops_controller/settings/schedules.rb:183 ../../app/controllers/ops_controller/diagnostics.rb:695
+msgid "%{table} no longer exists"
 msgstr ""
 
 #: ../../app/controllers/report_controller/reports.rb:317 ../../app/controllers/report_controller/reports.rb:359
@@ -526,11 +510,15 @@ msgstr ""
 msgid "%{task} does not apply to at least one of the selected %{model}"
 msgstr ""
 
+#: ../../app/controllers/provider_foreman_controller.rb:74
+msgid "%{task} initiated for %{count_model}"
+msgstr ""
+
 #: ../../app/controllers/application_controller/ci_processing.rb:1305
 msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:256 ../../app/controllers/repository_controller.rb:292 ../../app/controllers/repository_controller.rb:317 ../../app/controllers/repository_controller.rb:327 ../../app/controllers/storage_manager_controller.rb:454 ../../app/controllers/ems_common.rb:796 ../../app/controllers/miq_task_controller.rb:161 ../../app/controllers/miq_task_controller.rb:191 ../../app/controllers/miq_task_controller.rb:218 ../../app/controllers/provider_foreman_controller.rb:91 ../../app/controllers/application_controller/ci_processing.rb:1659
+#: ../../app/controllers/repository_controller.rb:256 ../../app/controllers/repository_controller.rb:292 ../../app/controllers/repository_controller.rb:317 ../../app/controllers/repository_controller.rb:327 ../../app/controllers/storage_manager_controller.rb:454 ../../app/controllers/ems_common.rb:796 ../../app/controllers/miq_task_controller.rb:161 ../../app/controllers/miq_task_controller.rb:191 ../../app/controllers/miq_task_controller.rb:218 ../../app/controllers/application_controller/ci_processing.rb:1659
 msgid "%{task} initiated for %{count_model} from the CFME Database"
 msgstr ""
 
@@ -558,15 +546,15 @@ msgstr ""
 msgid "%{type} Information"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:311 ../../app/controllers/chargeback_controller.rb:328 ../../app/controllers/chargeback_controller.rb:442 ../../app/controllers/chargeback_controller.rb:453 ../../app/controllers/report_controller/widgets.rb:267 ../../app/controllers/miq_policy_controller/policies.rb:227 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:121 ../../app/controllers/ops_controller/settings/common.rb:1107 ../../app/controllers/ops_controller/settings/common.rb:1110 ../../app/controllers/ops_controller/settings/common.rb:1113 ../../app/controllers/ops_controller/settings/common.rb:1116 ../../app/controllers/ops_controller/ops_rbac.rb:864 ../../app/controllers/ops_controller/ops_rbac.rb:867 ../../app/controllers/ops_controller/ops_rbac.rb:870 ../../app/controllers/ops_controller/ops_rbac.rb:873 ../../app/controllers/report_controller.rb:461 ../../app/controllers/report_controller.rb:481 ../../app/controllers/miq_policy_controller.rb:625 ../../app/controllers/miq_policy_controller.rb:931
+#: ../../app/controllers/chargeback_controller.rb:311 ../../app/controllers/chargeback_controller.rb:328 ../../app/controllers/chargeback_controller.rb:442 ../../app/controllers/chargeback_controller.rb:453 ../../app/controllers/report_controller/widgets.rb:267 ../../app/controllers/miq_policy_controller/policies.rb:228 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:121 ../../app/controllers/report_controller.rb:461 ../../app/controllers/report_controller.rb:481 ../../app/controllers/miq_policy_controller.rb:626 ../../app/controllers/miq_policy_controller.rb:953
 msgid "%{typ} %{model}"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:447 ../../app/controllers/report_controller/widgets.rb:273 ../../app/controllers/ops_controller/settings/common.rb:859 ../../app/controllers/ops_controller/settings/common.rb:863 ../../app/controllers/ops_controller/settings/common.rb:1063 ../../app/controllers/ops_controller/settings/common.rb:1127 ../../app/controllers/ops_controller/settings/common.rb:1133 ../../app/controllers/ops_controller/settings/common.rb:1137 ../../app/controllers/ops_controller/settings/common.rb:1142 ../../app/controllers/ops_controller/settings/common.rb:1150 ../../app/controllers/ops_controller/ops_rbac.rb:891 ../../app/controllers/ops_controller/settings.rb:149 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39 ../../app/controllers/ops_controller/diagnostics.rb:831 ../../app/controllers/ops_controller/diagnostics.rb:854 ../../app/controllers/ops_controller/diagnostics.rb:917
+#: ../../app/controllers/chargeback_controller.rb:447 ../../app/controllers/report_controller/widgets.rb:273 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39
 msgid "%{typ} %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:858 ../../app/controllers/ops_controller/settings/common.rb:862 ../../app/controllers/ops_controller/settings/common.rb:1149 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39 ../../app/controllers/ops_controller/diagnostics.rb:830 ../../app/controllers/ops_controller/diagnostics.rb:916
+#: ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39
 msgid "%{typ} %{model} \"%{name}\" (current)"
 msgstr ""
 
@@ -594,16 +582,12 @@ msgstr ""
 msgid "%{typ} in %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:419 ../../app/controllers/ops_controller/settings/common.rb:421 ../../app/controllers/ops_controller/settings/common.rb:472
-msgid "%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\""
-msgstr ""
-
-#: ../../app/controllers/miq_ae_tools_controller.rb:362 ../../app/controllers/miq_ae_tools_controller.rb:363 ../../app/controllers/miq_policy_controller/miq_actions.rb:388 ../../app/controllers/miq_policy_controller/miq_actions.rb:389 ../../app/controllers/miq_policy_controller.rb:1009 ../../app/controllers/miq_policy_controller.rb:1011 ../../app/controllers/miq_policy_controller.rb:1013 ../../app/controllers/miq_policy_controller.rb:1014 ../../app/controllers/miq_policy_controller.rb:1016 ../../app/controllers/miq_policy_controller.rb:1018 ../../app/controllers/miq_policy_controller.rb:1020
+#: ../../app/controllers/miq_ae_tools_controller.rb:362 ../../app/controllers/miq_ae_tools_controller.rb:363 ../../app/controllers/miq_policy_controller/miq_actions.rb:392 ../../app/controllers/miq_policy_controller/miq_actions.rb:393 ../../app/controllers/miq_policy_controller.rb:1036 ../../app/controllers/miq_policy_controller.rb:1038 ../../app/controllers/miq_policy_controller.rb:1040 ../../app/controllers/miq_policy_controller.rb:1041 ../../app/controllers/miq_policy_controller.rb:1043 ../../app/controllers/miq_policy_controller.rb:1045 ../../app/controllers/miq_policy_controller.rb:1047
 msgid "%{val} missing for %{field}"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/diagnostics.rb:69
-msgid "'%s' Worker restart initiated successfully"
+msgid "'%{type}' Worker restart initiated successfully"
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:221
@@ -934,15 +918,23 @@ msgstr ""
 msgid "A %s must be selected"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alerts.rb:533
+msgid "A Driving Event must be selected"
+msgstr ""
+
 #: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:17
 msgid "A Red Hat subscription that covers your product"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:1279
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:86
+msgid "A Tag Category must be selected"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:1285
 msgid "A User Group must be assigned a Role"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:992
+#: ../../app/controllers/ops_controller/ops_rbac.rb:998
 msgid "A User must be assigned to a Group"
 msgstr ""
 
@@ -978,7 +970,7 @@ msgstr ""
 msgid "A tag value must be chosen to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alerts.rb:529 ../../app/controllers/miq_policy_controller/conditions.rb:51
+#: ../../app/controllers/miq_policy_controller/alerts.rb:530 ../../app/controllers/miq_policy_controller/conditions.rb:52
 msgid "A valid expression must be present"
 msgstr ""
 
@@ -1022,6 +1014,14 @@ msgstr ""
 msgid "About"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:869 ../../app/controllers/ops_controller/ops_rbac.rb:872 ../../app/controllers/ops_controller/ops_rbac.rb:875 ../../app/controllers/ops_controller/ops_rbac.rb:878
+msgid "Access Control %{model}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:895
+msgid "Access Control %{model} \"%{name}\""
+msgstr ""
+
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:220
 msgid "Access Key"
 msgstr ""
@@ -1050,8 +1050,18 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.acctid
+#: ../dictionary_strings.rb:151
+msgid "Account ID"
+msgstr ""
+
 #: ../../app/views/vm_common/_config.html.haml:44 ../../app/views/vm_common/_config.html.haml:234
 msgid "Account Policies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.accttype
+#: ../dictionary_strings.rb:153
+msgid "Account Type"
 msgstr ""
 
 #: ../model_attributes.rb:3
@@ -1098,7 +1108,8 @@ msgstr ""
 msgid "Account|Name"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_form.html.haml:86 ../../app/views/ops/_schedule_show.html.haml:29 ../../app/views/shared/buttons/_ab_form.html.haml:27 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_sandt_tree_show.html.haml:234
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction
+#: ../../app/views/ops/_schedule_form.html.haml:86 ../../app/views/ops/_schedule_show.html.haml:29 ../../app/views/shared/buttons/_ab_form.html.haml:27 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_sandt_tree_show.html.haml:234 ../dictionary_strings.rb:1493
 msgid "Action"
 msgstr ""
 
@@ -1110,16 +1121,46 @@ msgstr ""
 msgid "Action Type"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1107 ../../app/views/miq_policy/_policy_details.html.haml:351
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:384
+msgid "Action Type must be selected"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1134 ../../app/views/miq_policy/_policy_details.html.haml:351 ../dictionary_strings.rb:1495
 msgid "Actions"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/events.rb:37
-msgid "Actions for Policy Event \"%s\" were saved"
+msgid "Actions for Policy Event \"%{events}\" were saved"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_form.html.haml:70 ../../app/views/ops/_schedule_show.html.haml:19 ../../app/views/ops/_diagnostics_replication_tab.html.haml:39 ../../app/views/report/_widget_show.html.haml:42 ../../app/views/report/_widget_form.html.haml:54 ../../app/views/report/_show_schedule.html.haml:19 ../../app/views/report/_schedule_form.html.haml:51 ../../app/views/report/_report_info.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:43 ../../app/views/miq_policy/_policy_details.html.haml:49 ../../app/views/miq_policy/_policy_details.html.haml:66
+#. TRANSLATORS: en.yml key: dictionary.column.active
+#. TRANSLATORS: en.yml key: dictionary.column.enabled
+#: ../../app/views/ops/_schedule_form.html.haml:70 ../../app/views/ops/_schedule_show.html.haml:19 ../../app/views/ops/_diagnostics_replication_tab.html.haml:39 ../../app/views/report/_widget_show.html.haml:42 ../../app/views/report/_widget_form.html.haml:54 ../../app/views/report/_show_schedule.html.haml:19 ../../app/views/report/_schedule_form.html.haml:51 ../../app/views/report/_report_info.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:43 ../../app/views/miq_policy/_policy_details.html.haml:49 ../../app/views/miq_policy/_policy_details.html.haml:66 ../dictionary_strings.rb:157 ../dictionary_strings.rb:387
 msgid "Active"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_date
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+#: ../dictionary_strings.rb:1003 ../dictionary_strings.rb:1245
+msgid "Activity Sample - Day (MM DD YY)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_month
+#: ../dictionary_strings.rb:1023
+msgid "Activity Sample - Month (YYYY/MM)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_time
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+#: ../dictionary_strings.rb:1067 ../dictionary_strings.rb:1247
+msgid "Activity Sample - Time (HH MM SS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.timestamp
+#. TRANSLATORS: en.yml key: dictionary.column.statistic_time
+#: ../dictionary_strings.rb:957 ../dictionary_strings.rb:1239
+msgid "Activity Sample - Timestamp (Day/Time)"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_edit_view.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:35 ../../app/views/storage_manager/_form.html.haml:240 ../../app/views/layouts/_x_edit_buttons.html.haml:46 ../../app/views/layouts/_x_edit_buttons.html.haml:141 ../../app/views/layouts/_edit_to_email.html.haml:92 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/vm_common/_add_to_service.html.haml:49 ../../app/views/configuration/_timeprofile_form.html.haml:117 ../../app/views/shared/views/ems_common/_form.html.haml:181
@@ -1202,6 +1243,14 @@ msgstr ""
 msgid "Add a New #{ui_lookup(:table=>\"ems_infra\")}"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:12
+msgid "Add a New #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:12
+msgid "Add a New #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:13
 msgid "Add a New #{ui_lookup(:table=>\"persistent_volume\")}"
 msgstr ""
@@ -1274,7 +1323,7 @@ msgstr ""
 msgid "Add a User"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:729 ../../app/controllers/provider_foreman_controller.rb:826
+#: ../../app/controllers/provider_foreman_controller.rb:710 ../../app/controllers/provider_foreman_controller.rb:807
 msgid "Add a new %s Provider"
 msgstr ""
 
@@ -1386,7 +1435,7 @@ msgstr ""
 msgid "Add of %{model} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:63 ../../app/controllers/report_controller/dashboards.rb:62 ../../app/controllers/report_controller/widgets.rb:47 ../../app/controllers/report_controller/reports/editor.rb:33 ../../app/controllers/report_controller/schedules.rb:217 ../../app/controllers/miq_policy_controller/policies.rb:13 ../../app/controllers/miq_policy_controller/miq_actions.rb:13 ../../app/controllers/miq_policy_controller/alerts.rb:11 ../../app/controllers/miq_policy_controller/alert_profiles.rb:11 ../../app/controllers/miq_policy_controller/conditions.rb:13 ../../app/controllers/miq_policy_controller/policy_profiles.rb:10 ../../app/controllers/miq_ae_class_controller.rb:650 ../../app/controllers/storage_manager_controller.rb:79 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:197 ../../app/controllers/ops_controller/settings/tags.rb:40 ../../app/controllers/ops_controller/settings/ldap.rb:36 ../../app/controllers/ops_controller/settings/ldap.rb:162 ../../app/controllers/ops_controller/settings/zones.rb:10 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:222 ../../app/controllers/ops_controller/settings/schedules.rb:41 ../../app/controllers/ops_controller/ops_rbac.rb:106 ../../app/controllers/ops_controller/ops_rbac.rb:652 ../../app/controllers/host_controller.rb:245 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:101 ../../app/controllers/pxe_controller/iso_datastores.rb:43 ../../app/controllers/pxe_controller/pxe_image_types.rb:31 ../../app/controllers/pxe_controller/pxe_servers.rb:48 ../../app/controllers/application_controller/miq_request_methods.rb:66 ../../app/views/shared/views/ems_common/_form.html.haml:188
+#: ../../app/controllers/repository_controller.rb:63 ../../app/controllers/report_controller/dashboards.rb:62 ../../app/controllers/report_controller/widgets.rb:47 ../../app/controllers/report_controller/reports/editor.rb:33 ../../app/controllers/report_controller/schedules.rb:217 ../../app/controllers/miq_ae_class_controller.rb:650 ../../app/controllers/storage_manager_controller.rb:79 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:197 ../../app/controllers/ops_controller/settings/ldap.rb:162 ../../app/controllers/host_controller.rb:245 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:101 ../../app/controllers/pxe_controller/iso_datastores.rb:43 ../../app/controllers/pxe_controller/pxe_image_types.rb:31 ../../app/controllers/pxe_controller/pxe_servers.rb:48 ../../app/controllers/application_controller/miq_request_methods.rb:66 ../../app/views/shared/views/ems_common/_form.html.haml:188
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
@@ -1394,12 +1443,24 @@ msgstr ""
 msgid "Add of new %{model_name} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:96 ../../app/controllers/catalog_controller.rb:613
+#: ../../app/controllers/miq_policy_controller/policies.rb:13 ../../app/controllers/miq_policy_controller/miq_actions.rb:13 ../../app/controllers/miq_policy_controller/alerts.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:10
+msgid "Add of new %{models} was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:11 ../../app/controllers/miq_policy_controller/conditions.rb:13 ../../app/controllers/catalog_controller.rb:96 ../../app/controllers/catalog_controller.rb:613 ../../app/controllers/ops_controller/settings/tags.rb:40 ../../app/controllers/ops_controller/settings/ldap.rb:36 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:222 ../../app/controllers/ops_controller/settings/schedules.rb:41 ../../app/controllers/ops_controller/ops_rbac.rb:106
 msgid "Add of new %{model} was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:656
+msgid "Add of new %{name} was cancelled by the user"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:1215 ../../app/controllers/miq_ae_class_controller.rb:1247 ../../app/controllers/miq_ae_class_controller.rb:1288 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:239 ../../app/controllers/configuration_controller.rb:484
 msgid "Add of new %{record} was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/zones.rb:10
+msgid "Add of new %{table} was cancelled by the user"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:360
@@ -1430,8 +1491,36 @@ msgstr ""
 msgid "Add this entry"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:546 ../../app/controllers/ops_controller.rb:558 ../../app/controllers/ops_controller.rb:566 ../../app/controllers/ops_controller.rb:579 ../../app/controllers/ops_controller.rb:590 ../../app/controllers/ops_controller.rb:601 ../../app/controllers/ops_controller.rb:647 ../../app/controllers/miq_ae_customization_controller.rb:414 ../../app/controllers/miq_ae_customization_controller.rb:418 ../../app/controllers/miq_ae_customization_controller.rb:433 ../../app/controllers/miq_ae_customization_controller.rb:470 ../../app/controllers/vm_common.rb:1804 ../../app/controllers/miq_ae_class_controller.rb:567 ../../app/controllers/miq_ae_class_controller.rb:712 ../../app/controllers/miq_ae_class_controller.rb:747 ../../app/controllers/miq_ae_class_controller.rb:787 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/catalog_controller.rb:280 ../../app/controllers/catalog_controller.rb:1178 ../../app/controllers/catalog_controller.rb:1327 ../../app/controllers/catalog_controller.rb:1377 ../../app/controllers/catalog_controller.rb:1814 ../../app/controllers/catalog_controller.rb:1818 ../../app/controllers/ops_controller/ops_rbac.rb:703 ../../app/controllers/pxe_controller.rb:167 ../../app/controllers/pxe_controller.rb:185 ../../app/controllers/pxe_controller.rb:199 ../../app/controllers/pxe_controller.rb:215 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:716 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:729 ../../app/controllers/report_controller.rb:744 ../../app/controllers/miq_policy_controller.rb:609 ../../app/controllers/miq_policy_controller.rb:634 ../../app/controllers/miq_policy_controller.rb:657 ../../app/controllers/miq_policy_controller.rb:670 ../../app/controllers/miq_policy_controller.rb:685 ../../app/controllers/miq_policy_controller.rb:693
+#: ../../app/controllers/ops_controller.rb:647 ../../app/controllers/miq_ae_customization_controller.rb:414 ../../app/controllers/miq_ae_customization_controller.rb:418 ../../app/controllers/miq_ae_customization_controller.rb:433 ../../app/controllers/miq_ae_customization_controller.rb:470 ../../app/controllers/vm_common.rb:1804 ../../app/controllers/miq_ae_class_controller.rb:567 ../../app/controllers/miq_ae_class_controller.rb:712 ../../app/controllers/miq_ae_class_controller.rb:747 ../../app/controllers/miq_ae_class_controller.rb:787 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/catalog_controller.rb:280 ../../app/controllers/catalog_controller.rb:1178 ../../app/controllers/catalog_controller.rb:1327 ../../app/controllers/catalog_controller.rb:1377 ../../app/controllers/catalog_controller.rb:1814 ../../app/controllers/catalog_controller.rb:1818 ../../app/controllers/pxe_controller.rb:167 ../../app/controllers/pxe_controller.rb:185 ../../app/controllers/pxe_controller.rb:199 ../../app/controllers/pxe_controller.rb:215 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:716 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:729 ../../app/controllers/report_controller.rb:744
 msgid "Adding a new %s"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:709
+msgid "Adding a new %{alerts}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:636
+msgid "Adding a new %{model_name} %{mode} Policy"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:639
+msgid "Adding a new %{model_name} Policy"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:546 ../../app/controllers/ops_controller.rb:566 ../../app/controllers/ops_controller.rb:579 ../../app/controllers/ops_controller.rb:590 ../../app/controllers/ops_controller.rb:601 ../../app/controllers/miq_policy_controller.rb:667
+msgid "Adding a new %{model}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:708
+msgid "Adding a new %{name}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:610 ../../app/controllers/miq_policy_controller.rb:686 ../../app/controllers/miq_policy_controller.rb:701
+msgid "Adding a new %{record}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:558
+msgid "Adding a new Category"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:792
@@ -1524,11 +1613,26 @@ msgstr ""
 msgid "Aggregate (free space)"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:92
-msgid "Alert Profile \"%s\" assignments succesfully saved"
+#: ../../app/controllers/ontap_storage_system_controller.rb:126
+msgid "Aggregate is required"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1108 ../../app/views/miq_policy/_alert_profile_folders.html.haml:24
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+#: ../dictionary_strings.rb:1517
+msgid "Alert"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+#: ../dictionary_strings.rb:1521
+msgid "Alert Profile"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:93
+msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1135 ../../app/views/miq_policy/_alert_profile_folders.html.haml:24 ../dictionary_strings.rb:1523
 msgid "Alert Profiles"
 msgstr ""
 
@@ -1536,7 +1640,8 @@ msgstr ""
 msgid "Alert Selection"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1109 ../../app/views/miq_policy/_export.html.haml:105 ../../app/views/miq_policy/_alert_profile_details.html.haml:39
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1136 ../../app/views/miq_policy/_export.html.haml:105 ../../app/views/miq_policy/_alert_profile_details.html.haml:39 ../dictionary_strings.rb:1519
 msgid "Alerts"
 msgstr ""
 
@@ -1548,19 +1653,15 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:82 ../../app/controllers/chargeback_controller.rb:83 ../../app/controllers/chargeback_controller.rb:84 ../../app/controllers/chargeback_controller.rb:439 ../../app/controllers/chargeback_controller.rb:455 ../../app/controllers/chargeback_controller.rb:466 ../../app/controllers/report_controller/dashboards.rb:217 ../../app/controllers/report_controller/dashboards.rb:237 ../../app/controllers/report_controller/widgets.rb:247 ../../app/controllers/report_controller/widgets.rb:261 ../../app/controllers/report_controller/menus.rb:739 ../../app/controllers/report_controller/saved_reports.rb:130 ../../app/controllers/report_controller/schedules.rb:52 ../../app/controllers/miq_policy_controller/events.rb:108 ../../app/controllers/miq_policy_controller/policies.rb:231 ../../app/controllers/miq_policy_controller/alert_profiles.rb:324 ../../app/controllers/miq_policy_controller/alert_profiles.rb:332 ../../app/controllers/miq_policy_controller/conditions.rb:226 ../../app/controllers/miq_policy_controller/conditions.rb:234 ../../app/controllers/miq_policy_controller/policy_profiles.rb:143 ../../app/controllers/vm_common.rb:1373 ../../app/controllers/vm_common.rb:1389 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1366 ../../app/controllers/service_controller.rb:247 ../../app/controllers/container_controller.rb:208 ../../app/controllers/catalog_controller.rb:1646 ../../app/controllers/catalog_controller.rb:1649 ../../app/controllers/ops_controller/db.rb:189 ../../app/controllers/pxe_controller.rb:162 ../../app/controllers/pxe_controller.rb:182 ../../app/controllers/pxe_controller.rb:214 ../../app/controllers/report_controller.rb:157 ../../app/controllers/report_controller.rb:501 ../../app/controllers/pxe_controller/iso_datastores.rb:307 ../../app/controllers/pxe_controller/pxe_image_types.rb:216 ../../app/controllers/pxe_controller/pxe_servers.rb:482 ../../app/controllers/miq_policy_controller.rb:442 ../../app/controllers/miq_policy_controller.rb:604
+#: ../../app/controllers/chargeback_controller.rb:82 ../../app/controllers/chargeback_controller.rb:83 ../../app/controllers/chargeback_controller.rb:84 ../../app/controllers/chargeback_controller.rb:439 ../../app/controllers/chargeback_controller.rb:455 ../../app/controllers/chargeback_controller.rb:466 ../../app/controllers/report_controller/dashboards.rb:217 ../../app/controllers/report_controller/dashboards.rb:237 ../../app/controllers/report_controller/widgets.rb:247 ../../app/controllers/report_controller/widgets.rb:261 ../../app/controllers/report_controller/menus.rb:739 ../../app/controllers/report_controller/saved_reports.rb:130 ../../app/controllers/report_controller/schedules.rb:52 ../../app/controllers/vm_common.rb:1373 ../../app/controllers/vm_common.rb:1389 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1366 ../../app/controllers/service_controller.rb:247 ../../app/controllers/container_controller.rb:208 ../../app/controllers/catalog_controller.rb:1646 ../../app/controllers/catalog_controller.rb:1649 ../../app/controllers/pxe_controller.rb:162 ../../app/controllers/pxe_controller.rb:182 ../../app/controllers/pxe_controller.rb:214 ../../app/controllers/report_controller.rb:157 ../../app/controllers/report_controller.rb:501 ../../app/controllers/pxe_controller/iso_datastores.rb:307 ../../app/controllers/pxe_controller/pxe_image_types.rb:216 ../../app/controllers/pxe_controller/pxe_servers.rb:482
 msgid "All %s"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:644 ../../app/controllers/provider_foreman_controller.rb:667
+#: ../../app/controllers/provider_foreman_controller.rb:625 ../../app/controllers/provider_foreman_controller.rb:648
 msgid "All %s Configured Systems"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/db.rb:191
-msgid "All %s Indexes"
-msgstr ""
-
-#: ../../app/controllers/provider_foreman_controller.rb:602 ../../app/controllers/provider_foreman_controller.rb:675
+#: ../../app/controllers/provider_foreman_controller.rb:583 ../../app/controllers/provider_foreman_controller.rb:656
 msgid "All %s Providers"
 msgstr ""
 
@@ -1572,11 +1673,27 @@ msgstr ""
 msgid "All %{dialogs}"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:443
+msgid "All %{items}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/policies.rb:232 ../../app/controllers/miq_policy_controller/conditions.rb:228 ../../app/controllers/miq_policy_controller/conditions.rb:236 ../../app/controllers/miq_policy_controller/policy_profiles.rb:146 ../../app/controllers/ops_controller/db.rb:189 ../../app/controllers/miq_policy_controller.rb:605
+msgid "All %{models}"
+msgstr ""
+
 #: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:250
 msgid "All %{model} - %{group}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:619 ../../app/controllers/miq_policy_controller.rb:622 ../../app/controllers/miq_policy_controller.rb:938 ../../app/controllers/miq_policy_controller.rb:946 ../../app/controllers/miq_policy_controller.rb:953
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:327 ../../app/controllers/miq_policy_controller/alert_profiles.rb:335
+msgid "All %{records}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/events.rb:108
+msgid "All %{tables}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:620 ../../app/controllers/miq_policy_controller.rb:623 ../../app/controllers/miq_policy_controller.rb:960 ../../app/controllers/miq_policy_controller.rb:968 ../../app/controllers/miq_policy_controller.rb:975
 msgid "All %{typ} %{model}"
 msgstr ""
 
@@ -1608,7 +1725,7 @@ msgstr ""
 msgid "All Conditions"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:64 ../../app/controllers/provider_foreman_controller.rb:679
+#: ../../app/presenters/tree_builder.rb:64 ../../app/controllers/provider_foreman_controller.rb:660
 msgid "All Configured Systems"
 msgstr ""
 
@@ -1712,6 +1829,10 @@ msgstr ""
 msgid "All VM and Instance Conditions"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:191
+msgid "All VMDB Indexes"
+msgstr ""
+
 #: ../../app/presenters/tree_builder.rb:103 ../../app/views/layouts/listnav/_resource_pool.html.haml:50 ../../app/views/layouts/listnav/_ems_cluster.html.haml:58 ../../app/views/miq_capacity/_planning_options.html.haml:16
 msgid "All VMs"
 msgstr ""
@@ -1744,7 +1865,7 @@ msgstr ""
 msgid "All attributes"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:148 ../../app/controllers/chargeback_controller.rb:268 ../../app/controllers/chargeback_controller.rb:347 ../../app/controllers/report_controller/dashboards.rb:44 ../../app/controllers/report_controller/dashboards.rb:103 ../../app/controllers/report_controller/widgets.rb:84 ../../app/controllers/report_controller/menus.rb:206 ../../app/controllers/report_controller/reports/editor.rb:84 ../../app/controllers/report_controller/schedules.rb:263 ../../app/controllers/miq_policy_controller/events.rb:17 ../../app/controllers/miq_policy_controller/policies.rb:23 ../../app/controllers/miq_policy_controller/miq_actions.rb:23 ../../app/controllers/miq_policy_controller/alerts.rb:43 ../../app/controllers/miq_policy_controller/alert_profiles.rb:22 ../../app/controllers/miq_policy_controller/alert_profiles.rb:100 ../../app/controllers/miq_policy_controller/conditions.rb:24 ../../app/controllers/miq_policy_controller/policy_profiles.rb:21 ../../app/controllers/vm_common.rb:906 ../../app/controllers/vm_common.rb:910 ../../app/controllers/vm_common.rb:1093 ../../app/controllers/miq_ae_class_controller.rb:638 ../../app/controllers/miq_ae_class_controller.rb:1026 ../../app/controllers/miq_ae_class_controller.rb:1074 ../../app/controllers/miq_ae_class_controller.rb:1119 ../../app/controllers/miq_ae_class_controller.rb:1175 ../../app/controllers/miq_ae_class_controller.rb:1511 ../../app/controllers/miq_ae_class_controller.rb:1551 ../../app/controllers/miq_ae_class_controller.rb:1723 ../../app/controllers/storage_manager_controller.rb:210 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:298 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:255 ../../app/controllers/catalog_controller.rb:108 ../../app/controllers/catalog_controller.rb:414 ../../app/controllers/catalog_controller.rb:651 ../../app/controllers/catalog_controller.rb:1021 ../../app/controllers/ops_controller/settings/tags.rb:122 ../../app/controllers/ops_controller/settings/ldap.rb:90 ../../app/controllers/ops_controller/settings/ldap.rb:251 ../../app/controllers/ops_controller/settings/zones.rb:53 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:338 ../../app/controllers/ops_controller/settings/cap_and_u.rb:44 ../../app/controllers/ops_controller/settings/schedules.rb:108 ../../app/controllers/ops_controller/settings/common.rb:498 ../../app/controllers/ops_controller/ops_rbac.rb:154 ../../app/controllers/ops_controller/ops_rbac.rb:221 ../../app/controllers/ops_controller/ops_rbac.rb:434 ../../app/controllers/ops_controller/ops_rbac.rb:604 ../../app/controllers/ops_controller/ops_rbac.rb:697 ../../app/controllers/ops_controller/settings.rb:186 ../../app/controllers/host_controller.rb:390 ../../app/controllers/configuration_controller.rb:282 ../../app/controllers/configuration_controller.rb:540 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:144 ../../app/controllers/pxe_controller/iso_datastores.rb:77 ../../app/controllers/pxe_controller/iso_datastores.rb:205 ../../app/controllers/pxe_controller/pxe_image_types.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:87 ../../app/controllers/pxe_controller/pxe_servers.rb:225 ../../app/controllers/pxe_controller/pxe_servers.rb:276 ../../app/controllers/ems_common.rb:285 ../../app/controllers/application_controller/explorer.rb:180 ../../app/controllers/application_controller/tags.rb:151 ../../app/controllers/application_controller/ci_processing.rb:171 ../../app/controllers/application_controller/ci_processing.rb:176 ../../app/controllers/application_controller/dialog_runner.rb:69 ../../app/controllers/application_controller/automate.rb:115 ../../app/controllers/application_controller/buttons.rb:50 ../../app/controllers/application_controller/buttons.rb:407 ../../app/controllers/application_controller/buttons.rb:551 ../../app/controllers/application_controller/policy_support.rb:36 ../../app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js:64 ../../app/assets/javascripts/controllers/ops/log_collection_form_controller.js:105 ../../app/assets/javascripts/controllers/ops/tenant_form_controller.js:69 ../../app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js:97 ../../app/assets/javascripts/controllers/service/service_form_controller.js:47 ../../app/assets/javascripts/controllers/repository/repository_form_controller.js:56 ../../app/assets/javascripts/controllers/host/host_form_controller.js:145 ../../app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js:174 ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:270
+#: ../../app/controllers/repository_controller.rb:148 ../../app/controllers/chargeback_controller.rb:268 ../../app/controllers/chargeback_controller.rb:347 ../../app/controllers/report_controller/dashboards.rb:44 ../../app/controllers/report_controller/dashboards.rb:103 ../../app/controllers/report_controller/widgets.rb:84 ../../app/controllers/report_controller/menus.rb:206 ../../app/controllers/report_controller/reports/editor.rb:84 ../../app/controllers/report_controller/schedules.rb:263 ../../app/controllers/miq_policy_controller/events.rb:17 ../../app/controllers/miq_policy_controller/policies.rb:23 ../../app/controllers/miq_policy_controller/miq_actions.rb:23 ../../app/controllers/miq_policy_controller/alerts.rb:43 ../../app/controllers/miq_policy_controller/alert_profiles.rb:22 ../../app/controllers/miq_policy_controller/alert_profiles.rb:102 ../../app/controllers/miq_policy_controller/conditions.rb:25 ../../app/controllers/miq_policy_controller/policy_profiles.rb:22 ../../app/controllers/vm_common.rb:906 ../../app/controllers/vm_common.rb:910 ../../app/controllers/vm_common.rb:1093 ../../app/controllers/miq_ae_class_controller.rb:638 ../../app/controllers/miq_ae_class_controller.rb:1026 ../../app/controllers/miq_ae_class_controller.rb:1074 ../../app/controllers/miq_ae_class_controller.rb:1119 ../../app/controllers/miq_ae_class_controller.rb:1175 ../../app/controllers/miq_ae_class_controller.rb:1511 ../../app/controllers/miq_ae_class_controller.rb:1551 ../../app/controllers/miq_ae_class_controller.rb:1723 ../../app/controllers/storage_manager_controller.rb:210 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:298 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:255 ../../app/controllers/catalog_controller.rb:108 ../../app/controllers/catalog_controller.rb:414 ../../app/controllers/catalog_controller.rb:651 ../../app/controllers/catalog_controller.rb:1021 ../../app/controllers/ops_controller/settings/tags.rb:123 ../../app/controllers/ops_controller/settings/ldap.rb:90 ../../app/controllers/ops_controller/settings/ldap.rb:251 ../../app/controllers/ops_controller/settings/zones.rb:53 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:338 ../../app/controllers/ops_controller/settings/cap_and_u.rb:44 ../../app/controllers/ops_controller/settings/schedules.rb:108 ../../app/controllers/ops_controller/settings/common.rb:503 ../../app/controllers/ops_controller/ops_rbac.rb:155 ../../app/controllers/ops_controller/ops_rbac.rb:222 ../../app/controllers/ops_controller/ops_rbac.rb:435 ../../app/controllers/ops_controller/ops_rbac.rb:605 ../../app/controllers/ops_controller/ops_rbac.rb:702 ../../app/controllers/ops_controller/settings.rb:188 ../../app/controllers/host_controller.rb:390 ../../app/controllers/configuration_controller.rb:282 ../../app/controllers/configuration_controller.rb:540 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:144 ../../app/controllers/pxe_controller/iso_datastores.rb:77 ../../app/controllers/pxe_controller/iso_datastores.rb:205 ../../app/controllers/pxe_controller/pxe_image_types.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:87 ../../app/controllers/pxe_controller/pxe_servers.rb:225 ../../app/controllers/pxe_controller/pxe_servers.rb:276 ../../app/controllers/ems_common.rb:285 ../../app/controllers/application_controller/explorer.rb:180 ../../app/controllers/application_controller/tags.rb:151 ../../app/controllers/application_controller/ci_processing.rb:171 ../../app/controllers/application_controller/ci_processing.rb:176 ../../app/controllers/application_controller/dialog_runner.rb:69 ../../app/controllers/application_controller/automate.rb:115 ../../app/controllers/application_controller/buttons.rb:50 ../../app/controllers/application_controller/buttons.rb:407 ../../app/controllers/application_controller/buttons.rb:551 ../../app/controllers/application_controller/policy_support.rb:36 ../../app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js:64 ../../app/assets/javascripts/controllers/ops/log_collection_form_controller.js:105 ../../app/assets/javascripts/controllers/ops/tenant_form_controller.js:69 ../../app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js:97 ../../app/assets/javascripts/controllers/service/service_form_controller.js:47 ../../app/assets/javascripts/controllers/repository/repository_form_controller.js:56 ../../app/assets/javascripts/controllers/host/host_form_controller.js:145 ../../app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js:174 ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:270
 msgid "All changes have been reset"
 msgstr ""
 
@@ -1788,6 +1909,11 @@ msgstr ""
 msgid "All system services of %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+#: ../dictionary_strings.rb:169
+msgid "Allocated Memory"
+msgstr ""
+
 #: ../../app/models/tenant_quota.rb:71
 msgid "Allocated Memory in GB"
 msgstr ""
@@ -1800,12 +1926,22 @@ msgstr ""
 msgid "Allocated Number of Virtual Machines"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+#: ../dictionary_strings.rb:171
+msgid "Allocated Storage"
+msgstr ""
+
 #: ../../app/models/tenant_quota.rb:73
 msgid "Allocated Storage in GB"
 msgstr ""
 
 #: ../../app/models/tenant_quota.rb:69
 msgid "Allocated Virtual CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+#: ../dictionary_strings.rb:173
+msgid "Allocated vCPU"
 msgstr ""
 
 #: ../../app/helpers/application_helper/discover.rb:6 ../../app/views/ops/_settings_authentication_tab.html.haml:55
@@ -1836,15 +1972,21 @@ msgstr ""
 msgid "Analysis"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:600
+#: ../../app/controllers/ops_controller/settings/common.rb:605
 msgid "Analysis Affinity was saved"
 msgstr ""
 
-#: ../../app/views/miq_policy/_action_details.html.haml:430
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
+#: ../../app/views/miq_policy/_action_details.html.haml:430 ../dictionary_strings.rb:1679
 msgid "Analysis Profile"
 msgstr ""
 
-#: ../../app/views/ops/_settings_details_tab.html.haml:69 ../../app/views/miq_policy/_action_options.html.haml:511 ../../app/views/miq_policy/_action_options.html.haml:520
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:386
+msgid "Analysis Profile is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
+#: ../../app/views/ops/_settings_details_tab.html.haml:69 ../../app/views/miq_policy/_action_options.html.haml:511 ../../app/views/miq_policy/_action_options.html.haml:520 ../dictionary_strings.rb:1681
 msgid "Analysis Profiles"
 msgstr ""
 
@@ -1874,6 +2016,16 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/host_center.rb:66
 msgid "Analyze then Check Compliance for this item?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+#: ../dictionary_strings.rb:1363
+msgid "Anonymous FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+#: ../dictionary_strings.rb:1365
+msgid "Anonymous FTPs"
 msgstr ""
 
 #: ../../app/views/pxe/_pxe_image_type_form.html.haml:39
@@ -1944,6 +2096,11 @@ msgstr ""
 msgid "Approval State:"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+#: ../dictionary_strings.rb:1967
+msgid "Approvals"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_request_center.rb:31
 msgid "Approve this Request"
 msgstr ""
@@ -1956,7 +2113,8 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
-#: ../../app/helpers/provider_foreman_helper.rb:88 ../../app/helpers/provider_foreman_helper.rb:169
+#. TRANSLATORS: en.yml key: dictionary.column.v_arch
+#: ../../app/helpers/provider_foreman_helper.rb:88 ../../app/helpers/provider_foreman_helper.rb:169 ../dictionary_strings.rb:997
 msgid "Architecture"
 msgstr ""
 
@@ -2144,6 +2302,16 @@ msgstr ""
 msgid "Ascending"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+#: ../dictionary_strings.rb:953
+msgid "Asset - Uptime (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.resource_name
+#: ../dictionary_strings.rb:739
+msgid "Asset Name"
+msgstr ""
+
 #: ../../app/views/shared/buttons/_group_form.html.haml:91
 msgid "Assign Buttons"
 msgstr ""
@@ -2200,7 +2368,7 @@ msgstr ""
 msgid "Assignments"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:221 ../../app/controllers/miq_policy_controller.rb:40
+#: ../../app/controllers/report_controller.rb:221
 msgid "At least %{num} %{model} must be selected for %{action}"
 msgstr ""
 
@@ -2212,7 +2380,7 @@ msgstr ""
 msgid "At least 1 item must be selected for discovery"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:122
+#: ../../app/controllers/miq_ae_customization_controller.rb:122 ../../app/controllers/miq_policy_controller.rb:40
 msgid "At least 1 item must be selected for export"
 msgstr ""
 
@@ -2224,11 +2392,11 @@ msgstr ""
 msgid "At least 2 Analyses must be selected for Drift"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:295 ../../app/controllers/miq_policy_controller/alerts.rb:557 ../../app/controllers/miq_policy_controller/alerts.rb:561
+#: ../../app/controllers/report_controller/schedules.rb:295
 msgid "At least one %s must be configured"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports.rb:236 ../../app/controllers/miq_request_controller.rb:356 ../../app/controllers/miq_capacity_controller.rb:98 ../../app/controllers/miq_capacity_controller.rb:239 ../../app/controllers/ops_controller/ops_rbac.rb:1266 ../../app/controllers/application_controller/timelines.rb:62 ../../app/controllers/application_controller/timelines.rb:72
+#: ../../app/controllers/report_controller/reports.rb:236 ../../app/controllers/application_controller/timelines.rb:62 ../../app/controllers/application_controller/timelines.rb:72
 msgid "At least one %s must be selected"
 msgstr ""
 
@@ -2236,28 +2404,60 @@ msgstr ""
 msgid "At least one %{model} must be selected for tagging"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:396
+msgid "At least one Alert must be selected"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:402
+msgid "At least one Category must be selected"
+msgstr ""
+
 #: ../../app/controllers/configuration_controller.rb:494 ../../app/controllers/configuration_controller.rb:552
 msgid "At least one Day must be selected"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alerts.rb:563
+msgid "At least one E-mail recipient must be configured"
 msgstr ""
 
 #: ../../app/controllers/configuration_controller.rb:497 ../../app/controllers/configuration_controller.rb:555
 msgid "At least one Hour must be selected"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:1272
+msgid "At least one Product Feature must be selected"
+msgstr ""
+
 #: ../../app/controllers/application_controller/buttons.rb:751
 msgid "At least one Role must be selected"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:88
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:89
 msgid "At least one Selection must be checked"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:418
+msgid "At least one Tag must be selected"
+msgstr ""
+
+#: ../../app/controllers/miq_capacity_controller.rb:98 ../../app/controllers/miq_capacity_controller.rb:239
+msgid "At least one VM Option must be selected"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:238
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alerts.rb:558
+msgid "At least one of E-mail, SNMP Trap, Timeline Event, or Management Event must be configured"
+msgstr ""
+
 #: ../../app/controllers/application_controller/ci_processing.rb:406
 msgid "At least one option must be selected to reconfigure"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:360
+msgid "At least one status must be selected"
 msgstr ""
 
 #: ../../app/views/miq_policy/_event_details.html.haml:41
@@ -2270,6 +2470,10 @@ msgstr ""
 
 #: ../../app/views/miq_policy/_action_options.html.haml:68 ../../app/views/miq_policy/_action_details.html.haml:233
 msgid "Attribute Name"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:389
+msgid "Attribute Name is required"
 msgstr ""
 
 #: ../../app/views/layouts/_ae_resolve_options.html.haml:190 ../../app/views/shared/buttons/_ab_show.html.haml:164 ../../app/views/miq_policy/_action_details.html.haml:160
@@ -2330,6 +2534,10 @@ msgstr ""
 
 #: ../../app/views/host/_main.html.haml:31
 msgid "Authentication Status"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:424
+msgid "Authentication settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\""
 msgstr ""
 
 #: ../model_attributes.rb:39
@@ -2404,6 +2612,56 @@ msgstr ""
 msgid "Automate"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+#: ../dictionary_strings.rb:1497
+msgid "Automate Class"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+#: ../dictionary_strings.rb:1499
+msgid "Automate Classes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+#: ../dictionary_strings.rb:1501
+msgid "Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+#: ../dictionary_strings.rb:1503
+msgid "Automate Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+#: ../dictionary_strings.rb:1505
+msgid "Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+#: ../dictionary_strings.rb:1507
+msgid "Automate Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+#: ../dictionary_strings.rb:1509
+msgid "Automate Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+#: ../dictionary_strings.rb:1511
+msgid "Automate Methods"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+#: ../dictionary_strings.rb:1513
+msgid "Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+#: ../dictionary_strings.rb:1515
+msgid "Automate Namespaces"
+msgstr ""
+
 #: ../../app/controllers/application_controller/automate.rb:21
 msgid "Automation Error: %{error_message}"
 msgstr ""
@@ -2416,7 +2674,15 @@ msgstr ""
 msgid "Automations Tasks"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:27 ../../app/views/configuration/_ui_2.html.haml:131
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone
+#: ../dictionary_strings.rb:1259 ../dictionary_strings.rb:1753
+msgid "Availability Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
+#: ../../app/presenters/menu/default_menu.rb:27 ../../app/views/configuration/_ui_2.html.haml:131 ../dictionary_strings.rb:1261 ../dictionary_strings.rb:1755
 msgid "Availability Zones"
 msgstr ""
 
@@ -2492,6 +2758,16 @@ msgstr ""
 msgid "Average"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+#: ../dictionary_strings.rb:1211
+msgid "Average Read Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+#: ../dictionary_strings.rb:1213
+msgid "Average Write Size"
+msgstr ""
+
 #: ../../app/views/report/_form_columns_performance.html.haml:31
 msgid "Averages Based On"
 msgstr ""
@@ -2500,8 +2776,28 @@ msgstr ""
 msgid "Azure"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+#: ../dictionary_strings.rb:1647
+msgid "Azure Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+#: ../dictionary_strings.rb:1649
+msgid "Azure Templates"
+msgstr ""
+
 #: ../../app/views/layouts/_discover_azure_credentials.html.haml:47
 msgid "Azure Tenant ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios
+#: ../dictionary_strings.rb:181
+msgid "BIOS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios_location
+#: ../dictionary_strings.rb:183
+msgid "BIOS Location"
 msgstr ""
 
 #: ../../app/views/layouts/_x_edit_buttons.html.haml:185 ../../app/views/miq_ae_tools/_import_export.html.haml:169 ../../app/views/vm_common/_right_size.html.haml:412 ../../app/views/dashboard/login.html.haml:80 ../../app/views/dashboard/login.html.haml:80
@@ -2518,6 +2814,11 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:339 ../../app/views/ops/_ldap_region_show.html.haml:73 ../../app/views/ops/_ldap_forest_entries.html.haml:24 ../../app/views/ops/_ldap_domain_form.html.haml:150 ../../app/views/ops/_ldap_domain_show.html.haml:193 ../../app/views/_ldap_domain_form.html.haml:150
 msgid "Base DN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+#: ../dictionary_strings.rb:1759
+msgid "Base Extents"
 msgstr ""
 
 #: ../../app/views/report/_form_tl_settings.html.haml:23
@@ -2552,8 +2853,12 @@ msgstr ""
 msgid "Belongs to Profiles"
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:612
-msgid "Best Fit %s"
+#: ../../app/controllers/miq_capacity_controller.rb:615
+msgid "Best Fit Clusters"
+msgstr ""
+
+#: ../../app/controllers/miq_capacity_controller.rb:613
+msgid "Best Fit Hosts"
 msgstr ""
 
 #: ../model_attributes.rb:56
@@ -2696,6 +3001,12 @@ msgstr ""
 msgid "Browser Version"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button
+#: ../dictionary_strings.rb:1291 ../dictionary_strings.rb:1833
+msgid "Button"
+msgstr ""
+
 #: ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:124
 msgid "Button \"%{name}\""
 msgstr ""
@@ -2752,8 +3063,22 @@ msgstr ""
 msgid "Button not yet implemented %{model}:%{action}"
 msgstr ""
 
-#: ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:50
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
+#: ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:50 ../dictionary_strings.rb:1293 ../dictionary_strings.rb:1835
 msgid "Buttons"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+#: ../dictionary_strings.rb:1295 ../dictionary_strings.rb:1837
+msgid "Buttons Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+#: ../dictionary_strings.rb:1297 ../dictionary_strings.rb:1839
+msgid "Buttons Groups"
 msgstr ""
 
 #: ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_policy/_rsop_form.html.haml:47 ../../app/views/miq_capacity/_planning_options.html.haml:16 ../../app/views/miq_capacity/_planning_options.html.haml:16
@@ -2800,11 +3125,20 @@ msgstr ""
 msgid "C & U Gap Collection"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:258
+msgid "C & U Gap Collection successfully initiated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cdroms
+#: ../dictionary_strings.rb:1757
+msgid "CD/DVD Drives"
+msgstr ""
+
 #: ../../app/controllers/ops_controller/diagnostics.rb:33
 msgid "CFME Appliance restart initiated successfully"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:265
+#: ../../app/controllers/ops_controller/settings/common.rb:266
 msgid "CFME Database settings validation was successful"
 msgstr ""
 
@@ -2812,7 +3146,7 @@ msgstr ""
 msgid "CFME Log"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:730 ../../app/controllers/ops_controller/diagnostics.rb:748
+#: ../../app/controllers/ops_controller/diagnostics.rb:733 ../../app/controllers/ops_controller/diagnostics.rb:751
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr ""
 
@@ -2824,40 +3158,457 @@ msgstr ""
 msgid "CPU"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+#: ../dictionary_strings.rb:711
+msgid "CPU %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+#: ../dictionary_strings.rb:683
+msgid "CPU - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+#: ../dictionary_strings.rb:1049
+msgid "CPU - % Ready"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+#: ../dictionary_strings.rb:1051
+msgid "CPU - % Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+#: ../dictionary_strings.rb:1053
+msgid "CPU - % Wait"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+#: ../dictionary_strings.rb:121
+msgid "CPU - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:119
+msgid "CPU - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+#: ../dictionary_strings.rb:137
+msgid "CPU - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:135
+msgid "CPU - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+#: ../dictionary_strings.rb:243
+msgid "CPU - Aggregate Time Child VMs Spent in Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+#: ../dictionary_strings.rb:255
+msgid "CPU - Aggregate Time Child VMs Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+#: ../dictionary_strings.rb:275
+msgid "CPU - Aggregate Time Spent in Wait State for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+#: ../dictionary_strings.rb:273
+msgid "CPU - Aggregate Time Used for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+#: ../dictionary_strings.rb:13
+msgid "CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:263
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+#: ../dictionary_strings.rb:265
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+#: ../dictionary_strings.rb:267
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+#: ../dictionary_strings.rb:269
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+#: ../dictionary_strings.rb:271
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+#: ../dictionary_strings.rb:767
+msgid "CPU - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+#: ../dictionary_strings.rb:769
+msgid "CPU - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+#: ../dictionary_strings.rb:771
+msgid "CPU - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+#: ../dictionary_strings.rb:751
+msgid "CPU - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+#: ../dictionary_strings.rb:287
+msgid "CPU - Available (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+#: ../dictionary_strings.rb:867
+msgid "CPU - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+#: ../dictionary_strings.rb:869
+msgid "CPU - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+#: ../dictionary_strings.rb:871
+msgid "CPU - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+#: ../dictionary_strings.rb:379
+msgid "CPU - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+#: ../dictionary_strings.rb:55
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:57
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+#: ../dictionary_strings.rb:553
+msgid "CPU - Min Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:555
+msgid "CPU - Min Usage for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+#: ../dictionary_strings.rb:881
+msgid "CPU - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+#: ../dictionary_strings.rb:883
+msgid "CPU - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+#: ../dictionary_strings.rb:885
+msgid "CPU - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+#: ../dictionary_strings.rb:19
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+#: ../dictionary_strings.rb:21
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+#: ../dictionary_strings.rb:25
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+#: ../dictionary_strings.rb:29
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+#: ../dictionary_strings.rb:23
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+#: ../dictionary_strings.rb:27
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+#: ../dictionary_strings.rb:31
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:33
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+#: ../dictionary_strings.rb:451
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+#: ../dictionary_strings.rb:453
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+#: ../dictionary_strings.rb:457
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+#: ../dictionary_strings.rb:461
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+#: ../dictionary_strings.rb:455
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+#: ../dictionary_strings.rb:459
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+#: ../dictionary_strings.rb:463
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:469
+msgid "CPU - Peak Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+#: ../dictionary_strings.rb:465
+msgid "CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+#: ../dictionary_strings.rb:467
+msgid "CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+#: ../dictionary_strings.rb:889
+msgid "CPU - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+#: ../dictionary_strings.rb:115
+msgid "CPU - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+#: ../dictionary_strings.rb:97
+msgid "CPU - Reserved (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+#: ../dictionary_strings.rb:85
+msgid "CPU - Time Spent In Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+#: ../dictionary_strings.rb:87
+msgid "CPU - Time Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+#: ../dictionary_strings.rb:93
+msgid "CPU - Time Spent in Wait State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+#: ../dictionary_strings.rb:91
+msgid "CPU - Time Used (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+#: ../dictionary_strings.rb:95
+msgid "CPU - Total - from VM Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+#: ../dictionary_strings.rb:15
+msgid "CPU - Total Installed - Sum of Child Hosts (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+#: ../dictionary_strings.rb:69
+msgid "CPU - Total Installed - from Host Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+#: ../dictionary_strings.rb:261
+msgid "CPU - Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:89
+msgid "CPU - Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+#: ../dictionary_strings.rb:759
+msgid "CPU - Usage Rate for Collected Intervals (Number of Cores)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+#: ../dictionary_strings.rb:73
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+#: ../dictionary_strings.rb:75
+msgid "CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+#: ../dictionary_strings.rb:77
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+#: ../dictionary_strings.rb:239
+msgid "CPU Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:965
+msgid "CPU Average Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+#: ../dictionary_strings.rb:999
+msgid "CPU Cores Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
+#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:241
 msgid "CPU Limit"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+#: ../dictionary_strings.rb:473
+msgid "CPU Max Available MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+#: ../dictionary_strings.rb:105
+msgid "CPU Max Reserved MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+#: ../dictionary_strings.rb:471
+msgid "CPU Max Total MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+#: ../dictionary_strings.rb:969
+msgid "CPU Max Used MHz Trend"
 msgstr ""
 
 #: ../../app/views/ops/_selected_by_servers.html.haml:128 ../../app/views/ops/_selected_by_roles.html.haml:176 ../../app/views/ops/_server_desc.html.haml:83
 msgid "CPU Percent"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
+#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:245
 msgid "CPU Reserve"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
+#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:247
 msgid "CPU Reserve Expand"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
+#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:249
 msgid "CPU Shares"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
+#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:251
 msgid "CPU Shares Level"
 msgstr ""
 
-#: ../../app/views/miq_capacity/_planning_options.html.haml:140 ../../app/views/miq_capacity/_planning_options.html.haml:308 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:16 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:67
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_speed
+#: ../../app/views/miq_capacity/_planning_options.html.haml:140 ../../app/views/miq_capacity/_planning_options.html.haml:308 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:16 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:67 ../dictionary_strings.rb:253
 msgid "CPU Speed"
 msgstr ""
 
-#: ../../app/views/ops/_selected_by_servers.html.haml:115 ../../app/views/ops/_selected_by_roles.html.haml:163 ../../app/views/ops/_server_desc.html.haml:73
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_time
+#: ../../app/views/ops/_selected_by_servers.html.haml:115 ../../app/views/ops/_selected_by_roles.html.haml:163 ../../app/views/ops/_server_desc.html.haml:73 ../dictionary_strings.rb:257
 msgid "CPU Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+#: ../dictionary_strings.rb:1147
+msgid "CPU Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+#: ../dictionary_strings.rb:1145
+msgid "CPU Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+#: ../dictionary_strings.rb:285
+msgid "CPU Total Installed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_type
+#: ../dictionary_strings.rb:259
+msgid "CPU Type"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:67
 msgid "CPU Usage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+#: ../dictionary_strings.rb:1151
+msgid "CPU Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+#: ../dictionary_strings.rb:1149
+msgid "CPU Used Cost"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:76 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:67
@@ -2956,11 +3707,11 @@ msgstr ""
 msgid "Cannot display binary content"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:613
+#: ../../app/controllers/ops_controller/diagnostics.rb:615
 msgid "Cannot start log collection, a log collection is already in progress within this scope"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:611
+#: ../../app/controllers/ops_controller/diagnostics.rb:613
 msgid "Cannot start log collection, requires a started server"
 msgstr ""
 
@@ -2974,6 +3725,241 @@ msgstr ""
 
 #: ../../app/controllers/vm_common.rb:1769
 msgid "Capacity & Utilization data for %{model} \"%{name}\""
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+#: ../dictionary_strings.rb:315
+msgid "Capacity - Avg Free Space for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+#: ../dictionary_strings.rb:795
+msgid "Capacity - Profile 1 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+#: ../dictionary_strings.rb:799
+msgid "Capacity - Profile 1 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+#: ../dictionary_strings.rb:801
+msgid "Capacity - Profile 1 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+#: ../dictionary_strings.rb:803
+msgid "Capacity - Profile 1 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+#: ../dictionary_strings.rb:797
+msgid "Capacity - Profile 1 - Available vCPUs for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+#: ../dictionary_strings.rb:779
+msgid "Capacity - Profile 1 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+#: ../dictionary_strings.rb:807
+msgid "Capacity - Profile 1 - Maximum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+#: ../dictionary_strings.rb:781
+msgid "Capacity - Profile 1 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+#: ../dictionary_strings.rb:777
+msgid "Capacity - Profile 1 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+#: ../dictionary_strings.rb:785
+msgid "Capacity - Profile 1 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+#: ../dictionary_strings.rb:787
+msgid "Capacity - Profile 1 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+#: ../dictionary_strings.rb:783
+msgid "Capacity - Profile 1 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+#: ../dictionary_strings.rb:811
+msgid "Capacity - Profile 1 - Minimum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+#: ../dictionary_strings.rb:813
+msgid "Capacity - Profile 1 - Number of vCPUs per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+#: ../dictionary_strings.rb:815
+msgid "Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+#: ../dictionary_strings.rb:775
+msgid "Capacity - Profile 1 - Total CPU with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+#: ../dictionary_strings.rb:773
+msgid "Capacity - Profile 1 - Total Memory with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+#: ../dictionary_strings.rb:789
+msgid "Capacity - Profile 1 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+#: ../dictionary_strings.rb:791
+msgid "Capacity - Profile 1 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+#: ../dictionary_strings.rb:793
+msgid "Capacity - Profile 1 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+#: ../dictionary_strings.rb:809
+msgid "Capacity - Profile 1 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+#: ../dictionary_strings.rb:805
+msgid "Capacity - Profile 1 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+#: ../dictionary_strings.rb:839
+msgid "Capacity - Profile 2 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+#: ../dictionary_strings.rb:843
+msgid "Capacity - Profile 2 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+#: ../dictionary_strings.rb:845
+msgid "Capacity - Profile 2 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+#: ../dictionary_strings.rb:847
+msgid "Capacity - Profile 2 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+#: ../dictionary_strings.rb:841
+msgid "Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+#: ../dictionary_strings.rb:819
+msgid "Capacity - Profile 2 - CPU Effective with HA (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+#: ../dictionary_strings.rb:857
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+#: ../dictionary_strings.rb:859
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+#: ../dictionary_strings.rb:823
+msgid "Capacity - Profile 2 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+#: ../dictionary_strings.rb:851
+msgid "Capacity - Profile 2 - Maximum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+#: ../dictionary_strings.rb:825
+msgid "Capacity - Profile 2 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+#: ../dictionary_strings.rb:821
+msgid "Capacity - Profile 2 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+#: ../dictionary_strings.rb:817
+msgid "Capacity - Profile 2 - Memory Effective with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+#: ../dictionary_strings.rb:829
+msgid "Capacity - Profile 2 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+#: ../dictionary_strings.rb:831
+msgid "Capacity - Profile 2 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+#: ../dictionary_strings.rb:827
+msgid "Capacity - Profile 2 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+#: ../dictionary_strings.rb:855
+msgid "Capacity - Profile 2 - Minimum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+#: ../dictionary_strings.rb:833
+msgid "Capacity - Profile 2 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+#: ../dictionary_strings.rb:835
+msgid "Capacity - Profile 2 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+#: ../dictionary_strings.rb:837
+msgid "Capacity - Profile 2 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+#: ../dictionary_strings.rb:853
+msgid "Capacity - Profile 2 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+#: ../dictionary_strings.rb:849
+msgid "Capacity - Profile 2 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+#: ../dictionary_strings.rb:333
+msgid "Capacity - Total Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+#: ../dictionary_strings.rb:1007
+msgid "Capacity - Used Space (B)"
 msgstr ""
 
 #: ../../app/views/ops/_db_summary.html.haml:7 ../../app/views/ontap_logical_disk/_main.html.haml:16
@@ -2992,27 +3978,39 @@ msgstr ""
 msgid "Capture C & U Data by Tag"
 msgstr ""
 
-#: ../../app/views/catalog/_form_basic_info.html.haml:54 ../../app/views/catalog/_sandt_tree_show.html.haml:56
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
+#: ../../app/views/catalog/_form_basic_info.html.haml:54 ../../app/views/catalog/_sandt_tree_show.html.haml:56 ../dictionary_strings.rb:1691 ../dictionary_strings.rb:2085
 msgid "Catalog"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.service_template
+#: ../dictionary_strings.rb:2081
+msgid "Catalog Item"
 msgstr ""
 
 #: ../../app/views/catalog/_st_form.html.haml:13
 msgid "Catalog Item Type"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:49 ../../app/views/catalog/_stcat_tree_show.html.haml:49
+#. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
+#: ../../app/views/configuration/_ui_2.html.haml:49 ../../app/views/catalog/_stcat_tree_show.html.haml:49 ../dictionary_strings.rb:2083
 msgid "Catalog Items"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:18
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
+#: ../../app/presenters/menu/default_menu.rb:18 ../dictionary_strings.rb:1693 ../dictionary_strings.rb:2087
 msgid "Catalogs"
 msgstr ""
 
-#: ../../app/views/ops/_ap_show.html.haml:67 ../../app/views/ops/_all_tabs.html.haml:85 ../../app/views/miq_policy/_action_options.html.haml:572 ../../app/views/miq_policy/_action_options.html.haml:602 ../../app/views/miq_policy/_action_details.html.haml:505 ../../app/views/miq_policy/_action_details.html.haml:529
+#. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
+#: ../../app/views/ops/_ap_show.html.haml:67 ../../app/views/ops/_all_tabs.html.haml:85 ../../app/views/miq_policy/_action_options.html.haml:572 ../../app/views/miq_policy/_action_options.html.haml:602 ../../app/views/miq_policy/_action_details.html.haml:505 ../../app/views/miq_policy/_action_details.html.haml:529 ../dictionary_strings.rb:1277
 msgid "Categories"
 msgstr ""
 
-#: ../../app/views/ops/_settings_co_tags_tab.html.haml:15 ../../app/views/ops/_ap_form.html.haml:82 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:517 ../../app/views/layouts/_classify_table.html.haml:11 ../../app/views/layouts/_tag_edit_assignments.html.haml:13
+#. TRANSLATORS: en.yml key: dictionary.model.Classification
+#: ../../app/views/ops/_settings_co_tags_tab.html.haml:15 ../../app/views/ops/_ap_form.html.haml:82 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:517 ../../app/views/layouts/_classify_table.html.haml:11 ../../app/views/layouts/_tag_edit_assignments.html.haml:13 ../dictionary_strings.rb:1275
 msgid "Category"
 msgstr ""
 
@@ -3042,6 +4040,11 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_advanced_tab.html.haml:18
 msgid "Caution: Manual changes to configuration files can disable the Server!"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.chain_id
+#: ../dictionary_strings.rb:185
+msgid "Chain ID"
 msgstr ""
 
 #: ../../app/views/layouts/_user_options.html.haml:29
@@ -3084,7 +4087,8 @@ msgstr ""
 msgid "Changing the UI Workers Count will immediately restart the webserver"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:9
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback
+#: ../../app/presenters/menu/default_menu.rb:9 ../dictionary_strings.rb:1263
 msgid "Chargeback"
 msgstr ""
 
@@ -3094,6 +4098,16 @@ msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:140
 msgid "Chargeback Interval"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+#: ../dictionary_strings.rb:1267
+msgid "Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+#: ../dictionary_strings.rb:1269
+msgid "Chargeback Rates"
 msgstr ""
 
 #: ../model_attributes.rb:82
@@ -3170,6 +4184,11 @@ msgstr ""
 
 #: ../model_attributes.rb:88
 msgid "ChargebackRate|Updated on"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+#: ../dictionary_strings.rb:1265
+msgid "Chargebacks"
 msgstr ""
 
 #: ../../app/views/report/_report_list.html.haml:143 ../../app/views/report/_report_info.html.haml:56
@@ -3348,7 +4367,7 @@ msgstr ""
 msgid "Choose an Owner"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/upload.rb:49 ../../app/controllers/ops_controller/settings/common.rb:1093
+#: ../../app/controllers/ops_controller/settings/upload.rb:49 ../../app/controllers/ops_controller/settings/common.rb:1104
 msgid "Choose the type of custom variables to be imported"
 msgstr ""
 
@@ -3632,12 +4651,76 @@ msgstr ""
 msgid "Cloud Networks"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+#: ../dictionary_strings.rb:1983
+msgid "Cloud Networks (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+#: ../dictionary_strings.rb:1421 ../dictionary_strings.rb:1841
+msgid "Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+#: ../dictionary_strings.rb:1469
+msgid "Cloud Provider (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+#: ../dictionary_strings.rb:1473
+msgid "Cloud Provider (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+#: ../dictionary_strings.rb:1465
+msgid "Cloud Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+#: ../dictionary_strings.rb:1423 ../dictionary_strings.rb:1843 ../dictionary_strings.rb:1845
+msgid "Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+#: ../dictionary_strings.rb:1471
+msgid "Cloud Providers (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+#: ../dictionary_strings.rb:1475
+msgid "Cloud Providers (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+#: ../dictionary_strings.rb:1467
+msgid "Cloud Providers (Openstack)"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:18
 msgid "Cloud Quota"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:22
 msgid "Cloud Tenant:"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+#: ../dictionary_strings.rb:1985
+msgid "Cloud Tenants (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+#: ../dictionary_strings.rb:1761
+msgid "Cloud Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+#: ../dictionary_strings.rb:1763 ../dictionary_strings.rb:1765
+msgid "Cloud Volumes"
 msgstr ""
 
 #: ../model_attributes.rb:111
@@ -3670,6 +4753,27 @@ msgstr ""
 
 #: ../model_attributes.rb:158
 msgid "Cloud volume snapshot"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+#: ../dictionary_strings.rb:1905
+msgid "Cloud/Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+#: ../dictionary_strings.rb:1907 ../dictionary_strings.rb:1909
+msgid "Cloud/Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+#: ../dictionary_strings.rb:1639
+msgid "CloudFormation Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+#: ../dictionary_strings.rb:1641
+msgid "CloudFormation Templates"
 msgstr ""
 
 #: ../../app/views/pxe/_template_form.html.haml:73
@@ -3864,11 +4968,14 @@ msgstr ""
 msgid "Clouds"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:1244 ../../app/helpers/application_helper.rb:1257
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
+#: ../../app/helpers/application_helper.rb:1244 ../../app/helpers/application_helper.rb:1257 ../dictionary_strings.rb:383
 msgid "Cluster"
 msgstr ""
 
-#: ../../app/presenters/tree_builder_utilization.rb:16 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:118 ../../app/helpers/application_helper.rb:1248
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
+#: ../../app/presenters/tree_builder_utilization.rb:16 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:118 ../../app/helpers/application_helper.rb:1248 ../dictionary_strings.rb:1335 ../dictionary_strings.rb:1847
 msgid "Cluster / Deployment Role"
 msgstr ""
 
@@ -3876,15 +4983,27 @@ msgstr ""
 msgid "Cluster / Deployment Role (Click to open)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+#: ../dictionary_strings.rb:1337 ../dictionary_strings.rb:1849
+msgid "Cluster / Deployment Roles"
+msgstr ""
+
 #: ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:156
 msgid "Cluster Selection"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+#: ../dictionary_strings.rb:1059
+msgid "Cluster in Datacenter"
 msgstr ""
 
 #: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1244
 msgid "Clusters"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1248
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
+#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1248 ../dictionary_strings.rb:1851
 msgid "Clusters / Deployment Roles"
 msgstr ""
 
@@ -4044,6 +5163,20 @@ msgstr ""
 msgid "Compliance Check"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+#: ../dictionary_strings.rb:1281 ../dictionary_strings.rb:1285 ../dictionary_strings.rb:1771
+msgid "Compliance Histories"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances
+#. TRANSLATORS: en.yml key: dictionary.table.compliances
+#: ../dictionary_strings.rb:1279 ../dictionary_strings.rb:1283 ../dictionary_strings.rb:1769
+msgid "Compliance History"
+msgstr ""
+
 #: ../../app/presenters/tree_builder_policy.rb:43
 msgid "Compliance Policies"
 msgstr ""
@@ -4120,11 +5253,12 @@ msgstr ""
 msgid "ComputerSystem|Managed entity type"
 msgstr ""
 
-#: ../model_attributes.rb:180
+#. TRANSLATORS: en.yml key: dictionary.model.Condition
+#: ../dictionary_strings.rb:1287 ../model_attributes.rb:180
 msgid "Condition"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/conditions.rb:110
+#: ../../app/controllers/miq_policy_controller/conditions.rb:111
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr ""
 
@@ -4180,7 +5314,8 @@ msgstr ""
 msgid "ConditionSet|Userid"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1106 ../../app/views/container_group/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:17 ../../app/views/miq_policy/_policy_details.html.haml:232
+#. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1133 ../../app/views/container_group/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:17 ../../app/views/miq_policy/_policy_details.html.haml:232 ../dictionary_strings.rb:1289
 msgid "Conditions"
 msgstr ""
 
@@ -4232,7 +5367,7 @@ msgstr ""
 msgid "Condition|Updated on"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:164 ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/saved_reports_center.rb:14 ../../app/helpers/application_helper/toolbar/saved_report_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_action_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_buttons_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:6 ../../app/helpers/application_helper/toolbar/host_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instances_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:6 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_set_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_method_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:6 ../../app/helpers/application_helper/toolbar/services_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_regions_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:11 ../../app/helpers/application_helper/toolbar/users_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_center.rb:13 ../../app/helpers/application_helper/toolbar/container_service_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:6 ../../app/helpers/application_helper/toolbar/container_center.rb:6 ../../app/helpers/application_helper/toolbar/condition_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_reports_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:6 ../../app/helpers/application_helper/toolbar/chargebacks_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/container_route_center.rb:6 ../../app/helpers/application_helper/toolbar/user_roles_center.rb:6 ../../app/helpers/application_helper/toolbar/user_role_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_region_center.rb:6 ../../app/helpers/application_helper/toolbar/time_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_actions_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:6 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/repository_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:6 ../../app/helpers/application_helper/toolbar/container_project_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_event_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policies_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_fields_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_server_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb:6 ../../app/helpers/application_helper/toolbar/vms_center.rb:6 ../../app/helpers/application_helper/toolbar/container_node_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastore_center.rb:6 ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/conditions_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:6 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:42 ../../app/helpers/application_helper/toolbar/custom_button_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/service_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_image_center.rb:6 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_methods_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:11 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:6 ../../app/helpers/application_helper/toolbar/container_group_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widgets_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_ae_class_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:6 ../../app/helpers/application_helper/toolbar/hosts_center.rb:6 ../../app/helpers/application_helper/toolbar/storages_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:6 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/windows_image_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_type_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_sets_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/repositories_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:74 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:6 ../../app/helpers/application_helper/toolbar/zone_center.rb:6 ../../app/helpers/application_helper/toolbar/dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alerts_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:6 ../../app/helpers/application_helper/toolbar/tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:6 ../../app/helpers/application_helper/toolbar/containers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/container_images_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instance_center.rb:6 ../../app/helpers/application_helper/toolbar/zones_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:11 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:13 ../../app/views/resource_pool/_main.html.haml:14 ../../app/views/vm_cloud/_main.html.haml:32 ../../app/views/host/_main.html.haml:21 ../../app/views/ems_cluster/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:217 ../../app/views/layouts/listnav/_ems_cluster.html.haml:19 ../../app/views/vm_common/_main.html.haml:33 ../../app/views/container_image/_main.html.haml:19 ../model_attributes.rb:205
+#: ../../app/presenters/menu/default_menu.rb:164 ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/saved_reports_center.rb:14 ../../app/helpers/application_helper/toolbar/saved_report_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_action_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_buttons_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:6 ../../app/helpers/application_helper/toolbar/host_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instances_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:6 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_set_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_method_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:6 ../../app/helpers/application_helper/toolbar/services_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_regions_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:11 ../../app/helpers/application_helper/toolbar/users_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_center.rb:13 ../../app/helpers/application_helper/toolbar/container_service_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:6 ../../app/helpers/application_helper/toolbar/container_center.rb:6 ../../app/helpers/application_helper/toolbar/condition_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_reports_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:6 ../../app/helpers/application_helper/toolbar/chargebacks_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/container_route_center.rb:6 ../../app/helpers/application_helper/toolbar/user_roles_center.rb:6 ../../app/helpers/application_helper/toolbar/user_role_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_region_center.rb:6 ../../app/helpers/application_helper/toolbar/time_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_actions_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:6 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/repository_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:6 ../../app/helpers/application_helper/toolbar/container_project_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_event_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policies_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_fields_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_server_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb:6 ../../app/helpers/application_helper/toolbar/vms_center.rb:6 ../../app/helpers/application_helper/toolbar/container_node_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastore_center.rb:6 ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/conditions_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:6 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:42 ../../app/helpers/application_helper/toolbar/custom_button_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/service_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_image_center.rb:6 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_methods_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:11 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:6 ../../app/helpers/application_helper/toolbar/container_group_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widgets_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_ae_class_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:6 ../../app/helpers/application_helper/toolbar/hosts_center.rb:6 ../../app/helpers/application_helper/toolbar/storages_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:6 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/windows_image_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_type_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_sets_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/repositories_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:74 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:6 ../../app/helpers/application_helper/toolbar/zone_center.rb:6 ../../app/helpers/application_helper/toolbar/dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alerts_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:6 ../../app/helpers/application_helper/toolbar/tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:6 ../../app/helpers/application_helper/toolbar/containers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/container_images_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instance_center.rb:6 ../../app/helpers/application_helper/toolbar/zones_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:11 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:13 ../../app/views/resource_pool/_main.html.haml:14 ../../app/views/vm_cloud/_main.html.haml:32 ../../app/views/host/_main.html.haml:21 ../../app/views/ems_cluster/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:217 ../../app/views/layouts/listnav/_ems_cluster.html.haml:19 ../../app/views/vm_common/_main.html.haml:33 ../../app/views/container_image/_main.html.haml:19 ../model_attributes.rb:205
 msgid "Configuration"
 msgstr ""
 
@@ -4264,12 +5399,37 @@ msgstr ""
 msgid "Configuration Management Providers"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+#: ../dictionary_strings.rb:1413
+msgid "Configuration Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+#: ../dictionary_strings.rb:1415
+msgid "Configuration Managers"
+msgstr ""
+
 #: ../../app/helpers/provider_foreman_helper.rb:115 ../../app/helpers/provider_foreman_helper.rb:196
 msgid "Configuration Organization"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+#: ../dictionary_strings.rb:1979
+msgid "Configuration Profile (Foreman)"
+msgstr ""
+
 #: ../../app/helpers/provider_foreman_helper.rb:33
 msgid "Configuration Profile Description"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+#: ../dictionary_strings.rb:1981
+msgid "Configuration Profiles (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.config_xml
+#: ../dictionary_strings.rb:235
+msgid "Configuration XML"
 msgstr ""
 
 #: ../../app/controllers/host_controller.rb:150
@@ -4288,8 +5448,12 @@ msgstr ""
 msgid "Configuration profile"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:423 ../../app/controllers/configuration_controller.rb:268
+#: ../../app/controllers/ops_controller/settings/common.rb:427 ../../app/controllers/configuration_controller.rb:268
 msgid "Configuration settings saved"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:421 ../../app/controllers/ops_controller/settings/common.rb:476
+msgid "Configuration settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone}\""
 msgstr ""
 
 #: ../model_attributes.rb:225
@@ -4444,7 +5608,7 @@ msgstr ""
 msgid "Connection Broker"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:597
+#: ../../app/controllers/ops_controller/diagnostics.rb:599
 msgid "Connection Broker cache cleared successfully"
 msgstr ""
 
@@ -4464,7 +5628,9 @@ msgstr ""
 msgid "Consolidating records will not show detail records in the report."
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1685 ../model_attributes.rb:237
+#. TRANSLATORS: en.yml key: dictionary.model.Container
+#. TRANSLATORS: en.yml key: dictionary.table.container
+#: ../../app/controllers/vm_common.rb:1685 ../dictionary_strings.rb:1299 ../dictionary_strings.rb:1773 ../model_attributes.rb:237
 msgid "Container"
 msgid_plural "Container"
 msgstr[0] ""
@@ -4476,6 +5642,46 @@ msgstr ""
 
 #: ../../app/presenters/menu/default_menu.rb:94
 msgid "Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+#: ../dictionary_strings.rb:1477
+msgid "Container Provider (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+#: ../dictionary_strings.rb:1481
+msgid "Container Provider (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+#: ../dictionary_strings.rb:1489
+msgid "Container Provider (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+#: ../dictionary_strings.rb:1485
+msgid "Container Provider (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+#: ../dictionary_strings.rb:1479
+msgid "Container Providers (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+#: ../dictionary_strings.rb:1483
+msgid "Container Providers (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+#: ../dictionary_strings.rb:1491
+msgid "Container Providers (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+#: ../dictionary_strings.rb:1487
+msgid "Container Providers (Openshift)"
 msgstr ""
 
 #: ../../app/presenters/menu/default_menu.rb:82
@@ -4846,8 +6052,24 @@ msgstr ""
 msgid "ContainerService|Session affinity"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:77 ../../app/views/configuration/_ui_2.html.haml:75 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:19
+#. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.containers
+#: ../../app/presenters/menu/default_menu.rb:77 ../../app/views/configuration/_ui_2.html.haml:75 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:19 ../dictionary_strings.rb:1301 ../dictionary_strings.rb:1775 ../dictionary_strings.rb:1777
 msgid "Containers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container
+#: ../dictionary_strings.rb:1433 ../dictionary_strings.rb:1877
+msgid "Containers Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_containers
+#: ../dictionary_strings.rb:1435 ../dictionary_strings.rb:1879 ../dictionary_strings.rb:1881
+msgid "Containers Providers"
 msgstr ""
 
 #: ../model_attributes.rb:238
@@ -4872,6 +6094,106 @@ msgstr ""
 
 #: ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:77 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:53 ../../app/views/layouts/listnav/_storage.html.haml:83 ../../app/views/storage/_main.html.haml:19
 msgid "Content"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+#: ../dictionary_strings.rb:343
+msgid "Content - Avg Count of Managed VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+#: ../dictionary_strings.rb:345
+msgid "Content - Avg Count of Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+#: ../dictionary_strings.rb:347
+msgid "Content - Avg Count of Unmanaged VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+#: ../dictionary_strings.rb:349
+msgid "Content - Avg Count of Unregistered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+#: ../dictionary_strings.rb:335
+msgid "Content - Avg Space Used by Managed VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+#: ../dictionary_strings.rb:337
+msgid "Content - Avg Space Used by Registered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+#: ../dictionary_strings.rb:339
+msgid "Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+#: ../dictionary_strings.rb:341
+msgid "Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+#: ../dictionary_strings.rb:307
+msgid "Content - Avg of Total Size of Managed VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+#: ../dictionary_strings.rb:317
+msgid "Content - Avg of Total Size of Managed VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+#: ../dictionary_strings.rb:325
+msgid "Content - Avg of Total Size of Managed VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+#: ../dictionary_strings.rb:309
+msgid "Content - Avg of Total Size of Registered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+#: ../dictionary_strings.rb:319
+msgid "Content - Avg of Total Size of Registered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+#: ../dictionary_strings.rb:327
+msgid "Content - Avg of Total Size of Registered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+#: ../dictionary_strings.rb:311
+msgid "Content - Avg of Total Size of Unmanaged VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+#: ../dictionary_strings.rb:321
+msgid "Content - Avg of Total Size of Unmanaged VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+#: ../dictionary_strings.rb:329
+msgid "Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+#: ../dictionary_strings.rb:313
+msgid "Content - Avg of Total Size of Unregistered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+#: ../dictionary_strings.rb:323
+msgid "Content - Avg of Total Size of Unregistered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+#: ../dictionary_strings.rb:331
+msgid "Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)"
 msgstr ""
 
 #: ../../app/controllers/report_controller/widgets.rb:129
@@ -5070,8 +6392,16 @@ msgstr ""
 msgid "Create Datastore"
 msgstr ""
 
+#: ../../app/controllers/ontap_file_share_controller.rb:99
+msgid "Create Datastore was cancelled by the user"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:13
 msgid "Create Logical Disk"
+msgstr ""
+
+#: ../../app/controllers/ontap_storage_system_controller.rb:106
+msgid "Create Logical Disk was cancelled by the user"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:12
@@ -5118,6 +6448,11 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+#: ../dictionary_strings.rb:873
+msgid "Created on Time"
+msgstr ""
+
 #: ../../app/controllers/catalog_controller.rb:1081
 msgid "Creation of a new Orchestration Template was cancelled by the user"
 msgstr ""
@@ -5127,7 +6462,7 @@ msgid "Creation of a new Service Dialog was cancelled by the user"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/rhn.rb:168
-msgid "Credential validation returned: %s"
+msgid "Credential validation returned: %{message}"
 msgstr ""
 
 #: ../../app/controllers/ems_cloud_controller.rb:83
@@ -5138,7 +6473,7 @@ msgstr ""
 msgid "Credential validation was not successful: %{details}"
 msgstr ""
 
-#: ../../app/controllers/storage_manager_controller.rb:133 ../../app/controllers/storage_manager_controller.rb:227 ../../app/controllers/ops_controller/settings/rhn.rb:171 ../../app/controllers/ops_controller/settings/ldap.rb:154 ../../app/controllers/host_controller.rb:280 ../../app/controllers/host_controller.rb:417 ../../app/controllers/ems_common.rb:310 ../../app/controllers/provider_foreman_controller.rb:257 ../../app/controllers/ems_cloud_controller.rb:81
+#: ../../app/controllers/storage_manager_controller.rb:133 ../../app/controllers/storage_manager_controller.rb:227 ../../app/controllers/ops_controller/settings/rhn.rb:171 ../../app/controllers/ops_controller/settings/ldap.rb:154 ../../app/controllers/host_controller.rb:280 ../../app/controllers/host_controller.rb:417 ../../app/controllers/ems_common.rb:310 ../../app/controllers/provider_foreman_controller.rb:238 ../../app/controllers/ems_cloud_controller.rb:81
 msgid "Credential validation was successful"
 msgstr ""
 
@@ -5158,7 +6493,7 @@ msgstr ""
 msgid "Current"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:584
+#: ../../app/controllers/ops_controller/ops_rbac.rb:585
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
@@ -5184,6 +6519,11 @@ msgstr ""
 
 #: ../../app/views/layouts/_user_options.html.haml:37
 msgid "Currently Selected Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+#: ../dictionary_strings.rb:995
+msgid "Currently Used Space"
 msgstr ""
 
 #: ../../app/views/miq_policy/_action_options.html.haml:59
@@ -5231,7 +6571,7 @@ msgid "Custom Logo Image (Shown on top right of all screens)"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/upload.rb:30
-msgid "Custom Logo file \"%s\" uploaded"
+msgid "Custom Logo file \"%{name}\" uploaded"
 msgstr ""
 
 #: ../../app/views/ops/_all_tabs.html.haml:37
@@ -5250,7 +6590,7 @@ msgstr ""
 msgid "Custom Support URL"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:519
+#: ../../app/controllers/ops_controller/settings/common.rb:524
 msgid "Custom Support URL and Description both must be entered."
 msgstr ""
 
@@ -5267,7 +6607,7 @@ msgid "Custom button set"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/upload.rb:32
-msgid "Custom login file \"%s\" uploaded"
+msgid "Custom login file \"%{name}\" uploaded"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/upload.rb:24
@@ -5398,6 +6738,16 @@ msgstr ""
 msgid "Customization Directory"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+#: ../dictionary_strings.rb:1655
+msgid "Customization Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+#: ../dictionary_strings.rb:1657
+msgid "Customization Templates"
+msgstr ""
+
 #: ../model_attributes.rb:363
 msgid "Customization script"
 msgstr ""
@@ -5458,11 +6808,13 @@ msgstr ""
 msgid "Customize Template"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
+#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:361
 msgid "DHCP Enabled"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
+#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:363
 msgid "DHCP Server"
 msgstr ""
 
@@ -5470,7 +6822,8 @@ msgstr ""
 msgid "DNS"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#. TRANSLATORS: en.yml key: dictionary.column.dns_server
+#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:377
 msgid "DNS Server"
 msgstr ""
 
@@ -5504,6 +6857,11 @@ msgstr ""
 
 #: ../../app/views/miq_ae_class/_method_inputs.html.haml:95 ../../app/views/miq_ae_class/_method_form.html.haml:100
 msgid "Data"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+#: ../dictionary_strings.rb:237
+msgid "Data Points"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_method_inputs.html.haml:132 ../../app/views/miq_ae_class/_method_form.html.haml:147 ../../app/views/miq_ae_class/_class_fields.html.haml:97
@@ -5546,6 +6904,14 @@ msgstr ""
 msgid "Database Backup Settings"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:334
+msgid "Database Backup successfully initiated"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:407
+msgid "Database Garbage Collection successfully initiated"
+msgstr ""
+
 #: ../../app/views/ops/_diagnostics_database_tab.html.haml:51
 msgid "Database Name"
 msgstr ""
@@ -5554,7 +6920,7 @@ msgstr ""
 msgid "Database backup"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:357
+#: ../../app/controllers/ops_controller/settings/common.rb:358
 msgid "Database settings successfully saved, they will take effect upon CFME Server restart"
 msgstr ""
 
@@ -5566,7 +6932,9 @@ msgstr ""
 msgid "Datacenter"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:48 ../../app/presenters/tree_builder.rb:49 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:60 ../../app/views/miq_request/_prov_host_dialog.html.haml:69 ../../app/views/shared/views/_prov_dialog.html.haml:140
+#. TRANSLATORS: en.yml key: dictionary.model.Storage
+#. TRANSLATORS: en.yml key: dictionary.table.storage
+#: ../../app/presenters/tree_builder.rb:48 ../../app/presenters/tree_builder.rb:49 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:60 ../../app/views/miq_request/_prov_host_dialog.html.haml:69 ../../app/views/shared/views/_prov_dialog.html.haml:140 ../dictionary_strings.rb:1699 ../dictionary_strings.rb:2091
 msgid "Datastore"
 msgstr ""
 
@@ -5576,6 +6944,24 @@ msgstr ""
 
 #: ../../app/views/vm_common/_main.html.haml:35
 msgid "Datastore Allocation Summary"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file
+#: ../dictionary_strings.rb:1703 ../dictionary_strings.rb:2095
+msgid "Datastore File"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_files
+#: ../dictionary_strings.rb:1705 ../dictionary_strings.rb:2097 ../dictionary_strings.rb:2099
+msgid "Datastore Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+#: ../dictionary_strings.rb:1001
+msgid "Datastore Path"
 msgstr ""
 
 #: ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:158
@@ -5599,12 +6985,36 @@ msgid ""
 "Methods updated/added: %{method_stats}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storages
+#: ../dictionary_strings.rb:1701 ../dictionary_strings.rb:2093 ../dictionary_strings.rb:2101
+msgid "Datastores"
+msgstr ""
+
 #: ../../app/views/layouts/_tl_options.html.haml:65 ../../app/views/layouts/_perf_options.html.haml:63 ../../app/views/report/_form_filter_chargeback.html.haml:122 ../../app/assets/javascripts/miq_application.js:99
 msgid "Date"
 msgstr ""
 
 #: ../../app/views/miq_request/_request_details.html.haml:71
 msgid "Date Approved/Denied"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.created_at
+#. TRANSLATORS: en.yml key: dictionary.column.created_on
+#: ../dictionary_strings.rb:277 ../dictionary_strings.rb:279
+msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.display_range
+#: ../dictionary_strings.rb:1161
+msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.updated_at
+#. TRANSLATORS: en.yml key: dictionary.column.updated_on
+#: ../dictionary_strings.rb:987 ../dictionary_strings.rb:989
+msgid "Date Updated"
 msgstr ""
 
 #: ../../app/assets/javascripts/miq_application.js:100
@@ -5623,7 +7033,7 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:388 ../../app/controllers/ops_controller/ops_rbac.rb:357
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:388 ../../app/controllers/ops_controller/ops_rbac.rb:358
 msgid "Default %{model} \"%{name}\" can not be deleted"
 msgstr ""
 
@@ -5631,7 +7041,7 @@ msgstr ""
 msgid "Default %{model} \"%{name}\" can not be edited"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:69 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:90 ../../app/controllers/ops_controller/ops_rbac.rb:270 ../../app/controllers/ops_controller/ops_rbac.rb:582 ../../app/controllers/configuration_controller.rb:377
+#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:69 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:90 ../../app/controllers/ops_controller/ops_rbac.rb:271 ../../app/controllers/ops_controller/ops_rbac.rb:583 ../../app/controllers/configuration_controller.rb:377
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
@@ -5937,6 +7347,16 @@ msgstr ""
 msgid "Deny this Request"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+#: ../dictionary_strings.rb:281
+msgid "Depends on Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+#: ../dictionary_strings.rb:283
+msgid "Depends on Service"
+msgstr ""
+
 #: ../../app/helpers/application_helper.rb:1246 ../../app/helpers/application_helper.rb:1257
 msgid "Deployment Role"
 msgstr ""
@@ -5969,7 +7389,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:149 ../../app/controllers/configuration_controller.rb:491 ../../app/controllers/configuration_controller.rb:549
+#: ../../app/controllers/chargeback_controller.rb:149 ../../app/controllers/miq_policy_controller/miq_actions.rb:383 ../../app/controllers/ops_controller/settings/tags.rb:57 ../../app/controllers/ops_controller/settings/zones.rb:22 ../../app/controllers/configuration_controller.rb:491 ../../app/controllers/configuration_controller.rb:549
 msgid "Description is required"
 msgstr ""
 
@@ -5977,11 +7397,27 @@ msgstr ""
 msgid "Desired"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+#: ../dictionary_strings.rb:355
+msgid "Destination Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+#: ../dictionary_strings.rb:357
+msgid "Destination VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+#: ../dictionary_strings.rb:359
+msgid "Destination VM Name"
+msgstr ""
+
 #: ../../app/views/layouts/_tl_options.html.haml:186
 msgid "Detail"
 msgstr ""
 
-#: ../../app/views/ops/_all_tabs.html.haml:77 ../../app/views/catalog/_form.html.haml:8 ../../app/views/catalog/_sandt_tree_show.html.haml:12 ../../app/views/miq_capacity/_utilization_tabs.html.haml:7 ../../app/assets/javascripts/miq_policy/import.js:46
+#. TRANSLATORS: en.yml key: dictionary.table.compliance_details
+#: ../../app/views/ops/_all_tabs.html.haml:77 ../../app/views/catalog/_form.html.haml:8 ../../app/views/catalog/_sandt_tree_show.html.haml:12 ../../app/views/miq_capacity/_utilization_tabs.html.haml:7 ../../app/assets/javascripts/miq_policy/import.js:46 ../dictionary_strings.rb:1767
 msgid "Details"
 msgstr ""
 
@@ -5997,7 +7433,8 @@ msgstr ""
 msgid "Device Type"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:43 ../../app/views/vm_common/_config.html.haml:113
+#. TRANSLATORS: en.yml key: dictionary.table.guest_devices
+#: ../../app/views/layouts/listnav/_host.html.haml:43 ../../app/views/vm_common/_config.html.haml:113 ../dictionary_strings.rb:1923
 msgid "Devices"
 msgstr ""
 
@@ -6005,7 +7442,16 @@ msgstr ""
 msgid "Diagnostics"
 msgstr ""
 
-#: ../../app/views/miq_ae_customization/_dialog_edit_tree.html.haml:11 ../../app/views/shared/buttons/_ab_show.html.haml:61 ../../app/views/shared/buttons/_ab_form.html.haml:108 ../../app/views/catalog/_form_basic_info.html.haml:77 ../../app/views/catalog/_sandt_tree_show.html.haml:69 ../model_attributes.rb:379
+#: ../../app/controllers/ops_controller/diagnostics.rb:837 ../../app/controllers/ops_controller/diagnostics.rb:863 ../../app/controllers/ops_controller/diagnostics.rb:931
+msgid "Diagnostics %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:833 ../../app/controllers/ops_controller/diagnostics.rb:927
+msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
+#: ../../app/views/miq_ae_customization/_dialog_edit_tree.html.haml:11 ../../app/views/shared/buttons/_ab_show.html.haml:61 ../../app/views/shared/buttons/_ab_form.html.haml:108 ../../app/views/catalog/_form_basic_info.html.haml:77 ../../app/views/catalog/_sandt_tree_show.html.haml:69 ../dictionary_strings.rb:1525 ../model_attributes.rb:379
 msgid "Dialog"
 msgstr ""
 
@@ -6197,6 +7643,11 @@ msgstr ""
 msgid "DialogTab|Position"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+#: ../dictionary_strings.rb:1527
+msgid "Dialogs"
+msgstr ""
+
 #: ../model_attributes.rb:380
 msgid "Dialog|Buttons"
 msgstr ""
@@ -6209,7 +7660,8 @@ msgstr ""
 msgid "Dialog|Label"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:42 ../../app/views/layouts/listnav/_ems_cluster.html.haml:51
+#. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
+#: ../../app/views/layouts/listnav/_resource_pool.html.haml:42 ../../app/views/layouts/listnav/_ems_cluster.html.haml:51 ../dictionary_strings.rb:1009
 msgid "Direct VMs"
 msgstr ""
 
@@ -6265,12 +7717,148 @@ msgstr ""
 msgid "Disk"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+#: ../dictionary_strings.rb:1011
+msgid "Disk Files Percent of Used"
+msgstr ""
+
 #: ../../app/helpers/application_helper/chargeback.rb:6
 msgid "Disk I/O"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+#: ../dictionary_strings.rb:125
+msgid "Disk I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:123
+msgid "Disk I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+#: ../dictionary_strings.rb:141
+msgid "Disk I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:139
+msgid "Disk I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+#: ../dictionary_strings.rb:17
+msgid "Disk I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+#: ../dictionary_strings.rb:373
+msgid "Disk I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+#: ../dictionary_strings.rb:59
+msgid "Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+#: ../dictionary_strings.rb:569
+msgid "Disk I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+#: ../dictionary_strings.rb:35
+msgid "Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+#: ../dictionary_strings.rb:493
+msgid "Disk I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+#: ../dictionary_strings.rb:973
+msgid "Disk I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+#: ../dictionary_strings.rb:1155
+msgid "Disk I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+#: ../dictionary_strings.rb:1153
+msgid "Disk I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+#: ../dictionary_strings.rb:1159
+msgid "Disk I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+#: ../dictionary_strings.rb:1157
+msgid "Disk I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+#: ../dictionary_strings.rb:369
+msgid "Disk Kernel Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+#: ../dictionary_strings.rb:367
+msgid "Disk Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+#: ../dictionary_strings.rb:371
+msgid "Disk Queue Latency - Avg (ms)"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_options.html.haml:223 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:43
 msgid "Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+#: ../dictionary_strings.rb:979
+msgid "Disk Space Average Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+#: ../dictionary_strings.rb:485
+msgid "Disk Space Max Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+#: ../dictionary_strings.rb:71 ../dictionary_strings.rb:487
+msgid "Disk Space Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+#: ../dictionary_strings.rb:977
+msgid "Disk Space Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+#: ../dictionary_strings.rb:531
+msgid "Disk Space Max Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+#: ../dictionary_strings.rb:563
+msgid "Disk Space Min Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+#: ../dictionary_strings.rb:591
+msgid "Disk Space Min Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+#: ../dictionary_strings.rb:375
+msgid "Disks Aligned"
 msgstr ""
 
 #: ../model_attributes.rb:426
@@ -6595,8 +8183,12 @@ msgstr ""
 msgid "E-mail Settings"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/miq_actions.rb:404 ../../app/controllers/miq_policy_controller/miq_actions.rb:405
-msgid "E-mail address '%s' is not valid"
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:408
+msgid "E-mail address 'From' is not valid"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:409
+msgid "E-mail address 'To' is not valid"
 msgstr ""
 
 #: ../../app/views/report/_schedule_form.html.haml:68
@@ -6611,12 +8203,95 @@ msgstr ""
 msgid "ESX Logs"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+#: ../dictionary_strings.rb:1255
+msgid "EVM Audit Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+#: ../dictionary_strings.rb:1257
+msgid "EVM Audit Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.server_builds
+#: ../dictionary_strings.rb:2079
+msgid "EVM Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+#: ../dictionary_strings.rb:1969
+msgid "EVM Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+#: ../dictionary_strings.rb:1971 ../dictionary_strings.rb:1973
+msgid "EVM Custom Attributes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+#: ../dictionary_strings.rb:1537
+msgid "EVM Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+#: ../dictionary_strings.rb:1539
+msgid "EVM Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner
+#: ../dictionary_strings.rb:1901
+msgid "EVM Owner"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+#: ../dictionary_strings.rb:1903
+msgid "EVM Owners"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guid
+#: ../dictionary_strings.rb:401
+msgid "EVM Unique ID (Guid)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User
+#: ../dictionary_strings.rb:1719
+msgid "EVM User"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+#: ../dictionary_strings.rb:1721
+msgid "EVM Users"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker
+#: ../dictionary_strings.rb:1597 ../dictionary_strings.rb:2031
+msgid "EVM Worker"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_workers
+#: ../dictionary_strings.rb:1599 ../dictionary_strings.rb:2033 ../dictionary_strings.rb:2035
+msgid "EVM Workers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.zone_name
+#: ../dictionary_strings.rb:1139
+msgid "EVM Zone"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:70 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:70
 msgid "Edit"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:731 ../../app/controllers/provider_foreman_controller.rb:829
+#: ../../app/controllers/provider_foreman_controller.rb:712 ../../app/controllers/provider_foreman_controller.rb:810
 msgid "Edit %s Provider"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:81
+msgid "Edit %{model} assignments cancelled by user"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:50
@@ -6657,6 +8332,10 @@ msgstr ""
 
 #: ../../app/views/chargeback/_assignments_list.html.haml:9 ../../app/views/chargeback/_assignments_list.html.haml:20 ../../app/views/chargeback/_assignments_list.html.haml:28 ../../app/views/chargeback/_assignments_list.html.haml:33
 msgid "Edit Compute Rate Assignments"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/events.rb:9
+msgid "Edit Event cancelled by user"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/diagnostics.rb:95
@@ -6723,6 +8402,14 @@ msgstr ""
 msgid "Edit Selected #{ui_lookup(:table=>\"ems_infra\")}"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:19
+msgid "Edit Selected #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:19
+msgid "Edit Selected #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:21
 msgid "Edit Selected #{ui_lookup(:table=>\"persistent_volume\")}"
 msgstr ""
@@ -6783,11 +8470,11 @@ msgstr ""
 msgid "Edit Sequence of User Groups for LDAP Look Up"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:401
+#: ../../app/controllers/ops_controller/ops_rbac.rb:402
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:15 ../../app/helpers/application_helper/toolbar/vm_center.rb:87 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:46 ../../app/helpers/application_helper/toolbar/host_center.rb:54 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:30 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:85 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:63 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:15 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:36 ../../app/helpers/application_helper/toolbar/services_center.rb:53 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:15 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:46 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:46 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:72 ../../app/helpers/application_helper/toolbar/container_service_center.rb:53 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:35 ../../app/helpers/application_helper/toolbar/container_center.rb:36 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:45 ../../app/helpers/application_helper/toolbar/container_route_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:15 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/security_group_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:58 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:41 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:86 ../../app/helpers/application_helper/toolbar/repository_center.rb:48 ../../app/helpers/application_helper/toolbar/container_project_center.rb:60 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:47 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:95 ../../app/helpers/application_helper/toolbar/vms_center.rb:87 ../../app/helpers/application_helper/toolbar/container_node_center.rb:60 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:46 ../../app/helpers/application_helper/toolbar/storage_center.rb:37 ../../app/helpers/application_helper/toolbar/flavors_center.rb:15 ../../app/helpers/application_helper/toolbar/container_image_center.rb:29 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:73 ../../app/helpers/application_helper/toolbar/service_center.rb:48 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:46 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:121 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:62 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:53 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:34 ../../app/helpers/application_helper/toolbar/container_group_center.rb:60 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:13 ../../app/helpers/application_helper/toolbar/flavor_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/container_services_center.rb:46 ../../app/helpers/application_helper/toolbar/hosts_center.rb:90 ../../app/helpers/application_helper/toolbar/storages_center.rb:45 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:44 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:112 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:73 ../../app/helpers/application_helper/toolbar/repositories_center.rb:66 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:28 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:46 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:52 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:64 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:60 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:13 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:13 ../../app/helpers/application_helper/toolbar/containers_center.rb:46 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:40 ../../app/helpers/application_helper/toolbar/container_images_center.rb:34 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:51 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:15 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:59
+#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:15 ../../app/helpers/application_helper/toolbar/vm_center.rb:87 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:46 ../../app/helpers/application_helper/toolbar/host_center.rb:54 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:30 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:85 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:63 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:15 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:46 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:36 ../../app/helpers/application_helper/toolbar/services_center.rb:53 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:15 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:46 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:46 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:72 ../../app/helpers/application_helper/toolbar/container_service_center.rb:53 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:35 ../../app/helpers/application_helper/toolbar/container_center.rb:36 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:45 ../../app/helpers/application_helper/toolbar/container_route_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:15 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/security_group_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:58 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:41 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:86 ../../app/helpers/application_helper/toolbar/repository_center.rb:48 ../../app/helpers/application_helper/toolbar/container_project_center.rb:60 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:47 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:95 ../../app/helpers/application_helper/toolbar/vms_center.rb:87 ../../app/helpers/application_helper/toolbar/container_node_center.rb:60 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:46 ../../app/helpers/application_helper/toolbar/storage_center.rb:37 ../../app/helpers/application_helper/toolbar/flavors_center.rb:15 ../../app/helpers/application_helper/toolbar/container_image_center.rb:29 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:73 ../../app/helpers/application_helper/toolbar/service_center.rb:48 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:46 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:121 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:62 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:53 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:34 ../../app/helpers/application_helper/toolbar/container_group_center.rb:60 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:48 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:13 ../../app/helpers/application_helper/toolbar/flavor_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/container_services_center.rb:46 ../../app/helpers/application_helper/toolbar/hosts_center.rb:90 ../../app/helpers/application_helper/toolbar/storages_center.rb:45 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:44 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:112 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:60 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:73 ../../app/helpers/application_helper/toolbar/repositories_center.rb:66 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:28 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:46 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:52 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:36 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:64 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:60 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:13 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:13 ../../app/helpers/application_helper/toolbar/containers_center.rb:46 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:40 ../../app/helpers/application_helper/toolbar/container_images_center.rb:34 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:51 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:15 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:59
 msgid "Edit Tags"
 msgstr ""
 
@@ -6795,7 +8482,7 @@ msgstr ""
 msgid "Edit Tags for %s"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:705
+#: ../../app/controllers/provider_foreman_controller.rb:686
 msgid "Edit Tags for Configured Systems"
 msgstr ""
 
@@ -6931,6 +8618,18 @@ msgstr ""
 msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_infra\")}"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:47 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:59
+msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:35
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:45
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_servers\")}"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:39
 msgid "Edit Tags for this #{ui_lookup(:table=>\"persistent_volume\")}"
 msgstr ""
@@ -7019,11 +8718,7 @@ msgstr ""
 msgid "Edit assignments for this Alert Profile"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:652
-msgid "Edit of %s was cancelled by the user"
-msgstr ""
-
-#: ../../app/controllers/repository_controller.rb:117 ../../app/controllers/report_controller/dashboards.rb:64 ../../app/controllers/report_controller/widgets.rb:49 ../../app/controllers/report_controller/reports/editor.rb:32 ../../app/controllers/report_controller/schedules.rb:219 ../../app/controllers/miq_policy_controller/policies.rb:11 ../../app/controllers/miq_policy_controller/miq_actions.rb:11 ../../app/controllers/miq_policy_controller/alerts.rb:13 ../../app/controllers/miq_policy_controller/alert_profiles.rb:13 ../../app/controllers/miq_policy_controller/conditions.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:12 ../../app/controllers/vm_common.rb:1035 ../../app/controllers/vm_common.rb:1039 ../../app/controllers/miq_ae_class_controller.rb:591 ../../app/controllers/miq_ae_class_controller.rb:998 ../../app/controllers/miq_ae_class_controller.rb:1092 ../../app/controllers/miq_ae_class_controller.rb:1136 ../../app/controllers/storage_manager_controller.rb:180 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:241 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:195 ../../app/controllers/service_controller.rb:149 ../../app/controllers/catalog_controller.rb:93 ../../app/controllers/catalog_controller.rb:358 ../../app/controllers/catalog_controller.rb:610 ../../app/controllers/catalog_controller.rb:980 ../../app/controllers/ops_controller/settings/tags.rb:42 ../../app/controllers/ops_controller/settings/ldap.rb:38 ../../app/controllers/ops_controller/settings/ldap.rb:164 ../../app/controllers/ops_controller/settings/zones.rb:9 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:220 ../../app/controllers/ops_controller/settings/schedules.rb:43 ../../app/controllers/ops_controller/ops_rbac.rb:108 ../../app/controllers/host_controller.rb:333 ../../app/controllers/configuration_controller.rb:531 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:100 ../../app/controllers/pxe_controller/iso_datastores.rb:173 ../../app/controllers/pxe_controller/pxe_image_types.rb:29 ../../app/controllers/pxe_controller/pxe_servers.rb:46 ../../app/controllers/pxe_controller/pxe_servers.rb:193 ../../app/controllers/pxe_controller/pxe_servers.rb:245 ../../app/controllers/ems_common.rb:244 ../../app/controllers/ems_cloud_controller.rb:33 ../../app/controllers/application_controller/buttons.rb:308 ../../app/controllers/application_controller/buttons.rb:433 ../../app/controllers/application_controller/miq_request_methods.rb:178
+#: ../../app/controllers/repository_controller.rb:117 ../../app/controllers/report_controller/dashboards.rb:64 ../../app/controllers/report_controller/widgets.rb:49 ../../app/controllers/report_controller/reports/editor.rb:32 ../../app/controllers/report_controller/schedules.rb:219 ../../app/controllers/miq_policy_controller/policies.rb:11 ../../app/controllers/miq_policy_controller/miq_actions.rb:11 ../../app/controllers/miq_policy_controller/alerts.rb:13 ../../app/controllers/miq_policy_controller/alert_profiles.rb:13 ../../app/controllers/miq_policy_controller/conditions.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:13 ../../app/controllers/vm_common.rb:1035 ../../app/controllers/vm_common.rb:1039 ../../app/controllers/miq_ae_class_controller.rb:591 ../../app/controllers/miq_ae_class_controller.rb:998 ../../app/controllers/miq_ae_class_controller.rb:1092 ../../app/controllers/miq_ae_class_controller.rb:1136 ../../app/controllers/storage_manager_controller.rb:180 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:241 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:195 ../../app/controllers/service_controller.rb:149 ../../app/controllers/catalog_controller.rb:93 ../../app/controllers/catalog_controller.rb:358 ../../app/controllers/catalog_controller.rb:610 ../../app/controllers/catalog_controller.rb:980 ../../app/controllers/ops_controller/settings/tags.rb:43 ../../app/controllers/ops_controller/settings/ldap.rb:38 ../../app/controllers/ops_controller/settings/ldap.rb:164 ../../app/controllers/ops_controller/settings/zones.rb:9 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:220 ../../app/controllers/ops_controller/settings/schedules.rb:43 ../../app/controllers/ops_controller/ops_rbac.rb:109 ../../app/controllers/host_controller.rb:333 ../../app/controllers/configuration_controller.rb:531 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:100 ../../app/controllers/pxe_controller/iso_datastores.rb:173 ../../app/controllers/pxe_controller/pxe_image_types.rb:29 ../../app/controllers/pxe_controller/pxe_servers.rb:46 ../../app/controllers/pxe_controller/pxe_servers.rb:193 ../../app/controllers/pxe_controller/pxe_servers.rb:245 ../../app/controllers/ems_common.rb:244 ../../app/controllers/ems_cloud_controller.rb:33 ../../app/controllers/application_controller/buttons.rb:308 ../../app/controllers/application_controller/buttons.rb:433 ../../app/controllers/application_controller/miq_request_methods.rb:178
 msgid "Edit of %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
@@ -7031,11 +8726,15 @@ msgstr ""
 msgid "Edit of %{model} for role \"%{role}\" was cancelled by the user"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:654
+msgid "Edit of %{name} was cancelled by the user"
+msgstr ""
+
 #: ../../app/controllers/miq_ae_class_controller.rb:1476
 msgid "Edit of Class Schema Sequence was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:512
+#: ../../app/controllers/ops_controller/settings/common.rb:517
 msgid "Edit of Customer Information was cancelled"
 msgstr ""
 
@@ -7217,6 +8916,14 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:24
 msgid "Edit this #{ui_lookup(:table=>\"ems_infra\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:19
+msgid "Edit this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:12
+msgid "Edit this #{ui_lookup(:table=>\"middleware_server\")}"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:13
@@ -7423,11 +9130,15 @@ msgstr ""
 msgid "Editing %s File"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:550 ../../app/controllers/ops_controller.rb:560 ../../app/controllers/ops_controller.rb:569 ../../app/controllers/ops_controller.rb:583 ../../app/controllers/ops_controller.rb:594 ../../app/controllers/ops_controller.rb:605 ../../app/controllers/ops_controller.rb:651 ../../app/controllers/miq_ae_customization_controller.rb:413 ../../app/controllers/miq_ae_customization_controller.rb:417 ../../app/controllers/miq_ae_customization_controller.rb:434 ../../app/controllers/miq_ae_customization_controller.rb:473 ../../app/controllers/report_controller/menus.rb:748 ../../app/controllers/vm_common.rb:1740 ../../app/controllers/miq_ae_class_controller.rb:568 ../../app/controllers/miq_ae_class_controller.rb:713 ../../app/controllers/miq_ae_class_controller.rb:748 ../../app/controllers/miq_ae_class_controller.rb:788 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/service_controller.rb:275 ../../app/controllers/container_controller.rb:234 ../../app/controllers/catalog_controller.rb:1177 ../../app/controllers/catalog_controller.rb:1329 ../../app/controllers/catalog_controller.rb:1379 ../../app/controllers/catalog_controller.rb:1813 ../../app/controllers/catalog_controller.rb:1817 ../../app/controllers/ops_controller/ops_rbac.rb:701 ../../app/controllers/pxe_controller.rb:201 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:715 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:728 ../../app/controllers/report_controller.rb:743 ../../app/controllers/report_controller.rb:850 ../../app/controllers/miq_policy_controller.rb:611 ../../app/controllers/miq_policy_controller.rb:637 ../../app/controllers/miq_policy_controller.rb:660 ../../app/controllers/miq_policy_controller.rb:666 ../../app/controllers/miq_policy_controller.rb:673 ../../app/controllers/miq_policy_controller.rb:687 ../../app/controllers/miq_policy_controller.rb:696
+#: ../../app/controllers/ops_controller.rb:550 ../../app/controllers/ops_controller.rb:560 ../../app/controllers/ops_controller.rb:569 ../../app/controllers/ops_controller.rb:583 ../../app/controllers/ops_controller.rb:594 ../../app/controllers/ops_controller.rb:605 ../../app/controllers/ops_controller.rb:651 ../../app/controllers/miq_ae_customization_controller.rb:413 ../../app/controllers/miq_ae_customization_controller.rb:417 ../../app/controllers/miq_ae_customization_controller.rb:434 ../../app/controllers/miq_ae_customization_controller.rb:473 ../../app/controllers/report_controller/menus.rb:748 ../../app/controllers/vm_common.rb:1740 ../../app/controllers/miq_ae_class_controller.rb:568 ../../app/controllers/miq_ae_class_controller.rb:713 ../../app/controllers/miq_ae_class_controller.rb:748 ../../app/controllers/miq_ae_class_controller.rb:788 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/service_controller.rb:275 ../../app/controllers/container_controller.rb:234 ../../app/controllers/catalog_controller.rb:1177 ../../app/controllers/catalog_controller.rb:1329 ../../app/controllers/catalog_controller.rb:1379 ../../app/controllers/catalog_controller.rb:1813 ../../app/controllers/catalog_controller.rb:1817 ../../app/controllers/ops_controller/ops_rbac.rb:706 ../../app/controllers/pxe_controller.rb:201 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:715 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:728 ../../app/controllers/report_controller.rb:743 ../../app/controllers/report_controller.rb:850 ../../app/controllers/miq_policy_controller.rb:612 ../../app/controllers/miq_policy_controller.rb:643 ../../app/controllers/miq_policy_controller.rb:682 ../../app/controllers/miq_policy_controller.rb:689 ../../app/controllers/miq_policy_controller.rb:703 ../../app/controllers/miq_policy_controller.rb:712
 msgid "Editing %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:606 ../../app/controllers/application_controller/explorer.rb:181
+#: ../../app/controllers/miq_policy_controller.rb:670
+msgid "Editing %{model} Condition \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:607 ../../app/controllers/application_controller/explorer.rb:181
 msgid "Editing %{model} for \"%{name}\""
 msgstr ""
 
@@ -7461,6 +9172,11 @@ msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_summary.html.haml:39
 msgid "Eligible %s "
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_email
+#: ../dictionary_strings.rb:649
+msgid "Email"
 msgstr ""
 
 #: ../model_attributes.rb:446
@@ -7579,6 +9295,11 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+#: ../dictionary_strings.rb:389
+msgid "End"
+msgstr ""
+
 #: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:59
 msgid "End Date"
 msgstr ""
@@ -7615,8 +9336,14 @@ msgstr ""
 msgid "Enter URL Manually"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:52
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
+#: ../../app/presenters/tree_builder.rb:52 ../dictionary_strings.rb:1529
 msgid "Enterprise"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+#: ../dictionary_strings.rb:1531
+msgid "Enterprises"
 msgstr ""
 
 #: ../../app/views/generic_mailer/policy_action_email.text.haml:5 ../../app/views/generic_mailer/policy_action_email.html.haml:25
@@ -7655,7 +9382,7 @@ msgstr ""
 msgid "Error building timeline  %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:718 ../../app/controllers/application_controller/timelines.rb:222 ../../app/controllers/application_controller/timelines.rb:477
+#: ../../app/controllers/miq_capacity_controller.rb:722 ../../app/controllers/application_controller/timelines.rb:222 ../../app/controllers/application_controller/timelines.rb:477
 msgid "Error building timeline %{error_message}"
 msgstr ""
 
@@ -7663,15 +9390,11 @@ msgstr ""
 msgid "Error details: %s"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:362 ../../app/controllers/ops_controller/settings/common.rb:598
-msgid "Error during %s: "
-msgstr ""
-
 #: ../../app/controllers/miq_ae_tools_controller.rb:227
 msgid "Error during %{task}: Status [%{status}] Message [%{message}]"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:239 ../../app/controllers/miq_ae_tools_controller.rb:198 ../../app/controllers/miq_policy_controller/alerts.rb:482 ../../app/controllers/miq_policy_controller/alert_profiles.rb:49 ../../app/controllers/miq_policy_controller/policy_profiles.rb:48 ../../app/controllers/vm_common.rb:589 ../../app/controllers/vm_common.rb:975 ../../app/controllers/vm_common.rb:988 ../../app/controllers/vm_common.rb:1072 ../../app/controllers/miq_ae_class_controller.rb:675 ../../app/controllers/miq_ae_class_controller.rb:1101 ../../app/controllers/storage_manager_controller.rb:448 ../../app/controllers/service_controller.rb:159 ../../app/controllers/ops_controller/settings/tags.rb:76 ../../app/controllers/ops_controller/settings/upload.rb:77 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:262 ../../app/controllers/ops_controller/settings/schedules.rb:239 ../../app/controllers/ops_controller/ops_rbac.rb:557 ../../app/controllers/ops_controller/settings.rb:21 ../../app/controllers/ops_controller/diagnostics.rb:29 ../../app/controllers/ops_controller/diagnostics.rb:65 ../../app/controllers/ops_controller/diagnostics.rb:124 ../../app/controllers/ops_controller/diagnostics.rb:149 ../../app/controllers/ops_controller/diagnostics.rb:254 ../../app/controllers/ops_controller/diagnostics.rb:277 ../../app/controllers/ops_controller/diagnostics.rb:404 ../../app/controllers/ops_controller/diagnostics.rb:593 ../../app/controllers/report_controller.rb:80 ../../app/controllers/miq_policy_controller.rb:63 ../../app/controllers/miq_policy_controller.rb:157 ../../app/controllers/miq_policy_controller.rb:189 ../../app/controllers/application_controller/ci_processing.rb:1303
+#: ../../app/controllers/repository_controller.rb:239 ../../app/controllers/miq_ae_tools_controller.rb:198 ../../app/controllers/vm_common.rb:589 ../../app/controllers/vm_common.rb:975 ../../app/controllers/vm_common.rb:988 ../../app/controllers/vm_common.rb:1072 ../../app/controllers/miq_ae_class_controller.rb:675 ../../app/controllers/miq_ae_class_controller.rb:1101 ../../app/controllers/storage_manager_controller.rb:448 ../../app/controllers/service_controller.rb:159 ../../app/controllers/ops_controller/settings/tags.rb:77 ../../app/controllers/ops_controller/settings/upload.rb:77 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:262 ../../app/controllers/report_controller.rb:80 ../../app/controllers/application_controller/ci_processing.rb:1303
 msgid "Error during '%s': "
 msgstr ""
 
@@ -7683,8 +9406,32 @@ msgstr ""
 msgid "Error during '%{task}': %{error_message}"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:49
+msgid "Error during 'Alert Profile %{params}': "
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:29
+msgid "Error during 'Appliance restart': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:255
+msgid "Error during 'C & U Gap Collection': %{message}"
+msgstr ""
+
 #: ../../app/controllers/catalog_controller.rb:628
 msgid "Error during 'Catalog Edit': %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:595
+msgid "Error during 'Clear Connection Broker cache': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:405
+msgid "Error during 'Database Garbage Collection': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:558
+msgid "Error during 'LDAP Group Look Up': %{message}"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:1059
@@ -7703,12 +9450,24 @@ msgstr ""
 msgid "Error during 'Orchestration Template creation': %{error_message}"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:157
+msgid "Error during 'Policy Import': %{messages}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/policy_profiles.rb:49
+msgid "Error during 'Policy Profile %{params}': %{messages}"
+msgstr ""
+
 #: ../../app/controllers/application_controller/dialog_runner.rb:29
 msgid "Error during 'Provisioning': %{error_message}"
 msgstr ""
 
 #: ../../app/controllers/chargeback_controller.rb:356
 msgid "Error during 'Rate assignments': %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:278
+msgid "Error during 'Reset/synchronization process': %{message}"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:1288
@@ -7719,8 +9478,16 @@ msgstr ""
 msgid "Error during 'Save Tags': %{error_message}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:124
+msgid "Error during 'Save': %{message}"
+msgstr ""
+
 #: ../../app/controllers/application_controller.rb:538
 msgid "Error during 'Validate': %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:239 ../../app/controllers/ops_controller/diagnostics.rb:149
+msgid "Error during 'Validate': %{message}"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:1226 ../../app/controllers/miq_ae_class_controller.rb:1263 ../../app/controllers/configuration_controller.rb:510 ../../app/controllers/application_controller/buttons.rb:498
@@ -7731,6 +9498,10 @@ msgstr ""
 msgid "Error during 'add': %{field_name} %{error_name}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:21
+msgid "Error during 'apply': %{error}"
+msgstr ""
+
 #: ../../app/controllers/application_controller/buttons.rb:358 ../../app/controllers/application_controller/buttons.rb:536
 msgid "Error during 'edit': %{field_name} %{error_message}"
 msgstr ""
@@ -7739,12 +9510,20 @@ msgstr ""
 msgid "Error during 'save': %{error_message}"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:65
+msgid "Error during 'workers restart': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:603
+msgid "Error during Analysis Affinity save: %{message}"
+msgstr ""
+
 #: ../../app/controllers/catalog_controller.rb:1094
 msgid "Error during Orchestration Template creation: new template content cannot be empty"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:418
-msgid "Error during Orphaned Records delete for user %s: "
+#: ../../app/controllers/ops_controller/diagnostics.rb:419
+msgid "Error during Orphaned Records delete for user %{id}: %{message}"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:1601
@@ -7753,12 +9532,28 @@ msgid_plural "Error during Saved Reports delete from the CFME Database"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:364
+msgid "Error during Server restart: %{message}"
+msgstr ""
+
 #: ../../app/controllers/application_controller/sysprep_answer_file.rb:16
 msgid "Error during Sysprep \"%s\" file upload: "
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller/alerts.rb:483
+msgid "Error during alarms: %{messages}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:63
+msgid "Error during export: %{error_message}"
+msgstr ""
+
 #: ../../app/controllers/ops_controller/settings/common.rb:249
 msgid "Error during sending test email: %{class_name}, %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:190
+msgid "Error during upload: %{messages}"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_customization_controller.rb:59
@@ -7774,14 +9569,14 @@ msgid "Error executing: \"%{task_description}\" %{error_message}"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/rhn.rb:301
-msgid "Error occured when queuing action: %s"
+msgid "Error occured when queuing action: %{message}"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:809
 msgid "Error on line %{line_num}: %{err_txt}"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:326
+#: ../../app/controllers/miq_request_controller.rb:330
 msgid "Error retrieving LDAP info: %{error_message}"
 msgstr ""
 
@@ -7790,23 +9585,23 @@ msgid "Error text:"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/schedules.rb:69
-msgid "Error when adding a new schedule: "
+msgid "Error when adding a new schedule: %{message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:125
-msgid "Error when adding a new tenant: "
+#: ../../app/controllers/ops_controller/ops_rbac.rb:126
+msgid "Error when adding a new tenant: %{message}"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:1147
 msgid "Error when creating a Service Dialog from Orchestration Template: %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:407
-msgid "Error when saving new server name: "
+#: ../../app/controllers/ops_controller/settings/common.rb:409
+msgid "Error when saving new server name: %{message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:202
-msgid "Error when saving tenant quota: "
+#: ../../app/controllers/ops_controller/ops_rbac.rb:203
+msgid "Error when saving tenant quota: %{message}"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_tools_controller.rb:152
@@ -7817,7 +9612,7 @@ msgstr ""
 msgid "Error: ImportFileUpload expired"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:289 ../../app/controllers/report_controller/schedules.rb:6 ../../app/controllers/vm_common.rb:1170 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:23 ../../app/controllers/mixins/vm_show_mixin.rb:105 ../../app/controllers/provider_foreman_controller.rb:419 ../../app/helpers/application_helper.rb:1059
+#: ../../app/controllers/chargeback_controller.rb:289 ../../app/controllers/report_controller/schedules.rb:6 ../../app/controllers/vm_common.rb:1170 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:23 ../../app/controllers/mixins/vm_show_mixin.rb:105 ../../app/controllers/provider_foreman_controller.rb:400 ../../app/helpers/application_helper.rb:1059
 msgid "Error: Record no longer exists in the database"
 msgstr ""
 
@@ -7835,6 +9630,12 @@ msgstr ""
 
 #: ../../app/views/layouts/_exception_contents.html.haml:12
 msgid "Errors in Management Engine can be caused by:"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+#: ../dictionary_strings.rb:1533 ../dictionary_strings.rb:1975
+msgid "Event"
 msgstr ""
 
 #: ../../app/views/miq_policy/_event_details.html.haml:30
@@ -7871,6 +9672,11 @@ msgstr ""
 msgid "Event Selection"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.event_src
+#: ../dictionary_strings.rb:393
+msgid "Event Source"
+msgstr ""
+
 #: ../../app/views/layouts/_tl_options.html.haml:134
 msgid "Event Type"
 msgstr ""
@@ -7879,8 +9685,25 @@ msgstr ""
 msgid "Event log"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:674
+msgid "Event log name is required"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alerts.rb:536
+msgid "Event name is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+#: ../dictionary_strings.rb:651
+msgid "Event on Timeline"
+msgstr ""
+
 #: ../model_attributes.rb:479
 msgid "Event stream"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alerts.rb:539
+msgid "Event to Check is required"
 msgstr ""
 
 #: ../../app/views/report/_form_tl_settings.html.haml:116
@@ -8011,7 +9834,9 @@ msgstr ""
 msgid "EventStream|Vm name"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1105 ../../app/views/miq_policy/_policy_details.html.haml:335
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1132 ../../app/views/miq_policy/_policy_details.html.haml:335 ../dictionary_strings.rb:1535 ../dictionary_strings.rb:1977
 msgid "Events"
 msgstr ""
 
@@ -8057,6 +9882,10 @@ msgstr ""
 
 #: ../../app/views/miq_ae_tools/_import_export.html.haml:68
 msgid "Export all classes and instances to a file"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:28
+msgid "Export cancelled by user"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/db.rb:104
@@ -8195,6 +10024,16 @@ msgstr ""
 msgid "FS Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+#: ../dictionary_strings.rb:1359
+msgid "FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+#: ../dictionary_strings.rb:1361
+msgid "FTPs"
+msgstr ""
+
 #: ../../app/views/vm_common/_policy_options.html.haml:54 ../../app/views/miq_policy/_rsop_results.html.haml:57
 msgid "Failed"
 msgstr ""
@@ -8235,7 +10074,8 @@ msgstr ""
 msgid "Fields not added: Adding the selected %{count} fields will exceed the maximum of %{max} fields"
 msgstr ""
 
-#: ../../app/views/ops/_settings_import_tab.html.haml:42 ../../app/views/ops/_settings_advanced_tab.html.haml:33 ../../app/views/ops/_ap_form.html.haml:75 ../../app/views/ops/_ap_form.html.haml:85
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem
+#: ../../app/views/ops/_settings_import_tab.html.haml:42 ../../app/views/ops/_settings_advanced_tab.html.haml:33 ../../app/views/ops/_ap_form.html.haml:75 ../../app/views/ops/_ap_form.html.haml:85 ../dictionary_strings.rb:1373
 msgid "File"
 msgstr ""
 
@@ -8243,8 +10083,27 @@ msgstr ""
 msgid "File Entry"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:582
+msgid "File Entry is required"
+msgstr ""
+
 #: ../../app/views/ops/_ap_show.html.haml:86
 msgid "File Items"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.filename
+#: ../dictionary_strings.rb:395
+msgid "File Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+#: ../dictionary_strings.rb:2041
+msgid "File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+#: ../dictionary_strings.rb:1911
+msgid "File System Drivers"
 msgstr ""
 
 #: ../model_attributes.rb:519
@@ -8271,7 +10130,14 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:145 ../../app/views/layouts/listnav/_host.html.haml:232
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+#: ../dictionary_strings.rb:2053
+msgid "Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.filesystems
+#: ../../app/controllers/host_controller.rb:145 ../../app/views/layouts/listnav/_host.html.haml:232 ../dictionary_strings.rb:1375 ../dictionary_strings.rb:1913
 msgid "Files"
 msgstr ""
 
@@ -8371,6 +10237,14 @@ msgstr ""
 msgid "Filter Message"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/schedules.rb:402
+msgid "Filter must be selected"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:406
+msgid "Filter value must be selected"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_show_list.html.haml:11 ../../app/views/configuration/_ui_3.html.haml:10
 msgid "Filters"
 msgstr ""
@@ -8467,11 +10341,41 @@ msgstr ""
 msgid "Fixed"
 msgstr ""
 
-#: ../model_attributes.rb:558
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+#: ../dictionary_strings.rb:1163
+msgid "Fixed Compute Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+#: ../dictionary_strings.rb:1165
+msgid "Fixed Compute Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+#: ../dictionary_strings.rb:1169
+msgid "Fixed Storage Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+#: ../dictionary_strings.rb:1171
+msgid "Fixed Storage Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+#: ../dictionary_strings.rb:1167
+msgid "Fixed Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor
+#. TRANSLATORS: en.yml key: dictionary.table.flavor
+#: ../dictionary_strings.rb:1377 ../dictionary_strings.rb:1915 ../model_attributes.rb:558
 msgid "Flavor"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:30 ../../app/views/configuration/_ui_2.html.haml:159
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavors
+#: ../../app/presenters/menu/default_menu.rb:30 ../../app/views/configuration/_ui_2.html.haml:159 ../dictionary_strings.rb:1379 ../dictionary_strings.rb:1917 ../dictionary_strings.rb:1919
 msgid "Flavors"
 msgstr ""
 
@@ -8543,8 +10447,67 @@ msgstr ""
 msgid "FloatingIp|Ems ref"
 msgstr ""
 
-#: ../../app/views/shared/views/_prov_dialog.html.haml:122
+#. TRANSLATORS: en.yml key: dictionary.table.floppies
+#: ../dictionary_strings.rb:1921
+msgid "Floppy Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder
+#: ../../app/views/shared/views/_prov_dialog.html.haml:122 ../dictionary_strings.rb:1347 ../dictionary_strings.rb:1865
 msgid "Folder"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+#: ../dictionary_strings.rb:691
+msgid "Folder Name (VMs & Templates) 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+#: ../dictionary_strings.rb:693
+msgid "Folder Name (VMs & Templates) 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+#: ../dictionary_strings.rb:695
+msgid "Folder Name (VMs & Templates) 3"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+#: ../dictionary_strings.rb:697
+msgid "Folder Name (VMs & Templates) 4"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+#: ../dictionary_strings.rb:699
+msgid "Folder Name (VMs & Templates) 5"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+#: ../dictionary_strings.rb:701
+msgid "Folder Name (VMs & Templates) 6"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+#: ../dictionary_strings.rb:703
+msgid "Folder Name (VMs & Templates) 7"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+#: ../dictionary_strings.rb:705
+msgid "Folder Name (VMs & Templates) 8"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+#: ../dictionary_strings.rb:707
+msgid "Folder Name (VMs & Templates) 9"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folders
+#: ../dictionary_strings.rb:1349 ../dictionary_strings.rb:1867 ../dictionary_strings.rb:1869
+msgid "Folders"
 msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:324 ../../app/views/ops/_ldap_domain_form.html.haml:135 ../../app/views/ops/_ldap_domain_show.html.haml:177 ../../app/views/_ldap_domain_form.html.haml:135
@@ -8559,12 +10522,27 @@ msgstr ""
 msgid "For questions or problem reporting, go to the"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+#: ../dictionary_strings.rb:1417
+msgid "Foreman Configured System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+#: ../dictionary_strings.rb:1419
+msgid "Foreman Configured Systems"
+msgstr ""
+
 #: ../../app/views/report/_form_formatting.html.haml:58
 msgid "Format"
 msgstr ""
 
 #: ../../app/views/report/_form_sort.html.haml:114
 msgid "Format on Summary Row"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+#: ../dictionary_strings.rb:1013
+msgid "Free Space Percent of Total"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
@@ -8595,12 +10573,18 @@ msgstr ""
 msgid "Front (...1234)"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_user_details.html.haml:26
+#. TRANSLATORS: en.yml key: dictionary.column.User.name
+#: ../../app/views/ops/_rbac_user_details.html.haml:26 ../dictionary_strings.rb:3
 msgid "Full Name"
 msgstr ""
 
 #: ../../app/views/vm_common/console_vmrc.html.haml:445
 msgid "Full&#160;Screen"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fqname
+#: ../dictionary_strings.rb:397
+msgid "Fully Qualified Name"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_options.html.haml:243 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:28
@@ -8740,6 +10724,11 @@ msgid "Guest Application"
 msgid_plural "Guest Applications"
 msgstr[0] ""
 msgstr[1] ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guest_os
+#: ../dictionary_strings.rb:399
+msgid "Guest OS"
+msgstr ""
 
 #: ../model_attributes.rb:576
 msgid "Guest application"
@@ -9025,12 +11014,37 @@ msgstr ""
 msgid "Hardware|Vmotion enabled"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+#: ../dictionary_strings.rb:403
+msgid "Has an RDM Disk?"
+msgstr ""
+
 #: ../../app/views/report/_form_formatting.html.haml:53 ../../app/views/report/_form_sort.html.haml:241
 msgid "Header"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.health_state_str
+#: ../dictionary_strings.rb:407
+msgid "Health State"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state
+#: ../dictionary_strings.rb:405
+msgid "Health State Code"
+msgstr ""
+
 #: ../../app/helpers/ems_container_helper/textual_summary.rb:25
 msgid "Healthy"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+#: ../dictionary_strings.rb:1643
+msgid "Heat Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+#: ../dictionary_strings.rb:1645
+msgid "Heat Templates"
 msgstr ""
 
 #: ../../app/views/report/_form_sort.html.haml:96
@@ -9053,12 +11067,30 @@ msgstr ""
 msgid "History"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.pct_hit
+#: ../dictionary_strings.rb:1223
+msgid "Hit %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.homedir
+#: ../dictionary_strings.rb:409
+msgid "Home Directory"
+msgstr ""
+
 #: ../../app/helpers/application_helper.rb:1229 ../../app/helpers/application_helper.rb:1253 ../../app/views/ops/_settings_server_tab.html.haml:383 ../../app/views/ops/_settings_workers_tab.html.haml:620 ../../app/views/configuration/_ui_1.html.haml:25 ../model_attributes.rb:638
 msgid "Host"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:116 ../../app/helpers/application_helper.rb:1233
+#. TRANSLATORS: en.yml key: dictionary.model.Host
+#. TRANSLATORS: en.yml key: dictionary.table.host
+#: ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:116 ../../app/helpers/application_helper.rb:1233 ../dictionary_strings.rb:1381 ../dictionary_strings.rb:1925
 msgid "Host / Node"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+#: ../dictionary_strings.rb:1383 ../dictionary_strings.rb:1927
+msgid "Host / Nodes"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_policy.rb:17
@@ -9085,6 +11117,11 @@ msgstr ""
 msgid "Host Default VNC Start Port"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.hostnames
+#: ../dictionary_strings.rb:413
+msgid "Host Names"
+msgstr ""
+
 #: ../../app/presenters/tree_builder_policy.rb:25
 msgid "Host Policies"
 msgstr ""
@@ -9099,6 +11136,10 @@ msgstr ""
 
 #: ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:152
 msgid "Host Selection"
+msgstr ""
+
+#: ../../app/controllers/ontap_file_share_controller.rb:118 ../../app/controllers/miq_policy_controller.rb:1022
+msgid "Host is required"
 msgstr ""
 
 #: ../../app/views/host/_form.html.haml:74
@@ -9121,6 +11162,10 @@ msgstr ""
 msgid "Hostname (or IPv4 or IPv6 address)"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/ldap.rb:218
+msgid "Hostname is required"
+msgstr ""
+
 #: ../../app/views/ems_middleware/_form_fields.html.haml:6 ../../app/views/ems_infra/_form_fields.html.haml:6 ../../app/views/ems_container/_form_fields.html.haml:6
 msgid "Hostname or IP address"
 msgstr ""
@@ -9133,7 +11178,8 @@ msgstr ""
 msgid "Hosts"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:39 ../../app/controllers/application_controller/ci_processing.rb:887 ../../app/helpers/application_helper.rb:1233
+#. TRANSLATORS: en.yml key: dictionary.table.hosts
+#: ../../app/presenters/menu/default_menu.rb:39 ../../app/controllers/application_controller/ci_processing.rb:887 ../../app/helpers/application_helper.rb:1233 ../dictionary_strings.rb:1929
 msgid "Hosts / Nodes"
 msgstr ""
 
@@ -9293,12 +11339,20 @@ msgstr ""
 msgid "Hyper-V"
 msgstr ""
 
-#: ../../app/helpers/provider_configuration_manager_helper.rb:23 ../../app/helpers/provider_foreman_helper.rb:24 ../../app/views/ops/_selected_by_servers.html.haml:35 ../../app/views/ops/_server_desc.html.haml:19 ../../app/views/ops/_settings_server_tab.html.haml:32 ../../app/views/storage_manager/_form.html.haml:82 ../../app/views/host/_config.html.haml:63
+#. TRANSLATORS: en.yml key: dictionary.column.ip_address
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddress
+#: ../../app/helpers/provider_configuration_manager_helper.rb:23 ../../app/helpers/provider_foreman_helper.rb:24 ../../app/views/ops/_selected_by_servers.html.haml:35 ../../app/views/ops/_server_desc.html.haml:19 ../../app/views/ops/_settings_server_tab.html.haml:32 ../../app/views/storage_manager/_form.html.haml:82 ../../app/views/host/_config.html.haml:63 ../dictionary_strings.rb:415 ../dictionary_strings.rb:419
 msgid "IP Address"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_host_dialog.html.haml:86 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:53 ../../app/views/shared/views/_prov_dialog.html.haml:339 ../../app/views/shared/views/_prov_dialog.html.haml:373
 msgid "IP Address Information"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+#: ../dictionary_strings.rb:417 ../dictionary_strings.rb:421
+msgid "IP Addresses"
 msgstr ""
 
 #: ../../app/views/vm_common/_config.html.haml:211
@@ -9313,7 +11367,13 @@ msgstr ""
 msgid "IPMI Credentials"
 msgstr ""
 
-#: ../../app/views/host/_form.html.haml:114
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+#: ../dictionary_strings.rb:425
+msgid "IPMI Enabled"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
+#: ../../app/views/host/_form.html.haml:114 ../dictionary_strings.rb:423
 msgid "IPMI IP Address"
 msgstr ""
 
@@ -9341,7 +11401,27 @@ msgstr ""
 msgid "ISO"
 msgstr ""
 
-#: ../../app/views/pxe/_iso_datastore_details.html.haml:16
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+#: ../dictionary_strings.rb:1389 ../dictionary_strings.rb:1933
+msgid "ISO Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+#: ../dictionary_strings.rb:1391 ../dictionary_strings.rb:1935
+msgid "ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image
+#: ../dictionary_strings.rb:1393 ../dictionary_strings.rb:1937
+msgid "ISO Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
+#: ../../app/views/pxe/_iso_datastore_details.html.haml:16 ../dictionary_strings.rb:1395 ../dictionary_strings.rb:1939
 msgid "ISO Images"
 msgstr ""
 
@@ -9357,8 +11437,25 @@ msgstr ""
 msgid "If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon."
 msgstr ""
 
-#: ../../app/views/shared/buttons/_ab_list.html.haml:179 ../../app/views/shared/buttons/_ab_show.html.haml:48
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.container_image
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud
+#: ../../app/views/shared/buttons/_ab_list.html.haml:179 ../../app/views/shared/buttons/_ab_show.html.haml:48 ../dictionary_strings.rb:1311 ../dictionary_strings.rb:1429 ../dictionary_strings.rb:1791 ../dictionary_strings.rb:2105
 msgid "Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+#: ../dictionary_strings.rb:1309 ../dictionary_strings.rb:1799 ../dictionary_strings.rb:1801
+msgid "Image Registries"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+#: ../dictionary_strings.rb:1307 ../dictionary_strings.rb:1797
+msgid "Image Registry"
 msgstr ""
 
 #: ../../app/views/pxe/_template_form.html.haml:49
@@ -9369,7 +11466,12 @@ msgstr ""
 msgid "Image shown at 25% of actual size"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:42 ../../app/views/configuration/_ui_2.html.haml:187 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:59
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_images
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
+#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:42 ../../app/views/configuration/_ui_2.html.haml:187 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:59 ../dictionary_strings.rb:1313 ../dictionary_strings.rb:1431 ../dictionary_strings.rb:1793 ../dictionary_strings.rb:1795 ../dictionary_strings.rb:2107
 msgid "Images"
 msgstr ""
 
@@ -9405,15 +11507,19 @@ msgstr ""
 msgid "Import Widgets"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:204
+msgid "Import cancelled by user"
+msgstr ""
+
 #: ../../app/controllers/report_controller.rb:71
 msgid "Import file cannot be empty"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:54 ../../app/controllers/miq_ae_tools_controller.rb:172 ../../app/controllers/report_controller.rb:238 ../../app/controllers/miq_policy_controller.rb:192
+#: ../../app/controllers/miq_ae_customization_controller.rb:54 ../../app/controllers/miq_ae_tools_controller.rb:172 ../../app/controllers/report_controller.rb:238 ../../app/controllers/miq_policy_controller.rb:193
 msgid "Import file was uploaded successfully"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:209
+#: ../../app/controllers/miq_policy_controller.rb:210
 msgid "Import not available due to conflicts"
 msgstr ""
 
@@ -9423,6 +11529,11 @@ msgstr ""
 
 #: ../../app/controllers/report_controller.rb:307
 msgid "Import/Export"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+#: ../dictionary_strings.rb:685
+msgid "In My LDAP Group?"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_form.html.haml:110
@@ -9463,6 +11574,59 @@ msgstr ""
 
 #: ../../app/presenters/menu/default_menu.rb:42 ../../app/views/configuration/_ui_2.html.haml:243
 msgid "Infrastructure"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra
+#: ../dictionary_strings.rb:1437 ../dictionary_strings.rb:1871
+msgid "Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+#: ../dictionary_strings.rb:1453
+msgid "Infrastructure Provider (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+#: ../dictionary_strings.rb:1449
+msgid "Infrastructure Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+#: ../dictionary_strings.rb:1457
+msgid "Infrastructure Provider (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+#: ../dictionary_strings.rb:1461
+msgid "Infrastructure Provider (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infras
+#: ../dictionary_strings.rb:1439 ../dictionary_strings.rb:1873 ../dictionary_strings.rb:1875
+msgid "Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+#: ../dictionary_strings.rb:1455
+msgid "Infrastructure Providers (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+#: ../dictionary_strings.rb:1451
+msgid "Infrastructure Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+#: ../dictionary_strings.rb:1459
+msgid "Infrastructure Providers (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+#: ../dictionary_strings.rb:1463
+msgid "Infrastructure Providers (Vmware)"
 msgstr ""
 
 #: ../../app/views/ontap_storage_system/_main.html.haml:16 ../../app/views/ontap_logical_disk/_main.html.haml:11 ../../app/views/ontap_storage_volume/_main.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:37 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:58 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:53 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:56 ../../app/views/ontap_file_share/_main.html.haml:16
@@ -9527,6 +11691,12 @@ msgstr ""
 msgid "Input Parameters"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+#: ../dictionary_strings.rb:1425 ../dictionary_strings.rb:2117
+msgid "Instance"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:126
 msgid "Instance Power Functions"
 msgstr ""
@@ -9535,7 +11705,10 @@ msgstr ""
 msgid "Instance Type:"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:32 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:32 ../../app/views/layouts/listnav/_security_group.html.haml:34 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38 ../../app/views/miq_ae_class/_class_instances.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:8 ../../app/views/miq_ae_class/_all_tabs.html.haml:35 ../../app/views/miq_ae_class/_class_props.html.haml:68 ../../app/views/configuration/_ui_2.html.haml:173
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
+#: ../../app/presenters/menu/default_menu.rb:32 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:32 ../../app/views/layouts/listnav/_security_group.html.haml:34 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38 ../../app/views/miq_ae_class/_class_instances.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:8 ../../app/views/miq_ae_class/_all_tabs.html.haml:35 ../../app/views/miq_ae_class/_class_props.html.haml:68 ../../app/views/configuration/_ui_2.html.haml:173 ../dictionary_strings.rb:1427 ../dictionary_strings.rb:2119 ../dictionary_strings.rb:2121
 msgid "Instances"
 msgstr ""
 
@@ -9559,7 +11732,8 @@ msgstr ""
 msgid "Internal RSS Feed"
 msgstr ""
 
-#: ../../app/views/layouts/_tl_options.html.haml:45 ../../app/views/layouts/_perf_options.html.haml:11 ../../app/views/report/_report_info.html.haml:139
+#. TRANSLATORS: en.yml key: dictionary.column.interval
+#: ../../app/views/layouts/_tl_options.html.haml:45 ../../app/views/layouts/_perf_options.html.haml:11 ../../app/views/report/_report_info.html.haml:139 ../dictionary_strings.rb:1215
 msgid "Interval"
 msgstr ""
 
@@ -9573,6 +11747,16 @@ msgstr ""
 
 #: ../../lib/report_formatter/chart_common.rb:568
 msgid "Invalid chart definition"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+#: ../dictionary_strings.rb:1017
+msgid "Is a Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+#: ../dictionary_strings.rb:427
+msgid "Is an EVM Appliance?"
 msgstr ""
 
 #: ../model_attributes.rb:670
@@ -9711,11 +11895,14 @@ msgid_plural "Kernel Drivers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/controllers/auth_key_pair_cloud_controller.rb:91
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
+#: ../../app/controllers/auth_key_pair_cloud_controller.rb:91 ../dictionary_strings.rb:1747
 msgid "Key Pair"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:34 ../../app/views/configuration/_ui_2.html.haml:229
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
+#: ../../app/presenters/menu/default_menu.rb:34 ../../app/views/configuration/_ui_2.html.haml:229 ../dictionary_strings.rb:1749 ../dictionary_strings.rb:1751
 msgid "Key Pairs"
 msgstr ""
 
@@ -9727,12 +11914,27 @@ msgstr ""
 msgid "Kickstart"
 msgstr ""
 
-#: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279
+#. TRANSLATORS: en.yml key: dictionary.table.ldap
+#: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279 ../dictionary_strings.rb:1947
 msgid "LDAP"
 msgstr ""
 
-#: ../../app/views/ops/_ldap_region_show.html.haml:58
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+#: ../dictionary_strings.rb:1397 ../dictionary_strings.rb:1951
+msgid "LDAP Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
+#: ../../app/views/ops/_ldap_region_show.html.haml:58 ../dictionary_strings.rb:1399 ../dictionary_strings.rb:1953
 msgid "LDAP Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ldap_group
+#. TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+#: ../dictionary_strings.rb:439 ../dictionary_strings.rb:689
+msgid "LDAP Group"
 msgstr ""
 
 #: ../../app/views/ops/_rbac_group_details.html.haml:150
@@ -9751,6 +11953,14 @@ msgstr ""
 msgid "LDAP Host Names"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:99
+msgid "LDAP Host is required"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings.rb:107
+msgid "LDAP Host should be unique"
+msgstr ""
+
 #: ../../app/views/ops/_ldap_forest_entries.html.haml:18
 msgid "LDAP Hostname"
 msgstr ""
@@ -9763,11 +11973,27 @@ msgstr ""
 msgid "LDAP Port"
 msgstr ""
 
-#: ../../app/views/ops/_settings_details_tab.html.haml:109
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region
+#: ../dictionary_strings.rb:1401 ../dictionary_strings.rb:1955
+msgid "LDAP Region"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
+#: ../../app/views/ops/_settings_details_tab.html.haml:109 ../dictionary_strings.rb:1403 ../dictionary_strings.rb:1957
 msgid "LDAP Regions"
 msgstr ""
 
-#: ../../app/views/ops/_ldap_domain_show.html.haml:242 ../../app/views/ops/_ldap_server_entries.html.haml:8
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server
+#: ../dictionary_strings.rb:1405 ../dictionary_strings.rb:1959
+msgid "LDAP Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
+#: ../../app/views/ops/_ldap_domain_show.html.haml:242 ../../app/views/ops/_ldap_server_entries.html.haml:8 ../dictionary_strings.rb:1407 ../dictionary_strings.rb:1961
 msgid "LDAP Servers"
 msgstr ""
 
@@ -9781,6 +12007,16 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279
 msgid "LDAPS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+#: ../dictionary_strings.rb:1949
+msgid "LDAPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+#: ../dictionary_strings.rb:2057
+msgid "LUNs"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_info.html.haml:15 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:14 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:15
@@ -9871,8 +12107,28 @@ msgstr ""
 msgid "Last 30 Days"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+#: ../dictionary_strings.rb:429
+msgid "Last Analysis Attempt On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+#: ../dictionary_strings.rb:431
+msgid "Last Analysis Time"
+msgstr ""
+
 #: ../../app/views/ops/rhn/_server_table.html.haml:94
 msgid "Last Checked for updates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+#: ../dictionary_strings.rb:1945
+msgid "Last Compliance Histories"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance
+#: ../dictionary_strings.rb:1943
+msgid "Last Compliance History"
 msgstr ""
 
 #: ../../app/views/ops/_logs_selected.html.haml:24
@@ -9891,12 +12147,27 @@ msgstr ""
 msgid "Last Run Time"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+#: ../dictionary_strings.rb:433
+msgid "Last Sync Time"
+msgstr ""
+
 #: ../../app/helpers/container_node_helper/textual_summary.rb:17
 msgid "Last Transition Time"
 msgstr ""
 
 #: ../../app/views/miq_request/_request.html.haml:126 ../../app/views/miq_request/_request_details.html.haml:31
 msgid "Last Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+#: ../dictionary_strings.rb:437
+msgid "Last Update Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status
+#: ../dictionary_strings.rb:435
+msgid "Last Update Status Code"
 msgstr ""
 
 #: ../../app/views/miq_policy/_policy_details.html.haml:91
@@ -10179,6 +12450,11 @@ msgstr ""
 msgid "Limit Request Ratio"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+#: ../dictionary_strings.rb:1963
+msgid "Linux Init Processes"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/gtl_view.rb:20 ../../app/helpers/application_helper/toolbar/x_gtl_view.rb:20 ../../app/helpers/configuration_helper/configuration_view_helper.rb:74 ../../app/helpers/configuration_helper/configuration_view_helper.rb:80 ../../app/helpers/configuration_helper/configuration_view_helper.rb:86 ../../app/views/configuration/_ui_1.html.haml:113
 msgid "List View"
 msgstr ""
@@ -10211,7 +12487,7 @@ msgstr ""
 msgid "Locale"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/upload.rb:47 ../../app/controllers/ops_controller/settings/common.rb:1085
+#: ../../app/controllers/ops_controller/settings/upload.rb:47 ../../app/controllers/ops_controller/settings/common.rb:1096
 msgid "Locate and upload a file to start the import process"
 msgstr ""
 
@@ -10221,6 +12497,11 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:28
 msgid "Lock this Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+#: ../dictionary_strings.rb:159
+msgid "Lockdown Mode"
 msgstr ""
 
 #: ../../app/views/report/_db_show.html.haml:46 ../../app/views/report/_db_form.html.haml:58
@@ -10247,11 +12528,11 @@ msgstr ""
 msgid "Log Level"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:619
+#: ../../app/controllers/ops_controller/diagnostics.rb:621
 msgid "Log collection error returned: %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:621
+#: ../../app/controllers/ops_controller/diagnostics.rb:623
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr ""
 
@@ -10323,7 +12604,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:38 ../../app/controllers/miq_ae_tools_controller.rb:50 ../../app/controllers/ops_controller/diagnostics.rb:194 ../../app/controllers/ops_controller/diagnostics.rb:205 ../../app/controllers/ops_controller/diagnostics.rb:216 ../../app/controllers/ops_controller/diagnostics.rb:860 ../../app/controllers/ops_controller/diagnostics.rb:866 ../../app/controllers/ops_controller/diagnostics.rb:872 ../../app/controllers/miq_policy_controller.rb:325 ../../app/controllers/miq_policy_controller.rb:340
+#: ../../app/controllers/miq_ae_tools_controller.rb:38 ../../app/controllers/miq_ae_tools_controller.rb:50 ../../app/controllers/ops_controller/diagnostics.rb:194 ../../app/controllers/ops_controller/diagnostics.rb:205 ../../app/controllers/ops_controller/diagnostics.rb:216 ../../app/controllers/ops_controller/diagnostics.rb:871 ../../app/controllers/ops_controller/diagnostics.rb:877 ../../app/controllers/ops_controller/diagnostics.rb:883 ../../app/controllers/miq_policy_controller.rb:326 ../../app/controllers/miq_policy_controller.rb:341
 msgid "Logs for this CFME Server are not available for viewing"
 msgstr ""
 
@@ -10331,12 +12612,24 @@ msgstr ""
 msgid "Long Description"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/tags.rb:60
+msgid "Long Description is required"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_field.html.haml:139
 msgid "Lookup"
 msgstr ""
 
-#: ../../app/views/host/_form.html.haml:138
+#. TRANSLATORS: en.yml key: dictionary.column.mac_address
+#. TRANSLATORS: en.yml key: dictionary.column.macaddress
+#: ../../app/views/host/_form.html.haml:138 ../dictionary_strings.rb:443 ../dictionary_strings.rb:447
 msgid "MAC Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.macaddresses
+#: ../dictionary_strings.rb:445 ../dictionary_strings.rb:449
+msgid "MAC Addresses"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_options.html.haml:214
@@ -10447,12 +12740,26 @@ msgstr ""
 msgid "Manage quotas for %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:188
+#: ../../app/controllers/ops_controller/ops_rbac.rb:189
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
-#: ../../app/views/miq_policy/_alert_mgmt_event.html.haml:5
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event
+#: ../../app/views/miq_policy/_alert_mgmt_event.html.haml:5 ../dictionary_strings.rb:1343 ../dictionary_strings.rb:1859
 msgid "Management Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_automate
+#: ../dictionary_strings.rb:647
+msgid "Management Event Raised"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_events
+#: ../dictionary_strings.rb:1345 ../dictionary_strings.rb:1861 ../dictionary_strings.rb:1863
+msgid "Management Events"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:19 ../../app/views/miq_request/_prov_host_dialog.html.haml:18 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:18 ../../app/views/shared/views/_prov_dialog.html.haml:19
@@ -10463,7 +12770,8 @@ msgstr ""
 msgid "Matching password fields are needed to perform verification of credentials"
 msgstr ""
 
-#: ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/vm_common/_right_size.html.haml:20
+#. TRANSLATORS: en.yml key: dictionary.column.max_trend_value
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/vm_common/_right_size.html.haml:20 ../dictionary_strings.rb:529
 msgid "Max"
 msgstr ""
 
@@ -10499,12 +12807,423 @@ msgstr ""
 msgid "Member VMs (%s)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/chargeback.rb:8 ../../app/views/miq_request/_reconfigure_show.html.haml:17 ../../app/views/vm_common/_reconfigure.html.haml:14 ../../app/views/vm_common/_right_size.html.haml:95 ../../app/views/vm_common/_right_size.html.haml:208 ../../app/views/vm_common/_right_size.html.haml:292 ../../app/views/vm_common/_right_size.html.haml:375 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:27 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:27
+#. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
+#: ../../app/helpers/application_helper/chargeback.rb:8 ../../app/views/miq_request/_reconfigure_show.html.haml:17 ../../app/views/vm_common/_reconfigure.html.haml:14 ../../app/views/vm_common/_right_size.html.haml:95 ../../app/views/vm_common/_right_size.html.haml:208 ../../app/views/vm_common/_right_size.html.haml:292 ../../app/views/vm_common/_right_size.html.haml:375 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:27 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:27 ../dictionary_strings.rb:533
 msgid "Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_memory
+#: ../dictionary_strings.rb:713
+msgid "Memory %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+#: ../dictionary_strings.rb:681
+msgid "Memory - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+#: ../dictionary_strings.rb:129
+msgid "Memory - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+#: ../dictionary_strings.rb:127
+msgid "Memory - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+#: ../dictionary_strings.rb:145
+msgid "Memory - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+#: ../dictionary_strings.rb:143
+msgid "Memory - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+#: ../dictionary_strings.rb:297
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+#: ../dictionary_strings.rb:299
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+#: ../dictionary_strings.rb:301
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+#: ../dictionary_strings.rb:303
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+#: ../dictionary_strings.rb:305
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+#: ../dictionary_strings.rb:765
+msgid "Memory - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+#: ../dictionary_strings.rb:761
+msgid "Memory - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+#: ../dictionary_strings.rb:763
+msgid "Memory - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+#: ../dictionary_strings.rb:755
+msgid "Memory - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+#: ../dictionary_strings.rb:295
+msgid "Memory - Available (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+#: ../dictionary_strings.rb:53
+msgid "Memory - Avg Usage of Total Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+#: ../dictionary_strings.rb:103
+msgid "Memory - Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+#: ../dictionary_strings.rb:79
+msgid "Memory - Avg Used for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+#: ../dictionary_strings.rb:81
+msgid "Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+#: ../dictionary_strings.rb:83
+msgid "Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+#: ../dictionary_strings.rb:545
+msgid "Memory - Balloon Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+#: ../dictionary_strings.rb:521
+msgid "Memory - Balloon Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+#: ../dictionary_strings.rb:581
+msgid "Memory - Balloon Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+#: ../dictionary_strings.rb:547
+msgid "Memory - Balloon Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+#: ../dictionary_strings.rb:523
+msgid "Memory - Balloon Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+#: ../dictionary_strings.rb:583
+msgid "Memory - Balloon Target Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+#: ../dictionary_strings.rb:865
+msgid "Memory - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+#: ../dictionary_strings.rb:861
+msgid "Memory - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+#: ../dictionary_strings.rb:863
+msgid "Memory - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_memory
+#: ../dictionary_strings.rb:381
+msgid "Memory - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+#: ../dictionary_strings.rb:61
+msgid "Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+#: ../dictionary_strings.rb:579
+msgid "Memory - Min Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+#: ../dictionary_strings.rb:561
+msgid "Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+#: ../dictionary_strings.rb:113
+msgid "Memory - Minimum Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+#: ../dictionary_strings.rb:879
+msgid "Memory - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+#: ../dictionary_strings.rb:875
+msgid "Memory - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+#: ../dictionary_strings.rb:877
+msgid "Memory - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+#: ../dictionary_strings.rb:37
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+#: ../dictionary_strings.rb:39
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+#: ../dictionary_strings.rb:43
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+#: ../dictionary_strings.rb:47
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+#: ../dictionary_strings.rb:41
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+#: ../dictionary_strings.rb:45
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+#: ../dictionary_strings.rb:49
+msgid "Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Intervals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+#: ../dictionary_strings.rb:483
+msgid "Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+#: ../dictionary_strings.rb:111
+msgid "Memory - Peak Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+#: ../dictionary_strings.rb:503
+msgid "Memory - Peak Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+#: ../dictionary_strings.rb:505
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+#: ../dictionary_strings.rb:509
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+#: ../dictionary_strings.rb:513
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+#: ../dictionary_strings.rb:517
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+#: ../dictionary_strings.rb:507
+msgid "Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+#: ../dictionary_strings.rb:511
+msgid "Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+#: ../dictionary_strings.rb:515
+msgid "Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+#: ../dictionary_strings.rb:519
+msgid "Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+#: ../dictionary_strings.rb:887
+msgid "Memory - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+#: ../dictionary_strings.rb:117
+msgid "Memory - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+#: ../dictionary_strings.rb:101
+msgid "Memory - Reserved (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+#: ../dictionary_strings.rb:535
+msgid "Memory - Swap In Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+#: ../dictionary_strings.rb:495
+msgid "Memory - Swap In Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+#: ../dictionary_strings.rb:571
+msgid "Memory - Swap In Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+#: ../dictionary_strings.rb:577
+msgid "Memory - Swap Min Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+#: ../dictionary_strings.rb:537
+msgid "Memory - Swap Out Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+#: ../dictionary_strings.rb:497
+msgid "Memory - Swap Out Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+#: ../dictionary_strings.rb:573
+msgid "Memory - Swap Out Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+#: ../dictionary_strings.rb:541
+msgid "Memory - Swap Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+#: ../dictionary_strings.rb:501
+msgid "Memory - Swap Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+#: ../dictionary_strings.rb:539
+msgid "Memory - Swapped Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+#: ../dictionary_strings.rb:499
+msgid "Memory - Swapped Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+#: ../dictionary_strings.rb:575
+msgid "Memory - Swapped Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+#: ../dictionary_strings.rb:99
+msgid "Memory - Total Allocated (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+#: ../dictionary_strings.rb:293
+msgid "Memory - Total Allocated for Child VMs (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+#: ../dictionary_strings.rb:543
+msgid "Memory - Usage of Total Allocated (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+#: ../dictionary_strings.rb:1173
+msgid "Memory Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+#: ../dictionary_strings.rb:1175
+msgid "Memory Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+#: ../dictionary_strings.rb:967
+msgid "Memory Average Used Trend"
 msgstr ""
 
 #: ../../app/views/vm_common/_config.html.haml:240
 msgid "Memory Limit"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+#: ../dictionary_strings.rb:107
+msgid "Memory Max Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+#: ../dictionary_strings.rb:481
+msgid "Memory Max Available"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+#: ../dictionary_strings.rb:109
+msgid "Memory Max Reserved"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+#: ../dictionary_strings.rb:479
+msgid "Memory Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+#: ../dictionary_strings.rb:971
+msgid "Memory Max Used Trend"
 msgstr ""
 
 #: ../../app/views/vm_common/_config.html.haml:240
@@ -10527,8 +13246,34 @@ msgstr ""
 msgid "Memory Size"
 msgstr ""
 
-#: ../../app/views/ops/_selected_by_servers.html.haml:89 ../../app/views/ops/_selected_by_roles.html.haml:137 ../../app/views/ops/_server_desc.html.haml:53 ../../app/views/vm_common/_right_size.html.haml:123
+#. TRANSLATORS: en.yml key: dictionary.column.memory_metric
+#: ../dictionary_strings.rb:1179
+msgid "Memory Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_cost
+#: ../dictionary_strings.rb:1177
+msgid "Memory Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_size
+#: ../../app/views/ops/_selected_by_servers.html.haml:89 ../../app/views/ops/_selected_by_roles.html.haml:137 ../../app/views/ops/_server_desc.html.haml:53 ../../app/views/vm_common/_right_size.html.haml:123 ../dictionary_strings.rb:551
 msgid "Memory Usage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+#: ../dictionary_strings.rb:1183
+msgid "Memory Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+#: ../dictionary_strings.rb:1181
+msgid "Memory Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+#: ../dictionary_strings.rb:1061
+msgid "Memory Virtual to Real Ratio"
 msgstr ""
 
 #: ../../app/controllers/application_controller/ci_processing.rb:419
@@ -10547,7 +13292,8 @@ msgstr ""
 msgid "Menu Shortcuts"
 msgstr ""
 
-#: ../../app/views/miq_request/_ae_prov_show.html.haml:20 ../../app/views/layouts/_ae_resolve_options.html.haml:42 ../../app/views/miq_ae_class/_instance_fields.html.haml:31 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/report/_widget_show.html.haml:106 ../../app/views/shared/buttons/_ab_show.html.haml:98 ../../app/assets/javascripts/miq_policy/import.js:47
+#. TRANSLATORS: en.yml key: dictionary.column.v_message
+#: ../../app/views/miq_request/_ae_prov_show.html.haml:20 ../../app/views/layouts/_ae_resolve_options.html.haml:42 ../../app/views/miq_ae_class/_instance_fields.html.haml:31 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/report/_widget_show.html.haml:106 ../../app/views/shared/buttons/_ab_show.html.haml:98 ../../app/assets/javascripts/miq_policy/import.js:47 ../dictionary_strings.rb:1021
 msgid "Message"
 msgstr ""
 
@@ -11095,7 +13841,36 @@ msgstr ""
 msgid "Middleware"
 msgstr ""
 
-#: ../../app/controllers/middleware_server_controller.rb:29
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+#: ../dictionary_strings.rb:1895
+msgid "Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+#: ../dictionary_strings.rb:1897 ../dictionary_strings.rb:1899
+msgid "Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+#: ../dictionary_strings.rb:1883
+msgid "Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+#: ../dictionary_strings.rb:1885 ../dictionary_strings.rb:1887
+msgid "Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server
+#: ../dictionary_strings.rb:1889
+msgid "Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
+#: ../../app/controllers/middleware_server_controller.rb:29 ../dictionary_strings.rb:1891 ../dictionary_strings.rb:1893
 msgid "Middleware Servers"
 msgstr ""
 
@@ -11115,7 +13890,8 @@ msgstr ""
 msgid "Migrate this VM to another Host/Datastore"
 msgstr ""
 
-#: ../../app/helpers/container_project_helper/textual_summary.rb:42
+#. TRANSLATORS: en.yml key: dictionary.column.min_trend_value
+#: ../../app/helpers/container_project_helper/textual_summary.rb:42 ../dictionary_strings.rb:589
 msgid "Min"
 msgstr ""
 
@@ -11833,6 +14609,10 @@ msgstr ""
 
 #: ../model_attributes.rb:1047
 msgid "MiqEventDefinition|Updated on"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:386
+msgid "MiqGroup no longer exists"
 msgstr ""
 
 #: ../model_attributes.rb:1061
@@ -12903,7 +15683,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:137 ../../app/helpers/application_helper/toolbar/host_center.rb:89 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:135 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:92 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:104 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:41 ../../app/helpers/application_helper/toolbar/container_service_center.rb:29 ../../app/helpers/application_helper/toolbar/container_center.rb:45 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:49 ../../app/helpers/application_helper/toolbar/container_project_center.rb:29 ../../app/helpers/application_helper/toolbar/container_node_center.rb:29 ../../app/helpers/application_helper/toolbar/storage_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:61 ../../app/helpers/application_helper/toolbar/container_group_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:21 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:36 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:93 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:29 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:67
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:137 ../../app/helpers/application_helper/toolbar/host_center.rb:89 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:135 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:92 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:104 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:41 ../../app/helpers/application_helper/toolbar/container_service_center.rb:29 ../../app/helpers/application_helper/toolbar/container_center.rb:45 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:49 ../../app/helpers/application_helper/toolbar/container_project_center.rb:29 ../../app/helpers/application_helper/toolbar/container_node_center.rb:29 ../../app/helpers/application_helper/toolbar/storage_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:61 ../../app/helpers/application_helper/toolbar/container_group_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:36 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:93 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:29 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:67
 msgid "Monitoring"
 msgstr ""
 
@@ -12971,7 +15751,11 @@ msgstr ""
 msgid "Move selected field up"
 msgstr ""
 
-#: ../../app/views/ops/_ldap_seq_form.html.haml:57 ../../app/views/ops/_ldap_seq_form.html.haml:57 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:47 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:40 ../../app/views/report/_column_lists.html.haml:35 ../../app/views/report/_column_lists.html.haml:95 ../../app/views/report/_db_seq_form.html.haml:55 ../../app/views/shared/buttons/_column_lists.html.haml:115 ../../app/views/shared/buttons/_group_order_form.html.haml:57
+#: ../../app/views/report/_column_lists.html.haml:40 ../../app/views/report/_column_lists.html.haml:98
+msgid "Move selected fields %{where}"
+msgstr ""
+
+#: ../../app/views/ops/_ldap_seq_form.html.haml:57 ../../app/views/ops/_ldap_seq_form.html.haml:57 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:47 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:40 ../../app/views/report/_db_seq_form.html.haml:55 ../../app/views/shared/buttons/_column_lists.html.haml:115 ../../app/views/shared/buttons/_group_order_form.html.haml:57
 msgid "Move selected fields down"
 msgstr ""
 
@@ -12983,15 +15767,15 @@ msgstr ""
 msgid "Move selected fields right"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:103 ../../app/views/shared/buttons/_column_lists.html.haml:131
+#: ../../app/views/shared/buttons/_column_lists.html.haml:131
 msgid "Move selected fields to bottom"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:79 ../../app/views/shared/buttons/_column_lists.html.haml:83
+#: ../../app/views/shared/buttons/_column_lists.html.haml:83
 msgid "Move selected fields to top"
 msgstr ""
 
-#: ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:35 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:33 ../../app/views/report/_column_lists.html.haml:43 ../../app/views/report/_column_lists.html.haml:87 ../../app/views/report/_db_seq_form.html.haml:43 ../../app/views/shared/buttons/_column_lists.html.haml:99 ../../app/views/shared/buttons/_group_order_form.html.haml:41
+#: ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/ops/_ldap_seq_form.html.haml:46 ../../app/views/miq_ae_class/_fields_seq_form.html.haml:35 ../../app/views/miq_ae_class/_domains_priority_form.html.haml:33 ../../app/views/report/_db_seq_form.html.haml:43 ../../app/views/shared/buttons/_column_lists.html.haml:99 ../../app/views/shared/buttons/_group_order_form.html.haml:41
 msgid "Move selected fields up"
 msgstr ""
 
@@ -13035,6 +15819,11 @@ msgstr ""
 msgid "Move selected reports up"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+#: ../dictionary_strings.rb:595
+msgid "Multiple Host Access"
+msgstr ""
+
 #: ../../app/presenters/tree_builder_vms_filter.rb:22 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:34 ../../app/views/layouts/listnav/_show_list.html.haml:38
 msgid "My Filters"
 msgstr ""
@@ -13053,6 +15842,11 @@ msgstr ""
 
 #: ../../app/views/miq_policy/_policy_details.html.haml:82 ../../app/views/miq_policy/_policy_details.html.haml:97
 msgid "N/A"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+#: ../dictionary_strings.rb:1367
+msgid "NFS"
 msgstr ""
 
 #: ../../app/helpers/container_group_helper/textual_summary.rb:37
@@ -13079,7 +15873,7 @@ msgstr ""
 msgid "Name / Description"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:596 ../../app/controllers/miq_ae_class_controller.rb:657 ../../app/controllers/miq_ae_class_controller.rb:2062 ../../app/controllers/miq_ae_class_controller.rb:2127 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:249 ../../app/controllers/catalog_controller.rb:369 ../../app/controllers/catalog_controller.rb:867
+#: ../../app/controllers/miq_ae_class_controller.rb:596 ../../app/controllers/miq_ae_class_controller.rb:657 ../../app/controllers/miq_ae_class_controller.rb:2062 ../../app/controllers/miq_ae_class_controller.rb:2127 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:249 ../../app/controllers/ontap_file_share_controller.rb:117 ../../app/controllers/catalog_controller.rb:369 ../../app/controllers/catalog_controller.rb:867 ../../app/controllers/ops_controller/settings/tags.rb:54 ../../app/controllers/ops_controller/settings/ldap.rb:49 ../../app/controllers/ontap_storage_system_controller.rb:125
 msgid "Name is required"
 msgstr ""
 
@@ -13123,6 +15917,16 @@ msgstr ""
 msgid "Need a valid UNC path"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+#: ../dictionary_strings.rb:1601
+msgid "NetApp Remote Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+#: ../dictionary_strings.rb:1603
+msgid "NetApp Remote Services"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:49 ../model_attributes.rb:1351
 msgid "Network"
 msgstr ""
@@ -13131,12 +15935,88 @@ msgstr ""
 msgid "Network Adapter Information"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:189
+#. TRANSLATORS: en.yml key: dictionary.table.nics
+#: ../../app/views/vm_common/_config.html.haml:189 ../dictionary_strings.rb:2037
 msgid "Network Adapters"
 msgstr ""
 
 #: ../../app/helpers/application_helper/chargeback.rb:9
 msgid "Network I/O"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+#: ../dictionary_strings.rb:133
+msgid "Network I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:131
+msgid "Network I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+#: ../dictionary_strings.rb:149
+msgid "Network I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+#: ../dictionary_strings.rb:147
+msgid "Network I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+#: ../dictionary_strings.rb:65
+msgid "Network I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+#: ../dictionary_strings.rb:597
+msgid "Network I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+#: ../dictionary_strings.rb:63
+msgid "Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+#: ../dictionary_strings.rb:585
+msgid "Network I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+#: ../dictionary_strings.rb:51
+msgid "Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+#: ../dictionary_strings.rb:525
+msgid "Network I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+#: ../dictionary_strings.rb:975
+msgid "Network I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+#: ../dictionary_strings.rb:1187
+msgid "Network I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+#: ../dictionary_strings.rb:1185
+msgid "Network I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+#: ../dictionary_strings.rb:1191
+msgid "Network I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+#: ../dictionary_strings.rb:1189
+msgid "Network I/O Used Cost"
 msgstr ""
 
 #: ../../app/views/security_group/_main.html.haml:20
@@ -13317,14 +16197,6 @@ msgstr ""
 msgid "No %s found."
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:884
-msgid "No %s selected to set to Asynchronous"
-msgstr ""
-
-#: ../../app/controllers/miq_policy_controller.rb:867
-msgid "No %s selected to set to Synchronous"
-msgstr ""
-
 #: ../../app/controllers/report_controller/reports/editor.rb:914
 msgid "No %s were moved up"
 msgstr ""
@@ -13341,15 +16213,15 @@ msgstr ""
 msgid "No %s were selected to be enabled"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:464 ../../app/controllers/report_controller/menus.rb:504 ../../app/controllers/report_controller/menus.rb:548 ../../app/controllers/report_controller/reports/editor.rb:882 ../../app/controllers/report_controller/reports/editor.rb:1011 ../../app/controllers/ops_controller/ops_rbac.rb:482
+#: ../../app/controllers/report_controller/dashboards.rb:464 ../../app/controllers/report_controller/menus.rb:504 ../../app/controllers/report_controller/menus.rb:548 ../../app/controllers/report_controller/reports/editor.rb:882 ../../app/controllers/report_controller/reports/editor.rb:1011
 msgid "No %s were selected to move down"
 msgstr ""
 
-#: ../../app/controllers/report_controller/menus.rb:439 ../../app/controllers/miq_policy_controller/miq_actions.rb:189 ../../app/controllers/miq_policy_controller/miq_actions.rb:209 ../../app/controllers/vm_common.rb:1862 ../../app/controllers/application_controller.rb:588 ../../app/controllers/miq_policy_controller.rb:782 ../../app/controllers/miq_policy_controller.rb:820
+#: ../../app/controllers/report_controller/menus.rb:439 ../../app/controllers/vm_common.rb:1862 ../../app/controllers/application_controller.rb:588 ../../app/controllers/miq_policy_controller.rb:798
 msgid "No %s were selected to move left"
 msgstr ""
 
-#: ../../app/controllers/report_controller/menus.rb:454 ../../app/controllers/miq_policy_controller/miq_actions.rb:199 ../../app/controllers/vm_common.rb:1850 ../../app/controllers/application_controller.rb:589 ../../app/controllers/miq_policy_controller.rb:803
+#: ../../app/controllers/report_controller/menus.rb:454 ../../app/controllers/vm_common.rb:1850 ../../app/controllers/application_controller.rb:589
 msgid "No %s were selected to move right"
 msgstr ""
 
@@ -13361,11 +16233,35 @@ msgstr ""
 msgid "No %s were selected to move to the top"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:440 ../../app/controllers/report_controller/menus.rb:483 ../../app/controllers/report_controller/menus.rb:527 ../../app/controllers/report_controller/reports/editor.rb:912 ../../app/controllers/report_controller/reports/editor.rb:989 ../../app/controllers/ops_controller/ops_rbac.rb:460
+#: ../../app/controllers/report_controller/dashboards.rb:440 ../../app/controllers/report_controller/menus.rb:483 ../../app/controllers/report_controller/menus.rb:527 ../../app/controllers/report_controller/reports/editor.rb:912 ../../app/controllers/report_controller/reports/editor.rb:989
 msgid "No %s were selected to move up"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:289 ../../app/controllers/repository_controller.rb:314 ../../app/controllers/miq_request_controller.rb:525 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:62 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1337 ../../app/controllers/service_controller.rb:218 ../../app/controllers/ops_controller/settings/ldap.rb:113 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:381 ../../app/controllers/ops_controller/settings/schedules.rb:172 ../../app/controllers/mixins/containers_common_mixin.rb:149 ../../app/controllers/miq_task_controller.rb:122 ../../app/controllers/miq_task_controller.rb:147 ../../app/controllers/miq_task_controller.rb:177 ../../app/controllers/provider_foreman_controller.rb:61 ../../app/controllers/application_controller/ci_processing.rb:1198 ../../app/controllers/application_controller/ci_processing.rb:1287 ../../app/controllers/application_controller/ci_processing.rb:1592 ../../app/controllers/application_controller/ci_processing.rb:1755 ../../app/controllers/application_controller/ci_processing.rb:1843 ../../app/controllers/application_controller/ci_processing.rb:1904
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:190 ../../app/controllers/miq_policy_controller/miq_actions.rb:212
+msgid "No %{members} were selected to move left"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:201
+msgid "No %{members} were selected to move right"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:905
+msgid "No %{member} selected to set to Asynchronous"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:887
+msgid "No %{member} selected to set to Synchronous"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:837
+msgid "No %{member} were selected to move left"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:819
+msgid "No %{member} were selected to move right"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:289 ../../app/controllers/repository_controller.rb:314 ../../app/controllers/miq_request_controller.rb:529 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:62 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1337 ../../app/controllers/service_controller.rb:218 ../../app/controllers/ops_controller/settings/ldap.rb:113 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:381 ../../app/controllers/ops_controller/settings/schedules.rb:172 ../../app/controllers/mixins/containers_common_mixin.rb:149 ../../app/controllers/miq_task_controller.rb:122 ../../app/controllers/miq_task_controller.rb:147 ../../app/controllers/miq_task_controller.rb:177 ../../app/controllers/provider_foreman_controller.rb:61 ../../app/controllers/application_controller/ci_processing.rb:1198 ../../app/controllers/application_controller/ci_processing.rb:1287 ../../app/controllers/application_controller/ci_processing.rb:1592 ../../app/controllers/application_controller/ci_processing.rb:1755 ../../app/controllers/application_controller/ci_processing.rb:1843 ../../app/controllers/application_controller/ci_processing.rb:1904
 msgid "No %{model} were selected for %{task}"
 msgstr ""
 
@@ -13617,7 +16513,7 @@ msgstr ""
 msgid "No child VMs to move right, no action taken"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:120
+#: ../../app/controllers/provider_foreman_controller.rb:101
 msgid "No common configuration profiles available for the selected configured %s"
 msgstr ""
 
@@ -13653,7 +16549,7 @@ msgstr ""
 msgid "No fields were selected to move bottom"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:653 ../../app/controllers/application_controller/buttons.rb:1051
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:653 ../../app/controllers/ops_controller/ops_rbac.rb:483 ../../app/controllers/application_controller/buttons.rb:1051
 msgid "No fields were selected to move down"
 msgstr ""
 
@@ -13661,7 +16557,7 @@ msgstr ""
 msgid "No fields were selected to move top"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:644 ../../app/controllers/application_controller/buttons.rb:1030
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:644 ../../app/controllers/ops_controller/ops_rbac.rb:461 ../../app/controllers/application_controller/buttons.rb:1030
 msgid "No fields were selected to move up"
 msgstr ""
 
@@ -13705,7 +16601,7 @@ msgstr ""
 msgid "No records found for this report"
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:729 ../../app/controllers/dashboard_controller.rb:775 ../../app/controllers/application_controller/timelines.rb:225 ../../app/controllers/application_controller/timelines.rb:481
+#: ../../app/controllers/miq_capacity_controller.rb:733 ../../app/controllers/dashboard_controller.rb:775 ../../app/controllers/application_controller/timelines.rb:225 ../../app/controllers/application_controller/timelines.rb:481
 msgid "No records found for this timeline"
 msgstr ""
 
@@ -13745,7 +16641,9 @@ msgstr ""
 msgid "No variables configured."
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:1231 ../../app/helpers/application_helper.rb:1253
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+#. TRANSLATORS: en.yml key: dictionary.table.container_node
+#: ../../app/helpers/application_helper.rb:1231 ../../app/helpers/application_helper.rb:1253 ../dictionary_strings.rb:1315 ../dictionary_strings.rb:1803
 msgid "Node"
 msgstr ""
 
@@ -13757,12 +16655,20 @@ msgstr ""
 msgid "Node Selector"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:39 ../../app/helpers/application_helper.rb:1231 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:11
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_nodes
+#: ../../app/presenters/menu/default_menu.rb:39 ../../app/helpers/application_helper.rb:1231 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:11 ../dictionary_strings.rb:1317 ../dictionary_strings.rb:1805 ../dictionary_strings.rb:1807
 msgid "Nodes"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_storage.html.haml:126
 msgid "Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+#: ../dictionary_strings.rb:1005
+msgid "Non-VM Files Percent of Used"
 msgstr ""
 
 #: ../../app/views/ops/_rbac_role_details.html.haml:61 ../../app/views/ops/_rbac_role_details.html.haml:64 ../../app/views/miq_request/_prov_vm_grid.html.haml:31 ../../app/views/miq_request/_prov_host_grid.html.haml:33 ../../app/views/miq_request/_prov_vc_grid.html.haml:27 ../../app/views/miq_request/_prov_pxe_img_grid.html.haml:26 ../../app/views/miq_request/_prov_ds_grid.html.haml:29 ../../app/views/miq_request/_prov_field.html.haml:258 ../../app/views/miq_request/_prov_field.html.haml:310 ../../app/views/miq_request/_prov_field.html.haml:433 ../../app/views/miq_request/_prov_field.html.haml:526 ../../app/views/miq_request/_prov_iso_img_grid.html.haml:26 ../../app/views/miq_request/_prov_template_grid.html.haml:26 ../../app/views/miq_request/_prov_windows_image_grid.html.haml:26 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:121 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:155 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:439 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/layouts/_edit_to_email.html.haml:22 ../../app/views/report/_form_columns_trend.html.haml:42 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:6 ../../app/views/shared/views/_retire.html.haml:49 ../../app/views/catalog/_form_resources_info.html.haml:119 ../../app/views/miq_policy/_alert_snmp.html.haml:129 ../../app/views/miq_policy/_action_options.html.haml:481 ../../app/views/miq_policy/_action_options.html.haml:493 ../../app/views/miq_capacity/_utilization_options.html.haml:45
@@ -13857,8 +16763,19 @@ msgstr ""
 msgid "Number List"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+#: ../dictionary_strings.rb:441
+msgid "Number of CPU Cores"
+msgstr ""
+
 #: ../../app/views/miq_policy/_action_options.html.haml:249 ../../app/views/miq_policy/_action_details.html.haml:270
 msgid "Number of CPU's"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_cpu
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+#: ../dictionary_strings.rb:655 ../dictionary_strings.rb:661
+msgid "Number of CPUs"
 msgstr ""
 
 #: ../../app/controllers/vm_common.rb:1671
@@ -13866,6 +16783,16 @@ msgid "Number of Disk"
 msgid_plural "Number of Disks"
 msgstr[0] ""
 msgstr[1] ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_disks
+#: ../dictionary_strings.rb:657
+msgid "Number of Disks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+#: ../dictionary_strings.rb:659
+msgid "Number of Hard Disks"
+msgstr ""
 
 #: ../../app/views/ems_infra/scaling.html.haml:27
 msgid "Number of Hosts"
@@ -13887,7 +16814,8 @@ msgstr ""
 msgid "OR with a new expression element"
 msgstr ""
 
-#: ../../app/helpers/provider_foreman_helper.rb:173
+#. TRANSLATORS: en.yml key: dictionary.table.operating_system
+#: ../../app/helpers/provider_foreman_helper.rb:173 ../dictionary_strings.rb:2071
 msgid "OS"
 msgstr ""
 
@@ -13903,6 +16831,11 @@ msgstr[1] ""
 
 #: ../../app/helpers/provider_foreman_helper.rb:92 ../../app/views/layouts/listnav/_host.html.haml:61
 msgid "OS Information"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.os_image_name
+#: ../dictionary_strings.rb:667
+msgid "OS Name"
 msgstr ""
 
 #: ../../app/views/miq_ae_tools/_results_tabs.html.haml:10
@@ -15837,6 +18770,16 @@ msgstr ""
 msgid "OperatingSystem|Version"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+#: ../dictionary_strings.rb:665
+msgid "Operational Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status
+#: ../dictionary_strings.rb:663
+msgid "Operational Status Code"
+msgstr ""
+
 #: ../../app/presenters/menu/default_menu.rb:153
 msgid "Optimize"
 msgstr ""
@@ -15865,7 +18808,9 @@ msgstr ""
 msgid "Orchestration Stack"
 msgstr ""
 
-#: ../../app/views/catalog/_form_basic_info.html.haml:105 ../../app/views/catalog/_sandt_tree_show.html.haml:83
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
+#: ../../app/views/catalog/_form_basic_info.html.haml:105 ../../app/views/catalog/_sandt_tree_show.html.haml:83 ../dictionary_strings.rb:1635 ../dictionary_strings.rb:2067
 msgid "Orchestration Template"
 msgstr ""
 
@@ -15873,7 +18818,9 @@ msgstr ""
 msgid "Orchestration Template \"%{name}\" was deleted."
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:49
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
+#: ../../app/views/configuration/_ui_2.html.haml:49 ../dictionary_strings.rb:1637 ../dictionary_strings.rb:2069
 msgid "Orchestration Templates"
 msgstr ""
 
@@ -16085,8 +19032,8 @@ msgstr ""
 msgid "Orphaned Instances"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:426
-msgid "Orphaned Records for userid %s were successfully deleted"
+#: ../../app/controllers/ops_controller/diagnostics.rb:428
+msgid "Orphaned Records for userid %{id} were successfully deleted"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_vandt.rb:16
@@ -16145,6 +19092,11 @@ msgstr ""
 msgid "Other VM Files"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+#: ../dictionary_strings.rb:1095
+msgid "Other VM Files Percent of Used"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:374
 msgid "Outgoing SMTP E-mail Server"
 msgstr ""
@@ -16161,7 +19113,13 @@ msgstr ""
 msgid "Overwrite existing reports?"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_form_filter_chargeback.html.haml:38 ../../app/views/report/_form_filter_chargeback.html.haml:104
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+#: ../dictionary_strings.rb:687
+msgid "Owned by Me?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owner_name
+#: ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_form_filter_chargeback.html.haml:38 ../../app/views/report/_form_filter_chargeback.html.haml:104 ../dictionary_strings.rb:1193
 msgid "Owner"
 msgstr ""
 
@@ -16177,6 +19135,11 @@ msgstr ""
 msgid "PDF Output"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.pid
+#: ../dictionary_strings.rb:715
+msgid "PID"
+msgstr ""
+
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:111
 msgid "PM:"
 msgstr ""
@@ -16189,12 +19152,28 @@ msgstr ""
 msgid "PXE Directory"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage
+#: ../dictionary_strings.rb:1659
+msgid "PXE Image"
+msgstr ""
+
 #: ../../app/views/pxe/_pxe_server_details.html.haml:17 ../../app/views/pxe/_pxe_server_details.html.haml:25 ../../app/views/pxe/_pxe_form.html.haml:146
 msgid "PXE Image Menus"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_server_details.html.haml:51
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
+#: ../../app/views/pxe/_pxe_server_details.html.haml:51 ../dictionary_strings.rb:1661
 msgid "PXE Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer
+#: ../dictionary_strings.rb:1667
+msgid "PXE Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+#: ../dictionary_strings.rb:1669
+msgid "PXE Servers"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_host.html.haml:220
@@ -16217,8 +19196,66 @@ msgstr ""
 msgid "Parent %{title}: %{name}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+#: ../dictionary_strings.rb:1029 ../dictionary_strings.rb:1039
+msgid "Parent Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+#: ../dictionary_strings.rb:1031 ../dictionary_strings.rb:1041
+msgid "Parent Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+#: ../dictionary_strings.rb:1043
+msgid "Parent Folder"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+#: ../dictionary_strings.rb:1033
+msgid "Parent Folder (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+#: ../dictionary_strings.rb:1025
+msgid "Parent Folder (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+#: ../dictionary_strings.rb:1035
+msgid "Parent Folder Path (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+#: ../dictionary_strings.rb:1027
+msgid "Parent Folder Path (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.host_name
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+#: ../dictionary_strings.rb:411 ../dictionary_strings.rb:1045
+msgid "Parent Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+#: ../dictionary_strings.rb:1015
+msgid "Parent Host Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+#: ../dictionary_strings.rb:1037 ../dictionary_strings.rb:1047
+msgid "Parent Resource Pool"
+msgstr ""
+
 #: ../../app/views/miq_policy/_action_options.html.haml:551 ../../app/views/miq_policy/_action_details.html.haml:492
 msgid "Parent Type"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:399
+msgid "Parent Type must be selected"
 msgstr ""
 
 #: ../../app/controllers/vm_common.rb:1693 ../../app/views/vm_common/_form.html.haml:73
@@ -16243,7 +19280,8 @@ msgstr ""
 msgid "Partition Table"
 msgstr ""
 
-#: ../../app/views/vm_common/_disks.html.haml:13
+#. TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
+#: ../../app/views/vm_common/_disks.html.haml:13 ../dictionary_strings.rb:709
 msgid "Partitions Aligned"
 msgstr ""
 
@@ -16315,7 +19353,7 @@ msgstr ""
 msgid "Password or Password+One-Time-Password"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:455 ../../app/controllers/ops_controller/ops_rbac.rb:988 ../../app/controllers/pxe_controller/pxe_servers.rb:314 ../../app/controllers/ems_common.rb:525 ../../app/controllers/application_controller/ci_processing.rb:841
+#: ../../app/controllers/ops_controller/settings/common.rb:459 ../../app/controllers/ops_controller/ops_rbac.rb:994 ../../app/controllers/pxe_controller/pxe_servers.rb:314 ../../app/controllers/ems_common.rb:525 ../../app/controllers/application_controller/ci_processing.rb:841
 msgid "Password/Verify Password do not match"
 msgstr ""
 
@@ -16405,6 +19443,11 @@ msgstr ""
 msgid "Pause this Instance?"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+#: ../dictionary_strings.rb:1055
+msgid "Pct Free Disk"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:173 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:183
 msgid "Per Minute"
 msgstr ""
@@ -16427,6 +19470,11 @@ msgstr ""
 
 #: ../../app/views/ops/_db_info.html.haml:91 ../../app/views/ops/_db_info.html.haml:184 ../../app/views/ops/_db_info.html.haml:221
 msgid "Percent Bloat"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+#: ../dictionary_strings.rb:993
+msgid "Percent Used Provisioned Space"
 msgstr ""
 
 #: ../../app/views/vm_common/_disks.html.haml:19
@@ -16509,12 +19557,72 @@ msgstr ""
 msgid "Perform SmartState Analysis on this item?"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+#: ../dictionary_strings.rb:1339
+msgid "Performance - Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+#: ../dictionary_strings.rb:1341
+msgid "Performance - Clusters"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+#: ../dictionary_strings.rb:1711
+msgid "Performance - Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+#: ../dictionary_strings.rb:1713
+msgid "Performance - Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+#: ../dictionary_strings.rb:1385
+msgid "Performance - Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+#: ../dictionary_strings.rb:1387
+msgid "Performance - Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+#: ../dictionary_strings.rb:1355
+msgid "Performance - Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+#: ../dictionary_strings.rb:1357
+msgid "Performance - Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+#: ../dictionary_strings.rb:1739
+msgid "Performance - VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+#: ../dictionary_strings.rb:1741
+msgid "Performance - VMs"
+msgstr ""
+
 #: ../../app/views/report/_form_columns_performance.html.haml:36
 msgid "Performance Interval"
 msgstr ""
 
 #: ../../app/views/report/_form_filter_performance.html.haml:6
 msgid "Performance Timeframe"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+#: ../dictionary_strings.rb:1723
+msgid "Performance Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+#: ../dictionary_strings.rb:1725
+msgid "Performance Trends"
 msgstr ""
 
 #: ../../app/helpers/container_group_helper/textual_summary.rb:42
@@ -16573,15 +19681,26 @@ msgstr ""
 msgid "Please select an Instance Type from above"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:43
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+#. TRANSLATORS: en.yml key: dictionary.table.container_group
+#: ../dictionary_strings.rb:1303 ../dictionary_strings.rb:1779
+msgid "Pod"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_groups
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:43 ../dictionary_strings.rb:1305 ../dictionary_strings.rb:1781 ../dictionary_strings.rb:1783
 msgid "Pods"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1104 ../../app/views/miq_policy/_profile_details.html.haml:134 ../../app/views/miq_policy/_export.html.haml:105
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1131 ../../app/views/miq_policy/_profile_details.html.haml:134 ../../app/views/miq_policy/_export.html.haml:105 ../dictionary_strings.rb:1543
 msgid "Policies"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:46 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:70 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:44 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:37 ../../app/helpers/application_helper/toolbar/host_center.rb:42 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:23 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:68 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:46 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:52 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:29 ../../app/helpers/application_helper/toolbar/services_center.rb:44 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:45 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:37 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:37 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:65 ../../app/helpers/application_helper/toolbar/users_center.rb:46 ../../app/helpers/application_helper/toolbar/container_service_center.rb:46 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:23 ../../app/helpers/application_helper/toolbar/container_center.rb:29 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:38 ../../app/helpers/application_helper/toolbar/container_route_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/security_group_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:49 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:57 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:29 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:61 ../../app/helpers/application_helper/toolbar/repository_center.rb:36 ../../app/helpers/application_helper/toolbar/container_project_center.rb:53 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:40 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:70 ../../app/helpers/application_helper/toolbar/vms_center.rb:62 ../../app/helpers/application_helper/toolbar/container_node_center.rb:53 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:37 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:28 ../../app/helpers/application_helper/toolbar/storage_center.rb:30 ../../app/helpers/application_helper/toolbar/flavors_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:22 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:56 ../../app/helpers/application_helper/toolbar/service_center.rb:41 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:37 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:41 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:25 ../../app/helpers/application_helper/toolbar/container_group_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:6 ../../app/helpers/application_helper/toolbar/flavor_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:37 ../../app/helpers/application_helper/toolbar/hosts_center.rb:73 ../../app/helpers/application_helper/toolbar/storages_center.rb:36 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:27 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:87 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:71 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:56 ../../app/helpers/application_helper/toolbar/repositories_center.rb:49 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:21 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:37 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:43 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:47 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:53 ../../app/helpers/application_helper/toolbar/tenants_center.rb:41 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:33 ../../app/helpers/application_helper/toolbar/containers_center.rb:37 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:32 ../../app/helpers/application_helper/toolbar/container_images_center.rb:25 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:41 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:6 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:47
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
+#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:46 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:70 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:44 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:37 ../../app/helpers/application_helper/toolbar/host_center.rb:42 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:23 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:68 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:46 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:52 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:37 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:29 ../../app/helpers/application_helper/toolbar/services_center.rb:44 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:45 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:37 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:37 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:65 ../../app/helpers/application_helper/toolbar/users_center.rb:46 ../../app/helpers/application_helper/toolbar/container_service_center.rb:46 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:23 ../../app/helpers/application_helper/toolbar/container_center.rb:29 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:38 ../../app/helpers/application_helper/toolbar/container_route_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/security_group_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:49 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:57 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:29 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:61 ../../app/helpers/application_helper/toolbar/repository_center.rb:36 ../../app/helpers/application_helper/toolbar/container_project_center.rb:53 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:40 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:70 ../../app/helpers/application_helper/toolbar/vms_center.rb:62 ../../app/helpers/application_helper/toolbar/container_node_center.rb:53 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:37 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:28 ../../app/helpers/application_helper/toolbar/storage_center.rb:30 ../../app/helpers/application_helper/toolbar/flavors_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:22 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:56 ../../app/helpers/application_helper/toolbar/service_center.rb:41 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:37 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:41 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:25 ../../app/helpers/application_helper/toolbar/container_group_center.rb:53 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:39 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:6 ../../app/helpers/application_helper/toolbar/flavor_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:37 ../../app/helpers/application_helper/toolbar/hosts_center.rb:73 ../../app/helpers/application_helper/toolbar/storages_center.rb:36 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:27 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:87 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:71 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:56 ../../app/helpers/application_helper/toolbar/repositories_center.rb:49 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:21 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:37 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:43 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:29 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:47 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:53 ../../app/helpers/application_helper/toolbar/tenants_center.rb:41 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:33 ../../app/helpers/application_helper/toolbar/containers_center.rb:37 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:32 ../../app/helpers/application_helper/toolbar/container_images_center.rb:25 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:41 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:6 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:47 ../dictionary_strings.rb:1541
 msgid "Policy"
 msgstr ""
 
@@ -16589,7 +19708,13 @@ msgstr ""
 msgid "Policy Conditions:"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1103 ../../app/views/miq_policy/_export.html.haml:105
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+#: ../dictionary_strings.rb:1545
+msgid "Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
+#: ../../app/controllers/miq_policy_controller.rb:1130 ../../app/views/miq_policy/_export.html.haml:105 ../dictionary_strings.rb:1547
 msgid "Policy Profiles"
 msgstr ""
 
@@ -16765,7 +19890,7 @@ msgstr ""
 msgid "Press Ctrl+Alt to release cursor."
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:211
+#: ../../app/controllers/miq_policy_controller.rb:212
 msgid "Press commit to Import"
 msgstr ""
 
@@ -16841,6 +19966,16 @@ msgstr ""
 msgid "Product Features (%s)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+#: ../dictionary_strings.rb:1651
+msgid "Product Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+#: ../dictionary_strings.rb:1653
+msgid "Product Updates"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_profile_details.html.haml:74
 msgid "Profile Alerts:"
 msgstr ""
@@ -16849,7 +19984,9 @@ msgstr ""
 msgid "Profile Policies:"
 msgstr ""
 
-#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:122
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+#. TRANSLATORS: en.yml key: dictionary.table.container_project
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:122 ../dictionary_strings.rb:1319 ../dictionary_strings.rb:1821
 msgid "Project"
 msgstr ""
 
@@ -16857,7 +19994,10 @@ msgstr ""
 msgid "Project/Tenant"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_tenant_details.html.haml:117 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:35
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_projects
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:117 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:35 ../dictionary_strings.rb:1321 ../dictionary_strings.rb:1823 ../dictionary_strings.rb:1825
 msgid "Projects"
 msgstr ""
 
@@ -16885,7 +20025,9 @@ msgstr ""
 msgid "Protocol"
 msgstr ""
 
-#: ../../app/helpers/provider_configuration_manager_helper.rb:31 ../../app/helpers/provider_foreman_helper.rb:42 ../../app/views/catalog/_form_basic_info.html.haml:127 ../../app/views/catalog/_sandt_tree_show.html.haml:97 ../model_attributes.rb:1901
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
+#: ../../app/helpers/provider_configuration_manager_helper.rb:31 ../../app/helpers/provider_foreman_helper.rb:42 ../../app/views/catalog/_form_basic_info.html.haml:127 ../../app/views/catalog/_sandt_tree_show.html.haml:97 ../dictionary_strings.rb:1351 ../dictionary_strings.rb:1409 ../model_attributes.rb:1901
 msgid "Provider"
 msgstr ""
 
@@ -16897,7 +20039,9 @@ msgstr ""
 msgid "Provider: "
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:26 ../../app/presenters/menu/default_menu.rb:43 ../../app/presenters/menu/default_menu.rb:79 ../../app/presenters/menu/default_menu.rb:114 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:4
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
+#: ../../app/presenters/menu/default_menu.rb:26 ../../app/presenters/menu/default_menu.rb:43 ../../app/presenters/menu/default_menu.rb:79 ../../app/presenters/menu/default_menu.rb:114 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:4 ../dictionary_strings.rb:1353 ../dictionary_strings.rb:1411
 msgid "Providers"
 msgstr ""
 
@@ -16917,7 +20061,9 @@ msgstr ""
 msgid "Provider|Verify ssl"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vms_center.rb:114
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision
+#: ../../app/helpers/application_helper/toolbar/vms_center.rb:114 ../dictionary_strings.rb:1549 ../dictionary_strings.rb:1987
 msgid "Provision"
 msgstr ""
 
@@ -16965,6 +20111,16 @@ msgstr ""
 msgid "Provision this item"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+#: ../dictionary_strings.rb:1991
+msgid "Provisioned From Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+#: ../dictionary_strings.rb:1993
+msgid "Provisioned From Templates"
+msgstr ""
+
 #: ../../app/views/miq_request/_request.html.haml:239
 msgid "Provisioned Hosts"
 msgstr ""
@@ -16973,7 +20129,13 @@ msgstr ""
 msgid "Provisioned Size"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:224
+#. TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+#: ../dictionary_strings.rb:1057
+msgid "Provisioned Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
+#: ../../app/views/miq_request/_request.html.haml:224 ../dictionary_strings.rb:1995
 msgid "Provisioned VMs"
 msgstr ""
 
@@ -16991,6 +20153,13 @@ msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:375 ../../app/controllers/catalog_controller.rb:869
 msgid "Provisioning Entry Point is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+#: ../dictionary_strings.rb:1551 ../dictionary_strings.rb:1989 ../dictionary_strings.rb:1997
+msgid "Provisions"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:161
@@ -17109,6 +20278,11 @@ msgstr ""
 msgid "Queue"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.queue_depth
+#: ../dictionary_strings.rb:1229
+msgid "Queue Depth"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_report_center.rb:6
 msgid "Queue this Report to be generated"
 msgstr ""
@@ -17129,8 +20303,18 @@ msgstr ""
 msgid "Quotas"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:207
+#: ../../app/controllers/ops_controller/ops_rbac.rb:208
 msgid "Quotas for %{model} \"%{name}\" were saved"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_mb
+#: ../dictionary_strings.rb:549
+msgid "RAM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ram_size
+#: ../dictionary_strings.rb:719
+msgid "RAM Size (MB)"
 msgstr ""
 
 #: ../../app/views/layouts/_multi_auth_credentials.html.haml:29 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:24
@@ -17197,11 +20381,31 @@ msgstr ""
 msgid "Re-apply the previous change"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.pct_read
+#: ../dictionary_strings.rb:1225
+msgid "Read %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+#: ../dictionary_strings.rb:1233
+msgid "Read (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+#: ../dictionary_strings.rb:1217
+msgid "Read (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+#: ../dictionary_strings.rb:1231
+msgid "Read Hit (IOPS)"
+msgstr ""
+
 #: ../../app/views/ops/_rbac_role_details.html.haml:102 ../../app/views/catalog/_ot_tree_show.html.haml:50
 msgid "Read Only"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:666
+#: ../../app/controllers/ops_controller/ops_rbac.rb:671
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr ""
 
@@ -17449,7 +20653,7 @@ msgstr ""
 msgid "Refresh initiated for %{count_model} from the CFME Database"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/ems_container_center.rb:18
+#: ../../app/helpers/application_helper/toolbar/ems_container_center.rb:18 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:13
 msgid "Refresh items and relationships"
 msgstr ""
 
@@ -17459,6 +20663,14 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_container_center.rb:19
 msgid "Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_container\")}?"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:12
+msgid "Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:14
+msgid "Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middleware\")}?"
 msgstr ""
 
 #: ../../app/controllers/application_controller/performance.rb:175
@@ -17581,7 +20793,9 @@ msgstr ""
 msgid "Refresh relationships for all items related to this Provider?"
 msgstr ""
 
-#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:75 ../../app/views/shared/views/ems_common/angular/_form.html.haml:103
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region
+#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:75 ../../app/views/shared/views/ems_common/angular/_form.html.haml:103 ../dictionary_strings.rb:1557 ../dictionary_strings.rb:2001
 msgid "Region"
 msgstr ""
 
@@ -17593,8 +20807,19 @@ msgstr ""
 msgid "Region based nodes shown as %{dimmed} text."
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings.rb:159
+msgid "Region description is required"
+msgstr ""
+
 #: ../../app/views/dashboard/login.html.haml:129
 msgid "Region:"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_regions
+#: ../dictionary_strings.rb:1559 ../dictionary_strings.rb:2003 ../dictionary_strings.rb:2005
+msgid "Regions"
 msgstr ""
 
 #: ../../app/views/ops/rhn/_server_table.html.haml:51
@@ -17609,16 +20834,22 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:27
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:27 ../dictionary_strings.rb:2075
 msgid "Registries"
 msgstr ""
 
-#: ../../app/views/ops/_ap_form.html.haml:88
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items
+#: ../../app/views/ops/_ap_form.html.haml:88 ../dictionary_strings.rb:2073
 msgid "Registry"
 msgstr ""
 
 #: ../../app/views/ops/_ap_form_registry.html.haml:3
 msgid "Registry Entry"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:616
+msgid "Registry Entry is required"
 msgstr ""
 
 #: ../../app/views/ops/_ap_form_registry.html.haml:13
@@ -17803,6 +21034,14 @@ msgstr ""
 msgid "Remove #{ui_lookup(:tables=>\"ems_infras\")} from the VMDB"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:27
+msgid "Remove #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:26
+msgid "Remove #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:13
 msgid "Remove #{ui_lookup(:tables=>\"orchestration_stack\")} from the VMDB"
 msgstr ""
@@ -17967,6 +21206,14 @@ msgstr ""
 msgid "Remove selected #{ui_lookup(:tables=>\"ems_infras\")} from the VMDB"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:26
+msgid "Remove selected #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:25
+msgid "Remove selected #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:12
 msgid "Remove selected #{ui_lookup(:tables=>\"orchestration_stack\")} from the VMDB"
 msgstr ""
@@ -18117,6 +21364,14 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:36
 msgid "Remove this #{ui_lookup(:table=>\"ems_infra\")} from the VMDB"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:25
+msgid "Remove this #{ui_lookup(:table=>\"ems_middleware\")} from the VMDB"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:18
+msgid "Remove this #{ui_lookup(:table=>\"middleware_server\")} from the VMDB"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:12
@@ -18307,7 +21562,25 @@ msgstr ""
 msgid "Replication Worker"
 msgstr ""
 
-#: ../../app/views/miq_capacity/_planning_tabs.html.haml:7 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:7 ../../app/views/miq_capacity/_utilization_tabs.html.haml:10
+#: ../../app/controllers/ops_controller/settings.rb:136
+msgid "Replication Worker Credentials validated successfully"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator
+#: ../dictionary_strings.rb:1327 ../dictionary_strings.rb:1785
+msgid "Replicator"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicators
+#: ../dictionary_strings.rb:1329 ../dictionary_strings.rb:1787 ../dictionary_strings.rb:1789
+msgid "Replicators"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport
+#: ../../app/views/miq_capacity/_planning_tabs.html.haml:7 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:7 ../../app/views/miq_capacity/_utilization_tabs.html.haml:10 ../dictionary_strings.rb:1561
 msgid "Report"
 msgstr ""
 
@@ -18387,7 +21660,8 @@ msgstr ""
 msgid "Reporting Workers"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:7 ../../app/controllers/report_controller.rb:286 ../../app/views/configuration/_ui_1.html.haml:113 ../../app/views/report/_role_list.html.haml:16
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
+#: ../../app/presenters/menu/default_menu.rb:7 ../../app/controllers/report_controller.rb:286 ../../app/views/configuration/_ui_1.html.haml:113 ../../app/views/report/_role_list.html.haml:16 ../dictionary_strings.rb:1563
 msgid "Reports"
 msgstr ""
 
@@ -18427,16 +21701,14 @@ msgstr ""
 msgid "Repository|Updated on"
 msgstr ""
 
-#: ../../app/views/layouts/_ae_resolve_options.html.haml:63 ../../app/views/shared/buttons/_ab_show.html.haml:111 ../../app/views/miq_policy/_action_details.html.haml:145
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request
+#: ../../app/views/layouts/_ae_resolve_options.html.haml:63 ../../app/views/shared/buttons/_ab_show.html.haml:111 ../../app/views/miq_policy/_action_details.html.haml:145 ../dictionary_strings.rb:1565 ../dictionary_strings.rb:2007
 msgid "Request"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:202
+#: ../../app/controllers/miq_request_controller.rb:206
 msgid "Request \"%{name}\" was %{task}"
-msgstr ""
-
-#: ../../app/controllers/miq_request_controller.rb:187
-msgid "Request %s was cancelled by the user"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_options.html.haml:86
@@ -18465,6 +21737,14 @@ msgstr ""
 
 #: ../../app/views/miq_request/_request.html.haml:71
 msgid "Request Type"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:188
+msgid "Request approval was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:190
+msgid "Request denial was cancelled by the user"
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:749
@@ -18499,7 +21779,10 @@ msgstr ""
 msgid "Requester:"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:20 ../../app/presenters/menu/default_menu.rb:54 ../../app/presenters/menu/default_menu.rb:148
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_requests
+#: ../../app/presenters/menu/default_menu.rb:20 ../../app/presenters/menu/default_menu.rb:54 ../../app/presenters/menu/default_menu.rb:148 ../dictionary_strings.rb:1567 ../dictionary_strings.rb:2009 ../dictionary_strings.rb:2011
 msgid "Requests"
 msgstr ""
 
@@ -18599,6 +21882,10 @@ msgstr ""
 msgid "Reset to Default"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:280
+msgid "Reset/synchronization process successfully initiated"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:48
 msgid "Resides on VM"
 msgstr ""
@@ -18613,11 +21900,14 @@ msgid_plural "Resources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:43 ../../app/views/shared/views/_prov_dialog.html.haml:114
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
+#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:43 ../../app/views/shared/views/_prov_dialog.html.haml:114 ../dictionary_strings.rb:1671
 msgid "Resource Pool"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:49 ../../app/views/layouts/listnav/_host.html.haml:122 ../../app/views/layouts/listnav/_ems_cluster.html.haml:79 ../../app/views/configuration/_ui_2.html.haml:321
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.resource_pools
+#: ../../app/presenters/menu/default_menu.rb:49 ../../app/views/layouts/listnav/_host.html.haml:122 ../../app/views/layouts/listnav/_ems_cluster.html.haml:79 ../../app/views/configuration/_ui_2.html.haml:321 ../dictionary_strings.rb:1673 ../dictionary_strings.rb:2077
 msgid "Resource Pools"
 msgstr ""
 
@@ -18739,6 +22029,11 @@ msgstr ""
 
 #: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:70 ../../app/views/catalog/_form_resources_info.html.haml:8 ../../app/views/catalog/_form.html.haml:12 ../../app/views/catalog/_sandt_tree_show.html.haml:221
 msgid "Resources"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+#: ../dictionary_strings.rb:1235
+msgid "Response Time (Seconds)"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/host_center.rb:148 ../../app/helpers/application_helper/toolbar/hosts_center.rb:166
@@ -18937,7 +22232,8 @@ msgstr ""
 msgid "Right-Sizing (Moderate - derived from High NORM)"
 msgstr ""
 
-#: ../../app/views/ops/_selected_by_servers.html.haml:168 ../../app/views/ops/_selected_by_roles.html.haml:7 ../../app/views/ops/_rbac_user_details.html.haml:200 ../../app/views/ops/_rbac_group_details.html.haml:54
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
+#: ../../app/views/ops/_selected_by_servers.html.haml:168 ../../app/views/ops/_selected_by_roles.html.haml:7 ../../app/views/ops/_rbac_user_details.html.haml:200 ../../app/views/ops/_rbac_group_details.html.haml:54 ../dictionary_strings.rb:1589
 msgid "Role"
 msgstr ""
 
@@ -18947,6 +22243,15 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:256 ../../app/views/ops/_settings_authentication_tab.html.haml:403 ../../app/views/ops/_settings_authentication_tab.html.haml:465 ../../app/views/ops/_ldap_domain_form.html.haml:99 ../../app/views/ops/_ldap_domain_show.html.haml:136 ../../app/views/_ldap_domain_form.html.haml:99
 msgid "Role Settings"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:322
+msgid "Role no longer exists"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+#: ../dictionary_strings.rb:1591
+msgid "Roles"
 msgstr ""
 
 #: ../../app/views/ops/_rbac_details_tab.html.haml:89
@@ -18965,7 +22270,16 @@ msgstr ""
 msgid "Roll Up Performance"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:67
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+#. TRANSLATORS: en.yml key: dictionary.table.container_route
+#: ../dictionary_strings.rb:1323 ../dictionary_strings.rb:1815
+msgid "Route"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_routes
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:67 ../dictionary_strings.rb:1325 ../dictionary_strings.rb:1817 ../dictionary_strings.rb:1819
 msgid "Routes"
 msgstr ""
 
@@ -19013,7 +22327,7 @@ msgstr ""
 msgid "Ruby Script"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/conditions.rb:22 ../../app/controllers/miq_policy_controller/conditions.rb:250
+#: ../../app/controllers/miq_policy_controller/conditions.rb:23 ../../app/controllers/miq_policy_controller/conditions.rb:252
 msgid "Ruby scripts are no longer supported in expressions, please change or remove them."
 msgstr ""
 
@@ -19059,8 +22373,28 @@ msgstr[1] ""
 msgid "Running system services of %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+#: ../dictionary_strings.rb:2015
+msgid "SCSI LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+#: ../dictionary_strings.rb:1581
+msgid "SMI-S Agent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+#: ../dictionary_strings.rb:1583
+msgid "SMI-S Agents"
+msgstr ""
+
 #: ../../app/views/ops/_email_verify_button.html.haml:19
 msgid "SMTP E-mail Server settings and Test E-mail Address are needed to send test email"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+#: ../dictionary_strings.rb:653
+msgid "SNMP"
 msgstr ""
 
 #: ../../app/views/miq_policy/_alert_snmp.html.haml:9 ../../app/views/miq_policy/_action_details.html.haml:333
@@ -19075,12 +22409,27 @@ msgstr ""
 msgid "SPICE Console"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+#: ../dictionary_strings.rb:947
+msgid "SSH Root Access"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:454
 msgid "SSL Verify Mode"
 msgstr ""
 
 #: ../../app/views/dashboard/login.html.haml:111 ../../app/views/dashboard/login.html.haml:111
 msgid "SSO Login"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+#: ../dictionary_strings.rb:1369
+msgid "Samba"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+#: ../dictionary_strings.rb:1371
+msgid "Sambas"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_details.html.haml:15 ../../app/views/report/_form_styling.html.haml:126
@@ -19168,6 +22517,16 @@ msgid "Scan History"
 msgid_plural "Scan History"
 msgstr[0] ""
 msgstr[1] ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem
+#: ../dictionary_strings.rb:1675
+msgid "Scan Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+#: ../dictionary_strings.rb:1677
+msgid "Scan Items"
+msgstr ""
 
 #: ../model_attributes.rb:1984
 msgid "Scan history"
@@ -19297,11 +22656,18 @@ msgstr ""
 msgid "ScanItem|Updated on"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+#: ../dictionary_strings.rb:1569
+msgid "Schedule"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:78 ../../app/views/miq_request/_prov_host_dialog.html.haml:121 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:63 ../../app/views/report/_show_schedule.html.haml:3 ../../app/views/shared/views/_prov_dialog.html.haml:408
 msgid "Schedule Info"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:291 ../../app/views/ops/_settings_evm_servers_tab.html.haml:148 ../../app/views/ops/_settings_details_tab.html.haml:95 ../../app/views/report/_report_info.html.haml:109
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
+#: ../../app/controllers/report_controller.rb:291 ../../app/views/ops/_settings_evm_servers_tab.html.haml:148 ../../app/views/ops/_settings_details_tab.html.haml:95 ../../app/views/report/_report_info.html.haml:109 ../dictionary_strings.rb:1571 ../dictionary_strings.rb:2013
 msgid "Schedules"
 msgstr ""
 
@@ -19337,6 +22703,11 @@ msgstr ""
 msgid "Script"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+#: ../dictionary_strings.rb:1573
+msgid "Search"
+msgstr ""
+
 #: ../../app/views/layouts/_adv_search_body.html.haml:101
 msgid "Search Expression"
 msgstr ""
@@ -19351,6 +22722,11 @@ msgstr ""
 
 #: ../../app/views/layouts/_x_adv_searchbox.html.haml:24
 msgid "Search by Name within results"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+#: ../dictionary_strings.rb:1575
+msgid "Searches"
 msgstr ""
 
 #: ../../app/assets/javascripts/miq_formatters.js:251
@@ -19541,6 +22917,14 @@ msgstr ""
 msgid "Select a single #{ui_lookup(:table=>\"ems_infra\")} to edit"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:18
+msgid "Select a single #{ui_lookup(:table=>\"ems_middleware\")} to edit"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:18
+msgid "Select a single #{ui_lookup(:table=>\"middleware_server\")} to edit"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:20
 msgid "Select a single #{ui_lookup(:table=>\"persistent_volume\")} to edit"
 msgstr ""
@@ -19681,7 +23065,7 @@ msgstr ""
 msgid "Select one or more items to delete"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:471 ../../app/controllers/report_controller/menus.rb:509 ../../app/controllers/report_controller/menus.rb:553 ../../app/controllers/report_controller/reports/editor.rb:1016 ../../app/controllers/ops_controller/ops_rbac.rb:487 ../../app/controllers/miq_policy_controller.rb:851
+#: ../../app/controllers/report_controller/dashboards.rb:471 ../../app/controllers/report_controller/menus.rb:509 ../../app/controllers/report_controller/menus.rb:553 ../../app/controllers/report_controller/reports/editor.rb:1016
 msgid "Select only one or consecutive %s to move down"
 msgstr ""
 
@@ -19693,8 +23077,16 @@ msgstr ""
 msgid "Select only one or consecutive %s to move to the top"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:447 ../../app/controllers/report_controller/menus.rb:488 ../../app/controllers/report_controller/menus.rb:532 ../../app/controllers/report_controller/reports/editor.rb:994 ../../app/controllers/ops_controller/ops_rbac.rb:465 ../../app/controllers/miq_policy_controller.rb:835
+#: ../../app/controllers/report_controller/dashboards.rb:447 ../../app/controllers/report_controller/menus.rb:488 ../../app/controllers/report_controller/menus.rb:532 ../../app/controllers/report_controller/reports/editor.rb:994
 msgid "Select only one or consecutive %s to move up"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:870
+msgid "Select only one or consecutive %{member} to move down"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:853
+msgid "Select only one or consecutive %{member} to move up"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:2355
@@ -19705,7 +23097,7 @@ msgstr ""
 msgid "Select only one or consecutive %{name} to move up"
 msgstr ""
 
-#: ../../app/controllers/application_controller/buttons.rb:1056
+#: ../../app/controllers/ops_controller/ops_rbac.rb:488 ../../app/controllers/application_controller/buttons.rb:1056
 msgid "Select only one or consecutive fields to move down"
 msgstr ""
 
@@ -19717,7 +23109,7 @@ msgstr ""
 msgid "Select only one or consecutive fields to move to the top"
 msgstr ""
 
-#: ../../app/controllers/application_controller/buttons.rb:1035
+#: ../../app/controllers/ops_controller/ops_rbac.rb:466 ../../app/controllers/application_controller/buttons.rb:1035
 msgid "Select only one or consecutive fields to move up"
 msgstr ""
 
@@ -19749,7 +23141,7 @@ msgstr ""
 msgid "Selected Day"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:59
+#: ../../app/views/report/_column_lists.html.haml:72
 msgid "Selected Fields:"
 msgstr ""
 
@@ -19829,7 +23221,9 @@ msgstr ""
 msgid "Send&#160;Ctrl-Alt-Delete"
 msgstr ""
 
-#: ../../app/views/ops/_all_tabs.html.haml:24
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server
+#: ../../app/views/ops/_all_tabs.html.haml:24 ../dictionary_strings.rb:1577 ../dictionary_strings.rb:2017
 msgid "Server"
 msgstr ""
 
@@ -19897,7 +23291,10 @@ msgstr ""
 msgid "ServerRole|Updated on"
 msgstr ""
 
-#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:100 ../../app/views/ops/_settings_evm_servers_tab.html.haml:163 ../../app/views/ops/_zone_form.html.haml:87 ../../app/views/ops/_settings_server_tab.html.haml:335 ../../app/views/ops/_all_tabs.html.haml:134 ../../app/views/ops/_all_tabs.html.haml:228 ../../app/views/vm_common/_evm_relationship.html.haml:8
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_servers
+#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:100 ../../app/views/ops/_settings_evm_servers_tab.html.haml:163 ../../app/views/ops/_zone_form.html.haml:87 ../../app/views/ops/_settings_server_tab.html.haml:335 ../../app/views/ops/_all_tabs.html.haml:134 ../../app/views/ops/_all_tabs.html.haml:228 ../../app/views/vm_common/_evm_relationship.html.haml:8 ../dictionary_strings.rb:1579 ../dictionary_strings.rb:2019 ../dictionary_strings.rb:2021
 msgid "Servers"
 msgstr ""
 
@@ -19905,7 +23302,10 @@ msgstr ""
 msgid "Servers by Roles"
 msgstr ""
 
-#: ../../app/views/ops/rhn/_info_subscribed.html.haml:13 ../../app/views/vm_common/_add_to_service.html.haml:29 ../model_attributes.rb:2029
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService
+#. TRANSLATORS: en.yml key: dictionary.model.Service
+#. TRANSLATORS: en.yml key: dictionary.table.container_service
+#: ../../app/views/ops/rhn/_info_subscribed.html.haml:13 ../../app/views/vm_common/_add_to_service.html.haml:29 ../dictionary_strings.rb:1331 ../dictionary_strings.rb:1683 ../dictionary_strings.rb:1809 ../model_attributes.rb:2029
 msgid "Service"
 msgstr ""
 
@@ -19915,6 +23315,16 @@ msgstr ""
 
 #: ../../app/views/layouts/angular/_auth_service_account_angular.html.haml:13
 msgid "Service Account JSON"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+#: ../dictionary_strings.rb:1687
+msgid "Service Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+#: ../dictionary_strings.rb:1689
+msgid "Service Catalog Items"
 msgstr ""
 
 #: ../../app/views/configuration/_ui_2.html.haml:49
@@ -19935,6 +23345,16 @@ msgstr ""
 
 #: ../../app/views/vm_common/_add_to_service.html.haml:22
 msgid "Service Selection"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+#: ../dictionary_strings.rb:1237
+msgid "Service Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.svc_type
+#: ../dictionary_strings.rb:951
+msgid "Service Type"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_customization_controller.rb:100
@@ -20045,7 +23465,12 @@ msgstr ""
 msgid "ServiceTemplate|Service type"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:16 ../../app/controllers/host_controller.rb:175 ../../app/views/layouts/listnav/_host.html.haml:226 ../../app/views/configuration/_ui_2.html.haml:46 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:51
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_services
+#. TRANSLATORS: en.yml key: dictionary.table.host_services
+#: ../../app/presenters/menu/default_menu.rb:16 ../../app/controllers/host_controller.rb:175 ../../app/views/layouts/listnav/_host.html.haml:226 ../../app/views/configuration/_ui_2.html.haml:46 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:51 ../dictionary_strings.rb:1333 ../dictionary_strings.rb:1685 ../dictionary_strings.rb:1811 ../dictionary_strings.rb:1813 ../dictionary_strings.rb:1931
 msgid "Services"
 msgstr ""
 
@@ -20217,7 +23642,7 @@ msgstr ""
 msgid "Set/Remove retirement date for %s"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:721 ../../app/controllers/ops_controller/diagnostics.rb:739
+#: ../../app/controllers/ops_controller/diagnostics.rb:724 ../../app/controllers/ops_controller/diagnostics.rb:742
 msgid "Setting priority is not allowed for the selected item"
 msgstr ""
 
@@ -20227,6 +23652,18 @@ msgstr ""
 
 #: ../../app/views/ops/_zone_form.html.haml:185 ../../app/views/ops/_all_tabs.html.haml:292
 msgid "Settings"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:1118 ../../app/controllers/ops_controller/settings/common.rb:1121 ../../app/controllers/ops_controller/settings/common.rb:1124 ../../app/controllers/ops_controller/settings/common.rb:1127
+msgid "Settings %{model}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:865 ../../app/controllers/ops_controller/settings/common.rb:871 ../../app/controllers/ops_controller/settings/common.rb:1072 ../../app/controllers/ops_controller/settings/common.rb:1138 ../../app/controllers/ops_controller/settings/common.rb:1145 ../../app/controllers/ops_controller/settings/common.rb:1150 ../../app/controllers/ops_controller/settings/common.rb:1156 ../../app/controllers/ops_controller/settings/common.rb:1166 ../../app/controllers/ops_controller/settings.rb:149
+msgid "Settings %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:863 ../../app/controllers/ops_controller/settings/common.rb:869 ../../app/controllers/ops_controller/settings/common.rb:1164
+msgid "Settings %{model} \"%{name}\" (current)"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:161 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:198
@@ -20447,6 +23884,10 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:73
 msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_infra\")}"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:42
+msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_middleware\")}"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/container_center.rb:51
@@ -20893,12 +24334,52 @@ msgstr ""
 msgid "Single Value"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:59 ../../app/views/ops/_db_info.html.haml:152 ../../app/views/ops/_db_info.html.haml:217 ../../app/views/vm_common/_snapshots_desc.html.haml:31
+#. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
+#: ../../app/views/ops/_db_info.html.haml:59 ../../app/views/ops/_db_info.html.haml:152 ../../app/views/ops/_db_info.html.haml:217 ../../app/views/vm_common/_snapshots_desc.html.haml:31 ../dictionary_strings.rb:1063
 msgid "Size"
 msgstr ""
 
 #: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:41
 msgid "Size (GB)"
+msgstr ""
+
+#: ../../app/controllers/ontap_storage_system_controller.rb:127
+msgid "Size is required"
+msgstr ""
+
+#: ../../app/controllers/ontap_storage_system_controller.rb:129
+msgid "Size must be an integer"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+#: ../dictionary_strings.rb:1069
+msgid "Size of Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+#: ../dictionary_strings.rb:1085
+msgid "Size of Other VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+#: ../dictionary_strings.rb:1075 ../dictionary_strings.rb:1087
+msgid "Size of VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+#: ../dictionary_strings.rb:1071
+msgid "Size of VM Provisioned Disk Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+#: ../dictionary_strings.rb:1079
+msgid "Size of VM Snapshot Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.slope
+#: ../dictionary_strings.rb:939
+msgid "Slope"
 msgstr ""
 
 #: ../../app/helpers/configuration_helper/configuration_view_helper.rb:63 ../../app/helpers/configuration_helper/configuration_view_helper.rb:68
@@ -20909,8 +24390,23 @@ msgstr ""
 msgid "Smart Management"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+#: ../dictionary_strings.rb:1555
+msgid "SmartProxies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+#: ../dictionary_strings.rb:1553
+msgid "SmartProxy"
+msgstr ""
+
 #: ../../app/views/ops/_all_tabs.html.haml:11
 msgid "SmartProxy Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+#: ../dictionary_strings.rb:1999
+msgid "SmartProxy Builds"
 msgstr ""
 
 #: ../../app/views/ops/_settings_evm_servers_tab.html.haml:45 ../../app/views/ops/_zone_form.html.haml:57
@@ -20925,6 +24421,15 @@ msgstr[1] ""
 
 #: ../../app/views/miq_policy/_action_options.html.haml:182 ../../app/views/miq_policy/_action_details.html.haml:89
 msgid "Snapshot Age Settings"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/miq_actions.rb:405
+msgid "Snapshot Age must be selected"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+#: ../dictionary_strings.rb:1065
+msgid "Snapshot Files Percent of Used"
 msgstr ""
 
 #: ../../app/views/vm_common/_snap.html.haml:9
@@ -21055,6 +24560,21 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.src_host_name
+#: ../dictionary_strings.rb:941
+msgid "Source Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+#: ../dictionary_strings.rb:943
+msgid "Source VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+#: ../dictionary_strings.rb:945
+msgid "Source VM Name"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:367
 msgid "Specified NTP settings applied here will override Zone NTP settings."
 msgstr ""
@@ -21075,11 +24595,23 @@ msgstr ""
 msgid "Specify Column Styles"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:33 ../../app/views/configuration/_ui_2.html.haml:201
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+#: ../dictionary_strings.rb:2063
+msgid "Stack"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
+#: ../../app/presenters/menu/default_menu.rb:33 ../../app/views/configuration/_ui_2.html.haml:201 ../dictionary_strings.rb:2065
 msgid "Stacks"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:140 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:168 ../../app/views/ems_cloud/discover.html.haml:54 ../../app/views/layouts/_discover.html.haml:103 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../../app/views/catalog/_sandt_tree_show.html.haml:238
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+#: ../dictionary_strings.rb:1965
+msgid "Stamped Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:140 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:168 ../../app/views/ems_cloud/discover.html.haml:54 ../../app/views/layouts/_discover.html.haml:103 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../dictionary_strings.rb:949
 msgid "Start"
 msgstr ""
 
@@ -21097,6 +24629,14 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:434
 msgid "Start TLS Automatically"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:660
+msgid "Start is not allowed for the selected item"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:668
+msgid "Start successfully initiated"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:25 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:25
@@ -21155,6 +24695,76 @@ msgstr ""
 msgid "State"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+#: ../dictionary_strings.rb:557
+msgid "State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+#: ../dictionary_strings.rb:559
+msgid "State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+#: ../dictionary_strings.rb:565
+msgid "State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+#: ../dictionary_strings.rb:567
+msgid "State - Min Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+#: ../dictionary_strings.rb:753
+msgid "State - Number of Hosts  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+#: ../dictionary_strings.rb:289
+msgid "State - Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+#: ../dictionary_strings.rb:291
+msgid "State - Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+#: ../dictionary_strings.rb:757
+msgid "State - Peak Avg VMs - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+#: ../dictionary_strings.rb:353
+msgid "State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+#: ../dictionary_strings.rb:351
+msgid "State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+#: ../dictionary_strings.rb:475
+msgid "State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+#: ../dictionary_strings.rb:477
+msgid "State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+#: ../dictionary_strings.rb:489
+msgid "State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+#: ../dictionary_strings.rb:491
+msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
 #: ../../app/views/catalog/_form_basic_info.html.haml:151 ../../app/views/catalog/_form_basic_info.html.haml:193 ../../app/views/catalog/_form_basic_info.html.haml:237 ../../app/views/catalog/_sandt_tree_show.html.haml:119
 msgid "State Machine (NS/Cls/Inst)"
 msgstr ""
@@ -21211,11 +24821,125 @@ msgstr ""
 msgid "Storage"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+#: ../dictionary_strings.rb:1605
+msgid "Storage - Aggregate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+#: ../dictionary_strings.rb:1607 ../dictionary_strings.rb:2039
+msgid "Storage - Aggregates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+#: ../dictionary_strings.rb:1271
+msgid "Storage - Extent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+#: ../dictionary_strings.rb:1273
+msgid "Storage - Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+#: ../dictionary_strings.rb:1609
+msgid "Storage - File Share"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+#: ../dictionary_strings.rb:1611 ../dictionary_strings.rb:2043
+msgid "Storage - File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+#: ../dictionary_strings.rb:1625
+msgid "Storage - Filer"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+#: ../dictionary_strings.rb:1627 ../dictionary_strings.rb:2055
+msgid "Storage - Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+#: ../dictionary_strings.rb:1629
+msgid "Storage - LUN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+#: ../dictionary_strings.rb:1631 ../dictionary_strings.rb:2059
+msgid "Storage - LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+#: ../dictionary_strings.rb:1695
+msgid "Storage - Local File System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+#: ../dictionary_strings.rb:1697 ../dictionary_strings.rb:2089
+msgid "Storage - Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+#: ../dictionary_strings.rb:1617
+msgid "Storage - Plex"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+#: ../dictionary_strings.rb:1619 ../dictionary_strings.rb:2049
+msgid "Storage - Plexes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+#: ../dictionary_strings.rb:1621
+msgid "Storage - Raid Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+#: ../dictionary_strings.rb:1623 ../dictionary_strings.rb:2051
+msgid "Storage - Raid Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+#: ../dictionary_strings.rb:1613
+msgid "Storage - Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+#: ../dictionary_strings.rb:1615 ../dictionary_strings.rb:2047
+msgid "Storage - Volumes"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:55
 msgid "Storage Adapters"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:128 ../../app/views/ops/_settings_evm_servers_tab.html.haml:132 ../../app/views/configuration/_ui_2.html.haml:419
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+#: ../dictionary_strings.rb:1197
+msgid "Storage Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+#: ../dictionary_strings.rb:1195
+msgid "Storage Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager
+#: ../dictionary_strings.rb:1707
+msgid "Storage Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
+#: ../../app/presenters/menu/default_menu.rb:128 ../../app/views/ops/_settings_evm_servers_tab.html.haml:132 ../../app/views/configuration/_ui_2.html.haml:419 ../dictionary_strings.rb:1709
 msgid "Storage Managers"
 msgstr ""
 
@@ -21223,8 +24947,34 @@ msgstr ""
 msgid "Storage Medium Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+#: ../dictionary_strings.rb:1633 ../dictionary_strings.rb:2061
+msgid "Storage Performance - Volumes"
+msgstr ""
+
 #: ../../app/views/host/_main.html.haml:15 ../../app/views/ems_cluster/_main.html.haml:10 ../../app/views/layouts/listnav/_host.html.haml:154 ../../app/views/layouts/listnav/_ems_cluster.html.haml:94 ../../app/views/vm_common/_main.html.haml:14 ../../app/views/storage/_main.html.haml:17
 msgid "Storage Relationships"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_metric
+#: ../dictionary_strings.rb:1201
+msgid "Storage Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_cost
+#: ../dictionary_strings.rb:1199
+msgid "Storage Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+#: ../dictionary_strings.rb:1205
+msgid "Storage Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+#: ../dictionary_strings.rb:1203
+msgid "Storage Used Cost"
 msgstr ""
 
 #: ../model_attributes.rb:2100
@@ -21489,6 +25239,14 @@ msgstr ""
 msgid "Suspend Role"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:677
+msgid "Suspend is not allowed for the selected item"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:685
+msgid "Suspend successfully initiated"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:31 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:31
 msgid "Suspend the #{@record.server_role.description} Role on Server #{@record.miq_server.name} [#{@record.miq_server.id}]"
 msgstr ""
@@ -21575,6 +25333,16 @@ msgstr ""
 
 #: ../../app/views/report/_form_columns.html.haml:65
 msgid "System Default"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+#: ../dictionary_strings.rb:1663
+msgid "System Image Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+#: ../dictionary_strings.rb:1665
+msgid "System Image Types"
 msgstr ""
 
 #: ../model_attributes.rb:2128
@@ -21701,7 +25469,7 @@ msgstr ""
 msgid "Tag Category"
 msgstr ""
 
-#: ../../app/controllers/application_controller/explorer.rb:202 ../../app/controllers/application_controller/tags.rb:176
+#: ../../app/controllers/ops_controller/ops_rbac.rb:628 ../../app/controllers/application_controller/explorer.rb:202 ../../app/controllers/application_controller/tags.rb:176
 msgid "Tag Edit was cancelled by the user"
 msgstr ""
 
@@ -21753,6 +25521,11 @@ msgstr ""
 msgid "Target Port"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task
+#: ../dictionary_strings.rb:2023
+msgid "Task"
+msgstr ""
+
 #: ../../app/views/miq_task/_tasks_options.html.haml:128
 msgid "Task State"
 msgstr ""
@@ -21761,11 +25534,14 @@ msgstr ""
 msgid "Task Status"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:163
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
+#: ../../app/presenters/menu/default_menu.rb:163 ../dictionary_strings.rb:2025
 msgid "Tasks"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_1.html.haml:25
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra
+#: ../../app/views/configuration/_ui_1.html.haml:25 ../dictionary_strings.rb:1445 ../dictionary_strings.rb:2109
 msgid "Template"
 msgstr ""
 
@@ -21777,7 +25553,9 @@ msgstr ""
 msgid "Template Type"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:138 ../../app/views/layouts/listnav/_repository.html.haml:29 ../../app/views/layouts/listnav/_ems_infra.html.haml:72 ../../app/views/configuration/_ui_2.html.haml:307
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
+#: ../../app/views/layouts/listnav/_host.html.haml:138 ../../app/views/layouts/listnav/_repository.html.haml:29 ../../app/views/layouts/listnav/_ems_infra.html.haml:72 ../../app/views/configuration/_ui_2.html.haml:307 ../dictionary_strings.rb:1447 ../dictionary_strings.rb:2111
 msgid "Templates"
 msgstr ""
 
@@ -21803,6 +25581,10 @@ msgstr ""
 
 #: ../../app/views/ops/_rbac_tenant_details.html.haml:151
 msgid "Tenant Quota"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:363
+msgid "Tenant no longer exists"
 msgstr ""
 
 #: ../model_attributes.rb:2167
@@ -21969,24 +25751,32 @@ msgstr ""
 msgid "The current search details have been reset"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:301 ../../app/controllers/report_controller/dashboards.rb:119 ../../app/controllers/report_controller/widgets.rb:112 ../../app/controllers/report_controller/saved_reports.rb:101 ../../app/controllers/report_controller/schedules.rb:88 ../../app/controllers/miq_policy_controller/policies.rb:129 ../../app/controllers/miq_policy_controller/miq_actions.rb:80 ../../app/controllers/miq_policy_controller/alerts.rb:60 ../../app/controllers/miq_policy_controller/alert_profiles.rb:116 ../../app/controllers/miq_policy_controller/conditions.rb:132 ../../app/controllers/miq_policy_controller/policy_profiles.rb:83 ../../app/controllers/miq_request_controller.rb:537 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:418 ../../app/controllers/ops_controller/diagnostics.rb:698
+#: ../../app/controllers/repository_controller.rb:301 ../../app/controllers/report_controller/dashboards.rb:119 ../../app/controllers/report_controller/widgets.rb:112 ../../app/controllers/report_controller/saved_reports.rb:101 ../../app/controllers/report_controller/schedules.rb:88
 msgid "The selected %s was deleted"
 msgstr ""
 
-#: ../../app/controllers/report_controller/widgets.rb:109 ../../app/controllers/report_controller/schedules.rb:88 ../../app/controllers/miq_request_controller.rb:528
+#: ../../app/controllers/report_controller/widgets.rb:109 ../../app/controllers/report_controller/schedules.rb:88
 msgid "The selected %s were deleted"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:141 ../../app/controllers/ops_controller/settings/schedules.rb:201
+#: ../../app/controllers/report_controller/schedules.rb:141
 msgid "The selected %s were disabled"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:138 ../../app/controllers/ops_controller/settings/schedules.rb:199
+#: ../../app/controllers/report_controller/schedules.rb:138
 msgid "The selected %s were enabled"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:1614
 msgid "The selected %{label} is not in the current region"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/policies.rb:129 ../../app/controllers/miq_policy_controller/miq_actions.rb:80 ../../app/controllers/miq_policy_controller/alerts.rb:60 ../../app/controllers/miq_policy_controller/conditions.rb:133 ../../app/controllers/miq_policy_controller/policy_profiles.rb:85
+msgid "The selected %{models} was deleted"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:118 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:419
+msgid "The selected %{model} was deleted"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:2478
@@ -22003,6 +25793,14 @@ msgstr ""
 
 #: ../../app/controllers/miq_ae_class_controller.rb:1863 ../../app/controllers/miq_ae_class_controller.rb:1891 ../../app/controllers/catalog_controller.rb:345
 msgid "The selected %{record} were deleted"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:532
+msgid "The selected %{tables} were deleted"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:542 ../../app/controllers/ops_controller/diagnostics.rb:700
+msgid "The selected %{table} was deleted"
 msgstr ""
 
 #: ../../app/controllers/application_controller/filter.rb:890
@@ -22033,6 +25831,14 @@ msgstr ""
 msgid "The selected Schedules have been queued to run"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/schedules.rb:201
+msgid "The selected Schedules were disabled"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:199
+msgid "The selected Schedules were enabled"
+msgstr ""
+
 #: ../../app/controllers/miq_task_controller.rb:136
 msgid "The selected Task was cancelled"
 msgstr ""
@@ -22050,7 +25856,7 @@ msgid "The server is initializing; access is being retried every 10 seconds %s"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/common.rb:252
-msgid "The test email is being delivered, check \"%s\" to verify it was successful"
+msgid "The test email is being delivered, check \"%{email}\" to verify it was successful"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:1302 ../../app/controllers/application_controller.rb:2570 ../../app/controllers/ontap_file_share_controller.rb:57 ../../app/controllers/dashboard_controller.rb:621 ../../app/controllers/ontap_storage_system_controller.rb:62
@@ -22059,6 +25865,11 @@ msgstr ""
 
 #: ../../app/controllers/application_controller/filter.rb:106
 msgid "There is an error in the selected expression element, perhaps it was imported or edited manually."
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+#: ../dictionary_strings.rb:955
+msgid "Thin Provisioned"
 msgstr ""
 
 #: ../../app/views/report/_form_tl_settings.html.haml:89
@@ -22165,7 +25976,8 @@ msgstr ""
 msgid "Tile View"
 msgstr ""
 
-#: ../../app/views/layouts/_perf_options.html.haml:130 ../../app/views/report/_form_filter_performance.html.haml:52 ../../app/views/miq_capacity/_utilization_options.html.haml:65 ../../app/views/miq_capacity/_planning_options.html.haml:435 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:116
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
+#: ../../app/views/layouts/_perf_options.html.haml:130 ../../app/views/report/_form_filter_performance.html.haml:52 ../../app/views/miq_capacity/_utilization_options.html.haml:65 ../../app/views/miq_capacity/_planning_options.html.haml:435 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:116 ../dictionary_strings.rb:1715
 msgid "Time Profile"
 msgstr ""
 
@@ -22173,7 +25985,8 @@ msgstr ""
 msgid "Time Profile Information"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:632
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
+#: ../../app/controllers/configuration_controller.rb:632 ../dictionary_strings.rb:1717
 msgid "Time Profiles"
 msgstr ""
 
@@ -22225,7 +26038,7 @@ msgstr ""
 msgid "Timeline Settings"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:10 ../../app/helpers/application_helper/toolbar/vm_center.rb:151 ../../app/helpers/application_helper/toolbar/host_center.rb:103 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:148 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:105 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:117 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:55 ../../app/helpers/application_helper/toolbar/container_center.rb:52 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:63 ../../app/helpers/application_helper/toolbar/container_project_center.rb:36 ../../app/helpers/application_helper/toolbar/container_node_center.rb:43 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:68 ../../app/helpers/application_helper/toolbar/container_group_center.rb:36 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:107 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:36 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:35 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:74 ../../app/views/ops/_all_tabs.html.haml:186 ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:46 ../../app/views/layouts/listnav/_ems_container.html.haml:38 ../../app/views/layouts/listnav/_ems_container.html.haml:46 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:46 ../../app/views/layouts/listnav/_container_node.html.haml:46 ../../app/views/layouts/listnav/_ems_cloud.html.haml:18 ../../app/views/layouts/listnav/_container_project.html.haml:46
+#: ../../app/presenters/menu/default_menu.rb:10 ../../app/helpers/application_helper/toolbar/vm_center.rb:151 ../../app/helpers/application_helper/toolbar/host_center.rb:103 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:148 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:105 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:117 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:55 ../../app/helpers/application_helper/toolbar/container_center.rb:52 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:63 ../../app/helpers/application_helper/toolbar/container_project_center.rb:36 ../../app/helpers/application_helper/toolbar/container_node_center.rb:43 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:68 ../../app/helpers/application_helper/toolbar/container_group_center.rb:36 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:43 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:107 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:36 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:35 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:74 ../../app/views/ops/_all_tabs.html.haml:186 ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:46 ../../app/views/layouts/listnav/_ems_container.html.haml:38 ../../app/views/layouts/listnav/_ems_container.html.haml:46 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:46 ../../app/views/layouts/listnav/_container_node.html.haml:46 ../../app/views/layouts/listnav/_ems_cloud.html.haml:18 ../../app/views/layouts/listnav/_container_project.html.haml:46
 msgid "Timelines"
 msgstr ""
 
@@ -22305,8 +26118,106 @@ msgstr ""
 msgid "Topology"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+#: ../dictionary_strings.rb:1241
+msgid "Total (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+#: ../dictionary_strings.rb:161
+msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_cost
+#: ../dictionary_strings.rb:1207
+msgid "Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+#: ../dictionary_strings.rb:1083
+msgid "Total Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+#: ../dictionary_strings.rb:1073
+msgid "Total Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+#: ../dictionary_strings.rb:9
+msgid "Total Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+#: ../dictionary_strings.rb:7 ../dictionary_strings.rb:11 ../dictionary_strings.rb:67
+msgid "Total Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+#: ../dictionary_strings.rb:165
+msgid "Total Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+#: ../dictionary_strings.rb:163
+msgid "Total Number of Logical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+#: ../dictionary_strings.rb:167
+msgid "Total Number of Physical CPUs"
+msgstr ""
+
 #: ../../app/views/miq_request/_reconfigure_show.html.haml:63 ../../app/views/vm_common/_reconfigure.html.haml:141
 msgid "Total Processors"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+#: ../dictionary_strings.rb:717 ../dictionary_strings.rb:1077
+msgid "Total Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+#: ../dictionary_strings.rb:1081
+msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+#: ../dictionary_strings.rb:991
+msgid "Total Used Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+#: ../dictionary_strings.rb:1089
+msgid "Total VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+#: ../dictionary_strings.rb:747
+msgid "Total VMs Power Suspended"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+#: ../dictionary_strings.rb:741
+msgid "Total VMs Powered Never"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+#: ../dictionary_strings.rb:743
+msgid "Total VMs Powered Off"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+#: ../dictionary_strings.rb:745
+msgid "Total VMs Powered On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+#: ../dictionary_strings.rb:749
+msgid "Total VMs Powered Unknown"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_report.html.haml:14
@@ -22329,20 +26240,42 @@ msgstr ""
 msgid "Totals for VMs"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+#: ../dictionary_strings.rb:1219
+msgid "Transferred (KBps)"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_snmp.html.haml:80 ../../app/views/miq_policy/_action_options.html.haml:417 ../../app/views/miq_policy/_alert_details.html.haml:352 ../../app/views/miq_policy/_action_details.html.haml:364
 msgid "Trap Number"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:1027
+msgid "Trap Number is required"
 msgstr ""
 
 #: ../../app/views/miq_policy/_alert_snmp.html.haml:80 ../../app/views/miq_policy/_action_options.html.haml:417 ../../app/views/miq_policy/_alert_details.html.haml:352 ../../app/views/miq_policy/_action_details.html.haml:364
 msgid "Trap Object ID"
 msgstr ""
 
+#: ../../app/controllers/miq_policy_controller.rb:1029
+msgid "Trap Object ID is required"
+msgstr ""
+
 #: ../../app/views/miq_ae_tools/_results_tabs.html.haml:4
 msgid "Tree View"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+#: ../dictionary_strings.rb:365
+msgid "Trend"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_options.html.haml:404 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:105
 msgid "Trend Options"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alerts.rb:550
+msgid "Trend Steepness must be an integer"
 msgstr ""
 
 #: ../../app/views/report/_form_columns_trend.html.haml:29
@@ -22381,8 +26314,16 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
-#: ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/ops/_settings_database_tab.html.haml:37 ../../app/views/ops/_schedule_form_filter.html.haml:19 ../../app/views/ops/_ap_show.html.haml:48 ../../app/views/ops/_log_collection.html.haml:27 ../../app/views/ops/_settings_import_tab.html.haml:20 ../../app/views/ops/_diagnostics_database_tab.html.haml:19 ../../app/views/ops/_diagnostics_database_tab.html.haml:140 ../../app/views/ops/_ap_form.html.haml:57 ../../app/views/provider_foreman/_form.html.haml:44 ../../app/views/storage_manager/_form.html.haml:41 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:53 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:69 ../../app/views/layouts/_ae_resolve_options.html.haml:92 ../../app/views/layouts/_ae_resolve_options.html.haml:116 ../../app/views/layouts/_edit_log_depot_settings.html.haml:21 ../../app/views/vm_common/_disks.html.haml:9 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_widget_show.html.haml:178 ../../app/views/report/_db_list.html.haml:15 ../../app/views/report/_widget_form_rss.html.haml:15 ../../app/views/shared/views/ems_common/angular/_form.html.haml:40 ../../app/views/shared/views/ems_common/_form.html.haml:35 ../../app/views/shared/buttons/_ab_list.html.haml:51 ../../app/views/shared/buttons/_ab_show.html.haml:135 ../../app/views/pxe/_pxe_image_type_form.html.haml:34 ../../app/views/pxe/_template_form.html.haml:70 ../../app/views/pxe/_pxe_img_form.html.haml:17 ../../app/views/pxe/_iso_img_form.html.haml:17 ../../app/views/pxe/_pxe_wimg_form.html.haml:17 ../../app/views/miq_policy/_event_details.html.haml:230 ../../app/views/miq_policy/_event_details.html.haml:422 ../../app/views/miq_policy/_alert_snmp.html.haml:108 ../../app/views/miq_policy/_action_options.html.haml:454 ../../app/views/miq_policy/_alert_details.html.haml:380 ../../app/views/miq_policy/_action_details.html.haml:398
+#. TRANSLATORS: en.yml key: dictionary.column.action_type_description
+#. TRANSLATORS: en.yml key: dictionary.column.emstype_description
+#. TRANSLATORS: en.yml key: dictionary.column.mode
+#: ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/ops/_settings_database_tab.html.haml:37 ../../app/views/ops/_schedule_form_filter.html.haml:19 ../../app/views/ops/_ap_show.html.haml:48 ../../app/views/ops/_log_collection.html.haml:27 ../../app/views/ops/_settings_import_tab.html.haml:20 ../../app/views/ops/_diagnostics_database_tab.html.haml:19 ../../app/views/ops/_diagnostics_database_tab.html.haml:140 ../../app/views/ops/_ap_form.html.haml:57 ../../app/views/provider_foreman/_form.html.haml:44 ../../app/views/storage_manager/_form.html.haml:41 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:53 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:69 ../../app/views/layouts/_ae_resolve_options.html.haml:92 ../../app/views/layouts/_ae_resolve_options.html.haml:116 ../../app/views/layouts/_edit_log_depot_settings.html.haml:21 ../../app/views/vm_common/_disks.html.haml:9 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_widget_show.html.haml:178 ../../app/views/report/_db_list.html.haml:15 ../../app/views/report/_widget_form_rss.html.haml:15 ../../app/views/shared/views/ems_common/angular/_form.html.haml:40 ../../app/views/shared/views/ems_common/_form.html.haml:35 ../../app/views/shared/buttons/_ab_list.html.haml:51 ../../app/views/shared/buttons/_ab_show.html.haml:135 ../../app/views/pxe/_pxe_image_type_form.html.haml:34 ../../app/views/pxe/_template_form.html.haml:70 ../../app/views/pxe/_pxe_img_form.html.haml:17 ../../app/views/pxe/_iso_img_form.html.haml:17 ../../app/views/pxe/_pxe_wimg_form.html.haml:17 ../../app/views/miq_policy/_event_details.html.haml:230 ../../app/views/miq_policy/_event_details.html.haml:422 ../../app/views/miq_policy/_alert_snmp.html.haml:108 ../../app/views/miq_policy/_action_options.html.haml:454 ../../app/views/miq_policy/_alert_details.html.haml:380 ../../app/views/miq_policy/_action_details.html.haml:398 ../dictionary_strings.rb:155 ../dictionary_strings.rb:385 ../dictionary_strings.rb:593
 msgid "Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.typename
+#: ../dictionary_strings.rb:981
+msgid "Type Name"
 msgstr ""
 
 #: ../../app/controllers/ems_common.rb:138
@@ -22403,6 +26344,11 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:183
 msgid "UI Worker"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uid
+#: ../dictionary_strings.rb:983
+msgid "UID"
 msgstr ""
 
 #: ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:36 ../../app/views/layouts/_edit_log_depot_settings.html.haml:60 ../../app/views/miq_ae_tools/_results_uri.html.haml:16 ../../app/views/pxe/_pxe_form.html.haml:55
@@ -22429,7 +26375,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: ../../app/presenters/tree_node_builder.rb:226 ../../app/controllers/provider_foreman_controller.rb:977 ../../app/controllers/provider_foreman_controller.rb:1002 ../../app/controllers/provider_foreman_controller.rb:1015
+#: ../../app/presenters/tree_node_builder.rb:226 ../../app/controllers/provider_foreman_controller.rb:958 ../../app/controllers/provider_foreman_controller.rb:983 ../../app/controllers/provider_foreman_controller.rb:996
 msgid "Unassigned Profiles Group"
 msgstr ""
 
@@ -22439,6 +26385,11 @@ msgstr ""
 
 #: ../../app/views/shared/views/_prov_dialog.html.haml:225
 msgid "Unattended GUI"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+#: ../dictionary_strings.rb:985
+msgid "Uncommitted Space"
 msgstr ""
 
 #: ../../app/views/layouts/_exp_editor.html.haml:19
@@ -22525,8 +26476,528 @@ msgstr ""
 msgid "Uploaded File '%s'"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+#: ../dictionary_strings.rb:587
+msgid "Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+#: ../dictionary_strings.rb:527
+msgid "Uptime - Peak Uptime for Collected Intervals (Seconds)"
+msgstr ""
+
 #: ../../app/views/provider_foreman/_form.html.haml:75
 msgid "Url"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data
+#: ../dictionary_strings.rb:1119
+msgid "Usage (All) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_max
+#: ../dictionary_strings.rb:1121
+msgid "Usage (All) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_min
+#: ../dictionary_strings.rb:1123
+msgid "Usage (All) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency
+#: ../dictionary_strings.rb:175
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+#: ../dictionary_strings.rb:177
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+#: ../dictionary_strings.rb:179
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops
+#: ../dictionary_strings.rb:959
+msgid "Usage (All) - Number of Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+#: ../dictionary_strings.rb:961
+msgid "Usage (All) - Number of Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+#: ../dictionary_strings.rb:963
+msgid "Usage (All) - Number of Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops
+#: ../dictionary_strings.rb:1131
+msgid "Usage (All) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+#: ../dictionary_strings.rb:1133
+msgid "Usage (All) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+#: ../dictionary_strings.rb:1135
+msgid "Usage (All) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency
+#: ../dictionary_strings.rb:1125
+msgid "Usage (All) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+#: ../dictionary_strings.rb:1127
+msgid "Usage (All) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+#: ../dictionary_strings.rb:1129
+msgid "Usage (All) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data
+#: ../dictionary_strings.rb:903
+msgid "Usage (Block Protocol) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+#: ../dictionary_strings.rb:905
+msgid "Usage (Block Protocol) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+#: ../dictionary_strings.rb:907
+msgid "Usage (Block Protocol) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data
+#: ../dictionary_strings.rb:921
+msgid "Usage (Block Protocol) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+#: ../dictionary_strings.rb:923
+msgid "Usage (Block Protocol) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+#: ../dictionary_strings.rb:925
+msgid "Usage (Block Protocol) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+#: ../dictionary_strings.rb:897
+msgid "Usage (Block Protocol) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+#: ../dictionary_strings.rb:899
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+#: ../dictionary_strings.rb:901
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+#: ../dictionary_strings.rb:915
+msgid "Usage (Block Protocol) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+#: ../dictionary_strings.rb:917
+msgid "Usage (Block Protocol) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+#: ../dictionary_strings.rb:919
+msgid "Usage (Block Protocol) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+#: ../dictionary_strings.rb:933
+msgid "Usage (Block Protocol) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+#: ../dictionary_strings.rb:935
+msgid "Usage (Block Protocol) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+#: ../dictionary_strings.rb:937
+msgid "Usage (Block Protocol) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+#: ../dictionary_strings.rb:909
+msgid "Usage (Block Protocol) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+#: ../dictionary_strings.rb:911
+msgid "Usage (Block Protocol) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+#: ../dictionary_strings.rb:913
+msgid "Usage (Block Protocol) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+#: ../dictionary_strings.rb:927
+msgid "Usage (Block Protocol) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+#: ../dictionary_strings.rb:929
+msgid "Usage (Block Protocol) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+#: ../dictionary_strings.rb:931
+msgid "Usage (Block Protocol) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+#: ../dictionary_strings.rb:199
+msgid "Usage (CIFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+#: ../dictionary_strings.rb:201
+msgid "Usage (CIFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+#: ../dictionary_strings.rb:203
+msgid "Usage (CIFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+#: ../dictionary_strings.rb:217
+msgid "Usage (CIFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+#: ../dictionary_strings.rb:219
+msgid "Usage (CIFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+#: ../dictionary_strings.rb:221
+msgid "Usage (CIFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+#: ../dictionary_strings.rb:193
+msgid "Usage (CIFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+#: ../dictionary_strings.rb:195
+msgid "Usage (CIFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+#: ../dictionary_strings.rb:197
+msgid "Usage (CIFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+#: ../dictionary_strings.rb:211
+msgid "Usage (CIFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+#: ../dictionary_strings.rb:213
+msgid "Usage (CIFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+#: ../dictionary_strings.rb:215
+msgid "Usage (CIFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+#: ../dictionary_strings.rb:229
+msgid "Usage (CIFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+#: ../dictionary_strings.rb:231
+msgid "Usage (CIFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+#: ../dictionary_strings.rb:233
+msgid "Usage (CIFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+#: ../dictionary_strings.rb:187
+msgid "Usage (CIFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+#: ../dictionary_strings.rb:189
+msgid "Usage (CIFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+#: ../dictionary_strings.rb:191
+msgid "Usage (CIFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+#: ../dictionary_strings.rb:205
+msgid "Usage (CIFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+#: ../dictionary_strings.rb:207
+msgid "Usage (CIFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+#: ../dictionary_strings.rb:209
+msgid "Usage (CIFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+#: ../dictionary_strings.rb:223
+msgid "Usage (CIFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+#: ../dictionary_strings.rb:225
+msgid "Usage (CIFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+#: ../dictionary_strings.rb:227
+msgid "Usage (CIFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+#: ../dictionary_strings.rb:611
+msgid "Usage (NFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+#: ../dictionary_strings.rb:613
+msgid "Usage (NFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+#: ../dictionary_strings.rb:615
+msgid "Usage (NFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+#: ../dictionary_strings.rb:629
+msgid "Usage (NFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+#: ../dictionary_strings.rb:631
+msgid "Usage (NFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+#: ../dictionary_strings.rb:633
+msgid "Usage (NFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+#: ../dictionary_strings.rb:605
+msgid "Usage (NFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+#: ../dictionary_strings.rb:607
+msgid "Usage (NFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+#: ../dictionary_strings.rb:609
+msgid "Usage (NFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+#: ../dictionary_strings.rb:623
+msgid "Usage (NFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+#: ../dictionary_strings.rb:625
+msgid "Usage (NFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+#: ../dictionary_strings.rb:627
+msgid "Usage (NFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+#: ../dictionary_strings.rb:641
+msgid "Usage (NFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+#: ../dictionary_strings.rb:643
+msgid "Usage (NFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+#: ../dictionary_strings.rb:645
+msgid "Usage (NFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+#: ../dictionary_strings.rb:599
+msgid "Usage (NFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+#: ../dictionary_strings.rb:601
+msgid "Usage (NFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+#: ../dictionary_strings.rb:603
+msgid "Usage (NFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+#: ../dictionary_strings.rb:617
+msgid "Usage (NFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+#: ../dictionary_strings.rb:619
+msgid "Usage (NFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+#: ../dictionary_strings.rb:621
+msgid "Usage (NFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+#: ../dictionary_strings.rb:635
+msgid "Usage (NFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+#: ../dictionary_strings.rb:637
+msgid "Usage (NFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+#: ../dictionary_strings.rb:639
+msgid "Usage (NFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data
+#: ../dictionary_strings.rb:721
+msgid "Usage (Other) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_max
+#: ../dictionary_strings.rb:723
+msgid "Usage (Other) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_min
+#: ../dictionary_strings.rb:725
+msgid "Usage (Other) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops
+#: ../dictionary_strings.rb:675
+msgid "Usage (Other) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+#: ../dictionary_strings.rb:677
+msgid "Usage (Other) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+#: ../dictionary_strings.rb:679
+msgid "Usage (Other) - Number of Other Operations per Second Miin"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops
+#: ../dictionary_strings.rb:733
+msgid "Usage (Other) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+#: ../dictionary_strings.rb:735
+msgid "Usage (Other) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+#: ../dictionary_strings.rb:737
+msgid "Usage (Other) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+#: ../dictionary_strings.rb:891
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+#: ../dictionary_strings.rb:893
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+#: ../dictionary_strings.rb:895
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency
+#: ../dictionary_strings.rb:669
+msgid "Usage (Other) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+#: ../dictionary_strings.rb:671
+msgid "Usage (Other) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+#: ../dictionary_strings.rb:673
+msgid "Usage (Other) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency
+#: ../dictionary_strings.rb:727
+msgid "Usage (Other) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+#: ../dictionary_strings.rb:729
+msgid "Usage (Other) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+#: ../dictionary_strings.rb:731
+msgid "Usage (Other) - Time for Reads Avg Min"
 msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:247
@@ -22565,15 +27036,19 @@ msgstr ""
 msgid "Use HTTP Proxy"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/upload.rb:37 ../../app/controllers/ops_controller/settings/upload.rb:96 ../../app/controllers/ops_controller/settings.rb:29
-msgid "Use the Browse button to locate %s file"
+#: ../../app/controllers/ops_controller/settings/upload.rb:37
+msgid "Use the Browse button to locate .png image file"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/upload.rb:96 ../../app/controllers/ops_controller/settings.rb:29
+msgid "Use the Browse button to locate CSV file"
 msgstr ""
 
 #: ../../app/controllers/catalog_controller.rb:468
 msgid "Use the Browse button to locate a %s image file"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:203 ../../app/controllers/report_controller.rb:91 ../../app/controllers/miq_policy_controller.rb:162
+#: ../../app/controllers/miq_ae_tools_controller.rb:203 ../../app/controllers/report_controller.rb:91 ../../app/controllers/miq_policy_controller.rb:163
 msgid "Use the Browse button to locate an Import file"
 msgstr ""
 
@@ -22587,6 +27062,16 @@ msgstr ""
 
 #: ../../app/views/vm_common/_disks.html.haml:17
 msgid "Used Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space
+#: ../dictionary_strings.rb:1091
+msgid "Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+#: ../dictionary_strings.rb:1093
+msgid "Used Space Percent of Total"
 msgstr ""
 
 #: ../../app/views/layouts/_multi_auth_credentials.html.haml:118 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:184
@@ -22623,7 +27108,7 @@ msgstr[1] ""
 msgid "User Data"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:420
+#: ../../app/controllers/ops_controller/ops_rbac.rb:421
 msgid "User Group Sequence was saved"
 msgstr ""
 
@@ -22645,6 +27130,10 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:493 ../../app/views/support/show.html.haml:17
 msgid "User Name"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:538
+msgid "User Password must be entered to perform LDAP Group Look Up"
 msgstr ""
 
 #: ../../app/views/ops/_ldap_domain_form.html.haml:44 ../../app/views/ops/_ldap_domain_show.html.haml:61 ../../app/views/_ldap_domain_form.html.haml:44
@@ -22671,6 +27160,14 @@ msgstr ""
 msgid "User Type"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/ops_rbac.rb:531
+msgid "User must be entered to perform LDAP Group Look Up"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:291
+msgid "User no longer exists"
+msgstr ""
+
 #: ../../app/views/ops/_rbac_group_details.html.haml:159 ../../app/views/ops/_rbac_group_details.html.haml:193
 msgid "User to Look Up"
 msgstr ""
@@ -22679,7 +27176,8 @@ msgstr ""
 msgid "User will input the value"
 msgstr ""
 
-#: ../../app/views/ops/_diagnostics_savedreports.html.haml:18 ../../app/views/ops/_zone_form.html.haml:133 ../../app/views/ops/_rbac_user_details.html.haml:55 ../../app/views/ops/_settings_workers_tab.html.haml:554 ../../app/views/ops/_rbac_group_details.html.haml:212 ../../app/views/ops/_diagnostics_database_tab.html.haml:67 ../../app/views/storage_manager/_form.html.haml:156 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:4 ../../app/views/layouts/_auth_credentials_keypair.html.haml:7 ../../app/views/layouts/_auth_credentials.html.haml:9 ../../app/views/layouts/_discover_credentials.html.haml:13 ../../app/views/layouts/angular/_auth_credentials_angular.html.haml:3 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:160 ../../app/views/dashboard/login.html.haml:35 ../../app/views/dashboard/login.html.haml:39 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_report_info.html.haml:155
+#. TRANSLATORS: en.yml key: dictionary.column.userid
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:18 ../../app/views/ops/_zone_form.html.haml:133 ../../app/views/ops/_rbac_user_details.html.haml:55 ../../app/views/ops/_settings_workers_tab.html.haml:554 ../../app/views/ops/_rbac_group_details.html.haml:212 ../../app/views/ops/_diagnostics_database_tab.html.haml:67 ../../app/views/storage_manager/_form.html.haml:156 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:4 ../../app/views/layouts/_auth_credentials_keypair.html.haml:7 ../../app/views/layouts/_auth_credentials.html.haml:9 ../../app/views/layouts/_discover_credentials.html.haml:13 ../../app/views/layouts/angular/_auth_credentials_angular.html.haml:3 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:160 ../../app/views/dashboard/login.html.haml:35 ../../app/views/dashboard/login.html.haml:39 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_report_info.html.haml:155 ../dictionary_strings.rb:5
 msgid "Username"
 msgstr ""
 
@@ -22693,6 +27191,10 @@ msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/ldap.rb:179 ../../app/controllers/ems_common.rb:522 ../../app/controllers/application_controller/ci_processing.rb:836
 msgid "Username must be entered if Password is entered"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:535
+msgid "Username must be entered to perform LDAP Group Look Up"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_host.html.haml:187 ../../app/views/layouts/_item.html.haml:112
@@ -22771,7 +27273,19 @@ msgstr ""
 msgid "Utilization"
 msgstr ""
 
-#: ../../app/views/vm_cloud/_main.html.haml:21 ../../app/views/host/_main.html.haml:29 ../../app/views/vm_common/_main.html.haml:22
+#. TRANSLATORS: en.yml key: dictionary.column.utilization
+#: ../dictionary_strings.rb:1243
+msgid "Utilization %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+#: ../dictionary_strings.rb:1853
+msgid "VC Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
+#: ../../app/views/vm_cloud/_main.html.haml:21 ../../app/views/host/_main.html.haml:29 ../../app/views/vm_common/_main.html.haml:22 ../dictionary_strings.rb:1855 ../dictionary_strings.rb:1857
 msgid "VC Custom Attributes"
 msgstr ""
 
@@ -22809,6 +27323,16 @@ msgstr ""
 
 #: ../../app/views/layouts/listnav/_storage.html.haml:110
 msgid "VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+#: ../dictionary_strings.rb:1019
+msgid "VM Memory Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vm_name
+#: ../dictionary_strings.rb:1209
+msgid "VM Name"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_field.html.haml:157 ../../app/views/miq_request/_prov_field.html.haml:166
@@ -22851,8 +27375,50 @@ msgstr ""
 msgid "VM Snapshot Files"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template
+#: ../dictionary_strings.rb:2027
+msgid "VM Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+#: ../dictionary_strings.rb:1585
+msgid "VM Template and Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+#: ../dictionary_strings.rb:1587
+msgid "VM Template and Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+#: ../dictionary_strings.rb:2029
+msgid "VM Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm
+#: ../dictionary_strings.rb:1727 ../dictionary_strings.rb:2113
+msgid "VM and Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+#: ../dictionary_strings.rb:1729 ../dictionary_strings.rb:2115
+msgid "VM and Instances"
+msgstr ""
+
 #: ../../app/views/ops/_settings_cu_collection_tab.html.haml:77
 msgid "VM data will be collected for VMs under selected %s only. Data is collected for a %s and all of its %s when at least one %s is selected."
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+#: ../dictionary_strings.rb:1735
+msgid "VM or Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+#: ../dictionary_strings.rb:1737
+msgid "VM or Templates"
 msgstr ""
 
 #: ../../app/controllers/vm_common.rb:990
@@ -22867,11 +27433,62 @@ msgstr ""
 msgid "VMDB"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/db.rb:218
+msgid "VMDB \"%{name}\" Table Utilization"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/db.rb:187
+msgid "VMDB Client Connections"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/db.rb:193
+msgid "VMDB Settings"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/db.rb:177
+msgid "VMDB Summary"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+#: ../dictionary_strings.rb:1731
+msgid "VMDB Table"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+#: ../dictionary_strings.rb:1733
+msgid "VMDB Tables"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/db.rb:183
+msgid "VMDB Utilization"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+#: ../dictionary_strings.rb:1099
+msgid "VMM Build Number"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:67
 msgid "VMM Information"
 msgstr ""
 
-#: ../../app/views/service/_svcs_show.html.haml:30 ../../app/views/layouts/listnav/_host.html.haml:130 ../../app/views/layouts/listnav/_storage.html.haml:37 ../../app/views/layouts/listnav/_ems_infra.html.haml:65 ../../app/views/configuration/_ui_2.html.haml:293 ../../app/views/miq_capacity/_planning_summary.html.haml:20
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_product
+#: ../dictionary_strings.rb:1101
+msgid "VMM Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+#: ../dictionary_strings.rb:1103
+msgid "VMM Vendor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_version
+#: ../dictionary_strings.rb:1105
+msgid "VMM Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.vms
+#: ../../app/views/service/_svcs_show.html.haml:30 ../../app/views/layouts/listnav/_host.html.haml:130 ../../app/views/layouts/listnav/_storage.html.haml:37 ../../app/views/layouts/listnav/_ems_infra.html.haml:65 ../../app/views/configuration/_ui_2.html.haml:293 ../../app/views/miq_capacity/_planning_summary.html.haml:20 ../dictionary_strings.rb:2131
 msgid "VMs"
 msgstr ""
 
@@ -22885,6 +27502,36 @@ msgstr ""
 
 #: ../../app/views/vm_cloud/_main.html.haml:17 ../../app/views/vm_common/_main.html.haml:16
 msgid "VMsafe"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+#: ../dictionary_strings.rb:1107
+msgid "VMsafe Agent Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+#: ../dictionary_strings.rb:1109
+msgid "VMsafe Agent Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+#: ../dictionary_strings.rb:1111
+msgid "VMsafe Enable"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+#: ../dictionary_strings.rb:1113
+msgid "VMsafe Fail Open"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+#: ../dictionary_strings.rb:1115
+msgid "VMsafe Immutable VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+#: ../dictionary_strings.rb:1117
+msgid "VMsafe Timeout (ms)"
 msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:238
@@ -22925,6 +27572,10 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:308
 msgid "VNC Proxy Port"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:528
+msgid "VNC Proxy Port must be numeric"
 msgstr ""
 
 #: ../../app/views/ops/_settings_database_tab.html.haml:123 ../../app/views/ops/_settings_database_tab.html.haml:134 ../../app/views/ops/_ldap_server_entry.html.haml:135 ../../app/views/ops/_amazon_verify_button.html.haml:2 ../../app/views/ops/_amazon_verify_button.html.haml:16 ../../app/views/ops/_ldap_verify_button.html.haml:4 ../../app/views/ops/_ldap_verify_button.html.haml:18 ../../app/views/layouts/_form_buttons.html.haml:23 ../../app/views/layouts/_form_buttons.html.haml:37 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:155 ../../app/views/layouts/_form_buttons_verify.html.haml:19 ../../app/views/layouts/_form_buttons_verify.html.haml:28 ../../app/views/layouts/_form_buttons_verify.html.haml:46
@@ -22969,6 +27620,10 @@ msgstr ""
 
 #: ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/views/ops/_tenant_quota_form.html.haml:32 ../../app/views/miq_ae_customization/_field_values.html.haml:18 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:11 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/miq_ae_class/_instance_form.html.haml:89 ../../app/views/miq_ae_class/_instance_fields.html.haml:17 ../../app/views/report/_form_columns_trend.html.haml:61 ../../app/views/miq_policy/_alert_snmp.html.haml:110 ../../app/views/miq_policy/_action_options.html.haml:459 ../../app/views/miq_policy/_alert_details.html.haml:382 ../../app/views/miq_policy/_action_details.html.haml:400
 msgid "Value"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller/alerts.rb:545
+msgid "Value Threshold must be an integer"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:456 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:554
@@ -23291,7 +27946,22 @@ msgstr ""
 msgid "VimPerformanceTagValue|Value"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:46
+#. TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+#: ../dictionary_strings.rb:1097
+msgid "Virtual Hardware Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+#: ../dictionary_strings.rb:1441 ../dictionary_strings.rb:2123 ../dictionary_strings.rb:2127
+msgid "Virtual Machine"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
+#: ../../app/presenters/menu/default_menu.rb:46 ../dictionary_strings.rb:1443 ../dictionary_strings.rb:2125 ../dictionary_strings.rb:2129
 msgid "Virtual Machines"
 msgstr ""
 
@@ -23731,7 +28401,8 @@ msgstr ""
 msgid "VmdbTable|Prior raw metrics"
 msgstr ""
 
-#: ../model_attributes.rb:2314
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+#: ../dictionary_strings.rb:1827 ../model_attributes.rb:2314
 msgid "Volume"
 msgstr ""
 
@@ -23743,7 +28414,10 @@ msgstr ""
 msgid "Volume Path"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:29 ../../app/presenters/menu/default_menu.rb:95 ../../app/views/container_group/_main.html.haml:15 ../../app/views/configuration/_ui_2.html.haml:215
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
+#: ../../app/presenters/menu/default_menu.rb:29 ../../app/presenters/menu/default_menu.rb:95 ../../app/views/container_group/_main.html.haml:15 ../../app/views/configuration/_ui_2.html.haml:215 ../dictionary_strings.rb:1829 ../dictionary_strings.rb:1831 ../dictionary_strings.rb:2045
 msgid "Volumes"
 msgstr ""
 
@@ -23789,6 +28463,11 @@ msgstr ""
 
 #: ../../app/views/shared/views/_prov_dialog.html.haml:356
 msgid "WINS Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+#: ../dictionary_strings.rb:1249
+msgid "Wait Time (Seconds)"
 msgstr ""
 
 #: ../../app/views/miq_task/_tasks_options.html.haml:96 ../../app/views/miq_task/_tasks_options.html.haml:120 ../../app/views/miq_task/_tasks_options.html.haml:120
@@ -23849,6 +28528,14 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:46
 msgid "Warning: The selected #{ui_lookup(:tables=>\"ems_infras\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_infras\")}?"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:29
+msgid "Warning: The selected #{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_middlewares\")}?"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:28
+msgid "Warning: The selected #{ui_lookup(:tables=>\"middleware_servers\")} and ALL of their components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"middleware_servers\")}?"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:15
@@ -23991,6 +28678,14 @@ msgstr ""
 msgid "Warning: This #{ui_lookup(:table=>\"ems_infra\")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>\"ems_infra\")}?"
 msgstr ""
 
+#: ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:28
+msgid "Warning: This #{ui_lookup(:table=>\"ems_middleware\")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>\"ems_middleware\")}?"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:21
+msgid "Warning: This #{ui_lookup(:table=>\"middleware_server\")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>\"middleware_server\")}?"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:15
 msgid "Warning: This #{ui_lookup(:table=>\"orchestration_stack\")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>\"orchestration_stack\")}?"
 msgstr ""
@@ -24111,6 +28806,11 @@ msgstr ""
 msgid "Web Services"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ws_port
+#: ../dictionary_strings.rb:1137
+msgid "Web Services Port"
+msgstr ""
+
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Wednesday"
 msgstr ""
@@ -24123,12 +28823,22 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+#: ../dictionary_strings.rb:391
+msgid "What is evaluated"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_details.html.haml:98
 msgid "What to Evaluate"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:529
+#: ../../app/controllers/ops_controller/settings/common.rb:534
 msgid "When configuring a VNC Proxy, both Address and Port are required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+#: ../dictionary_strings.rb:1593
+msgid "Widget"
 msgstr ""
 
 #: ../../app/controllers/report_controller/widgets.rb:127
@@ -24143,7 +28853,8 @@ msgstr ""
 msgid "Widget name"
 msgstr ""
 
-#: ../../app/views/report/_export_widgets.html.haml:75 ../../app/views/report/_report_info.html.haml:228
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
+#: ../../app/views/report/_export_widgets.html.haml:75 ../../app/views/report/_report_info.html.haml:228 ../dictionary_strings.rb:1595
 msgid "Widgets"
 msgstr ""
 
@@ -24221,6 +28932,26 @@ msgstr ""
 msgid "Wrap this expression element with a NOT"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.pct_write
+#: ../dictionary_strings.rb:1227
+msgid "Write %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+#: ../dictionary_strings.rb:1253
+msgid "Write (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+#: ../dictionary_strings.rb:1251
+msgid "Write Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+#: ../dictionary_strings.rb:1221
+msgid "Written (KBps)"
+msgstr ""
+
 #: ../../app/views/miq_ae_tools/_results_tabs.html.haml:7
 msgid "XML View"
 msgstr ""
@@ -24253,12 +28984,18 @@ msgstr ""
 msgid "Your Red Hat Account login or Red Hat Network Satellite login"
 msgstr ""
 
-#: ../../app/helpers/provider_configuration_manager_helper.rb:39 ../../app/helpers/provider_foreman_helper.rb:50 ../../app/views/ops/_ldap_region_show.html.haml:44 ../../app/views/ops/rhn/_server_table.html.haml:90 ../../app/views/ops/_schedule_show.html.haml:122 ../../app/views/ops/_all_tabs.html.haml:8 ../../app/views/ops/_ldap_region_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:116 ../../app/views/miq_task/_tasks_options.html.haml:16 ../../app/views/report/_show_schedule.html.haml:120 ../../app/views/report/_report_info.html.haml:160 ../../app/views/shared/views/ems_common/angular/_form.html.haml:279 ../../app/views/shared/views/ems_common/_form.html.haml:120 ../model_attributes.rb:2330
+#. TRANSLATORS: en.yml key: dictionary.model.Zone
+#. TRANSLATORS: en.yml key: dictionary.table.zone
+#: ../../app/helpers/provider_configuration_manager_helper.rb:39 ../../app/helpers/provider_foreman_helper.rb:50 ../../app/views/ops/_ldap_region_show.html.haml:44 ../../app/views/ops/rhn/_server_table.html.haml:90 ../../app/views/ops/_schedule_show.html.haml:122 ../../app/views/ops/_all_tabs.html.haml:8 ../../app/views/ops/_ldap_region_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:116 ../../app/views/miq_task/_tasks_options.html.haml:16 ../../app/views/report/_show_schedule.html.haml:120 ../../app/views/report/_report_info.html.haml:160 ../../app/views/shared/views/ems_common/angular/_form.html.haml:279 ../../app/views/shared/views/ems_common/_form.html.haml:120 ../dictionary_strings.rb:1743 ../dictionary_strings.rb:2133 ../model_attributes.rb:2330
 msgid "Zone"
 msgstr ""
 
 #: ../../app/views/ops/_zone_form.html.haml:7
 msgid "Zone Information"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/zones.rb:19
+msgid "Zone name is required"
 msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:107
@@ -24269,7 +29006,10 @@ msgstr ""
 msgid "Zone:"
 msgstr ""
 
-#: ../../app/views/ops/_settings_details_tab.html.haml:82
+#. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zones
+#: ../../app/views/ops/_settings_details_tab.html.haml:82 ../dictionary_strings.rb:1745 ../dictionary_strings.rb:2135 ../dictionary_strings.rb:2137
 msgid "Zones"
 msgstr ""
 
@@ -24339,6 +29079,10 @@ msgstr ""
 
 #: ../../app/views/miq_policy/_rsop_results.html.haml:81
 msgid "do not change the outcome of the scope or expression"
+msgstr ""
+
+#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:94
+msgid "down"
 msgstr ""
 
 #: ../../app/views/ops/_schedule_form_timer.html.haml:24 ../../app/views/report/_schedule_form_timer.html.haml:32 ../../app/views/report/_schedule_form_timer.html.haml:44 ../../app/views/report/_schedule_form_timer.html.haml:56 ../../app/views/report/_schedule_form_timer.html.haml:68
@@ -24414,7 +29158,7 @@ msgstr ""
 msgid "selected to copy"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:120
+#: ../../app/controllers/provider_foreman_controller.rb:101
 msgid "system"
 msgid_plural "systems"
 msgstr[0] ""
@@ -24422,6 +29166,14 @@ msgstr[1] ""
 
 #: ../../app/views/miq_policy/_alert_list.html.haml:4 ../../app/views/miq_policy/_action_list.html.haml:4
 msgid "that match the entered search string"
+msgstr ""
+
+#: ../../app/views/report/_column_lists.html.haml:94
+msgid "to bottom"
+msgstr ""
+
+#: ../../app/views/report/_column_lists.html.haml:94
+msgid "to top"
 msgstr ""
 
 #: ../../app/views/layouts/exp_atom/_edit_field.html.haml:69 ../../app/views/layouts/exp_atom/_edit_find.html.haml:46 ../../app/views/layouts/exp_atom/_edit_find.html.haml:181 ../../app/views/report/_form_styling.html.haml:79
@@ -24440,6 +29192,10 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
+#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:94
+msgid "up"
+msgstr ""
+
 #: ../../app/views/layouts/exp_atom/_edit_field.html.haml:164 ../../app/views/layouts/exp_atom/_edit_count.html.haml:47 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:56
 msgid "user input"
 msgstr ""
@@ -24452,8 +29208,28 @@ msgstr ""
 msgid "vCPU per Core"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+#: ../dictionary_strings.rb:1141
+msgid "vCPUs Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+#: ../dictionary_strings.rb:1143
+msgid "vCPUs Allocated over Time Period"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_options.html.haml:332
 msgid "vCPUs per Core"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.lans
+#: ../dictionary_strings.rb:1941
+msgid "vLANs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.switches
+#: ../dictionary_strings.rb:2103
+msgid "vSwitches"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:11

--- a/config/locales/nl/manageiq.po
+++ b/config/locales/nl/manageiq.po
@@ -20,6 +20,7 @@ msgstr ""
 msgid "CPU"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
 msgid "Memory"
 msgstr ""
 
@@ -47,30 +48,58 @@ msgstr ""
 msgid "Network Utilization Trends"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
 msgid "Providers"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_nodes
 msgid "Nodes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.containers
 msgid "Containers"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
 msgid "Registries"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_projects
 msgid "Projects"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_groups
 msgid "Pods"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_services
+#. TRANSLATORS: en.yml key: dictionary.table.host_services
 msgid "Services"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_images
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
 msgid "Images"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_routes
 msgid "Routes"
 msgstr ""
 
@@ -215,9 +244,11 @@ msgstr ""
 msgid "Second"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.compliance_details
 msgid "Details"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_message
 msgid "Message"
 msgstr ""
 
@@ -476,6 +507,7 @@ msgstr ""
 msgid "%{model}: %{task} successfully initiated"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.hosts
 msgid "Hosts / Nodes"
 msgstr ""
 
@@ -742,6 +774,7 @@ msgstr ""
 msgid "* You are not authorized to view %{children} on this %{model}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
 msgid "Key Pair"
 msgstr ""
 
@@ -969,6 +1002,7 @@ msgstr ""
 msgid "Default Filters"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
 msgid "Time Profiles"
 msgstr ""
 
@@ -1075,6 +1109,8 @@ msgstr ""
 msgid "%s (All cloud tenants present on this host)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.filesystems
 msgid "Files"
 msgstr ""
 
@@ -1096,6 +1132,8 @@ msgstr ""
 msgid "Credentials/Settings saved successfully"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
 msgid "Middleware Servers"
 msgstr ""
 
@@ -1206,9 +1244,13 @@ msgstr ""
 msgid "%{typ} Button Group \"Unassigned Buttons\""
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Host
+#. TRANSLATORS: en.yml key: dictionary.table.host
 msgid "Host / Node"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
 msgid "Cluster / Deployment Role"
 msgstr ""
 
@@ -1295,6 +1337,9 @@ msgstr ""
 msgid "%{val} missing for %{field}"
 msgstr ""
 
+msgid "At least one VM Option must be selected"
+msgstr ""
+
 msgid "No Utilization data available to generate planning results"
 msgstr ""
 
@@ -1304,13 +1349,25 @@ msgstr ""
 msgid "Planning options have been reset by the user"
 msgstr ""
 
-msgid "Best Fit %s"
+msgid "Best Fit Hosts"
 msgstr ""
 
-msgid "%s cancelled by user"
+msgid "Best Fit Clusters"
 msgstr ""
 
-msgid "At least %{num} %{model} must be selected for %{action}"
+msgid "Export cancelled by user"
+msgstr ""
+
+msgid "Error during export: %{error_message}"
+msgstr ""
+
+msgid "Error during 'Policy Import': %{messages}"
+msgstr ""
+
+msgid "Error during upload: %{messages}"
+msgstr ""
+
+msgid "Import cancelled by user"
 msgstr ""
 
 msgid "Import not available due to conflicts"
@@ -1319,67 +1376,158 @@ msgstr ""
 msgid "Press commit to Import"
 msgstr ""
 
-msgid "%s no longer exists"
+msgid "All %{items}"
+msgstr ""
+
+msgid "All %{models}"
+msgstr ""
+
+msgid "Adding a new %{record}"
 msgstr ""
 
 msgid "All %{typ} %{model}"
 msgstr ""
 
-msgid " %s Assignments"
+msgid "Adding a new %{model_name} %{mode} Policy"
 msgstr ""
 
-msgid "Select only one or consecutive %s to move up"
+msgid "Adding a new %{model_name} Policy"
 msgstr ""
 
-msgid "Select only one or consecutive %s to move down"
+msgid " %{model} Assignments"
 msgstr ""
 
-msgid "No %s selected to set to Synchronous"
+msgid "Adding a new %{model}"
 msgstr ""
 
-msgid "No %s selected to set to Asynchronous"
+msgid "Editing %{model} Condition \"%{name}\""
 msgstr ""
 
+msgid "%{model} Condition \"%{name}\""
+msgstr ""
+
+msgid "Adding a new %{alerts}"
+msgstr ""
+
+msgid "No %{member} were selected to move right"
+msgstr ""
+
+msgid "No %{member} were selected to move left"
+msgstr ""
+
+msgid "Select only one or consecutive %{member} to move up"
+msgstr ""
+
+msgid "Select only one or consecutive %{member} to move down"
+msgstr ""
+
+msgid "No %{member} selected to set to Synchronous"
+msgstr ""
+
+msgid "No %{member} selected to set to Asynchronous"
+msgstr ""
+
+msgid "Host is required"
+msgstr ""
+
+msgid "Trap Number is required"
+msgstr ""
+
+msgid "Trap Object ID is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
 msgid "Policy Profiles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
 msgid "Policies"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
 msgid "Events"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
 msgid "Conditions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
 msgid "Actions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
 msgid "Alert Profiles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
 msgid "Alerts"
 msgstr ""
 
 msgid "%{model} must contain at least one %{field}"
 msgstr ""
 
+msgid "Error during 'Alert Profile %{params}': "
+msgstr ""
+
+msgid "Edit %{model} assignments cancelled by user"
+msgstr ""
+
+msgid "A Tag Category must be selected"
+msgstr ""
+
 msgid "At least one Selection must be checked"
 msgstr ""
 
-msgid "Alert Profile \"%s\" assignments succesfully saved"
+msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
 msgstr ""
 
-msgid "The selected %s was deleted"
+msgid "%{model} no longer exists"
+msgstr ""
+
+msgid "The selected %{model} was deleted"
+msgstr ""
+
+msgid "All %{records}"
+msgstr ""
+
+msgid "Add of new %{models} was cancelled by the user"
+msgstr ""
+
+msgid "%{models} no longer exists"
+msgstr ""
+
+msgid "The selected %{models} was deleted"
+msgstr ""
+
+msgid "Error during alarms: %{messages}"
 msgstr ""
 
 msgid "A valid expression must be present"
 msgstr ""
 
-msgid "%s must be an integer"
+msgid "A Driving Event must be selected"
 msgstr ""
 
-msgid "At least one %s must be configured"
+msgid "Event name is required"
+msgstr ""
+
+msgid "Event to Check is required"
+msgstr ""
+
+msgid "Value Threshold must be an integer"
+msgstr ""
+
+msgid "Trend Steepness must be an integer"
+msgstr ""
+
+msgid ""
+"At least one of E-mail, SNMP Trap, Timeline Event, or Management Event must be"
+" configured"
+msgstr ""
+
+msgid "At least one E-mail recipient must be configured"
 msgstr ""
 
 msgid ""
@@ -1390,13 +1538,55 @@ msgstr ""
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr ""
 
-msgid "Actions for Policy Event \"%s\" were saved"
+msgid "Edit Event cancelled by user"
 msgstr ""
 
-msgid "E-mail address '%s' is not valid"
+msgid "Actions for Policy Event \"%{events}\" were saved"
+msgstr ""
+
+msgid "All %{tables}"
+msgstr ""
+
+msgid "No %{members} were selected to move left"
+msgstr ""
+
+msgid "No %{members} were selected to move right"
+msgstr ""
+
+msgid "Action Type must be selected"
+msgstr ""
+
+msgid "Analysis Profile is required"
+msgstr ""
+
+msgid "Attribute Name is required"
+msgstr ""
+
+msgid "At least one Alert must be selected"
+msgstr ""
+
+msgid "Parent Type must be selected"
+msgstr ""
+
+msgid "At least one Category must be selected"
+msgstr ""
+
+msgid "Snapshot Age must be selected"
+msgstr ""
+
+msgid "E-mail address 'From' is not valid"
+msgstr ""
+
+msgid "E-mail address 'To' is not valid"
+msgstr ""
+
+msgid "At least one Tag must be selected"
 msgstr ""
 
 msgid "%{model} \"%{name}\" already exists"
+msgstr ""
+
+msgid "Error during 'Policy Profile %{params}': %{messages}"
 msgstr ""
 
 msgid "No VMs match the selection criteria"
@@ -1405,7 +1595,10 @@ msgstr ""
 msgid "Policy Simulation generation returned: %{error_message}"
 msgstr ""
 
-msgid "Request %s was cancelled by the user"
+msgid "Request approval was cancelled by the user"
+msgstr ""
+
+msgid "Request denial was cancelled by the user"
 msgstr ""
 
 msgid "Request \"%{name}\" was %{task}"
@@ -1414,7 +1607,16 @@ msgstr ""
 msgid "Error retrieving LDAP info: %{error_message}"
 msgstr ""
 
-msgid "The selected %s were deleted"
+msgid "At least one status must be selected"
+msgstr ""
+
+msgid "The selected %{tables} were deleted"
+msgstr ""
+
+msgid "%{table} no longer exists"
+msgstr ""
+
+msgid "The selected %{table} was deleted"
 msgstr ""
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
@@ -1429,10 +1631,34 @@ msgstr ""
 msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr ""
 
+msgid "%s no longer exists"
+msgstr ""
+
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
 msgid "\"%{record}\": Analysis successfully initiated"
+msgstr ""
+
+msgid "Create Datastore was cancelled by the user"
+msgstr ""
+
+msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
+msgstr ""
+
+msgid "Create Logical Disk was cancelled by the user"
+msgstr ""
+
+msgid "Aggregate is required"
+msgstr ""
+
+msgid "Size is required"
+msgstr ""
+
+msgid "Size must be an integer"
+msgstr ""
+
+msgid "Adding a new Category"
 msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\""
@@ -1444,34 +1670,49 @@ msgstr ""
 msgid "Export generation returned: Status [%{status}] Message [%{message}]"
 msgstr ""
 
-msgid "%s Summary"
+msgid "VMDB Summary"
 msgstr ""
 
-msgid "%s Utilization"
+msgid "VMDB Utilization"
 msgstr ""
 
-msgid "%s Client Connections"
+msgid "VMDB Client Connections"
 msgstr ""
 
-msgid "All %s Indexes"
+msgid "All VMDB Indexes"
 msgstr ""
 
-msgid "%s Settings"
+msgid "VMDB Settings"
 msgstr ""
 
 msgid "Indexes for %{model} \"%{name}\""
 msgstr ""
 
+msgid "VMDB \"%{name}\" Table Utilization"
+msgstr ""
+
+msgid "Error during 'Appliance restart': %{message}"
+msgstr ""
+
 msgid "CFME Appliance restart initiated successfully"
 msgstr ""
 
-msgid "'%s' Worker restart initiated successfully"
+msgid "Error during 'workers restart': %{message}"
+msgstr ""
+
+msgid "'%{type}' Worker restart initiated successfully"
 msgstr ""
 
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr ""
 
+msgid "Error during 'Save': %{message}"
+msgstr ""
+
 msgid "Log Depot Settings were saved"
+msgstr ""
+
+msgid "Error during 'Validate': %{message}"
 msgstr ""
 
 msgid "Log Depot Settings were validated"
@@ -1480,13 +1721,34 @@ msgstr ""
 msgid "End Date cannot be greater than Start Date"
 msgstr ""
 
-msgid "%s successfully initiated"
+msgid "Error during 'C & U Gap Collection': %{message}"
 msgstr ""
 
-msgid "Error during Orphaned Records delete for user %s: "
+msgid "C & U Gap Collection successfully initiated"
 msgstr ""
 
-msgid "Orphaned Records for userid %s were successfully deleted"
+msgid "Error during 'Reset/synchronization process': %{message}"
+msgstr ""
+
+msgid "Reset/synchronization process successfully initiated"
+msgstr ""
+
+msgid "Database Backup successfully initiated"
+msgstr ""
+
+msgid "Error during 'Database Garbage Collection': %{message}"
+msgstr ""
+
+msgid "Database Garbage Collection successfully initiated"
+msgstr ""
+
+msgid "Error during Orphaned Records delete for user %{id}: %{message}"
+msgstr ""
+
+msgid "Orphaned Records for userid %{id} were successfully deleted"
+msgstr ""
+
+msgid "Error during 'Clear Connection Broker cache': %{message}"
 msgstr ""
 
 msgid "Connection Broker cache cleared successfully"
@@ -1506,7 +1768,16 @@ msgstr ""
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr ""
 
-msgid "%s is not allowed for the selected item"
+msgid "Start is not allowed for the selected item"
+msgstr ""
+
+msgid "Start successfully initiated"
+msgstr ""
+
+msgid "Suspend is not allowed for the selected item"
+msgstr ""
+
+msgid "Suspend successfully initiated"
 msgstr ""
 
 msgid "Setting priority is not allowed for the selected item"
@@ -1515,19 +1786,37 @@ msgstr ""
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr ""
 
-msgid "Error when adding a new tenant: "
+msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr ""
+
+msgid "Diagnostics %{model} \"%{name}\""
+msgstr ""
+
+msgid "Error when adding a new tenant: %{message}"
 msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
-msgid "Error when saving tenant quota: "
+msgid "Error when saving tenant quota: %{message}"
 msgstr ""
 
 msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr ""
 
+msgid "User no longer exists"
+msgstr ""
+
+msgid "Role no longer exists"
+msgstr ""
+
 msgid "Default %{model} \"%{name}\" can not be deleted"
+msgstr ""
+
+msgid "Tenant no longer exists"
+msgstr ""
+
+msgid "MiqGroup no longer exists"
 msgstr ""
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
@@ -1536,25 +1825,43 @@ msgstr ""
 msgid "User Group Sequence was saved"
 msgstr ""
 
-msgid "No %s were selected to move up"
+msgid "User must be entered to perform LDAP Group Look Up"
 msgstr ""
 
-msgid "No %s were selected to move down"
+msgid "Username must be entered to perform LDAP Group Look Up"
 msgstr ""
 
-msgid "%s must be entered to perform LDAP Group Look Up"
+msgid "User Password must be entered to perform LDAP Group Look Up"
+msgstr ""
+
+msgid "Error during 'LDAP Group Look Up': %{message}"
 msgstr ""
 
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
-msgid "Edit of %s was cancelled by the user"
+msgid "Edit of %{name} was cancelled by the user"
+msgstr ""
+
+msgid "Add of new %{name} was cancelled by the user"
 msgstr ""
 
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr ""
 
+msgid "Adding a new %{name}"
+msgstr ""
+
+msgid "Access Control %{model}"
+msgstr ""
+
+msgid "Access Control %{model} \"%{name}\""
+msgstr ""
+
 msgid "A User must be assigned to a Group"
+msgstr ""
+
+msgid "At least one Product Feature must be selected"
 msgstr ""
 
 msgid "A User Group must be assigned a Role"
@@ -1563,22 +1870,43 @@ msgstr ""
 msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
+msgid "Error during 'apply': %{error}"
+msgstr ""
+
 msgid "Records were successfully imported"
 msgstr ""
 
-msgid "Use the Browse button to locate %s file"
+msgid "Use the Browse button to locate CSV file"
 msgstr ""
 
-msgid "%s should be unique"
+msgid "LDAP Host is required"
 msgstr ""
 
-msgid "%s Credentials validated successfully"
+msgid "LDAP Host should be unique"
+msgstr ""
+
+msgid "Replication Worker Credentials validated successfully"
+msgstr ""
+
+msgid "Settings %{model} \"%{name}\""
+msgstr ""
+
+msgid "Region description is required"
 msgstr ""
 
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr ""
 
 msgid "Sample %{model} \"%{name}\" can not be edited"
+msgstr ""
+
+msgid "File Entry is required"
+msgstr ""
+
+msgid "Registry Entry is required"
+msgstr ""
+
+msgid "Event log name is required"
 msgstr ""
 
 msgid "Capacity and Utilization Collection settings saved"
@@ -1596,7 +1924,9 @@ msgstr ""
 msgid "Error during sending test email: %{class_name}, %{error_message}"
 msgstr ""
 
-msgid "The test email is being delivered, check \"%s\" to verify it was successful"
+msgid ""
+"The test email is being delivered, check \"%{email}\" to verify it was successfu"
+"l"
 msgstr ""
 
 msgid "CFME Database settings validation was successful"
@@ -1607,18 +1937,26 @@ msgid ""
 "estart"
 msgstr ""
 
-msgid "Error during %s: "
+msgid "Error during Server restart: %{message}"
 msgstr ""
 
-msgid "%s file saved"
+msgid "%{model}: Restart successfully initiated"
 msgstr ""
 
-msgid "Error when saving new server name: "
+msgid "%{name} file saved"
+msgstr ""
+
+msgid "Error when saving new server name: %{message}"
 msgstr ""
 
 msgid ""
-"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone"
-"}\""
+"Configuration settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone "
+"\"%{zone}\""
+msgstr ""
+
+msgid ""
+"Authentication settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone"
+" \"%{zone}\""
 msgstr ""
 
 msgid "Edit of Customer Information was cancelled"
@@ -1627,10 +1965,19 @@ msgstr ""
 msgid "Custom Support URL and Description both must be entered."
 msgstr ""
 
+msgid "VNC Proxy Port must be numeric"
+msgstr ""
+
 msgid "When configuring a VNC Proxy, both Address and Port are required"
 msgstr ""
 
+msgid "Error during Analysis Affinity save: %{message}"
+msgstr ""
+
 msgid "Analysis Affinity was saved"
+msgstr ""
+
+msgid "Settings %{model} \"%{name}\" (current)"
 msgstr ""
 
 msgid "Locate and upload a file to start the import process"
@@ -1639,10 +1986,19 @@ msgstr ""
 msgid "Choose the type of custom variables to be imported"
 msgstr ""
 
+msgid "Settings %{model}"
+msgstr ""
+
+msgid "Hostname is required"
+msgstr ""
+
 msgid "Customer Information successfully saved"
 msgstr ""
 
-msgid "Credential validation returned: %s"
+msgid "Credential validation returned: %{message}"
+msgstr ""
+
+msgid "%{name} is required"
 msgstr ""
 
 msgid "No Server was selected"
@@ -1657,27 +2013,36 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-msgid "%s has been initiated for the selected Servers"
+msgid "%{item} has been initiated for the selected Servers"
 msgstr ""
 
-msgid "Error occured when queuing action: %s"
+msgid "Error occured when queuing action: %{message}"
 msgstr ""
 
-msgid "Error when adding a new schedule: "
+msgid "Error when adding a new schedule: %{message}"
 msgstr ""
 
-msgid "The selected %s were enabled"
+msgid "The selected Schedules were enabled"
 msgstr ""
 
-msgid "The selected %s were disabled"
+msgid "The selected Schedules were disabled"
 msgstr ""
 
 msgid "Depot Settings successfuly validated"
 msgstr ""
 
+msgid "Filter must be selected"
+msgstr ""
+
+msgid "Filter value must be selected"
+msgstr ""
+
 msgid ""
 "Warning: This 'Run Once' timer is in the past and will never run as currently "
 "configured"
+msgstr ""
+
+msgid "Long Description is required"
 msgstr ""
 
 msgid "Custom logo image must be a .png file"
@@ -1686,10 +2051,13 @@ msgstr ""
 msgid "Custom login image must be a .png file"
 msgstr ""
 
-msgid "Custom Logo file \"%s\" uploaded"
+msgid "Custom Logo file \"%{name}\" uploaded"
 msgstr ""
 
-msgid "Custom login file \"%s\" uploaded"
+msgid "Custom login file \"%{name}\" uploaded"
+msgstr ""
+
+msgid "Use the Browse button to locate .png image file"
 msgstr ""
 
 msgid "Import validation complete: %{good_record}, %{bad_record}"
@@ -1699,6 +2067,15 @@ msgid "No valid import records were found, please upload another file"
 msgstr ""
 
 msgid "Press the Apply button to import the good records into the CFME database"
+msgstr ""
+
+msgid "Add of new %{table} was cancelled by the user"
+msgstr ""
+
+msgid "Zone name is required"
+msgstr ""
+
+msgid "%{task} initiated for %{count_model}"
 msgstr ""
 
 msgid "No common configuration profiles available for the selected configured %s"
@@ -1754,6 +2131,9 @@ msgstr ""
 msgid "Import file cannot be empty"
 msgstr ""
 
+msgid "At least %{num} %{model} must be selected for %{action}"
+msgstr ""
+
 msgid "Error: the file uploaded contains no widgets"
 msgstr ""
 
@@ -1772,9 +2152,12 @@ msgstr ""
 msgid "Saved Reports"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
 msgid "Reports"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
 msgid "Schedules"
 msgstr ""
 
@@ -1803,6 +2186,9 @@ msgstr ""
 msgid "Dashboard Sequence was saved"
 msgstr ""
 
+msgid "The selected %s was deleted"
+msgstr ""
+
 msgid "%{model} for \"%{name}\""
 msgstr ""
 
@@ -1810,6 +2196,18 @@ msgid "%{field} cannot contain \"%{character}\""
 msgstr ""
 
 msgid "%s must be unique for this group"
+msgstr ""
+
+msgid "No %s were selected to move up"
+msgstr ""
+
+msgid "Select only one or consecutive %s to move up"
+msgstr ""
+
+msgid "No %s were selected to move down"
+msgstr ""
+
+msgid "Select only one or consecutive %s to move down"
 msgstr ""
 
 msgid ""
@@ -1897,6 +2295,9 @@ msgstr ""
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr ""
 
+msgid "The selected %s were deleted"
+msgstr ""
+
 msgid "No Report Schedules were selected to be Run now"
 msgstr ""
 
@@ -1909,7 +2310,16 @@ msgstr ""
 msgid "No %s were selected to be enabled"
 msgstr ""
 
+msgid "The selected %s were enabled"
+msgstr ""
+
 msgid "No %s were selected to be disabled"
+msgstr ""
+
+msgid "The selected %s were disabled"
+msgstr ""
+
+msgid "At least one %s must be configured"
 msgstr ""
 
 msgid "Widget content generation error: "
@@ -2023,6 +2433,8 @@ msgid_plural "Guest Applications"
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container
+#. TRANSLATORS: en.yml key: dictionary.table.container
 #, fuzzy
 msgid "Container"
 msgid_plural "Container"
@@ -2160,9 +2572,12 @@ msgstr ""
 msgid "Hosts"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+#. TRANSLATORS: en.yml key: dictionary.table.container_node
 msgid "Node"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
 msgid "Cluster"
 msgstr ""
 
@@ -2175,6 +2590,7 @@ msgstr ""
 msgid "Deployment Roles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
 msgid "Clusters / Deployment Roles"
 msgstr ""
 
@@ -2250,6 +2666,7 @@ msgstr ""
 msgid "Analysis"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
 msgid "Policy"
 msgstr ""
 
@@ -3334,6 +3751,56 @@ msgstr ""
 msgid "Edit Tags for the selected #{ui_lookup(:tables=>\"ems_infras\")}"
 msgstr ""
 
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}"
+msgstr ""
+
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}?"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"ems_middleware\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"ems_middleware\")} and ALL of its components"
+" will be permanently removed from the Virtual Management Database.  Are you su"
+"re you want to remove this #{ui_lookup(:table=>\"ems_middleware\")}?"
+msgstr ""
+
+msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"ems_middleware\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of thei"
+"r components will be permanently removed from the Virtual Management Database."
+"  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_middl"
+"ewares\")}?"
+msgstr ""
+
 msgid "Edit Tags for this Flavor"
 msgstr ""
 
@@ -3631,6 +4098,46 @@ msgid "Reload the #{@msg_title} Log Display"
 msgstr ""
 
 msgid "Download the Entire #{@msg_title} Log File"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"middleware_server\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"middleware_server\")} and ALL of its compone"
+"nts will be permanently removed from the Virtual Management Database.  Are you"
+" sure you want to remove this #{ui_lookup(:table=>\"middleware_server\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"middleware_server\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"middleware_servers\")} and ALL of t"
+"heir components will be permanently removed from the Virtual Management Databa"
+"se.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"middle"
+"ware_servers\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_servers\")}"
 msgstr ""
 
 msgid "Edit this Action"
@@ -5350,6 +5857,7 @@ msgstr ""
 msgid "Start the selected items"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
 msgid "Start"
 msgstr ""
 
@@ -5476,6 +5984,8 @@ msgstr ""
 msgid "Request to Provision"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision
 msgid "Provision"
 msgstr ""
 
@@ -5787,6 +6297,9 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.action_type_description
+#. TRANSLATORS: en.yml key: dictionary.column.emstype_description
+#. TRANSLATORS: en.yml key: dictionary.column.mode
 msgid "Type"
 msgstr ""
 
@@ -5808,9 +6321,11 @@ msgstr ""
 msgid "Default Limit"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.max_trend_value
 msgid "Max"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_trend_value
 msgid "Min"
 msgstr ""
 
@@ -5892,15 +6407,21 @@ msgstr ""
 msgid "IPMI Present"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ip_address
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddress
 msgid "IP Address"
 msgstr ""
 
 msgid "Mac address"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
 msgid "Provider"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone
+#. TRANSLATORS: en.yml key: dictionary.table.zone
 msgid "Zone"
 msgstr ""
 
@@ -5919,6 +6440,7 @@ msgstr ""
 msgid "Compute Profile"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_arch
 msgid "Architecture"
 msgstr ""
 
@@ -5937,6 +6459,7 @@ msgstr ""
 msgid "Configuration Organization"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.operating_system
 msgid "OS"
 msgstr ""
 
@@ -5995,6 +6518,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Wachtwoord"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback
 msgid "Chargeback"
 msgstr ""
 
@@ -6004,48 +6528,72 @@ msgstr ""
 msgid "My Services"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
 msgid "Catalogs"
 msgstr ""
 
 msgid "Workloads"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_requests
 msgid "Requests"
 msgstr ""
 
 msgid "Clouds"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
 msgid "Availability Zones"
 msgstr ""
 
 msgid "Tenants"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
 msgid "Volumes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavors
 msgid "Flavors"
 msgstr ""
 
 msgid "Security Groups"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
 msgid "Instances"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
 msgid "Stacks"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
 msgid "Key Pairs"
 msgstr ""
 
 msgid "Infrastructure"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
 msgid "Virtual Machines"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.resource_pools
 msgid "Resource Pools"
 msgstr ""
 
@@ -6073,6 +6621,7 @@ msgstr ""
 msgid "Middleware"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
 msgid "Storage Managers"
 msgstr ""
 
@@ -6110,6 +6659,7 @@ msgstr ""
 msgid "My Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
 msgid "Tasks"
 msgstr ""
 
@@ -6119,9 +6669,12 @@ msgstr ""
 msgid "Object Types"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Storage
+#. TRANSLATORS: en.yml key: dictionary.table.storage
 msgid "Datastore"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
 msgid "Enterprise"
 msgstr ""
 
@@ -6483,12 +7036,15 @@ msgstr ""
 msgid "Display in Catalog"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
 msgid "Catalog"
 msgstr ""
 
 msgid "Unassigned"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
 msgid "Dialog"
 msgstr ""
 
@@ -6498,6 +7054,8 @@ msgstr ""
 msgid "Choose"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
 msgid "Orchestration Template"
 msgstr ""
 
@@ -6552,6 +7110,7 @@ msgstr ""
 msgid "Selected Resources"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction
 msgid "Action"
 msgstr ""
 
@@ -6636,6 +7195,7 @@ msgstr ""
 msgid "No Catalog Items found."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
 msgid "Catalog Items"
 msgstr ""
 
@@ -6777,6 +7337,8 @@ msgstr ""
 msgid "Grid/Tile Icons"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra
 msgid "Template"
 msgstr ""
 
@@ -6840,6 +7402,8 @@ msgstr ""
 msgid "Tagging"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
 msgid "Orchestration Templates"
 msgstr ""
 
@@ -6852,9 +7416,12 @@ msgstr ""
 msgid "VMs & Instances"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.vms
 msgid "VMs"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
 msgid "Templates"
 msgstr ""
 
@@ -6876,6 +7443,7 @@ msgstr ""
 msgid "Roll Up Performance"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.userid
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -7074,9 +7642,12 @@ msgstr ""
 msgid "Custom Identifier"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
 msgid "IPMI IP Address"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.mac_address
+#. TRANSLATORS: en.yml key: dictionary.column.macaddress
 msgid "MAC Address"
 msgstr ""
 
@@ -7099,6 +7670,8 @@ msgstr ""
 msgid "Custom Attributes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
 msgid "VC Custom Attributes"
 msgstr ""
 
@@ -7186,6 +7759,8 @@ msgstr ""
 msgid "System/Process"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request
 msgid "Request"
 msgstr ""
 
@@ -7230,6 +7805,7 @@ msgstr "Nieuw wachtwoord"
 msgid "Private Key"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification
 msgid "Category"
 msgstr ""
 
@@ -7488,6 +8064,7 @@ msgstr ""
 msgid "Options %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.interval
 msgid "Interval"
 msgstr ""
 
@@ -7507,6 +8084,7 @@ msgstr ""
 msgid "Show VM Types"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
 msgid "Time Profile"
 msgstr ""
 
@@ -7883,6 +8461,7 @@ msgstr ""
 msgid "Show %{host_title}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
 msgid "Direct VMs"
 msgstr ""
 
@@ -7943,6 +8522,7 @@ msgstr ""
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.guest_devices
 msgid "Devices"
 msgstr ""
 
@@ -8429,6 +9009,8 @@ msgstr ""
 msgid "Dialog Information"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
 msgid "Buttons"
 msgstr ""
 
@@ -8576,6 +9158,7 @@ msgstr ""
 msgid "Select a node on the left to view Bottlenecks timeline."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport
 msgid "Report"
 msgstr ""
 
@@ -8632,6 +9215,7 @@ msgstr ""
 msgid "VM Options"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_speed
 msgid "CPU Speed"
 msgstr ""
 
@@ -8814,6 +9398,7 @@ msgstr ""
 msgid "Object ID"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
 msgid "Analysis Profile"
 msgstr ""
 
@@ -8835,6 +9420,7 @@ msgstr ""
 msgid "Parent Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
 msgid "Categories"
 msgstr ""
 
@@ -8892,6 +9478,7 @@ msgstr ""
 msgid "SNMP Trap Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
 msgid "Analysis Profiles"
 msgstr ""
 
@@ -8931,6 +9518,8 @@ msgstr ""
 msgid "Choose a %s first"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.active
+#. TRANSLATORS: en.yml key: dictionary.column.enabled
 msgid "Active"
 msgstr ""
 
@@ -9015,6 +9604,8 @@ msgstr ""
 msgid "No Alerts are defined %s."
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event
 msgid "Management Event"
 msgstr ""
 
@@ -9439,6 +10030,7 @@ msgstr ""
 msgid "Datacenter"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
 msgid "Resource Pool"
 msgstr ""
 
@@ -9490,6 +10082,7 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
 msgid "Provisioned VMs"
 msgstr ""
 
@@ -9556,6 +10149,8 @@ msgstr ""
 msgid "SmartProxy Affinity"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server
 msgid "Server"
 msgstr ""
 
@@ -9589,6 +10184,9 @@ msgstr ""
 msgid "Servers by Roles"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_servers
 msgid "Servers"
 msgstr ""
 
@@ -9625,9 +10223,11 @@ msgstr ""
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem
 msgid "File"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items
 msgid "Registry"
 msgstr ""
 
@@ -9703,6 +10303,7 @@ msgstr ""
 msgid "Rows"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
 msgid "Size"
 msgstr ""
 
@@ -9822,12 +10423,15 @@ msgstr ""
 msgid "LDAP Groups for User"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
 msgid "LDAP Servers"
 msgstr ""
 
 msgid "Mode"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.ldap
 msgid "LDAP"
 msgstr ""
 
@@ -9864,6 +10468,8 @@ msgstr ""
 msgid "Click to edit this forest"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
 msgid "LDAP Domains"
 msgstr ""
 
@@ -9946,6 +10552,7 @@ msgstr ""
 msgid "(Look Up LDAP Groups)"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
 msgid "Role"
 msgstr ""
 
@@ -10048,6 +10655,7 @@ msgstr ""
 msgid "User Information"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.User.name
 #, fuzzy
 msgid "Full Name"
 msgstr "Nederlands"
@@ -10117,9 +10725,11 @@ msgstr "Aangepast op"
 msgid "Stopped On"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.memory_size
 msgid "Memory Usage"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_time
 msgid "CPU Time"
 msgstr ""
 
@@ -10282,6 +10892,9 @@ msgstr ""
 msgid "View Zones"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zones
 msgid "Zones"
 msgstr ""
 
@@ -10291,6 +10904,8 @@ msgstr ""
 msgid "View LDAP Regions"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
 msgid "LDAP Regions"
 msgstr ""
 
@@ -10529,6 +11144,9 @@ msgstr ""
 msgid "Appliances in this region can be registered with:"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService
+#. TRANSLATORS: en.yml key: dictionary.model.Service
+#. TRANSLATORS: en.yml key: dictionary.table.container_service
 msgid "Service"
 msgstr ""
 
@@ -10612,6 +11230,8 @@ msgstr ""
 msgid "Tenancy"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
 msgid "ISO Images"
 msgstr ""
 
@@ -10651,6 +11271,7 @@ msgid ""
 " PXE Server"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
 msgid "PXE Images"
 msgstr ""
 
@@ -10696,13 +11317,22 @@ msgstr ""
 msgid "Available Fields:"
 msgstr ""
 
+msgid "down"
+msgstr ""
+
+msgid "up"
+msgstr ""
+
+msgid "Move selected fields %{where}"
+msgstr ""
+
 msgid "Selected Fields:"
 msgstr ""
 
-msgid "Move selected fields to top"
+msgid "to bottom"
 msgstr ""
 
-msgid "Move selected fields to bottom"
+msgid "to top"
 msgstr ""
 
 msgid "Tab Title"
@@ -10762,6 +11392,7 @@ msgstr ""
 msgid "Commit Changes"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
 msgid "Widgets"
 msgstr ""
 
@@ -10905,6 +11536,7 @@ msgstr ""
 msgid "Show Costs by"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.owner_name
 msgid "Owner"
 msgstr ""
 
@@ -11396,6 +12028,10 @@ msgstr ""
 msgid "Hover Text"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.container_image
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud
 msgid "Image"
 msgstr ""
 
@@ -11419,6 +12055,12 @@ msgid "Move selected fields right"
 msgstr ""
 
 msgid "Move selected fields left"
+msgstr ""
+
+msgid "Move selected fields to top"
+msgstr ""
+
+msgid "Move selected fields to bottom"
 msgstr ""
 
 msgid "Button Group Text"
@@ -11478,6 +12120,8 @@ msgstr ""
 msgid "Placement"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder
 msgid "Folder"
 msgstr ""
 
@@ -11587,9 +12231,13 @@ msgstr ""
 msgid "Add this %s"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region
 msgid "Region"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+#. TRANSLATORS: en.yml key: dictionary.table.container_project
 msgid "Project"
 msgstr ""
 
@@ -11684,18 +12332,22 @@ msgstr ""
 msgid "Network Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.nics
 msgid "Network Adapters"
 msgstr ""
 
 msgid "%s has no network adapters"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
 msgid "DHCP Enabled"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
 msgid "DHCP Server"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.dns_server
 msgid "DNS Server"
 msgstr ""
 
@@ -11708,18 +12360,23 @@ msgstr ""
 msgid "Subnet Mask"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
 msgid "CPU Limit"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
 msgid "CPU Reserve"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
 msgid "CPU Reserve Expand"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
 msgid "CPU Shares"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
 msgid "CPU Shares Level"
 msgstr ""
 
@@ -11741,6 +12398,7 @@ msgstr ""
 msgid "Device Type"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
 msgid "Partitions Aligned"
 msgstr ""
 
@@ -11941,6 +12599,3293 @@ msgstr ""
 #. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
 msgid "locale_name"
 msgstr "Nederlands"
+
+#. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+msgid "Total Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+msgid "Total Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+msgid "CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+msgid "CPU - Total Installed - Sum of Child Hosts (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+msgid "Disk I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg ("
+"%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High "
+"Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low A"
+"vg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+msgid "Memory - Avg Usage of Total Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+msgid ""
+"Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Interv"
+"als (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+msgid "Network I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+msgid "CPU - Total Installed - from Host Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+msgid "Disk Space Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+msgid "CPU - Time Spent In Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+msgid "CPU - Time Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+msgid "CPU - Time Used (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+msgid "CPU - Time Spent in Wait State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+msgid "CPU - Total - from VM Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+msgid "CPU - Reserved (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+msgid "Memory - Total Allocated (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+msgid "Memory - Reserved (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+msgid "Memory - Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+msgid "CPU Max Reserved MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+msgid "Memory Max Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+msgid "Memory Max Reserved"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+msgid "Memory - Peak Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+msgid "Memory - Minimum Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+msgid "CPU - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+msgid "Memory - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+msgid "CPU - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+msgid "Memory - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+msgid "Network I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+msgid "CPU - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+msgid "Memory - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+msgid "Network I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.acctid
+msgid "Account ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.accttype
+msgid "Account Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+msgid "Lockdown Mode"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+msgid "Total Number of Logical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+msgid "Total Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+msgid "Total Number of Physical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+msgid "Allocated Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+msgid "Allocated Storage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+msgid "Allocated vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios
+msgid "BIOS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios_location
+msgid "BIOS Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.chain_id
+msgid "Chain ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+msgid "Usage (CIFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+msgid "Usage (CIFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+msgid "Usage (CIFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+msgid "Usage (CIFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+msgid "Usage (CIFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+msgid "Usage (CIFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+msgid "Usage (CIFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+msgid "Usage (CIFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+msgid "Usage (CIFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+msgid "Usage (CIFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+msgid "Usage (CIFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+msgid "Usage (CIFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+msgid "Usage (CIFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+msgid "Usage (CIFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+msgid "Usage (CIFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+msgid "Usage (CIFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+msgid "Usage (CIFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+msgid "Usage (CIFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+msgid "Usage (CIFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+msgid "Usage (CIFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+msgid "Usage (CIFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+msgid "Usage (CIFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+msgid "Usage (CIFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+msgid "Usage (CIFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.config_xml
+msgid "Configuration XML"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+msgid "Data Points"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+msgid "CPU Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_type
+#, fuzzy
+msgid "CPU Type"
+msgstr "Gebruikersnaam"
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High A"
+"vg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Av"
+"g (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+msgid "CPU - Aggregate Time Used for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+msgid "CPU - Aggregate Time Spent in Wait State for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.created_at
+#. TRANSLATORS: en.yml key: dictionary.column.created_on
+msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+msgid "Depends on Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+msgid "Depends on Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+msgid "CPU Total Installed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+msgid "CPU - Available (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+msgid "State - Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+msgid "State - Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+msgid "Memory - Total Allocated for Child VMs (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+msgid "Memory - Available (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg "
+"(MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg ("
+"MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+msgid "Content - Avg of Total Size of Managed VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+msgid "Content - Avg of Total Size of Registered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+msgid "Capacity - Avg Free Space for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+msgid "Content - Avg of Total Size of Managed VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+msgid "Content - Avg of Total Size of Registered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+msgid "Content - Avg of Total Size of Managed VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+msgid "Content - Avg of Total Size of Registered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+msgid "Capacity - Total Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+msgid "Content - Avg Space Used by Managed VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+msgid "Content - Avg Space Used by Registered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+msgid "Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+msgid "Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+msgid "Content - Avg Count of Managed VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+msgid "Content - Avg Count of Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+msgid "Content - Avg Count of Unmanaged VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+msgid "Content - Avg Count of Unregistered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+msgid "State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+msgid "State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+msgid "Destination Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+msgid "Destination VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+msgid "Destination VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+msgid "Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+msgid "Disk Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+msgid "Disk Kernel Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+msgid "Disk Queue Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+msgid "Disk I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+msgid "Disks Aligned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+msgid "CPU - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_memory
+msgid "Memory - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+msgid "End"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+msgid "What is evaluated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.event_src
+msgid "Event Source"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.filename
+#, fuzzy
+msgid "File Name"
+msgstr "Nederlands"
+
+#. TRANSLATORS: en.yml key: dictionary.column.fqname
+msgid "Fully Qualified Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guest_os
+msgid "Guest OS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guid
+msgid "EVM Unique ID (Guid)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+msgid "Has an RDM Disk?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state
+msgid "Health State Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state_str
+msgid "Health State"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.homedir
+msgid "Home Directory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.host_name
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+msgid "Parent Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.hostnames
+msgid "Host Names"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+msgid "IP Addresses"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+msgid "IPMI Enabled"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+msgid "Is an EVM Appliance?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+msgid "Last Analysis Attempt On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+msgid "Last Analysis Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+msgid "Last Sync Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status
+msgid "Last Update Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+msgid "Last Update Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ldap_group
+#. TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+msgid "LDAP Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+msgid "Number of CPU Cores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.macaddresses
+msgid "MAC Addresses"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+msgid "CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max"
+" (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+msgid "CPU Max Total MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+msgid "CPU Max Available MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+msgid "State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+msgid "State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+msgid "Memory Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+msgid "Memory Max Available"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+msgid "Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+msgid "Disk Space Max Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+msgid "State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+msgid "Memory - Swap In Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+msgid "Memory - Swap Out Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+msgid "Memory - Swapped Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+msgid "Memory - Peak Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+msgid "Uptime - Peak Uptime for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+msgid "Disk Space Max Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+msgid "Memory - Swap In Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+msgid "Memory - Swap Out Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+msgid "Memory - Swapped Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+msgid "Memory - Usage of Total Allocated (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_mb
+msgid "RAM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+msgid "State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+msgid "State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+msgid "Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+msgid "Disk Space Min Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+msgid "State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+msgid "State - Min Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+msgid "Memory - Swap In Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+msgid "Memory - Swap Out Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+msgid "Memory - Swapped Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+msgid "Memory - Swap Min Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+msgid "Memory - Min Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+msgid "Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+msgid "Disk Space Min Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+msgid "Multiple Host Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+msgid "Network I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+msgid "Usage (NFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+msgid "Usage (NFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+msgid "Usage (NFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+msgid "Usage (NFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+msgid "Usage (NFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+msgid "Usage (NFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+msgid "Usage (NFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+msgid "Usage (NFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+msgid "Usage (NFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+msgid "Usage (NFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+msgid "Usage (NFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+msgid "Usage (NFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+msgid "Usage (NFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+msgid "Usage (NFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+msgid "Usage (NFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+msgid "Usage (NFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+msgid "Usage (NFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+msgid "Usage (NFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+msgid "Usage (NFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+msgid "Usage (NFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+msgid "Usage (NFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+msgid "Usage (NFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+msgid "Usage (NFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+msgid "Usage (NFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_automate
+msgid "Management Event Raised"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_email
+msgid "Email"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+msgid "Event on Timeline"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+msgid "SNMP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_cpu
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+msgid "Number of CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_disks
+msgid "Number of Disks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+msgid "Number of Hard Disks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status
+msgid "Operational Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+msgid "Operational Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.os_image_name
+msgid "OS Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency
+msgid "Usage (Other) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+msgid "Usage (Other) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+msgid "Usage (Other) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops
+msgid "Usage (Other) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+msgid "Usage (Other) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+msgid "Usage (Other) - Number of Other Operations per Second Miin"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+msgid "Memory - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+msgid "CPU - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+msgid "In My LDAP Group?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+msgid "Owned by Me?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+msgid "Folder Name (VMs & Templates) 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+msgid "Folder Name (VMs & Templates) 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+msgid "Folder Name (VMs & Templates) 3"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+msgid "Folder Name (VMs & Templates) 4"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+msgid "Folder Name (VMs & Templates) 5"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+msgid "Folder Name (VMs & Templates) 6"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+msgid "Folder Name (VMs & Templates) 7"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+msgid "Folder Name (VMs & Templates) 8"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+msgid "Folder Name (VMs & Templates) 9"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+msgid "CPU %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_memory
+msgid "Memory %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pid
+msgid "PID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+msgid "Total Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ram_size
+msgid "RAM Size (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data
+msgid "Usage (Other) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_max
+msgid "Usage (Other) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_min
+msgid "Usage (Other) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency
+msgid "Usage (Other) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+msgid "Usage (Other) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+msgid "Usage (Other) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops
+msgid "Usage (Other) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+msgid "Usage (Other) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+msgid "Usage (Other) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.resource_name
+#, fuzzy
+msgid "Asset Name"
+msgstr "Gebruikersnaam"
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+msgid "Total VMs Powered Never"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+msgid "Total VMs Powered Off"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+msgid "Total VMs Powered On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+msgid "Total VMs Power Suspended"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+msgid "Total VMs Powered Unknown"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+msgid "CPU - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+msgid "State - Number of Hosts  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+msgid "Memory - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+msgid "State - Peak Avg VMs - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+msgid "CPU - Usage Rate for Collected Intervals (Number of Cores)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+msgid "Memory - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+msgid "Memory - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+msgid "Memory - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+msgid "CPU - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+msgid "CPU - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+msgid "CPU - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+msgid "Capacity - Profile 1 - Total Memory with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+msgid "Capacity - Profile 1 - Total CPU with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+msgid "Capacity - Profile 1 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+msgid "Capacity - Profile 1 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+msgid "Capacity - Profile 1 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+msgid "Capacity - Profile 1 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+msgid "Capacity - Profile 1 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+msgid "Capacity - Profile 1 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+msgid "Capacity - Profile 1 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+msgid "Capacity - Profile 1 - Available vCPUs for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 1 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+msgid "Capacity - Profile 1 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+msgid "Capacity - Profile 1 - Maximum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+msgid "Capacity - Profile 1 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+msgid "Capacity - Profile 1 - Minimum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+msgid "Capacity - Profile 1 - Number of vCPUs per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+msgid "Capacity - Profile 2 - Memory Effective with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+msgid "Capacity - Profile 2 - CPU Effective with HA (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+msgid "Capacity - Profile 2 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+msgid "Capacity - Profile 2 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+msgid "Capacity - Profile 2 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+msgid "Capacity - Profile 2 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+msgid "Capacity - Profile 2 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+msgid "Capacity - Profile 2 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+msgid "Capacity - Profile 2 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+msgid "Capacity - Profile 2 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+msgid "Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 2 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+msgid "Capacity - Profile 2 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+msgid "Capacity - Profile 2 - Maximum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+msgid "Capacity - Profile 2 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+msgid "Capacity - Profile 2 - Minimum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+msgid "Memory - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+msgid "Memory - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+msgid "Memory - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+msgid "CPU - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+msgid "CPU - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+msgid "CPU - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+msgid "Created on Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+msgid "Memory - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+msgid "Memory - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+msgid "Memory - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+msgid "CPU - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+msgid "CPU - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+msgid "CPU - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+msgid "Memory - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+msgid "CPU - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+msgid "Usage (Block Protocol) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data
+msgid "Usage (Block Protocol) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+msgid "Usage (Block Protocol) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+msgid "Usage (Block Protocol) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+msgid "Usage (Block Protocol) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+msgid "Usage (Block Protocol) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+msgid "Usage (Block Protocol) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+msgid "Usage (Block Protocol) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+msgid "Usage (Block Protocol) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+msgid "Usage (Block Protocol) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data
+msgid "Usage (Block Protocol) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+msgid "Usage (Block Protocol) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+msgid "Usage (Block Protocol) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+msgid "Usage (Block Protocol) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+msgid "Usage (Block Protocol) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+msgid "Usage (Block Protocol) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+msgid "Usage (Block Protocol) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+msgid "Usage (Block Protocol) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+msgid "Usage (Block Protocol) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.slope
+msgid "Slope"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_host_name
+msgid "Source Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+msgid "Source VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+msgid "Source VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+msgid "SSH Root Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.svc_type
+msgid "Service Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+msgid "Asset - Uptime (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+msgid "Thin Provisioned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.timestamp
+#. TRANSLATORS: en.yml key: dictionary.column.statistic_time
+msgid "Activity Sample - Timestamp (Day/Time)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops
+msgid "Usage (All) - Number of Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+msgid "Usage (All) - Number of Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+msgid "Usage (All) - Number of Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+msgid "CPU Average Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+msgid "Memory Average Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+msgid "CPU Max Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+msgid "Memory Max Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+msgid "Disk I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+msgid "Network I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+msgid "Disk Space Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+msgid "Disk Space Average Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.typename
+msgid "Type Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uid
+msgid "UID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+msgid "Uncommitted Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.updated_at
+#. TRANSLATORS: en.yml key: dictionary.column.updated_on
+msgid "Date Updated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+msgid "Total Used Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+msgid "Percent Used Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+msgid "Currently Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+msgid "CPU Cores Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+msgid "Datastore Path"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_date
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+msgid "Activity Sample - Day (MM DD YY)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+msgid "Non-VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+msgid "Capacity - Used Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+msgid "Disk Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+msgid "Free Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+msgid "Parent Host Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+msgid "Is a Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+msgid "VM Memory Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_month
+msgid "Activity Sample - Month (YYYY/MM)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+msgid "Parent Folder (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+msgid "Parent Folder Path (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+msgid "Parent Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+msgid "Parent Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+msgid "Parent Folder (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+msgid "Parent Folder Path (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+msgid "Parent Resource Pool"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+msgid "Parent Folder"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+msgid "CPU - % Ready"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+msgid "CPU - % Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+msgid "CPU - % Wait"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+msgid "Pct Free Disk"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+msgid "Provisioned Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+msgid "Cluster in Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+msgid "Memory Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+msgid "Snapshot Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_time
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+msgid "Activity Sample - Time (HH MM SS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+msgid "Size of Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+msgid "Size of VM Provisioned Disk Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+msgid "Total Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+msgid "Size of VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+msgid "Size of VM Snapshot Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+msgid "Total Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+msgid "Size of Other VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+msgid "Total VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space
+#, fuzzy
+msgid "Used Space"
+msgstr "Gebruikersnaam"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+msgid "Used Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+msgid "Other VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+msgid "Virtual Hardware Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+msgid "VMM Build Number"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_product
+msgid "VMM Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+msgid "VMM Vendor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_version
+msgid "VMM Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+msgid "VMsafe Agent Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+msgid "VMsafe Agent Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+msgid "VMsafe Enable"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+msgid "VMsafe Fail Open"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+msgid "VMsafe Immutable VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+msgid "VMsafe Timeout (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data
+msgid "Usage (All) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_max
+msgid "Usage (All) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_min
+msgid "Usage (All) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency
+msgid "Usage (All) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+msgid "Usage (All) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+msgid "Usage (All) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops
+msgid "Usage (All) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+msgid "Usage (All) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+msgid "Usage (All) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ws_port
+msgid "Web Services Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.zone_name
+msgid "EVM Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+msgid "vCPUs Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+msgid "vCPUs Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+msgid "CPU Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+msgid "CPU Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+msgid "CPU Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+msgid "CPU Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+msgid "Disk I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+msgid "Disk I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+msgid "Disk I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+msgid "Disk I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.display_range
+msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+msgid "Fixed Compute Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+msgid "Fixed Compute Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+msgid "Fixed Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+msgid "Fixed Storage Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+msgid "Fixed Storage Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+msgid "Memory Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+msgid "Memory Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_cost
+msgid "Memory Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_metric
+msgid "Memory Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+msgid "Memory Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+msgid "Memory Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+msgid "Network I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+msgid "Network I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+msgid "Network I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+msgid "Network I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+msgid "Storage Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+msgid "Storage Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_cost
+msgid "Storage Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_metric
+msgid "Storage Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+msgid "Storage Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+msgid "Storage Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_cost
+msgid "Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vm_name
+msgid "VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+msgid "Average Read Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+msgid "Average Write Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+msgid "Read (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+msgid "Transferred (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+msgid "Written (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_hit
+msgid "Hit %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_read
+msgid "Read %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_write
+msgid "Write %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.queue_depth
+msgid "Queue Depth"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+msgid "Read Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+msgid "Read (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+msgid "Response Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+msgid "Service Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+msgid "Total (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.utilization
+msgid "Utilization %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+msgid "Wait Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+msgid "Write Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+msgid "Write (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+msgid "EVM Audit Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+msgid "EVM Audit Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone
+msgid "Availability Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+msgid "Chargebacks"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+msgid "Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+msgid "Chargeback Rates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+msgid "Storage - Extent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+msgid "Storage - Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances
+#. TRANSLATORS: en.yml key: dictionary.table.compliances
+msgid "Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+#, fuzzy
+msgid "Compliance Histories"
+msgstr "Toestel:"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Condition
+msgid "Condition"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button
+msgid "Button"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+msgid "Buttons Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+msgid "Buttons Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+#. TRANSLATORS: en.yml key: dictionary.table.container_group
+msgid "Pod"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+msgid "Image Registry"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+msgid "Image Registries"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+#. TRANSLATORS: en.yml key: dictionary.table.container_route
+msgid "Route"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator
+msgid "Replicator"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicators
+msgid "Replicators"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+msgid "Cluster / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+msgid "Performance - Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+msgid "Performance - Clusters"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_events
+msgid "Management Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folders
+msgid "Folders"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+msgid "Performance - Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+msgid "Performance - Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+msgid "FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+msgid "FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+msgid "Anonymous FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+msgid "Anonymous FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+msgid "NFS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+msgid "Samba"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+msgid "Sambas"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor
+#. TRANSLATORS: en.yml key: dictionary.table.flavor
+msgid "Flavor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+msgid "Host / Nodes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+msgid "Performance - Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+msgid "Performance - Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+msgid "ISO Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+msgid "ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image
+msgid "ISO Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+msgid "LDAP Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region
+msgid "LDAP Region"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server
+msgid "LDAP Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+msgid "Configuration Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+msgid "Configuration Managers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+msgid "Foreman Configured System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+msgid "Foreman Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+msgid "Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+msgid "Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+msgid "Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container
+msgid "Containers Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_containers
+msgid "Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra
+msgid "Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infras
+msgid "Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+msgid "Virtual Machine"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+msgid "Infrastructure Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+msgid "Infrastructure Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+msgid "Infrastructure Provider (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+msgid "Infrastructure Providers (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+msgid "Infrastructure Provider (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+msgid "Infrastructure Providers (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+msgid "Infrastructure Provider (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+msgid "Infrastructure Providers (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+msgid "Cloud Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+msgid "Cloud Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+msgid "Cloud Provider (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+msgid "Cloud Providers (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+msgid "Cloud Provider (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+msgid "Cloud Providers (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+msgid "Container Provider (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+msgid "Container Providers (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+msgid "Container Provider (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+msgid "Container Providers (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+msgid "Container Provider (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+msgid "Container Providers (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+msgid "Container Provider (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+msgid "Container Providers (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+msgid "Automate Class"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+msgid "Automate Classes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+msgid "Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+msgid "Automate Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+msgid "Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+msgid "Automate Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+msgid "Automate Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+msgid "Automate Methods"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+msgid "Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+msgid "Automate Namespaces"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+msgid "Alert"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+msgid "Alert Profile"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+msgid "Dialogs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+msgid "Enterprises"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+msgid "Event"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+msgid "EVM Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+msgid "EVM Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+msgid "Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+msgid "Provisions"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+msgid "SmartProxy"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+msgid "SmartProxies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_regions
+#, fuzzy
+msgid "Regions"
+msgstr "Regio:"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+msgid "Schedule"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+msgid "Search"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+msgid "Searches"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+msgid "SMI-S Agent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+msgid "SMI-S Agents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+msgid "VM Template and Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+msgid "VM Template and Images"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+msgid "Roles"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+msgid "Widget"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker
+msgid "EVM Worker"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_workers
+msgid "EVM Workers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+msgid "NetApp Remote Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+msgid "NetApp Remote Services"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+msgid "Storage - Aggregate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+msgid "Storage - Aggregates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+msgid "Storage - File Share"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+msgid "Storage - File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+msgid "Storage - Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+msgid "Storage - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+msgid "Storage - Plex"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+msgid "Storage - Plexes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+msgid "Storage - Raid Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+msgid "Storage - Raid Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+msgid "Storage - Filer"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+msgid "Storage - Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+msgid "Storage - LUN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+msgid "Storage - LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+msgid "Storage Performance - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+msgid "CloudFormation Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+msgid "CloudFormation Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+msgid "Heat Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+msgid "Heat Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+msgid "Azure Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+msgid "Azure Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+msgid "Product Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+msgid "Product Updates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+msgid "Customization Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+msgid "Customization Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage
+msgid "PXE Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+msgid "System Image Type"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+msgid "System Image Types"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer
+msgid "PXE Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+msgid "PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem
+msgid "Scan Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+msgid "Scan Items"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+msgid "Service Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+msgid "Service Catalog Items"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+msgid "Storage - Local File System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+msgid "Storage - Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storages
+msgid "Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file
+msgid "Datastore File"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_files
+msgid "Datastore Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager
+msgid "Storage Manager"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+msgid "Performance - Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+msgid "Performance - Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User
+msgid "EVM User"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+msgid "EVM Users"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+msgid "Performance Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+msgid "Performance Trends"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm
+msgid "VM and Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+msgid "VM and Instances"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+msgid "VMDB Table"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+msgid "VMDB Tables"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+msgid "VM or Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+msgid "VM or Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+msgid "Performance - VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+msgid "Performance - VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cdroms
+msgid "CD/DVD Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+msgid "Base Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+msgid "Cloud Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+msgid "Cloud Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+msgid "Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+msgid "VC Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+msgid "Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+msgid "Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server
+msgid "Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+msgid "Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+msgid "Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner
+msgid "EVM Owner"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+msgid "EVM Owners"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+msgid "Cloud/Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+msgid "Cloud/Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+msgid "File System Drivers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.floppies
+msgid "Floppy Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.lans
+msgid "vLANs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance
+msgid "Last Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+msgid "Last Compliance Histories"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+msgid "LDAPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+msgid "Linux Init Processes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+msgid "Stamped Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+msgid "Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+msgid "EVM Custom Attribute"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+msgid "EVM Custom Attributes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+msgid "Configuration Profile (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+msgid "Configuration Profiles (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+msgid "Cloud Networks (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+msgid "Cloud Tenants (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+msgid "Provisioned From Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+msgid "Provisioned From Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+msgid "SmartProxy Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+msgid "SCSI LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task
+msgid "Task"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template
+msgid "VM Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+msgid "VM Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+msgid "File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+msgid "Filers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+msgid "LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+#, fuzzy
+msgid "Stack"
+msgstr "Terug"
+
+#. TRANSLATORS: en.yml key: dictionary.table.server_builds
+msgid "EVM Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.service_template
+msgid "Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.switches
+msgid "vSwitches"
+msgstr ""
 
 msgid "Account|Acctid"
 msgstr ""
@@ -12462,9 +16407,6 @@ msgid "Computer system"
 msgstr ""
 
 msgid "ComputerSystem|Managed entity type"
-msgstr ""
-
-msgid "Condition"
 msgstr ""
 
 msgid "Condition|Applies to exp"
@@ -13581,9 +17523,6 @@ msgid "FirewallRule|Source ip range"
 msgstr ""
 
 msgid "FirewallRule|Updated on"
-msgstr ""
-
-msgid "Flavor"
 msgstr ""
 
 msgid "Flavor|Block storage based only"
@@ -18817,9 +22756,6 @@ msgid "VmdbTable|Name"
 msgstr ""
 
 msgid "VmdbTable|Prior raw metrics"
-msgstr ""
-
-msgid "Volume"
 msgstr ""
 
 msgid "Volume|Created on"

--- a/config/locales/zh_CN/manageiq.po
+++ b/config/locales/zh_CN/manageiq.po
@@ -17,6 +17,7 @@ msgstr ""
 msgid "CPU"
 msgstr "CPU"
 
+#. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
 msgid "Memory"
 msgstr "内存"
 
@@ -46,32 +47,60 @@ msgstr ""
 msgid "Network Utilization Trends"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
 msgid "Providers"
 msgstr "提供者"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_nodes
 msgid "Nodes"
 msgstr "节点"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.containers
 msgid "Containers"
 msgstr "容器"
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
 #, fuzzy
 msgid "Registries"
 msgstr "注册表"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_projects
 msgid "Projects"
 msgstr "项目"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_groups
 #, fuzzy
 msgid "Pods"
 msgstr "节点"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_services
+#. TRANSLATORS: en.yml key: dictionary.table.host_services
 msgid "Services"
 msgstr "服务"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_images
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
 msgid "Images"
 msgstr "图像"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_routes
 #, fuzzy
 msgid "Routes"
 msgstr "速率"
@@ -232,9 +261,11 @@ msgstr ""
 msgid "Second"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.compliance_details
 msgid "Details"
 msgstr "细节"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_message
 msgid "Message"
 msgstr "消息"
 
@@ -516,6 +547,7 @@ msgstr ""
 msgid "%{model}: %{task} successfully initiated"
 msgstr "%{model}: %{task} 已成功初始化"
 
+#. TRANSLATORS: en.yml key: dictionary.table.hosts
 msgid "Hosts / Nodes"
 msgstr "主机/节点"
 
@@ -817,6 +849,7 @@ msgstr "没有找到这个时间轴的记录"
 msgid "* You are not authorized to view %{children} on this %{model}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
 msgid "Key Pair"
 msgstr ""
 
@@ -1065,6 +1098,7 @@ msgstr "默认视图"
 msgid "Default Filters"
 msgstr "默认过滤器"
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
 msgid "Time Profiles"
 msgstr "Time 配置集"
 
@@ -1178,6 +1212,8 @@ msgstr "必须修改值，否则提供者无法进行缩放。"
 msgid "%s (All cloud tenants present on this host)"
 msgstr "%s（存在于主机上的所有云 tenant）"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.filesystems
 msgid "Files"
 msgstr "文件"
 
@@ -1199,6 +1235,8 @@ msgstr "用户取消了对所选 %s 的凭证的编辑"
 msgid "Credentials/Settings saved successfully"
 msgstr "成功地保存了凭证/设置"
 
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
 msgid "Middleware Servers"
 msgstr ""
 
@@ -1317,10 +1355,14 @@ msgstr ""
 msgid "%{typ} Button Group \"Unassigned Buttons\""
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.Host
+#. TRANSLATORS: en.yml key: dictionary.table.host
 #, fuzzy
 msgid "Host / Node"
 msgstr "主机/节点"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
 #, fuzzy
 msgid "Cluster / Deployment Role"
 msgstr "群集/部署角色"
@@ -1416,6 +1458,10 @@ msgstr "所有自定义类和实例已被重置为默认值"
 msgid "%{val} missing for %{field}"
 msgstr "%{field} 缺失了 %{val} "
 
+#, fuzzy
+msgid "At least one VM Option must be selected"
+msgstr "必须选择至少一个 %s"
+
 msgid "No Utilization data available to generate planning results"
 msgstr "没有可用的 Utilization 数据来生成计划结果。"
 
@@ -1425,14 +1471,29 @@ msgstr "%{model} \"%{name}\" %{typ}"
 msgid "Planning options have been reset by the user"
 msgstr "用户已重置 Planning 选项"
 
-msgid "Best Fit %s"
+#, fuzzy
+msgid "Best Fit Hosts"
 msgstr "最适合 %s"
 
-msgid "%s cancelled by user"
+msgid "Best Fit Clusters"
+msgstr ""
+
+#, fuzzy
+msgid "Export cancelled by user"
 msgstr "%s 被用户取消"
 
-msgid "At least %{num} %{model} must be selected for %{action}"
-msgstr "必须为 %{action} 选择至少 %{num} 个 %{model}"
+msgid "Error during export: %{error_message}"
+msgstr ""
+
+msgid "Error during 'Policy Import': %{messages}"
+msgstr ""
+
+msgid "Error during upload: %{messages}"
+msgstr ""
+
+#, fuzzy
+msgid "Import cancelled by user"
+msgstr "%s 被用户取消"
 
 msgid "Import not available due to conflicts"
 msgstr "因存在冲突导入不可用"
@@ -1440,68 +1501,181 @@ msgstr "因存在冲突导入不可用"
 msgid "Press commit to Import"
 msgstr "按 Commit 进行导入"
 
-msgid "%s no longer exists"
-msgstr "%s 不再存在"
+#, fuzzy
+msgid "All %{items}"
+msgstr "所有的对话框"
+
+msgid "All %{models}"
+msgstr ""
+
+#, fuzzy
+msgid "Adding a new %{record}"
+msgstr "添加新的 %s"
 
 msgid "All %{typ} %{model}"
 msgstr "所有的 %{typ} %{model}"
 
-msgid " %s Assignments"
+msgid "Adding a new %{model_name} %{mode} Policy"
+msgstr ""
+
+msgid "Adding a new %{model_name} Policy"
+msgstr ""
+
+#, fuzzy
+msgid " %{model} Assignments"
 msgstr " %s 分配"
 
-msgid "Select only one or consecutive %s to move up"
+#, fuzzy
+msgid "Adding a new %{model}"
+msgstr "添加新的 %s"
+
+#, fuzzy
+msgid "Editing %{model} Condition \"%{name}\""
+msgstr "正在编辑 \"%{name}\" 的 %{model} "
+
+#, fuzzy
+msgid "%{model} Condition \"%{name}\""
+msgstr "\"%{name}\" 的 %{model} "
+
+#, fuzzy
+msgid "Adding a new %{alerts}"
+msgstr "添加新的 %s"
+
+#, fuzzy
+msgid "No %{member} were selected to move right"
+msgstr "没有选择要右移的 %s"
+
+#, fuzzy
+msgid "No %{member} were selected to move left"
+msgstr "没有选择要左移的 %s"
+
+#, fuzzy
+msgid "Select only one or consecutive %{member} to move up"
 msgstr "选择一个或连续的 %s 上移"
 
-msgid "Select only one or consecutive %s to move down"
+#, fuzzy
+msgid "Select only one or consecutive %{member} to move down"
 msgstr "选择下移的一个或连续的 %s。"
 
-msgid "No %s selected to set to Synchronous"
+#, fuzzy
+msgid "No %{member} selected to set to Synchronous"
 msgstr "没有选择要设置同步方式的 %s"
 
-msgid "No %s selected to set to Asynchronous"
+#, fuzzy
+msgid "No %{member} selected to set to Asynchronous"
 msgstr "没有选择要设置异步方式的 %s"
 
+#, fuzzy
+msgid "Host is required"
+msgstr "%s 是必需的"
+
+msgid "Trap Number is required"
+msgstr ""
+
+msgid "Trap Object ID is required"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
 msgid "Policy Profiles"
 msgstr "策略配置集"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
 msgid "Policies"
 msgstr "策略"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
 msgid "Events"
 msgstr "事件"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
 msgid "Conditions"
 msgstr "条件"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
 msgid "Actions"
 msgstr "动作"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
 msgid "Alert Profiles"
 msgstr "Alert 配置集"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
 msgid "Alerts"
 msgstr "警告"
 
 msgid "%{model} must contain at least one %{field}"
 msgstr "%{model} 必须包含至少一个 %{field}"
 
+msgid "Error during 'Alert Profile %{params}': "
+msgstr ""
+
+#, fuzzy
+msgid "Edit %{model} assignments cancelled by user"
+msgstr "用户取消了对策略分配的编辑"
+
+msgid "A Tag Category must be selected"
+msgstr ""
+
 msgid "At least one Selection must be checked"
 msgstr "必须勾选至少一个选项"
 
-msgid "Alert Profile \"%s\" assignments succesfully saved"
+#, fuzzy
+msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
 msgstr "Alert 配置集 \"%s\" 分配已成功保存"
 
-msgid "The selected %s was deleted"
+#, fuzzy
+msgid "%{model} no longer exists"
+msgstr "%s 记录不再存在"
+
+#, fuzzy
+msgid "The selected %{model} was deleted"
 msgstr "所选的 %s 已被删除"
+
+msgid "All %{records}"
+msgstr ""
+
+#, fuzzy
+msgid "Add of new %{models} was cancelled by the user"
+msgstr "用户取消了添加 %{model}"
+
+#, fuzzy
+msgid "%{models} no longer exists"
+msgstr "%s 记录不再存在"
+
+#, fuzzy
+msgid "The selected %{models} was deleted"
+msgstr "所选的 %s 已被删除"
+
+msgid "Error during alarms: %{messages}"
+msgstr ""
 
 msgid "A valid expression must be present"
 msgstr "必须存在有效的表达式"
 
-msgid "%s must be an integer"
-msgstr "%s 必须是整数"
+msgid "A Driving Event must be selected"
+msgstr ""
 
-msgid "At least one %s must be configured"
-msgstr "必须配置至少一个 %s"
+#, fuzzy
+msgid "Event name is required"
+msgstr "%s 是必需的"
+
+msgid "Event to Check is required"
+msgstr ""
+
+msgid "Value Threshold must be an integer"
+msgstr ""
+
+msgid "Trend Steepness must be an integer"
+msgstr ""
+
+msgid ""
+"At least one of E-mail, SNMP Trap, Timeline Event, or Management Event must be"
+" configured"
+msgstr ""
+
+msgid "At least one E-mail recipient must be configured"
+msgstr ""
 
 msgid ""
 "Ruby scripts are no longer supported in expressions, please change or remove t"
@@ -1511,14 +1685,68 @@ msgstr "表达式里不再支持 Ruby 脚本，请修改或删除它们。"
 msgid "Condition \"%{cond_name}\" has been removed from Policy \"%{pol_name}\""
 msgstr "条件 \"%{cond_name}\" 已从策略 \"%{pol_name}\" 里删除"
 
-msgid "Actions for Policy Event \"%s\" were saved"
+msgid "Edit Event cancelled by user"
+msgstr ""
+
+#, fuzzy
+msgid "Actions for Policy Event \"%{events}\" were saved"
 msgstr "策略事件 \"%s\" 的动作已保存"
 
-msgid "E-mail address '%s' is not valid"
+#, fuzzy
+msgid "All %{tables}"
+msgstr "所有的对话框"
+
+#, fuzzy
+msgid "No %{members} were selected to move left"
+msgstr "没有选择要左移的 %s"
+
+#, fuzzy
+msgid "No %{members} were selected to move right"
+msgstr "没有选择要右移的 %s"
+
+#, fuzzy
+msgid "Action Type must be selected"
+msgstr "%s 必须被选择"
+
+msgid "Analysis Profile is required"
+msgstr ""
+
+msgid "Attribute Name is required"
+msgstr ""
+
+#, fuzzy
+msgid "At least one Alert must be selected"
+msgstr "必须选择至少一个 %s"
+
+#, fuzzy
+msgid "Parent Type must be selected"
+msgstr "%s 必须被选择"
+
+#, fuzzy
+msgid "At least one Category must be selected"
+msgstr "必须选择至少一个 %s"
+
+#, fuzzy
+msgid "Snapshot Age must be selected"
+msgstr "%s 必须被选择"
+
+#, fuzzy
+msgid "E-mail address 'From' is not valid"
 msgstr "电子邮件 '%s' 是无效的"
+
+#, fuzzy
+msgid "E-mail address 'To' is not valid"
+msgstr "电子邮件 '%s' 是无效的"
+
+#, fuzzy
+msgid "At least one Tag must be selected"
+msgstr "必须选择至少一个 %s"
 
 msgid "%{model} \"%{name}\" already exists"
 msgstr "%{model} \"%{name}\" 已存在"
+
+msgid "Error during 'Policy Profile %{params}': %{messages}"
+msgstr ""
 
 msgid "No VMs match the selection criteria"
 msgstr "没有虚拟机符合选择标准"
@@ -1527,7 +1755,12 @@ msgstr "没有虚拟机符合选择标准"
 msgid "Policy Simulation generation returned: %{error_message}"
 msgstr "返回的策略模拟生成结果："
 
-msgid "Request %s was cancelled by the user"
+#, fuzzy
+msgid "Request approval was cancelled by the user"
+msgstr "请求 %s 被用户取消"
+
+#, fuzzy
+msgid "Request denial was cancelled by the user"
 msgstr "请求 %s 被用户取消"
 
 msgid "Request \"%{name}\" was %{task}"
@@ -1536,7 +1769,20 @@ msgstr "请求 \"%{name}\" 是 %{task}"
 msgid "Error retrieving LDAP info: %{error_message}"
 msgstr ""
 
-msgid "The selected %s were deleted"
+#, fuzzy
+msgid "At least one status must be selected"
+msgstr "必须选择至少一个 %s"
+
+#, fuzzy
+msgid "The selected %{tables} were deleted"
+msgstr "所选的 %s 已被删除"
+
+#, fuzzy
+msgid "%{table} no longer exists"
+msgstr "%s 记录不再存在"
+
+#, fuzzy
+msgid "The selected %{table} was deleted"
 msgstr "所选的 %s 已被删除"
 
 msgid "%{model} \"%{name}\": Error during '%{task}': "
@@ -1551,11 +1797,41 @@ msgstr "所选的任务已被取消"
 msgid "The selected job no longer exists, Delete all older Tasks was not completed"
 msgstr "所选的任务不再存在，删除所有更旧的任务还未完成。"
 
+msgid "%s no longer exists"
+msgstr "%s 不再存在"
+
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr "%{model} \"%{name}\": 'Analysis' 期间出现错误："
 
 msgid "\"%{record}\": Analysis successfully initiated"
 msgstr "\"%{record}\": Analysis 已成功初始化"
+
+#, fuzzy
+msgid "Create Datastore was cancelled by the user"
+msgstr "用户取消了对 %s 的编辑"
+
+#, fuzzy
+msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
+msgstr "%{model} \"%{name}\": %{task} 已成功初始化"
+
+#, fuzzy
+msgid "Create Logical Disk was cancelled by the user"
+msgstr "用户取消了对 %s 的编辑"
+
+#, fuzzy
+msgid "Aggregate is required"
+msgstr "%s 是必需的"
+
+#, fuzzy
+msgid "Size is required"
+msgstr "%s 是必需的"
+
+#, fuzzy
+msgid "Size must be an integer"
+msgstr "%s 必须是整数"
+
+msgid "Adding a new Category"
+msgstr ""
 
 msgid "Manage quotas for %{model} \"%{name}\""
 msgstr "管理 %{model} \"%{name}\" 的配额"
@@ -1566,35 +1842,56 @@ msgstr "%{typ} %{model} \"%{name}\"（当前）"
 msgid "Export generation returned: Status [%{status}] Message [%{message}]"
 msgstr "导出生成返回：状态 [%{status}] 消息 [%{message}]"
 
-msgid "%s Summary"
+#, fuzzy
+msgid "VMDB Summary"
 msgstr "%s 概述"
 
-msgid "%s Utilization"
+#, fuzzy
+msgid "VMDB Utilization"
 msgstr "%s Utilization"
 
-msgid "%s Client Connections"
+#, fuzzy
+msgid "VMDB Client Connections"
 msgstr "%s 客户连接"
 
-msgid "All %s Indexes"
+#, fuzzy
+msgid "All VMDB Indexes"
 msgstr "所有 %s 索引"
 
-msgid "%s Settings"
-msgstr "%s 设置"
+#, fuzzy
+msgid "VMDB Settings"
+msgstr "我的设置"
 
 msgid "Indexes for %{model} \"%{name}\""
 msgstr "%{model} \"%{name}\" 的索引"
 
+msgid "VMDB \"%{name}\" Table Utilization"
+msgstr ""
+
+msgid "Error during 'Appliance restart': %{message}"
+msgstr ""
+
 msgid "CFME Appliance restart initiated successfully"
 msgstr "CFME Appliance 已成功初始化"
 
-msgid "'%s' Worker restart initiated successfully"
+msgid "Error during 'workers restart': %{message}"
+msgstr ""
+
+#, fuzzy
+msgid "'%{type}' Worker restart initiated successfully"
 msgstr "'%s' 工作节点成功地重新初始化"
 
 msgid "Edit Log Depot settings was cancelled by the user"
 msgstr "用户取消了对 Log Depot 设置的编辑"
 
+msgid "Error during 'Save': %{message}"
+msgstr ""
+
 msgid "Log Depot Settings were saved"
 msgstr "Log Depot 设置已保存"
+
+msgid "Error during 'Validate': %{message}"
+msgstr ""
 
 msgid "Log Depot Settings were validated"
 msgstr "Log Depot 设置已检验"
@@ -1602,14 +1899,37 @@ msgstr "Log Depot 设置已检验"
 msgid "End Date cannot be greater than Start Date"
 msgstr "结束日期不能早于开始日期"
 
-msgid "%s successfully initiated"
-msgstr "%s 已成功初始化"
+msgid "Error during 'C & U Gap Collection': %{message}"
+msgstr ""
 
-msgid "Error during Orphaned Records delete for user %s: "
+msgid "C & U Gap Collection successfully initiated"
+msgstr ""
+
+msgid "Error during 'Reset/synchronization process': %{message}"
+msgstr ""
+
+msgid "Reset/synchronization process successfully initiated"
+msgstr ""
+
+msgid "Database Backup successfully initiated"
+msgstr ""
+
+msgid "Error during 'Database Garbage Collection': %{message}"
+msgstr ""
+
+msgid "Database Garbage Collection successfully initiated"
+msgstr ""
+
+#, fuzzy
+msgid "Error during Orphaned Records delete for user %{id}: %{message}"
 msgstr "删除用户 %s 的 Orphaned 记录时出错："
 
-msgid "Orphaned Records for userid %s were successfully deleted"
+#, fuzzy
+msgid "Orphaned Records for userid %{id} were successfully deleted"
 msgstr "已成功删除 userid %s 的孤立记录"
+
+msgid "Error during 'Clear Connection Broker cache': %{message}"
+msgstr ""
 
 msgid "Connection Broker cache cleared successfully"
 msgstr "连接代理缓存已成功清除"
@@ -1628,8 +1948,21 @@ msgstr ""
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr "CFME %{object_type} %{name} 的日志采集已经初始化"
 
-msgid "%s is not allowed for the selected item"
+#, fuzzy
+msgid "Start is not allowed for the selected item"
 msgstr "%s 对于所选项目是不允许的"
+
+#, fuzzy
+msgid "Start successfully initiated"
+msgstr "%s 已成功初始化"
+
+#, fuzzy
+msgid "Suspend is not allowed for the selected item"
+msgstr "%s 对于所选项目是不允许的"
+
+#, fuzzy
+msgid "Suspend successfully initiated"
+msgstr "%s 已成功初始化"
 
 msgid "Setting priority is not allowed for the selected item"
 msgstr "所选的项目不允许设置优先级"
@@ -1637,20 +1970,46 @@ msgstr "所选的项目不允许设置优先级"
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr "CFME 服务器 \"%{name}\" 为角色 \"%{role_description}\" 设置为 %{priority} 优先级"
 
-msgid "Error when adding a new tenant: "
+#, fuzzy
+msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr "%{typ} %{model} \"%{name}\"（当前）"
+
+#, fuzzy
+msgid "Diagnostics %{model} \"%{name}\""
+msgstr "正在编辑 %{model} \"%{name}\""
+
+#, fuzzy
+msgid "Error when adding a new tenant: %{message}"
 msgstr "添加新 tenant 时出错："
 
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
 msgstr "用户取消了对 %{model} \"%{name}\" 的配额管理"
 
-msgid "Error when saving tenant quota: "
+#, fuzzy
+msgid "Error when saving tenant quota: %{message}"
 msgstr "保存 Tenant 配额时出错："
 
 msgid "Quotas for %{model} \"%{name}\" were saved"
 msgstr " %{model} \"%{name}\" 的配额已保存"
 
+#, fuzzy
+msgid "User no longer exists"
+msgstr "%s 不再存在"
+
+#, fuzzy
+msgid "Role no longer exists"
+msgstr "报表不再存在"
+
 msgid "Default %{model} \"%{name}\" can not be deleted"
 msgstr "无法删除默认的 %{model} \"%{name}\""
+
+#, fuzzy
+msgid "Tenant no longer exists"
+msgstr "报表不再存在"
+
+#, fuzzy
+msgid "MiqGroup no longer exists"
+msgstr "报表不再存在"
 
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr "用户取消了对 Sequence of User Groups 的编辑"
@@ -1658,26 +2017,52 @@ msgstr "用户取消了对 Sequence of User Groups 的编辑"
 msgid "User Group Sequence was saved"
 msgstr "用户组序列已保存"
 
-msgid "No %s were selected to move up"
-msgstr "没有选择要上移的 %s"
-
-msgid "No %s were selected to move down"
-msgstr "没有选择要下移的 %s"
-
-msgid "%s must be entered to perform LDAP Group Look Up"
+#, fuzzy
+msgid "User must be entered to perform LDAP Group Look Up"
 msgstr "必须输入 %s 以执行 LDAP 组查找"
+
+#, fuzzy
+msgid "Username must be entered to perform LDAP Group Look Up"
+msgstr "必须输入 %s 以执行 LDAP 组查找"
+
+#, fuzzy
+msgid "User Password must be entered to perform LDAP Group Look Up"
+msgstr "必须输入 %s 以执行 LDAP 组查找"
+
+msgid "Error during 'LDAP Group Look Up': %{message}"
+msgstr ""
 
 msgid "Current %{model} \"%{name}\" cannot be deleted"
 msgstr "无法删除当前的 %{model} \"%{name}\""
 
-msgid "Edit of %s was cancelled by the user"
+#, fuzzy
+msgid "Edit of %{name} was cancelled by the user"
 msgstr "用户取消了对 %s 的编辑"
+
+#, fuzzy
+msgid "Add of new %{name} was cancelled by the user"
+msgstr "用户取消了添加 %{model}"
 
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr "无法编辑只读的 %{model} \"%{name}\""
 
+#, fuzzy
+msgid "Adding a new %{name}"
+msgstr "添加新的 %s"
+
+msgid "Access Control %{model}"
+msgstr ""
+
+#, fuzzy
+msgid "Access Control %{model} \"%{name}\""
+msgstr "%{model} \"%{name}\" 的索引"
+
 msgid "A User must be assigned to a Group"
 msgstr "必须将用户分配给组"
+
+#, fuzzy
+msgid "At least one Product Feature must be selected"
+msgstr "必须选择至少一个 %s"
 
 msgid "A User Group must be assigned a Role"
 msgstr "必须为用户组分配一个角色"
@@ -1685,23 +2070,48 @@ msgstr "必须为用户组分配一个角色"
 msgid "Access Rules for all Virtual Machines"
 msgstr "所有虚拟机的访问规则"
 
+msgid "Error during 'apply': %{error}"
+msgstr ""
+
 msgid "Records were successfully imported"
 msgstr "已成功导入记录"
 
-msgid "Use the Browse button to locate %s file"
+#, fuzzy
+msgid "Use the Browse button to locate CSV file"
 msgstr "使用 Browse 按钮来定位 %s 文件"
 
-msgid "%s should be unique"
+#, fuzzy
+msgid "LDAP Host is required"
+msgstr "%s 是必需的"
+
+#, fuzzy
+msgid "LDAP Host should be unique"
 msgstr "%s 应该是唯一的"
 
-msgid "%s Credentials validated successfully"
-msgstr "%s 凭证验证成功"
+msgid "Replication Worker Credentials validated successfully"
+msgstr ""
+
+#, fuzzy
+msgid "Settings %{model} \"%{name}\""
+msgstr "正在编辑 %{model} \"%{name}\""
+
+msgid "Region description is required"
+msgstr ""
 
 msgid "At least one item must be entered to create Analysis Profile"
 msgstr "必须至少输入一个项目来创建 Analysis 配置集"
 
 msgid "Sample %{model} \"%{name}\" can not be edited"
 msgstr "无法编辑样本 %{model} \"%{name}\" "
+
+msgid "File Entry is required"
+msgstr ""
+
+msgid "Registry Entry is required"
+msgstr ""
+
+msgid "Event log name is required"
+msgstr ""
 
 msgid "Capacity and Utilization Collection settings saved"
 msgstr "已保存 Capacity & Utilization 收集的设置"
@@ -1718,7 +2128,10 @@ msgstr "Amazon 设置检验成功"
 msgid "Error during sending test email: %{class_name}, %{error_message}"
 msgstr ""
 
-msgid "The test email is being delivered, check \"%s\" to verify it was successful"
+#, fuzzy
+msgid ""
+"The test email is being delivered, check \"%{email}\" to verify it was successfu"
+"l"
 msgstr "正在递送测试邮件，请检查 \"%s\" 来验证是否成功。"
 
 msgid "CFME Database settings validation was successful"
@@ -1729,18 +2142,31 @@ msgid ""
 "estart"
 msgstr "已成功保存数据库，它们会在重启 CFME 服务器后生效。"
 
-msgid "Error during %s: "
-msgstr "%s 过程中出错："
+msgid "Error during Server restart: %{message}"
+msgstr ""
 
-msgid "%s file saved"
+#, fuzzy
+msgid "%{model}: Restart successfully initiated"
+msgstr "%{model}: %{task} 已成功初始化"
+
+#, fuzzy
+msgid "%{name} file saved"
 msgstr "%s 文件已保存"
 
-msgid "Error when saving new server name: "
+#, fuzzy
+msgid "Error when saving new server name: %{message}"
 msgstr "保存新服务器名称时出错："
 
+#, fuzzy
 msgid ""
-"%{typ} settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone \"%{zone"
-"}\""
+"Configuration settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone "
+"\"%{zone}\""
+msgstr "为区 \"%{zone}\" 里的 CFME 服务器 \"%{name} [%{server_id}]\" 保存 %{typ} 设置"
+
+#, fuzzy
+msgid ""
+"Authentication settings saved for CFME Server \"%{name} [%{server_id}]\" in Zone"
+" \"%{zone}\""
 msgstr "为区 \"%{zone}\" 里的 CFME 服务器 \"%{name} [%{server_id}]\" 保存 %{typ} 设置"
 
 msgid "Edit of Customer Information was cancelled"
@@ -1749,11 +2175,21 @@ msgstr "Customer Information 的编辑已取消"
 msgid "Custom Support URL and Description both must be entered."
 msgstr "您必须输入自定义支持 URL 和描述"
 
+msgid "VNC Proxy Port must be numeric"
+msgstr ""
+
 msgid "When configuring a VNC Proxy, both Address and Port are required"
 msgstr "当配置 VNC 代理时，地址和端口都是必需的。"
 
+msgid "Error during Analysis Affinity save: %{message}"
+msgstr ""
+
 msgid "Analysis Affinity was saved"
 msgstr "Analysis Affinity 已保存"
+
+#, fuzzy
+msgid "Settings %{model} \"%{name}\" (current)"
+msgstr "%{typ} %{model} \"%{name}\"（当前）"
 
 msgid "Locate and upload a file to start the import process"
 msgstr "定位并上传文件以启动导入过程"
@@ -1761,11 +2197,23 @@ msgstr "定位并上传文件以启动导入过程"
 msgid "Choose the type of custom variables to be imported"
 msgstr "选择要导入的客户变量类型"
 
+msgid "Settings %{model}"
+msgstr ""
+
+#, fuzzy
+msgid "Hostname is required"
+msgstr "%s 是必需的"
+
 msgid "Customer Information successfully saved"
 msgstr "已成功保存客户信息"
 
-msgid "Credential validation returned: %s"
+#, fuzzy
+msgid "Credential validation returned: %{message}"
 msgstr "返回的凭证检验结果：%s"
+
+#, fuzzy
+msgid "%{name} is required"
+msgstr "%s 是必需的"
 
 msgid "No Server was selected"
 msgstr "没有选择服务器"
@@ -1779,28 +2227,43 @@ msgstr "检查更新"
 msgid "Update"
 msgstr "更新"
 
-msgid "%s has been initiated for the selected Servers"
+#, fuzzy
+msgid "%{item} has been initiated for the selected Servers"
 msgstr "%s 已为选择的服务器初始化"
 
-msgid "Error occured when queuing action: %s"
+#, fuzzy
+msgid "Error occured when queuing action: %{message}"
 msgstr "当将动作排队时出错：%s"
 
-msgid "Error when adding a new schedule: "
+#, fuzzy
+msgid "Error when adding a new schedule: %{message}"
 msgstr "添加新的时间表时出错："
 
-msgid "The selected %s were enabled"
+#, fuzzy
+msgid "The selected Schedules were enabled"
 msgstr "所选的 %s 已被启用"
 
-msgid "The selected %s were disabled"
+#, fuzzy
+msgid "The selected Schedules were disabled"
 msgstr "所选的 %s 已被禁用"
 
 msgid "Depot Settings successfuly validated"
 msgstr "已成功检验 Depot 设置"
 
+#, fuzzy
+msgid "Filter must be selected"
+msgstr "%s 必须被选择"
+
+msgid "Filter value must be selected"
+msgstr ""
+
 msgid ""
 "Warning: This 'Run Once' timer is in the past and will never run as currently "
 "configured"
 msgstr "警告：这个 'Run Once' 定时器已过时，无法作为当前配置运行。"
+
+msgid "Long Description is required"
+msgstr ""
 
 msgid "Custom logo image must be a .png file"
 msgstr "自定义 logo 图像必须是一个 .png 文件"
@@ -1808,11 +2271,17 @@ msgstr "自定义 logo 图像必须是一个 .png 文件"
 msgid "Custom login image must be a .png file"
 msgstr "自定义登录图像必须是一个 .png 文件"
 
-msgid "Custom Logo file \"%s\" uploaded"
+#, fuzzy
+msgid "Custom Logo file \"%{name}\" uploaded"
 msgstr "已上传自定义 Logo 文件 \"%s\""
 
-msgid "Custom login file \"%s\" uploaded"
+#, fuzzy
+msgid "Custom login file \"%{name}\" uploaded"
 msgstr "已上传自定义登录文件 \"%s\""
+
+#, fuzzy
+msgid "Use the Browse button to locate .png image file"
+msgstr "使用 Browse 按钮来定位 %s 图像文件"
 
 msgid "Import validation complete: %{good_record}, %{bad_record}"
 msgstr "导入检验完成：%{good_record}, %{bad_record}"
@@ -1822,6 +2291,17 @@ msgstr "没有找到有效的导入记录，请上传另外一个文件。"
 
 msgid "Press the Apply button to import the good records into the CFME database"
 msgstr "按 Apply 按钮将好记的录导入进 CFME 数据库"
+
+#, fuzzy
+msgid "Add of new %{table} was cancelled by the user"
+msgstr "用户取消了添加 %{model}"
+
+#, fuzzy
+msgid "Zone name is required"
+msgstr "%s 是必需的"
+
+msgid "%{task} initiated for %{count_model}"
+msgstr ""
 
 msgid "No common configuration profiles available for the selected configured %s"
 msgstr "所选的 %s 没有可用的公共配置集"
@@ -1876,6 +2356,9 @@ msgstr "%{group} \"%{name}\" 的 %{model}"
 msgid "Import file cannot be empty"
 msgstr "导入文件不能为空"
 
+msgid "At least %{num} %{model} must be selected for %{action}"
+msgstr "必须为 %{action} 选择至少 %{num} 个 %{model}"
+
 msgid "Error: the file uploaded contains no widgets"
 msgstr "错误：上传的文件没有包含 widget"
 
@@ -1894,9 +2377,12 @@ msgstr "Widget 导入已取消"
 msgid "Saved Reports"
 msgstr "已保存的报表"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
 msgid "Reports"
 msgstr "报表"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
 msgid "Schedules"
 msgstr "时间表"
 
@@ -1927,6 +2413,9 @@ msgstr "用户取消了对 Dashboard Sequence 的编辑"
 msgid "Dashboard Sequence was saved"
 msgstr "仪表板序列已保存"
 
+msgid "The selected %s was deleted"
+msgstr "所选的 %s 已被删除"
+
 msgid "%{model} for \"%{name}\""
 msgstr "\"%{name}\" 的 %{model} "
 
@@ -1935,6 +2424,18 @@ msgstr "%{field} 不能包含 \"%{character}\""
 
 msgid "%s must be unique for this group"
 msgstr "%s 对于这个组必须是唯一的"
+
+msgid "No %s were selected to move up"
+msgstr "没有选择要上移的 %s"
+
+msgid "Select only one or consecutive %s to move up"
+msgstr "选择一个或连续的 %s 上移"
+
+msgid "No %s were selected to move down"
+msgstr "没有选择要下移的 %s"
+
+msgid "Select only one or consecutive %s to move down"
+msgstr "选择下移的一个或连续的 %s。"
 
 msgid ""
 "Can not delete folder, one or more reports in the selected folder are not owne"
@@ -2021,6 +2522,9 @@ msgstr "选择一个或连续的 %s 下移至底部"
 msgid "Saved Report \"%s\" not found, Schedule may have failed"
 msgstr "未找到保存的报表 \"%s\"，调度可能已失败。"
 
+msgid "The selected %s were deleted"
+msgstr "所选的 %s 已被删除"
+
 msgid "No Report Schedules were selected to be Run now"
 msgstr "没有选择现在运行的报表时间表。"
 
@@ -2033,8 +2537,17 @@ msgstr "所选的时间表已放入队列等待运行"
 msgid "No %s were selected to be enabled"
 msgstr "没有选择要启用的 %s"
 
+msgid "The selected %s were enabled"
+msgstr "所选的 %s 已被启用"
+
 msgid "No %s were selected to be disabled"
 msgstr "没有选择要禁用的 %s"
+
+msgid "The selected %s were disabled"
+msgstr "所选的 %s 已被禁用"
+
+msgid "At least one %s must be configured"
+msgstr "必须配置至少一个 %s"
 
 msgid "Widget content generation error: "
 msgstr "Widget 内容生成错误："
@@ -2144,6 +2657,8 @@ msgid "Guest Application"
 msgid_plural "Guest Applications"
 msgstr[0] "客体应用程序"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Container
+#. TRANSLATORS: en.yml key: dictionary.table.container
 #, fuzzy
 msgid "Container"
 msgid_plural "Container"
@@ -2274,10 +2789,13 @@ msgstr "主机"
 msgid "Hosts"
 msgstr "主机"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
+#. TRANSLATORS: en.yml key: dictionary.table.container_node
 #, fuzzy
 msgid "Node"
 msgstr "节点"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
 #, fuzzy
 msgid "Cluster"
 msgstr "群集"
@@ -2292,6 +2810,7 @@ msgstr "部署角色"
 msgid "Deployment Roles"
 msgstr "部署角色"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
 msgid "Clusters / Deployment Roles"
 msgstr "群集/部署角色"
 
@@ -2370,6 +2889,7 @@ msgstr ""
 msgid "Analysis"
 msgstr "分析"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
 #, fuzzy
 msgid "Policy"
 msgstr "策略"
@@ -3521,6 +4041,56 @@ msgstr ""
 msgid "Edit Tags for the selected #{ui_lookup(:tables=>\"ems_infras\")}"
 msgstr ""
 
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}"
+msgstr ""
+
+msgid ""
+"Refresh items and relationships related to this #{ui_lookup(:table=>\"ems_middl"
+"eware\")}?"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"ems_middleware\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"ems_middleware\")} and ALL of its components"
+" will be permanently removed from the Virtual Management Database.  Are you su"
+"re you want to remove this #{ui_lookup(:table=>\"ems_middleware\")}?"
+msgstr ""
+
+msgid "Show Timelines for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"ems_middleware\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"ems_middleware\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"ems_middlewares\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"ems_middlewares\")} and ALL of thei"
+"r components will be permanently removed from the Virtual Management Database."
+"  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"ems_middl"
+"ewares\")}?"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Tags for this Flavor"
 msgstr "为 %s 编辑标签"
@@ -3852,6 +4422,46 @@ msgid "Reload the #{@msg_title} Log Display"
 msgstr ""
 
 msgid "Download the Entire #{@msg_title} Log File"
+msgstr ""
+
+msgid "Edit this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove this #{ui_lookup(:table=>\"middleware_server\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: This #{ui_lookup(:table=>\"middleware_server\")} and ALL of its compone"
+"nts will be permanently removed from the Virtual Management Database.  Are you"
+" sure you want to remove this #{ui_lookup(:table=>\"middleware_server\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Add a New #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Select a single #{ui_lookup(:table=>\"middleware_server\")} to edit"
+msgstr ""
+
+msgid "Edit Selected #{ui_lookup(:table=>\"middleware_server\")}"
+msgstr ""
+
+msgid "Remove selected #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid "Remove #{ui_lookup(:tables=>\"middleware_servers\")} from the VMDB"
+msgstr ""
+
+msgid ""
+"Warning: The selected #{ui_lookup(:tables=>\"middleware_servers\")} and ALL of t"
+"heir components will be permanently removed from the Virtual Management Databa"
+"se.  Are you sure you want to remove the selected #{ui_lookup(:tables=>\"middle"
+"ware_servers\")}?"
+msgstr ""
+
+msgid "Edit Tags for this #{ui_lookup(:table=>\"middleware_servers\")}"
 msgstr ""
 
 #, fuzzy
@@ -5832,6 +6442,7 @@ msgstr "应用所选的过滤器"
 msgid "Start the selected items"
 msgstr "应用所选的过滤器"
 
+#. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
 msgid "Start"
 msgstr "启动"
 
@@ -5990,6 +6601,8 @@ msgstr ""
 msgid "Request to Provision"
 msgstr "请求信息"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision
 #, fuzzy
 msgid "Provision"
 msgstr "Provision %s"
@@ -6329,6 +6942,9 @@ msgstr "属性"
 msgid "Value"
 msgstr "值"
 
+#. TRANSLATORS: en.yml key: dictionary.column.action_type_description
+#. TRANSLATORS: en.yml key: dictionary.column.emstype_description
+#. TRANSLATORS: en.yml key: dictionary.column.mode
 msgid "Type"
 msgstr "类型"
 
@@ -6350,9 +6966,11 @@ msgstr "Observed"
 msgid "Default Limit"
 msgstr "默认限制"
 
+#. TRANSLATORS: en.yml key: dictionary.column.max_trend_value
 msgid "Max"
 msgstr "最大的"
 
+#. TRANSLATORS: en.yml key: dictionary.column.min_trend_value
 msgid "Min"
 msgstr "Min"
 
@@ -6434,15 +7052,21 @@ msgstr "主机名"
 msgid "IPMI Present"
 msgstr "IPMI Present"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ip_address
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddress
 msgid "IP Address"
 msgstr "IP 地址"
 
 msgid "Mac address"
 msgstr "Mac 地址"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
 msgid "Provider"
 msgstr "提供者"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone
+#. TRANSLATORS: en.yml key: dictionary.table.zone
 msgid "Zone"
 msgstr "区"
 
@@ -6461,6 +7085,7 @@ msgstr "区"
 msgid "Compute Profile"
 msgstr "Compute 配置集"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_arch
 msgid "Architecture"
 msgstr "架构"
 
@@ -6479,6 +7104,7 @@ msgstr "配置位置"
 msgid "Configuration Organization"
 msgstr "配置机构"
 
+#. TRANSLATORS: en.yml key: dictionary.table.operating_system
 msgid "OS"
 msgstr "OS"
 
@@ -6539,6 +7165,7 @@ msgstr "云集成"
 msgid "Dashboard"
 msgstr "仪表板"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback
 msgid "Chargeback"
 msgstr "计费"
 
@@ -6548,48 +7175,72 @@ msgstr "RSS"
 msgid "My Services"
 msgstr "我的服务"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
 msgid "Catalogs"
 msgstr "目录"
 
 msgid "Workloads"
 msgstr "工作负载"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_requests
 msgid "Requests"
 msgstr "请求"
 
 msgid "Clouds"
 msgstr "云"
 
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
 msgid "Availability Zones"
 msgstr "可用性区"
 
 msgid "Tenants"
 msgstr "Tenants"
 
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
 msgid "Volumes"
 msgstr "卷"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.flavors
 msgid "Flavors"
 msgstr "Flavors"
 
 msgid "Security Groups"
 msgstr "安全组"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
 msgid "Instances"
 msgstr "实例"
 
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
 msgid "Stacks"
 msgstr "栈"
 
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
 msgid "Key Pairs"
 msgstr ""
 
 msgid "Infrastructure"
 msgstr "基础架构"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
 msgid "Virtual Machines"
 msgstr "虚拟机"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.resource_pools
 msgid "Resource Pools"
 msgstr "资源池"
 
@@ -6617,6 +7268,7 @@ msgstr "容器图像"
 msgid "Middleware"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
 msgid "Storage Managers"
 msgstr "存储管理者"
 
@@ -6653,6 +7305,7 @@ msgstr "配置"
 msgid "My Settings"
 msgstr "我的设置"
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
 msgid "Tasks"
 msgstr "任务"
 
@@ -6662,9 +7315,12 @@ msgstr "关于"
 msgid "Object Types"
 msgstr "对象类型"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Storage
+#. TRANSLATORS: en.yml key: dictionary.table.storage
 msgid "Datastore"
 msgstr "数据存储区"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
 msgid "Enterprise"
 msgstr "企业"
 
@@ -7021,12 +7677,15 @@ msgstr "名称 / 描述"
 msgid "Display in Catalog"
 msgstr "Display in Catalog"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
+#. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
 msgid "Catalog"
 msgstr "目录"
 
 msgid "Unassigned"
 msgstr "未分配的"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
 msgid "Dialog"
 msgstr "对话框"
 
@@ -7036,6 +7695,8 @@ msgstr "没有对话框"
 msgid "Choose"
 msgstr "选择"
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
 msgid "Orchestration Template"
 msgstr "Orchestration 模版"
 
@@ -7090,6 +7751,7 @@ msgstr "添加资源"
 msgid "Selected Resources"
 msgstr "选择的资源"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAction
 msgid "Action"
 msgstr "动作"
 
@@ -7174,6 +7836,7 @@ msgstr "分配目录项"
 msgid "No Catalog Items found."
 msgstr "没有找到类别项。"
 
+#. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
 msgid "Catalog Items"
 msgstr "目录项"
 
@@ -7315,6 +7978,8 @@ msgstr "目前使用这个 Time 配置集的报表"
 msgid "Grid/Tile Icons"
 msgstr "网格/平铺图标"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra
 msgid "Template"
 msgstr "模版"
 
@@ -7378,6 +8043,8 @@ msgstr "Drift 模式"
 msgid "Tagging"
 msgstr "标签"
 
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
 msgid "Orchestration Templates"
 msgstr "Orchestration 模版"
 
@@ -7390,9 +8057,12 @@ msgstr "模版和图像"
 msgid "VMs & Instances"
 msgstr "虚拟机和实例"
 
+#. TRANSLATORS: en.yml key: dictionary.table.vms
 msgid "VMs"
 msgstr "虚拟机"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
 msgid "Templates"
 msgstr "模版"
 
@@ -7415,6 +8085,7 @@ msgstr "没有找到记录。"
 msgid "Roll Up Performance"
 msgstr "汇总性能"
 
+#. TRANSLATORS: en.yml key: dictionary.column.userid
 msgid "Username"
 msgstr "用户名"
 
@@ -7614,9 +8285,12 @@ msgstr "主机平台"
 msgid "Custom Identifier"
 msgstr "自定义标识符"
 
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
 msgid "IPMI IP Address"
 msgstr "IPMI IP 地址"
 
+#. TRANSLATORS: en.yml key: dictionary.column.mac_address
+#. TRANSLATORS: en.yml key: dictionary.column.macaddress
 msgid "MAC Address"
 msgstr "MAC 地址"
 
@@ -7638,6 +8312,8 @@ msgstr "对话框"
 msgid "Custom Attributes"
 msgstr "自定义属性"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attributes
 msgid "VC Custom Attributes"
 msgstr "VC 自定义属性"
 
@@ -7725,6 +8401,8 @@ msgstr "对象细节"
 msgid "System/Process"
 msgstr "系统/进程"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRequest
+#. TRANSLATORS: en.yml key: dictionary.table.miq_request
 msgid "Request"
 msgstr "请求"
 
@@ -7767,6 +8445,7 @@ msgstr "确认 %s"
 msgid "Private Key"
 msgstr "私有密钥"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification
 msgid "Category"
 msgstr "类别"
 
@@ -8026,6 +8705,7 @@ msgstr "虚拟机 \"%{name}\""
 msgid "Options %s"
 msgstr "选项 %s"
 
+#. TRANSLATORS: en.yml key: dictionary.column.interval
 msgid "Interval"
 msgstr "间隔"
 
@@ -8044,6 +8724,7 @@ msgstr "分组"
 msgid "Show VM Types"
 msgstr "显示虚拟机类型"
 
+#. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
 msgid "Time Profile"
 msgstr "Time 配置集"
 
@@ -8417,6 +9098,7 @@ msgstr "显示配置"
 msgid "Show %{host_title}"
 msgstr ""
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
 #, fuzzy
 msgid "Direct VMs"
 msgstr "直接虚拟机：0"
@@ -8482,6 +9164,7 @@ msgstr "显示所有的模版"
 msgid "Show this Flavor's parent %s"
 msgstr "显示这个 Flavor 的父 %s"
 
+#. TRANSLATORS: en.yml key: dictionary.table.guest_devices
 msgid "Devices"
 msgstr "设备"
 
@@ -8985,6 +9668,8 @@ msgstr "导入服务对话框"
 msgid "Dialog Information"
 msgstr "对话框信息"
 
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
 msgid "Buttons"
 msgstr "按钮"
 
@@ -9133,6 +9818,7 @@ msgstr "瓶颈事件细节"
 msgid "Select a node on the left to view Bottlenecks timeline."
 msgstr "在左侧选择节点来查看 Bottlenecks 时间轴。"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqReport
 msgid "Report"
 msgstr "报表"
 
@@ -9189,6 +9875,7 @@ msgstr "选择虚拟机"
 msgid "VM Options"
 msgstr "虚拟机选项"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_speed
 msgid "CPU Speed"
 msgstr "CPU 速度"
 
@@ -9371,6 +10058,7 @@ msgstr "没有配置变量。"
 msgid "Object ID"
 msgstr "对象 ID"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
 msgid "Analysis Profile"
 msgstr "Analysis 配置集"
 
@@ -9392,6 +10080,7 @@ msgstr "继承标签"
 msgid "Parent Type"
 msgstr "父类型"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
 msgid "Categories"
 msgstr "类别"
 
@@ -9449,6 +10138,7 @@ msgstr "从这个动作删除所选的警告"
 msgid "SNMP Trap Settings"
 msgstr "SNMP Trap 设置"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
 msgid "Analysis Profiles"
 msgstr "Analysis 配置集"
 
@@ -9488,6 +10178,8 @@ msgstr "没有找到可选 %s 的警告"
 msgid "Choose a %s first"
 msgstr "先选择 %s"
 
+#. TRANSLATORS: en.yml key: dictionary.column.active
+#. TRANSLATORS: en.yml key: dictionary.column.enabled
 msgid "Active"
 msgstr "活动的"
 
@@ -9572,6 +10264,8 @@ msgstr "查看这个动作"
 msgid "No Alerts are defined %s."
 msgstr "没有定义警告 %s。"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event
 msgid "Management Event"
 msgstr "管理事件"
 
@@ -9996,6 +10690,7 @@ msgstr "重置过滤器修改"
 msgid "Datacenter"
 msgstr "数据中心"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
 msgid "Resource Pool"
 msgstr "资源池"
 
@@ -10047,6 +10742,7 @@ msgstr "批准/拒绝者"
 msgid "Approved/Denied on"
 msgstr "批准/拒绝日期"
 
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_vms
 msgid "Provisioned VMs"
 msgstr "Provisioned 虚拟机"
 
@@ -10113,6 +10809,8 @@ msgstr "提交这个 Create Logical Disk 请求"
 msgid "SmartProxy Affinity"
 msgstr "SmartProxy Affinity"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server
 msgid "Server"
 msgstr "服务器"
 
@@ -10146,6 +10844,9 @@ msgstr "角色（按服务器）"
 msgid "Servers by Roles"
 msgstr "服务器（按角色）"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_server (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_servers
 msgid "Servers"
 msgstr "服务器"
 
@@ -10182,9 +10883,11 @@ msgstr "验证 Amazon 设置"
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr "检验 Amazon 设置需要 Amazon 访问密钥和 secret。"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Filesystem
 msgid "File"
 msgstr "文件"
 
+#. TRANSLATORS: en.yml key: dictionary.table.registry_items
 msgid "Registry"
 msgstr "注册表"
 
@@ -10260,6 +10963,7 @@ msgstr "Metrics"
 msgid "Rows"
 msgstr "行"
 
+#. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
 msgid "Size"
 msgstr "大小"
 
@@ -10379,12 +11083,15 @@ msgstr "发送测试邮件需要 SMTP 邮件服务器和测试邮件地址"
 msgid "LDAP Groups for User"
 msgstr "用户的 LDAP 组"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server (plural form)
 msgid "LDAP Servers"
 msgstr "LDAP 服务器"
 
 msgid "Mode"
 msgstr "模式"
 
+#. TRANSLATORS: en.yml key: dictionary.table.ldap
 msgid "LDAP"
 msgstr "LDAP"
 
@@ -10421,6 +11128,8 @@ msgstr "点击以删除这个预测"
 msgid "Click to edit this forest"
 msgstr "点击以编辑这个 预测"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain (plural form)
 msgid "LDAP Domains"
 msgstr "LDAP 域"
 
@@ -10501,6 +11210,7 @@ msgstr "组信息"
 msgid "(Look Up LDAP Groups)"
 msgstr "(查找 LDAP 组)"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
 msgid "Role"
 msgstr "角色"
 
@@ -10605,6 +11315,7 @@ msgstr ""
 msgid "User Information"
 msgstr "用户信息"
 
+#. TRANSLATORS: en.yml key: dictionary.column.User.name
 msgid "Full Name"
 msgstr "全名"
 
@@ -10671,9 +11382,11 @@ msgstr "启动日期"
 msgid "Stopped On"
 msgstr "停止日期"
 
+#. TRANSLATORS: en.yml key: dictionary.column.memory_size
 msgid "Memory Usage"
 msgstr "内存使用"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_time
 msgid "CPU Time"
 msgstr "CPU 时间"
 
@@ -10836,6 +11549,9 @@ msgstr "查看 Analysis 配置集"
 msgid "View Zones"
 msgstr "查看区"
 
+#. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.zones
 msgid "Zones"
 msgstr "区"
 
@@ -10845,6 +11561,8 @@ msgstr "查看时间表"
 msgid "View LDAP Regions"
 msgstr "查看 LDAP 区域"
 
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region (plural form)
 msgid "LDAP Regions"
 msgstr "LDAP 区域"
 
@@ -11079,6 +11797,9 @@ msgstr "dimmed"
 msgid "Appliances in this region can be registered with:"
 msgstr "这个区域里的应用可以注册："
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerService
+#. TRANSLATORS: en.yml key: dictionary.model.Service
+#. TRANSLATORS: en.yml key: dictionary.table.container_service
 msgid "Service"
 msgstr "服务"
 
@@ -11160,6 +11881,8 @@ msgstr "操作系统"
 msgid "Tenancy"
 msgstr "租期"
 
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
 msgid "ISO Images"
 msgstr "ISO 映像文件"
 
@@ -11198,6 +11921,7 @@ msgid ""
 " PXE Server"
 msgstr "* 选中这个复选框将将删除这个 PXE 服务器上所有其它的 PXE 图像"
 
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
 msgid "PXE Images"
 msgstr "PXE 图像"
 
@@ -11243,14 +11967,24 @@ msgstr "Sysprep"
 msgid "Available Fields:"
 msgstr "可用的字段："
 
+msgid "down"
+msgstr ""
+
+msgid "up"
+msgstr ""
+
+#, fuzzy
+msgid "Move selected fields %{where}"
+msgstr "下移所选的字段"
+
 msgid "Selected Fields:"
 msgstr "选择的字段："
 
-msgid "Move selected fields to top"
-msgstr "移动所选的字段至顶部"
+msgid "to bottom"
+msgstr ""
 
-msgid "Move selected fields to bottom"
-msgstr "移动所选的字段至底部"
+msgid "to top"
+msgstr ""
 
 msgid "Tab Title"
 msgstr "标签页标题"
@@ -11309,6 +12043,7 @@ msgstr ""
 msgid "Commit Changes"
 msgstr "提交修改"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
 msgid "Widgets"
 msgstr "Widgets"
 
@@ -11450,6 +12185,7 @@ msgstr "计费 过滤器"
 msgid "Show Costs by"
 msgstr "显示成本"
 
+#. TRANSLATORS: en.yml key: dictionary.column.owner_name
 msgid "Owner"
 msgstr "所有者"
 
@@ -11939,6 +12675,10 @@ msgstr "未找到项目。"
 msgid "Hover Text"
 msgstr "悬停文本"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
+#. TRANSLATORS: en.yml key: dictionary.table.container_image
+#. TRANSLATORS: en.yml key: dictionary.table.template_cloud
 msgid "Image"
 msgstr "图像"
 
@@ -11962,6 +12702,12 @@ msgstr "右移所选的字段"
 
 msgid "Move selected fields left"
 msgstr "左移所选的字段"
+
+msgid "Move selected fields to top"
+msgstr "移动所选的字段至顶部"
+
+msgid "Move selected fields to bottom"
+msgstr "移动所选的字段至底部"
 
 msgid "Button Group Text"
 msgstr "按钮组文本"
@@ -12020,6 +12766,8 @@ msgstr "命名"
 msgid "Placement"
 msgstr "Placement"
 
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder
 msgid "Folder"
 msgstr "文件夹"
 
@@ -12125,9 +12873,13 @@ msgstr "主机的默认 VNC 端口范围"
 msgid "Add this %s"
 msgstr "添加这个 %s"
 
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region
 msgid "Region"
 msgstr "区域"
 
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
+#. TRANSLATORS: en.yml key: dictionary.table.container_project
 #, fuzzy
 msgid "Project"
 msgstr "项目"
@@ -12221,18 +12973,22 @@ msgstr "帐号政策"
 msgid "Network Type"
 msgstr "网络类型"
 
+#. TRANSLATORS: en.yml key: dictionary.table.nics
 msgid "Network Adapters"
 msgstr "网络适配器"
 
 msgid "%s has no network adapters"
 msgstr "%s 没有网络适配器"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
 msgid "DHCP Enabled"
 msgstr "已启用 DHCP"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
 msgid "DHCP Server"
 msgstr "DHCP 服务器"
 
+#. TRANSLATORS: en.yml key: dictionary.column.dns_server
 msgid "DNS Server"
 msgstr "DNS 服务器"
 
@@ -12245,18 +13001,23 @@ msgstr "IP 地址"
 msgid "Subnet Mask"
 msgstr "子网掩码"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
 msgid "CPU Limit"
 msgstr "CPU 限制"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
 msgid "CPU Reserve"
 msgstr "CPU Reserve"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
 msgid "CPU Reserve Expand"
 msgstr "CPU Reserve Expand"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
 msgid "CPU Shares"
 msgstr "CPU 共享"
 
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
 msgid "CPU Shares Level"
 msgstr "CPU 共享级别"
 
@@ -12278,6 +13039,7 @@ msgstr "内存共享级别"
 msgid "Device Type"
 msgstr "设备类型"
 
+#. TRANSLATORS: en.yml key: dictionary.column.partitions_aligned
 msgid "Partitions Aligned"
 msgstr "对齐的分区"
 
@@ -12479,6 +13241,3441 @@ msgstr "无效的图表定义"
 #. TRANSLATORS: Provide locale name in native language (e.g. English, Deutsch or Português)
 msgid "locale_name"
 msgstr "简体中文"
+
+#. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_vms
+#. TRANSLATORS: en.yml key: dictionary.column.flavor.total_vms
+#, fuzzy
+msgid "Total Instances"
+msgstr "所有实例"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
+#, fuzzy
+msgid "Total Images"
+msgstr "所有的图像"
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.cpu_usage_rate_average
+msgid "CPU - Aggregate Usage Rate for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.derived_cpu_available
+msgid "CPU - Total Installed - Sum of Child Hosts (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.disk_usage_rate_average
+msgid "Disk I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Avg ("
+"%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day High "
+"Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals 30 Day Low A"
+"vg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Child Hosts for Collected Intervals Without Host"
+" Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate Avg for Child Hosts for Collected intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Child Hosts  for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Aggregate Usage of Allocated for Child Hosts for Collected Inter"
+"vals Without Host Overhead 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.mem_usage_absolute_average
+msgid "Memory - Avg Usage of Total Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage Rate Avg for Child Hosts for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_mem_usage_absolute_average
+msgid ""
+"Memory - Min Aggregate Usage of Allocated for Child Hosts for Collected Interv"
+"als (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Child Hosts for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.EmsClusterPerformance.net_usage_rate_average
+msgid "Network I/O - Aggregate of Avg for Child Hosts (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.HostPerformance.derived_cpu_available
+msgid "CPU - Total Installed - from Host Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.StoragePerformance.max_derived_storage_total
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_total
+msgid "Disk Space Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_avg_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_high_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day High Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.cpu_usagemhz_rate_average_low_over_time_period
+msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_avg_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_high_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day High Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.Vm.derived_memory_used_low_over_time_period
+msgid "Memory - Avg Used for Collected Intervals 30 Day Low Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_ready_delta_summation
+msgid "CPU - Time Spent In Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_system_delta_summation
+msgid "CPU - Time Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_usagemhz_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_used_delta_summation
+msgid "CPU - Time Used (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.cpu_wait_delta_summation
+msgid "CPU - Time Spent in Wait State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_available
+msgid "CPU - Total - from VM Analysis (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_cpu_reserved
+msgid "CPU - Reserved (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_available
+msgid "Memory - Total Allocated (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_reserved
+msgid "Memory - Reserved (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.derived_memory_used
+msgid "Memory - Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_cpu_reserved
+msgid "CPU Max Reserved MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_available
+msgid "Memory Max Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_reserved
+#, fuzzy
+msgid "Memory Max Reserved"
+msgstr "内存保留"
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.max_derived_memory_used
+msgid "Memory - Peak Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.min_derived_memory_used
+msgid "Memory - Minimum Avg Used for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_cpu_reserved_pct
+msgid "CPU - Reserved (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.VmPerformance.v_derived_memory_reserved_pct
+#, fuzzy
+msgid "Memory - Reserved (%)"
+msgstr "内存保留"
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_cpu_usage_rate_average_value
+msgid "CPU - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_mem_usage_absolute_average_value
+msgid "Memory - Absolute Max Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Max Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_max_net_usage_rate_average_value
+msgid "Network I/O - Absolute Max Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_timestamp
+msgid "CPU - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_cpu_usage_rate_average_value
+msgid "CPU - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_timestamp
+msgid "Disk I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_disk_usage_rate_average_value
+msgid "Disk I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_timestamp
+msgid "Memory - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_mem_usage_absolute_average_value
+msgid "Memory - Absolute Min Usage Rate (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_timestamp
+msgid "Network I/O - Absolute Min Usage Rate (Timestamp)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.abs_min_net_usage_rate_average_value
+msgid "Network I/O - Absolute Min Usage Rate (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.acctid
+#, fuzzy
+msgid "Account ID"
+msgstr "帐号"
+
+#. TRANSLATORS: en.yml key: dictionary.column.accttype
+#, fuzzy
+msgid "Account Type"
+msgstr "动作类型"
+
+#. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
+msgid "Lockdown Mode"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
+msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_total_cores
+msgid "Total Number of Logical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
+msgid "Total Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggregate_physical_cpus
+msgid "Total Number of Physical CPUs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
+msgid "Allocated Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
+msgid "Allocated Storage"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
+msgid "Allocated vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_max
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_latency_min
+msgid "Usage (All) - Latency in MicroSeconds for All Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios
+msgid "BIOS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.bios_location
+msgid "BIOS Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.chain_id
+msgid "Chain ID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency
+msgid "Usage (CIFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_max
+msgid "Usage (CIFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_latency_min
+msgid "Usage (CIFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops
+msgid "Usage (CIFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_max
+msgid "Usage (CIFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_other_ops_min
+msgid "Usage (CIFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data
+msgid "Usage (CIFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_max
+msgid "Usage (CIFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_data_min
+msgid "Usage (CIFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency
+msgid "Usage (CIFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_max
+msgid "Usage (CIFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_latency_min
+msgid "Usage (CIFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops
+msgid "Usage (CIFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_max
+msgid "Usage (CIFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_read_ops_min
+msgid "Usage (CIFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data
+msgid "Usage (CIFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_max
+msgid "Usage (CIFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_data_min
+msgid "Usage (CIFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency
+msgid "Usage (CIFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_max
+msgid "Usage (CIFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_latency_min
+msgid "Usage (CIFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops
+msgid "Usage (CIFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_max
+msgid "Usage (CIFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cifs_write_ops_min
+msgid "Usage (CIFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.config_xml
+#, fuzzy
+msgid "Configuration XML"
+msgstr "配置标签"
+
+#. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
+msgid "Data Points"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
+msgid "CPU Affinity"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_ready_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in Ready State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_system_delta_summation
+msgid "CPU - Aggregate Time Child VMs Spent in System State (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_type
+#, fuzzy
+msgid "CPU Type"
+msgstr "CPU 时间"
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usage_rate_average
+msgid "CPU - Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average
+msgid "CPU - Aggregate Usage Rate for Child VMs for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_avg_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Avg (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_high_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day High A"
+"vg (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_low_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Low Av"
+"g (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_usagemhz_rate_average_max_over_time_period
+msgid ""
+"CPU - Aggregate Usage Rate for Child VMs for Collected Intervals 30 Day Max (M"
+"Hz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_delta_summation
+msgid "CPU - Aggregate Time Used for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_wait_delta_summation
+msgid "CPU - Aggregate Time Spent in Wait State for Child VMs (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.created_at
+#. TRANSLATORS: en.yml key: dictionary.column.created_on
+msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
+msgid "Depends on Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.depend_on_service
+msgid "Depends on Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_available
+msgid "CPU Total Installed"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_cpu_reserved
+msgid "CPU - Available (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_off
+msgid "State - Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_host_count_on
+msgid "State - Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_available
+msgid "Memory - Total Allocated for Child VMs (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_reserved
+msgid "Memory - Available (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_avg_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Avg (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_high_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day High Avg "
+"(MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_low_over_time_period
+msgid ""
+"Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Low Avg ("
+"MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_memory_used_max_over_time_period
+msgid "Memory - Aggregate Used for Child VMs for Collected Intervals 30 Day Max (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_managed
+msgid "Content - Avg of Total Size of Managed VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_registered
+msgid "Content - Avg of Total Size of Registered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_disk_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Disk Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_free
+msgid "Capacity - Avg Free Space for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_managed
+msgid "Content - Avg of Total Size of Managed VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_registered
+msgid "Content - Avg of Total Size of Registered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_mem_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Memory Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_managed
+msgid "Content - Avg of Total Size of Managed VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_registered
+msgid "Content - Avg of Total Size of Registered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unmanaged
+msgid "Content - Avg of Total Size of Unmanaged VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_snapshot_unregistered
+msgid "Content - Avg of Total Size of Unregistered VMs Snapshot Files (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_total
+msgid "Capacity - Total Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_managed
+msgid "Content - Avg Space Used by Managed VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_registered
+msgid "Content - Avg Space Used by Registered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unmanaged
+msgid "Content - Avg Space Used by Unmanaged VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_used_unregistered
+msgid "Content - Avg Space Used by Unregistered VMs for Collected Intervals (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_managed
+msgid "Content - Avg Count of Managed VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_registered
+msgid "Content - Avg Count of Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unmanaged
+msgid "Content - Avg Count of Unmanaged VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_storage_vm_count_unregistered
+msgid "Content - Avg Count of Unregistered VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_off
+msgid "State - Peak Avg VMs Powered-off - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.derived_vm_count_on
+msgid "State - Peak Avg VMs Powered-On - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
+msgid "Destination Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
+msgid "Destination VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.dest_vm_name
+msgid "Destination VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.direction_of_trend
+msgid "Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_devicelatency_absolute_average
+msgid "Disk Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_kernellatency_absolute_average
+msgid "Disk Kernel Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_queuelatency_absolute_average
+msgid "Disk Queue Latency - Avg (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_usage_rate_average
+msgid "Disk I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
+msgid "Disks Aligned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_cpu
+msgid "CPU - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.effective_memory
+msgid "Memory - Effective"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
+msgid "End"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
+#, fuzzy
+msgid "What is evaluated"
+msgstr "要评估的内容"
+
+#. TRANSLATORS: en.yml key: dictionary.column.event_src
+#, fuzzy
+msgid "Event Source"
+msgstr "EventLog|来源"
+
+#. TRANSLATORS: en.yml key: dictionary.column.filename
+#, fuzzy
+msgid "File Name"
+msgstr "全名"
+
+#. TRANSLATORS: en.yml key: dictionary.column.fqname
+msgid "Fully Qualified Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guest_os
+msgid "Guest OS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.guid
+msgid "EVM Unique ID (Guid)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.has_rdm_disk
+msgid "Has an RDM Disk?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state
+msgid "Health State Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.health_state_str
+msgid "Health State"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.homedir
+#, fuzzy
+msgid "Home Directory"
+msgstr "PXE 目录"
+
+#. TRANSLATORS: en.yml key: dictionary.column.host_name
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_host
+#, fuzzy
+msgid "Parent Host"
+msgstr "父虚拟机"
+
+#. TRANSLATORS: en.yml key: dictionary.column.hostnames
+#, fuzzy
+msgid "Host Names"
+msgstr "Host|名称"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
+#, fuzzy
+msgid "IP Addresses"
+msgstr "IP 地址"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
+#, fuzzy
+msgid "IPMI Enabled"
+msgstr "已启用 DHCP"
+
+#. TRANSLATORS: en.yml key: dictionary.column.is_evm_appliance
+msgid "Is an EVM Appliance?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
+msgid "Last Analysis Attempt On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
+msgid "Last Analysis Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
+#, fuzzy
+msgid "Last Sync Time"
+msgstr "最近运行时间"
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status
+msgid "Last Update Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
+#, fuzzy
+msgid "Last Update Status"
+msgstr "更新状态"
+
+#. TRANSLATORS: en.yml key: dictionary.column.ldap_group
+#. TRANSLATORS: en.yml key: dictionary.column.owning_ldap_group
+msgid "LDAP Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
+#, fuzzy
+msgid "Number of CPU Cores"
+msgstr "CPU 的数量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.mac_addresses
+#. TRANSLATORS: en.yml key: dictionary.column.macaddresses
+#, fuzzy
+msgid "MAC Addresses"
+msgstr "MAC 地址"
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_avg_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_high_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period
+msgid "CPU - Peak Usage Rate Avg for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_low_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate Avg for Collected Intervals Without Host Overhead 30 Day"
+" Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period
+msgid "CPU - Peak Usage Rate for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usage_rate_average_max_over_time_period_without_overhead
+msgid ""
+"CPU - Peak Usage Rate for Collected Intervals Without Host Overhead 30 Day Max"
+" (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_cpu_usagemhz_rate_average
+msgid "CPU - Peak Usage Rate for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_available
+msgid "CPU Max Total MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_cpu_reserved
+msgid "CPU Max Available MHz"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_off
+msgid "State - Peak Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_host_count_on
+msgid "State - Peak Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_available
+msgid "Memory Max Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_reserved
+msgid "Memory Max Available"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_memory_used
+msgid "Memory - Peak Aggregate Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_storage_free
+msgid "Disk Space Max Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_off
+msgid "State - Peak Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_derived_vm_count_on
+msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_disk_usage_rate_average
+msgid "Disk I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapin_absolute_average
+msgid "Memory - Swap In Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapout_absolute_average
+msgid "Memory - Swap Out Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swapped_absolute_average
+msgid "Memory - Swapped Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average
+msgid "Memory - Peak Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_avg_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_high_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day High Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_low_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Low Avg (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period
+msgid "Memory - Peak Usage of Allocated for Collected Intervals 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_usage_absolute_average_max_over_time_period_without_overhead
+msgid ""
+"Memory - Peak Usage of Allocated for Collected Intervals Without Host Overhead"
+" 30 Day Max (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Max Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_net_usage_rate_average
+msgid "Network I/O - Peak Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_sys_uptime_absolute_latest
+msgid "Uptime - Peak Uptime for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.max_v_derived_storage_used
+msgid "Disk Space Max Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapin_absolute_average
+msgid "Memory - Swap In Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapout_absolute_average
+msgid "Memory - Swap Out Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swapped_absolute_average
+msgid "Memory - Swapped Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_swaptarget_absolute_average
+msgid "Memory - Swap Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_usage_absolute_average
+msgid "Memory - Usage of Total Allocated (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_mb
+msgid "RAM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usage_rate_average
+msgid "CPU - Min Usage Rate for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_cpu_usagemhz_rate_average
+msgid "CPU - Min Usage for Collected Intervals (MHz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_off
+msgid "State - Min Number of Hosts Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_host_count_on
+msgid "State - Min Number of Hosts Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_memory_used
+msgid "Memory - Minimum Aggregate Avg Used for Child VMs for Collected Intervals (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_storage_free
+msgid "Disk Space Min Free"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_off
+msgid "State - Min Number of VMs Powered Off  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_derived_vm_count_on
+msgid "State - Min Number of VMs Powered On  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_disk_usage_rate_average
+msgid "Disk I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapin_absolute_average
+msgid "Memory - Swap In Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapout_absolute_average
+msgid "Memory - Swap Out Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swapped_absolute_average
+msgid "Memory - Swapped Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_swaptarget_absolute_average
+msgid "Memory - Swap Min Target Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_usage_absolute_average
+msgid "Memory - Min Usage of Allocated for Collected Intervals (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctl_absolute_average
+msgid "Memory - Balloon Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_mem_vmmemctltarget_absolute_average
+msgid "Memory - Balloon Target Min Average"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_net_usage_rate_average
+msgid "Network I/O - Min Avg for Collected Intervals (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_sys_uptime_absolute_latest
+msgid "Uptime - Minimum Time Between Startups for Collected Intervals (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.min_v_derived_storage_used
+msgid "Disk Space Min Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.multiplehostaccess
+msgid "Multiple Host Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_usage_rate_average
+msgid "Network I/O - Avg (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency
+msgid "Usage (NFS) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_max
+msgid "Usage (NFS) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_latency_min
+msgid "Usage (NFS) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops
+msgid "Usage (NFS) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_max
+msgid "Usage (NFS) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_other_ops_min
+msgid "Usage (NFS) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data
+msgid "Usage (NFS) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_max
+msgid "Usage (NFS) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_data_min
+msgid "Usage (NFS) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency
+msgid "Usage (NFS) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_max
+msgid "Usage (NFS) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_latency_min
+msgid "Usage (NFS) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops
+msgid "Usage (NFS) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_max
+msgid "Usage (NFS) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_read_ops_min
+msgid "Usage (NFS) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data
+msgid "Usage (NFS) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_max
+msgid "Usage (NFS) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_data_min
+msgid "Usage (NFS) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency
+msgid "Usage (NFS) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_max
+msgid "Usage (NFS) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_latency_min
+msgid "Usage (NFS) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops
+msgid "Usage (NFS) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_max
+msgid "Usage (NFS) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.nfs_write_ops_min
+msgid "Usage (NFS) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_automate
+#, fuzzy
+msgid "Management Event Raised"
+msgstr "管理事件"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_email
+#, fuzzy
+msgid "Email"
+msgstr "电子邮件"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
+#, fuzzy
+msgid "Event on Timeline"
+msgstr "显示时间线"
+
+#. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
+msgid "SNMP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_cpu
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
+#, fuzzy
+msgid "Number of CPUs"
+msgstr "CPU 的数量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_disks
+#, fuzzy
+msgid "Number of Disks"
+msgstr "虚拟机的数量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
+#, fuzzy
+msgid "Number of Hard Disks"
+msgstr "虚拟机的数量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status
+msgid "Operational Status Code"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
+msgid "Operational Status"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.os_image_name
+#, fuzzy
+msgid "OS Name"
+msgstr "新的名称"
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency
+msgid "Usage (Other) - Time for Other Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_max
+msgid "Usage (Other) - Time for Other Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_latency_min
+msgid "Usage (Other) - Time for Other Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops
+msgid "Usage (Other) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_max
+msgid "Usage (Other) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.other_ops_min
+msgid "Usage (Other) - Number of Other Operations per Second Miin"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_mem_pct
+msgid "Memory - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.overallocated_vcpus_pct
+msgid "CPU - % Overallocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
+msgid "In My LDAP Group?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_user
+msgid "Owned by Me?"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_1_name
+msgid "Folder Name (VMs & Templates) 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_2_name
+msgid "Folder Name (VMs & Templates) 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_3_name
+msgid "Folder Name (VMs & Templates) 3"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_4_name
+msgid "Folder Name (VMs & Templates) 4"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_5_name
+msgid "Folder Name (VMs & Templates) 5"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_6_name
+msgid "Folder Name (VMs & Templates) 6"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_7_name
+msgid "Folder Name (VMs & Templates) 7"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_8_name
+msgid "Folder Name (VMs & Templates) 8"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.parent_blue_folder_9_name
+msgid "Folder Name (VMs & Templates) 9"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
+#, fuzzy
+msgid "CPU %"
+msgstr "CPU"
+
+#. TRANSLATORS: en.yml key: dictionary.column.percent_memory
+#, fuzzy
+msgid "Memory %"
+msgstr "内存"
+
+#. TRANSLATORS: en.yml key: dictionary.column.pid
+msgid "PID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
+msgid "Total Provisioned Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ram_size
+msgid "RAM Size (MB)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data
+msgid "Usage (Other) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_max
+msgid "Usage (Other) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_data_min
+msgid "Usage (Other) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency
+msgid "Usage (Other) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_max
+msgid "Usage (Other) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_latency_min
+msgid "Usage (Other) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops
+msgid "Usage (Other) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_max
+msgid "Usage (Other) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ops_min
+msgid "Usage (Other) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.resource_name
+#, fuzzy
+msgid "Asset Name"
+msgstr "用户名"
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_never
+msgid "Total VMs Powered Never"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_off
+msgid "Total VMs Powered Off"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_on
+msgid "Total VMs Powered On"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_suspended
+msgid "Total VMs Power Suspended"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_vms_unknown
+msgid "Total VMs Powered Unknown"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_reserved_pct
+msgid "CPU - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_host_count
+msgid "State - Number of Hosts  - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_memory_reserved_pct
+msgid "Memory - Available (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_vm_count
+msgid "State - Peak Avg VMs - Hourly Count / Daily Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_cpu_total_cores_used
+msgid "CPU - Usage Rate for Collected Intervals (Number of Cores)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change
+msgid "Memory - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_mem_recommended_change_pct
+msgid "Memory - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_mem
+msgid "Memory - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_recommended_vcpus
+msgid "CPU - Aggressive Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change
+msgid "CPU - Aggressive Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.aggressive_vcpus_recommended_change_pct
+msgid "CPU - Aggressive Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_memory
+msgid "Capacity - Profile 1 - Total Memory with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_available_host_vcpu
+msgid "Capacity - Profile 1 - Total CPU with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_commitment_ratio
+msgid "Capacity - Profile 1 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_maximum
+msgid "Capacity - Profile 1 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_method
+msgid "Capacity - Profile 1 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_minimum
+msgid "Capacity - Profile 1 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm
+msgid "Capacity - Profile 1 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_memory_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_all
+msgid "Capacity - Profile 1 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_memory
+msgid "Capacity - Profile 1 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_host_vcpu
+msgid "Capacity - Profile 1 - Available vCPUs for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 1 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 1 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 1 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_commitment_ratio
+msgid "Capacity - Profile 1 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_maximum
+msgid "Capacity - Profile 1 - Maximum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_method
+msgid "Capacity - Profile 1 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_minimum
+msgid "Capacity - Profile 1 - Minimum vCPU per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm
+msgid "Capacity - Profile 1 - Number of vCPUs per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_1_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 1 - Number of vCPUs per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_memory
+msgid "Capacity - Profile 2 - Memory Effective with HA"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_available_host_vcpu
+msgid "Capacity - Profile 2 - CPU Effective with HA (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_commitment_ratio
+msgid "Capacity - Profile 2 - Memory Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_maximum
+msgid "Capacity - Profile 2 - Maximum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_method
+msgid "Capacity - Profile 2 - Memory Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_minimum
+msgid "Capacity - Profile 2 - Minimum Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm
+msgid "Capacity - Profile 2 - Memory per VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_memory_per_vm_with_min_max
+msgid "Capacity - Profile 2 - Memory per VM Used in Calculation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_all
+msgid "Capacity - Profile 2 - VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_projected_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_memory
+msgid "Capacity - Profile 2 - Available Memory for New VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_host_vcpu
+msgid "Capacity - Profile 2 - Available vCPUs for New VMs (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_all
+msgid "Capacity - Profile 2 - Available VM Count (combined)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_memory
+msgid "Capacity - Profile 2 - Available VM Count based on Memory"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_remaining_vm_count_based_on_vcpu
+msgid "Capacity - Profile 2 - Available VM Count based on vCPU"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_commitment_ratio
+msgid "Capacity - Profile 2 - vCPU Commitment Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_maximum
+msgid "Capacity - Profile 2 - Maximum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_method
+msgid "Capacity - Profile 2 - vCPU Calculation Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_minimum
+msgid "Capacity - Profile 2 - Minimum vCPU per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.capacity_profile_2_vcpu_per_vm_with_min_max
+msgid "Capacity - Profile 2 - CPU Peak Avg per VM Used in Calculation (Mhz)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change
+msgid "Memory - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_mem_recommended_change_pct
+msgid "Memory - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_mem
+msgid "Memory - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_recommended_vcpus
+msgid "CPU - Conservative Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change
+msgid "CPU - Conservative Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.conservative_vcpus_recommended_change_pct
+msgid "CPU - Conservative Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ems_created_on
+msgid "Created on Time"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change
+msgid "Memory - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_mem_recommended_change_pct
+msgid "Memory - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_mem
+msgid "Memory - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_recommended_vcpus
+msgid "CPU - Moderate Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change
+msgid "CPU - Moderate Recommendation Savings"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.moderate_vcpus_recommended_change_pct
+msgid "CPU - Moderate Recommendation Savings (%)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_mem
+msgid "Memory - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.recommended_vcpus
+msgid "CPU - Recommendation"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_max
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_latency_min
+msgid "Usage (Other) - Time for Other Block Protocol Operations Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops
+msgid "Usage (Block Protocol) - Number of Other Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_max
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_other_ops_min
+msgid "Usage (Block Protocol) - Number of Other Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data
+msgid "Usage (Block Protocol) - Bytes Read per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_max
+msgid "Usage (Block Protocol) - Bytes Read per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_data_min
+msgid "Usage (Block Protocol) - Bytes Read per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency
+msgid "Usage (Block Protocol) - Time for Reads Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_max
+msgid "Usage (Block Protocol) - Time for Reads Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_latency_min
+msgid "Usage (Block Protocol) - Time for Reads Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops
+msgid "Usage (Block Protocol) - Number of Reads per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_max
+msgid "Usage (Block Protocol) - Number of Reads per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_read_ops_min
+msgid "Usage (Block Protocol) - Number of Reads per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data
+msgid "Usage (Block Protocol) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_max
+msgid "Usage (Block Protocol) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_data_min
+msgid "Usage (Block Protocol) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency
+msgid "Usage (Block Protocol) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_max
+msgid "Usage (Block Protocol) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_latency_min
+msgid "Usage (Block Protocol) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops
+msgid "Usage (Block Protocol) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_max
+msgid "Usage (Block Protocol) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.san_write_ops_min
+msgid "Usage (Block Protocol) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.slope
+#, fuzzy
+msgid "Slope"
+msgstr "作用域"
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_host_name
+msgid "Source Host Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
+msgid "Source VM Location"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.src_vm_name
+msgid "Source VM Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
+msgid "SSH Root Access"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.svc_type
+#, fuzzy
+msgid "Service Type"
+msgstr "设备类型"
+
+#. TRANSLATORS: en.yml key: dictionary.column.sys_uptime_absolute_latest
+msgid "Asset - Uptime (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
+msgid "Thin Provisioned"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.timestamp
+#. TRANSLATORS: en.yml key: dictionary.column.statistic_time
+msgid "Activity Sample - Timestamp (Day/Time)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops
+msgid "Usage (All) - Number of Operations per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_max
+msgid "Usage (All) - Number of Operations per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ops_min
+msgid "Usage (All) - Number of Operations per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_cpu_usagemhz_rate_average
+msgid "CPU Average Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_derived_memory_used
+msgid "Memory Average Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_cpu_usagemhz_rate_average
+msgid "CPU Max Used MHz Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_derived_memory_used
+msgid "Memory Max Used Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_disk_usage_rate_average
+msgid "Disk I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_net_usage_rate_average
+msgid "Network I/O Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_max_v_derived_storage_used
+msgid "Disk Space Max Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
+msgid "Disk Space Average Trend"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.typename
+msgid "Type Name"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uid
+msgid "UID"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
+msgid "Uncommitted Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.updated_at
+#. TRANSLATORS: en.yml key: dictionary.column.updated_on
+#, fuzzy
+msgid "Date Updated"
+msgstr "最近更新的"
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
+msgid "Total Used Disk Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_percent_of_provisioned
+#, fuzzy
+msgid "Percent Used Provisioned Space"
+msgstr "Provisioned Size 的使用比例"
+
+#. TRANSLATORS: en.yml key: dictionary.column.used_storage_by_state
+msgid "Currently Used Space"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
+msgid "CPU Cores Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
+#, fuzzy
+msgid "Datastore Path"
+msgstr "数据存储区空间"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_date
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_date
+msgid "Activity Sample - Day (MM DD YY)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_debris_percent_of_used
+msgid "Non-VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_derived_storage_used
+msgid "Capacity - Used Space (B)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
+msgid "Disk Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
+msgid "Free Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_host_vmm_product
+msgid "Parent Host Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
+#, fuzzy
+msgid "Is a Template"
+msgstr "虚拟机和模版"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_memory_percent_of_used
+msgid "VM Memory Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_month
+msgid "Activity Sample - Month (YYYY/MM)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder
+msgid "Parent Folder (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_blue_folder_path
+msgid "Parent Folder Path (VMs & Templates)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_cluster
+msgid "Parent Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
+msgid "Parent Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder
+msgid "Parent Folder (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_folder_path
+msgid "Parent Folder Path (Hosts & Clusters)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_owning_resource_pool
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_resource_pool
+msgid "Parent Resource Pool"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_parent_folder
+#, fuzzy
+msgid "Parent Folder"
+msgstr "打开文件夹"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_ready_delta_summation
+msgid "CPU - % Ready"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_used_delta_summation
+msgid "CPU - % Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_cpu_wait_delta_summation
+msgid "CPU - % Wait"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_pct_free_disk_space
+msgid "Pct Free Disk"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_provisioned_percent_of_total
+msgid "Provisioned Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_qualified_desc
+msgid "Cluster in Datacenter"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_ram_vr_ratio
+msgid "Memory Virtual to Real Ratio"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
+msgid "Snapshot Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_time
+#. TRANSLATORS: en.yml key: dictionary.column.v_statistic_time
+msgid "Activity Sample - Time (HH MM SS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_debris_size
+msgid "Size of Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_disk_size
+#, fuzzy
+msgid "Size of VM Provisioned Disk Files"
+msgstr "虚拟机的 Provisioned 磁盘文件"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
+msgid "Total Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_memory_size
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_ram_size
+msgid "Size of VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshot_size
+#, fuzzy
+msgid "Size of VM Snapshot Files"
+msgstr "虚拟机快照文件"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
+msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
+msgid "Total Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vm_misc_size
+msgid "Size of Other VM Files"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
+#, fuzzy
+msgid "Total VMs"
+msgstr "虚拟机总数"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space
+#, fuzzy
+msgid "Used Space"
+msgstr "已用大小"
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
+msgid "Used Space Percent of Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.v_vm_misc_percent_of_used
+msgid "Other VM Files Percent of Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.virtual_hw_version
+msgid "Virtual Hardware Version"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_buildnumber
+msgid "VMM Build Number"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_product
+msgid "VMM Platform"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_vendor
+msgid "VMM Vendor"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmm_version
+#, fuzzy
+msgid "VMM Version"
+msgstr "CFME 版本"
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_address
+msgid "VMsafe Agent Address"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_agent_port
+msgid "VMsafe Agent Port"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_enable
+msgid "VMsafe Enable"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_fail_open
+msgid "VMsafe Fail Open"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_immutable_vm
+msgid "VMsafe Immutable VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vmsafe_timeout_ms
+msgid "VMsafe Timeout (ms)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data
+msgid "Usage (All) - Bytes Written per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_max
+msgid "Usage (All) - Bytes Written per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_data_min
+msgid "Usage (All) - Bytes Written per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency
+msgid "Usage (All) - Time for Writes Avg"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_max
+msgid "Usage (All) - Time for Writes Avg Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_latency_min
+msgid "Usage (All) - Time for Writes Avg Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops
+msgid "Usage (All) - Number of Writes per Second"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_max
+msgid "Usage (All) - Number of Writes per Second Max"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ops_min
+msgid "Usage (All) - Number of Writes per Second Min"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.ws_port
+#, fuzzy
+msgid "Web Services Port"
+msgstr "Web 服务"
+
+#. TRANSLATORS: en.yml key: dictionary.column.zone_name
+msgid "EVM Zone"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_cost
+msgid "vCPUs Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_allocated_metric
+msgid "vCPUs Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_cost
+msgid "CPU Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_metric
+msgid "CPU Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
+msgid "CPU Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.cpu_used_metric
+#, fuzzy
+msgid "CPU Used"
+msgstr "CPU 速度"
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_cost
+msgid "Disk I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_metric
+msgid "Disk I/O Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_cost
+msgid "Disk I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.disk_io_used_metric
+msgid "Disk I/O Used"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.display_range
+msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_1_cost
+msgid "Fixed Compute Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_compute_2_cost
+msgid "Fixed Compute Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_cost
+msgid "Fixed Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_1_cost
+msgid "Fixed Storage Cost 1"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.fixed_storage_2_cost
+msgid "Fixed Storage Cost 2"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_cost
+msgid "Memory Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_allocated_metric
+msgid "Memory Allocated over Time Period"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_cost
+msgid "Memory Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_metric
+msgid "Memory Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_cost
+msgid "Memory Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.memory_used_metric
+#, fuzzy
+msgid "Memory Used"
+msgstr "内存使用"
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_cost
+msgid "Network I/O Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_metric
+#, fuzzy
+msgid "Network I/O Total"
+msgstr "网络类型"
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_cost
+msgid "Network I/O Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.net_io_used_metric
+#, fuzzy
+msgid "Network I/O Used"
+msgstr "网络类型"
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_cost
+msgid "Storage Allocated Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_allocated_metric
+msgid "Storage Allocated"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_cost
+#, fuzzy
+msgid "Storage Total Cost"
+msgstr "Storage|总共空间"
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_metric
+msgid "Storage Total"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
+msgid "Storage Used Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.storage_used_metric
+#, fuzzy
+msgid "Storage Used"
+msgstr "存储文件"
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_cost
+msgid "Total Cost"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.vm_name
+#, fuzzy
+msgid "VM Name"
+msgstr "虚拟机数量"
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_read_size
+msgid "Average Read Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.avg_write_size
+msgid "Average Write Size"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_read_per_sec
+msgid "Read (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_transferred_per_sec
+msgid "Transferred (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.k_bytes_written_per_sec
+msgid "Written (KBps)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_hit
+msgid "Hit %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_read
+msgid "Read %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.pct_write
+msgid "Write %"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.queue_depth
+msgid "Queue Depth"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_hit_ios_per_sec
+msgid "Read Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.read_ios_per_sec
+msgid "Read (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.response_time_sec
+msgid "Response Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.service_time_sec
+msgid "Service Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
+msgid "Total (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.utilization
+#, fuzzy
+msgid "Utilization %"
+msgstr "Utilization"
+
+#. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
+msgid "Wait Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_hit_ios_per_sec
+msgid "Write Hit (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.column.write_ios_per_sec
+msgid "Write (IOPS)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent
+#, fuzzy
+msgid "EVM Audit Event"
+msgstr "审计事件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.AuditEvent (plural form)
+msgid "EVM Audit Events"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
+#. TRANSLATORS: en.yml key: dictionary.table.availability_zone
+#, fuzzy
+msgid "Availability Zone"
+msgstr "可用性区"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Chargeback (plural form)
+#, fuzzy
+msgid "Chargebacks"
+msgstr "计费"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate
+#, fuzzy
+msgid "Chargeback Rate"
+msgstr "计费 速度"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
+#, fuzzy
+msgid "Chargeback Rates"
+msgstr "计费 速度"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent
+msgid "Storage - Extent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.CimStorageExtent (plural form)
+#, fuzzy
+msgid "Storage - Extents"
+msgstr "存储适配器"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances
+#. TRANSLATORS: en.yml key: dictionary.table.compliances
+#, fuzzy
+msgid "Compliance History"
+msgstr "合规性细节"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Compliance (plural form)
+#. TRANSLATORS: en.yml key: dictionary.model.Compliances (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.compliances (plural form)
+#, fuzzy
+msgid "Compliance Histories"
+msgstr "合规性策略"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Condition
+msgid "Condition"
+msgstr "条件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButton
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button
+#, fuzzy
+msgid "Button"
+msgstr "按钮"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set
+#, fuzzy
+msgid "Buttons Group"
+msgstr "按钮组文本"
+
+#. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
+#, fuzzy
+msgid "Buttons Groups"
+msgstr "按钮组文本"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
+#. TRANSLATORS: en.yml key: dictionary.table.container_group
+#, fuzzy
+msgid "Pod"
+msgstr "节点"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
+msgid "Image Registry"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registry (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_image_registries
+msgid "Image Registries"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
+#. TRANSLATORS: en.yml key: dictionary.table.container_route
+#, fuzzy
+msgid "Route"
+msgstr "速率"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator
+#, fuzzy
+msgid "Replicator"
+msgstr "复制"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.container_replicators
+#, fuzzy
+msgid "Replicators"
+msgstr "复制"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsCluster (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cluster (plural form)
+#, fuzzy
+msgid "Cluster / Deployment Roles"
+msgstr "群集/部署角色"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance
+msgid "Performance - Cluster"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsClusterPerformance (plural form)
+msgid "Performance - Clusters"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsEvent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_event (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_events
+#, fuzzy
+msgid "Management Events"
+msgstr "管理事件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_folders
+#, fuzzy
+msgid "Folders"
+msgstr "文件夹"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance
+msgid "Performance - Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystemPerformance (plural form)
+msgid "Performance - Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp
+msgid "FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtp (plural form)
+msgid "FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous
+msgid "Anonymous FTP"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
+msgid "Anonymous FTPs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotNfs
+msgid "NFS"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb
+msgid "Samba"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.FileDepotSmb (plural form)
+msgid "Sambas"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Flavor
+#. TRANSLATORS: en.yml key: dictionary.table.flavor
+msgid "Flavor"
+msgstr "Flavor"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Host (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
+#, fuzzy
+msgid "Host / Nodes"
+msgstr "主机/节点"
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance
+msgid "Performance - Host"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.HostPerformance (plural form)
+msgid "Performance - Hosts"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore
+#, fuzzy
+msgid "ISO Datastore"
+msgstr "ISO 数据存储区"
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
+#, fuzzy
+msgid "ISO Datastores"
+msgstr "所有的 ISO 数据存储区"
+
+#. TRANSLATORS: en.yml key: dictionary.model.IsoImage
+#. TRANSLATORS: en.yml key: dictionary.table.iso_image
+#, fuzzy
+msgid "ISO Image"
+msgstr "ISO 映像文件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapDomain
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_domain
+#, fuzzy
+msgid "LDAP Domain"
+msgstr "LDAP 域"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapRegion
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_region
+#, fuzzy
+msgid "LDAP Region"
+msgstr "LDAP 区域"
+
+#. TRANSLATORS: en.yml key: dictionary.model.LdapServer
+#. TRANSLATORS: en.yml key: dictionary.table.ldap_server
+#, fuzzy
+msgid "LDAP Server"
+msgstr "LDAP 服务器"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager
+#, fuzzy
+msgid "Configuration Manager"
+msgstr "配置管理"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ConfigurationManager (plural form)
+#, fuzzy
+msgid "Configuration Managers"
+msgstr "配置管理"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem
+#, fuzzy
+msgid "Foreman Configured System"
+msgstr "所有 %s 配置的系统"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
+#, fuzzy
+msgid "Foreman Configured Systems"
+msgstr "所有 %s 配置的系统"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
+msgid "Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
+#, fuzzy
+msgid "Cloud Providers"
+msgstr "所有 %s 提供者"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
+#, fuzzy
+msgid "Instance"
+msgstr "实例"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container
+#, fuzzy
+msgid "Containers Provider"
+msgstr "容器服务"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_containers
+#, fuzzy
+msgid "Containers Providers"
+msgstr "容器服务"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra
+#, fuzzy
+msgid "Infrastructure Provider"
+msgstr "Scale 基础架构提供者"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_infras
+#, fuzzy
+msgid "Infrastructure Providers"
+msgstr "Scale 基础架构提供者"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm_infra
+#. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
+#, fuzzy
+msgid "Virtual Machine"
+msgstr "虚拟机"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager
+msgid "Infrastructure Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::InfraManager (plural form)
+msgid "Infrastructure Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager
+msgid "Infrastructure Provider (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Microsoft::InfraManager (plural form)
+msgid "Infrastructure Providers (Microsoft)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager
+msgid "Infrastructure Provider (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Redhat::InfraManager (plural form)
+msgid "Infrastructure Providers (Redhat)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager
+msgid "Infrastructure Provider (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Vmware::InfraManager (plural form)
+msgid "Infrastructure Providers (Vmware)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager
+msgid "Cloud Provider (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openstack::CloudManager (plural form)
+msgid "Cloud Providers (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager
+msgid "Cloud Provider (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Amazon::CloudManager (plural form)
+msgid "Cloud Providers (Amazon)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager
+msgid "Cloud Provider (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Azure::CloudManager (plural form)
+msgid "Cloud Providers (Microsoft Azure)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
+msgid "Container Provider (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager (plural form)
+msgid "Container Providers (Atomic)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager
+msgid "Container Provider (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Kubernetes::ContainerManager (plural form)
+msgid "Container Providers (Kubernetes)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager
+msgid "Container Provider (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Openshift::ContainerManager (plural form)
+msgid "Container Providers (Openshift)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager
+msgid "Container Provider (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::OpenshiftEnterprise::ContainerManager (plural form)
+msgid "Container Providers (Openshift Enterprise)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
+msgid "Automate Class"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass (plural form)
+msgid "Automate Classes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain
+msgid "Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
+msgid "Automate Domains"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
+msgid "Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance (plural form)
+#, fuzzy
+msgid "Automate Instances"
+msgstr "归档的实例"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
+msgid "Automate Method"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod (plural form)
+msgid "Automate Methods"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
+msgid "Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
+#, fuzzy
+msgid "Automate Namespaces"
+msgstr "命名空间"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlert
+#, fuzzy
+msgid "Alert"
+msgstr "警告"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet
+#, fuzzy
+msgid "Alert Profile"
+msgstr "Alert 配置集"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
+#, fuzzy
+msgid "Dialogs"
+msgstr "对话框"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise (plural form)
+#, fuzzy
+msgid "Enterprises"
+msgstr "企业"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
+#. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
+#, fuzzy
+msgid "Event"
+msgstr "事件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup
+#, fuzzy
+msgid "EVM Group"
+msgstr "没有组"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqGroup (plural form)
+#, fuzzy
+msgid "EVM Groups"
+msgstr "事件组"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
+#, fuzzy
+msgid "Policy Profile"
+msgstr "策略配置集"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
+#, fuzzy
+msgid "Provisions"
+msgstr "Provision %s"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy
+msgid "SmartProxy"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqProxy (plural form)
+msgid "SmartProxies"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqRegion (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_region (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_regions
+#, fuzzy
+msgid "Regions"
+msgstr "区域："
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
+#, fuzzy
+msgid "Schedule"
+msgstr "时间表"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch
+msgid "Search"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSearch (plural form)
+#, fuzzy
+msgid "Searches"
+msgstr "补丁"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
+msgid "SMI-S Agent"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent (plural form)
+msgid "SMI-S Agents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate
+msgid "VM Template and Image"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqTemplate (plural form)
+#, fuzzy
+msgid "VM Template and Images"
+msgstr "所有模版 & 图像"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
+#, fuzzy
+msgid "Roles"
+msgstr "角色"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWidget
+#, fuzzy
+msgid "Widget"
+msgstr "Widgets"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker
+#, fuzzy
+msgid "EVM Worker"
+msgstr "UI Worker"
+
+#. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_workers
+#, fuzzy
+msgid "EVM Workers"
+msgstr "工作节点"
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
+msgid "NetApp Remote Service"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService (plural form)
+msgid "NetApp Remote Services"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent
+msgid "Storage - Aggregate"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapConcreteExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_concrete_extents
+msgid "Storage - Aggregates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare
+msgid "Storage - File Share"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapFileShare (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_shares
+msgid "Storage - File Shares"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk
+msgid "Storage - Volume"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapLogicalDisk (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disks
+msgid "Storage - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent
+#, fuzzy
+msgid "Storage - Plex"
+msgstr "存储文件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapPlexExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_plex_extents
+msgid "Storage - Plexes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent
+msgid "Storage - Raid Group"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapRaidGroupExtent (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_raid_group_extents
+msgid "Storage - Raid Groups"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem
+#, fuzzy
+msgid "Storage - Filer"
+msgstr "存储文件"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_systems
+#, fuzzy
+msgid "Storage - Filers"
+msgstr "存储管理者"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume
+msgid "Storage - LUN"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapStorageVolume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volumes
+msgid "Storage - LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OntapVolumeMetricsRollup
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_volume_metrics_rollup
+msgid "Storage Performance - Volumes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn
+msgid "CloudFormation Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
+#, fuzzy
+msgid "CloudFormation Templates"
+msgstr "Orchestration 模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot
+msgid "Heat Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
+#, fuzzy
+msgid "Heat Templates"
+msgstr "所有模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
+#, fuzzy
+msgid "Azure Template"
+msgstr "所有模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
+#, fuzzy
+msgid "Azure Templates"
+msgstr "所有模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
+msgid "Product Update"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
+msgid "Product Updates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
+#, fuzzy
+msgid "Customization Template"
+msgstr "自定义模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
+#, fuzzy
+msgid "Customization Templates"
+msgstr "自定义模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImage
+#, fuzzy
+msgid "PXE Image"
+msgstr "PXE 图像"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType
+#, fuzzy
+msgid "System Image Type"
+msgstr "所有系统图像类型"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
+#, fuzzy
+msgid "System Image Types"
+msgstr "所有系统图像类型"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer
+#, fuzzy
+msgid "PXE Server"
+msgstr "NFS 服务器"
+
+#. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
+#, fuzzy
+msgid "PXE Servers"
+msgstr "所有 PXE 服务器"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem
+#, fuzzy
+msgid "Scan Item"
+msgstr "扫描项"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ScanItem (plural form)
+#, fuzzy
+msgid "Scan Items"
+msgstr "扫描项"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate
+#, fuzzy
+msgid "Service Catalog Item"
+msgstr "服务类别"
+
+#. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplate (plural form)
+#, fuzzy
+msgid "Service Catalog Items"
+msgstr "服务类别"
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem
+msgid "Storage - Local File System"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.SniaLocalFileSystem (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.snia_local_file_system
+msgid "Storage - Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storages
+#, fuzzy
+msgid "Datastores"
+msgstr "数据存储区"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file
+#, fuzzy
+msgid "Datastore File"
+msgstr "数据存储区空间"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.storage_files
+#, fuzzy
+msgid "Datastore Files"
+msgstr "数据存储区空间"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StorageManager
+#, fuzzy
+msgid "Storage Manager"
+msgstr "存储管理者"
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance
+msgid "Performance - Datastore"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.StoragePerformance (plural form)
+msgid "Performance - Datastores"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User
+msgid "EVM User"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.User (plural form)
+#, fuzzy
+msgid "EVM Users"
+msgstr "所有用户"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend
+#, fuzzy
+msgid "Performance Trend"
+msgstr "性能时间框架"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VimPerformanceTrend (plural form)
+#, fuzzy
+msgid "Performance Trends"
+msgstr "性能时间框架"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm
+#. TRANSLATORS: en.yml key: dictionary.table.vm
+#, fuzzy
+msgid "VM and Instance"
+msgstr "孤立的实例"
+
+#. TRANSLATORS: en.yml key: dictionary.model.Vm (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.vm (plural form)
+#, fuzzy
+msgid "VM and Instances"
+msgstr "虚拟机和实例"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable
+msgid "VMDB Table"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmdbTable (plural form)
+msgid "VMDB Tables"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate
+#, fuzzy
+msgid "VM or Template"
+msgstr "Vm 或模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmOrTemplate (plural form)
+#, fuzzy
+msgid "VM or Templates"
+msgstr "虚拟机和模版"
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance
+msgid "Performance - VM"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.model.VmPerformance (plural form)
+msgid "Performance - VMs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cdroms
+msgid "CD/DVD Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cim_base_storage_extent
+msgid "Base Extents"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
+#, fuzzy
+msgid "Cloud Volume"
+msgstr "云卷"
+
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
+#, fuzzy
+msgid "Cloud Volumes"
+msgstr "云卷"
+
+#. TRANSLATORS: en.yml key: dictionary.table.persistent_volume
+msgid "Volume"
+msgstr "卷"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_custom_attribute
+#, fuzzy
+msgid "VC Custom Attribute"
+msgstr "VC 自定义属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware
+msgid "Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
+msgid "Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_server
+msgid "Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment
+msgid "Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
+msgid "Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner
+#, fuzzy
+msgid "EVM Owner"
+msgstr "没有所有者"
+
+#. TRANSLATORS: en.yml key: dictionary.table.evm_owner (plural form)
+msgid "EVM Owners"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system
+#, fuzzy
+msgid "Cloud/Infrastructure Provider"
+msgstr "Scale 基础架构提供者"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_system (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.ext_management_systems
+#, fuzzy
+msgid "Cloud/Infrastructure Providers"
+msgstr "Scale 基础架构提供者"
+
+#. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
+#, fuzzy
+msgid "File System Drivers"
+msgstr "Filesystem|Atime"
+
+#. TRANSLATORS: en.yml key: dictionary.table.floppies
+msgid "Floppy Drives"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.lans
+msgid "vLANs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance
+msgid "Last Compliance History"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
+#, fuzzy
+msgid "Last Compliance Histories"
+msgstr "主机遵循策略"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ldap (plural form)
+#, fuzzy
+msgid "LDAPs"
+msgstr "LDAP"
+
+#. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
+msgid "Linux Init Processes"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approval_stamps
+msgid "Stamped Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_approvals
+msgid "Approvals"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
+#, fuzzy
+msgid "EVM Custom Attribute"
+msgstr "VC 自定义属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute (plural form)
+#. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attributes
+#, fuzzy
+msgid "EVM Custom Attributes"
+msgstr "VC 自定义属性"
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
+#, fuzzy
+msgid "Configuration Profile (Foreman)"
+msgstr "配置集描述"
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile (plural form)
+msgid "Configuration Profiles (Foreman)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_infra_manager_cloud_networks
+msgid "Cloud Networks (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
+msgid "Cloud Tenants (Openstack)"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template
+msgid "Provisioned From Template"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_provision_template (plural form)
+msgid "Provisioned From Templates"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_proxy_builds
+msgid "SmartProxy Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
+msgid "SCSI LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_task
+#, fuzzy
+msgid "Task"
+msgstr "任务"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template
+#, fuzzy
+msgid "VM Template"
+msgstr "虚拟机和模版"
+
+#. TRANSLATORS: en.yml key: dictionary.table.miq_template (plural form)
+#, fuzzy
+msgid "VM Templates"
+msgstr "虚拟机和模版"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
+#, fuzzy
+msgid "File Shares"
+msgstr "CPU 共享"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_system
+#, fuzzy
+msgid "Filers"
+msgstr "过滤器"
+
+#. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
+msgid "LUNs"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack
+#, fuzzy
+msgid "Stack"
+msgstr "栈"
+
+#. TRANSLATORS: en.yml key: dictionary.table.server_builds
+msgid "EVM Builds"
+msgstr ""
+
+#. TRANSLATORS: en.yml key: dictionary.table.service_template
+#, fuzzy
+msgid "Catalog Item"
+msgstr "目录项"
+
+#. TRANSLATORS: en.yml key: dictionary.table.switches
+#, fuzzy
+msgid "vSwitches"
+msgstr "切换"
 
 msgid "Account|Acctid"
 msgstr "Account|Acctid"
@@ -13001,9 +17198,6 @@ msgstr "计算机系统"
 
 msgid "ComputerSystem|Managed entity type"
 msgstr "ComputerSystem|Managed Entity 类型"
-
-msgid "Condition"
-msgstr "条件"
 
 msgid "Condition|Applies to exp"
 msgstr "条件|应用到表达式"
@@ -14120,9 +18314,6 @@ msgstr "FirewallRule|源 IP 范围"
 
 msgid "FirewallRule|Updated on"
 msgstr "FirewallRule|更新日期"
-
-msgid "Flavor"
-msgstr "Flavor"
 
 msgid "Flavor|Block storage based only"
 msgstr "Flavor|只基于块存储的"
@@ -19355,9 +23546,6 @@ msgstr "VmdbTable|名称"
 
 msgid "VmdbTable|Prior raw metrics"
 msgstr "VmdbTable|之前的原始度量"
-
-msgid "Volume"
-msgstr "卷"
 
 msgid "Volume|Created on"
 msgstr "Volume|创建日期"

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -1,0 +1,38 @@
+namespace :gettext do
+  task :store_dictionary_strings do
+    output_strings = ["# Strings extracted from en.yml for gettext to find"]
+    no_plurals = %w(NFS OS) # strings which we don't want to create automatic plurals for
+
+    dict = YAML.load(File.open(Rails.root.join("config/locales/en.yml")))["en"]["dictionary"]
+    dict.keys.each do |tree|
+      next unless %w(column model table).include?(tree) # subtrees of interest
+
+      dict[tree].keys.each do |item|
+        if dict[tree][item].kind_of?(String) # leaf node
+          output_strings.push("# TRANSLATORS: en.yml key: dictionary.#{tree}.#{item}")
+          value = dict[tree][item]
+          output_strings.push('_("%s")' % value)
+
+          if %w(model table).include?(tree) && # create automatic plurals for model and table subtrees
+             !no_plurals.include?(value)
+            m = /(.+)(\s+\(.+\))/.match(value) # strings like: "Infrastructure Provider (Openstack)"
+            value_plural = m ? "#{m[1].pluralize}#{m[2]}" : value.pluralize
+            if value != value_plural
+              output_strings.push("# TRANSLATORS: en.yml key: dictionary.#{tree}.#{item} (plural form)")
+              output_strings.push('_("%s")' % value_plural)
+            end
+          end
+        elsif dict[tree][item].kind_of?(Hash) # subtree
+          dict[tree][item].keys.each do |subitem|
+            output_strings.push("# TRANSLATORS: en.yml key: dictionary.#{tree}.#{item}.#{subitem}")
+            output_strings.push('_("%s")' % dict[tree][item][subitem])
+          end
+        end
+      end
+    end
+
+    File.open(Rails.root.join("config/dictionary_strings.rb"), "w+") do |f|
+      f.puts(output_strings)
+    end
+  end
+end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -69,29 +69,19 @@ module Vmdb
 
     # Get dictionary name with default settings
     def ui_lookup(options = {})
-      # Pass in singular or plural key to determine format of returned string
       if options[:table]
-        ui_lookup_for_table(options[:table]).singularize
+        Dictionary.gettext(options[:table], :type => :table, :notfound => :titleize, :plural => false)
       elsif options[:tables]
-        ui_lookup_for_table(options[:tables]).pluralize
+        Dictionary.gettext(options[:tables], :type => :table, :notfound => :titleize, :plural => true)
       elsif options[:model]
-        ui_lookup_for_model(options[:model]).singularize
+        Dictionary.gettext(options[:model], :type => :model, :notfound => :titleize, :plural => false)
       elsif options[:models]
-        ui_lookup_for_model(options[:models]).pluralize
+        Dictionary.gettext(options[:models], :type => :model, :notfound => :titleize, :plural => true)
       elsif options[:ui_title]
         ui_lookup_for_title(options[:ui_title])
       else
         ''
       end
-    end
-
-    def ui_lookup_for_table(text)
-      # Pass in singular or plural key to determine format of returned string
-      Dictionary.gettext(text, :type => :table, :notfound => :titleize)
-    end
-
-    def ui_lookup_for_model(text)
-      Dictionary.gettext(text, :type => :model, :notfound => :titleize)
     end
 
     def ui_lookup_for_title(text)


### PR DESCRIPTION
Things done:

* new rake task `store_dictionary_strings` to extract strings from `en.yml` and store them in
`config/dictionary_strings.rb` for another rake task (`gettext:find`) to find.
* added `config/dictionary_strings.rb` file with extracted strings
* updated gettext catalogs with latest strings (dictionary strings included)
* modify `Dictionary` model to use standard gettext