### PR TITLE
When tag is deleted, remove it also from managed filter of all groups

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -502,8 +502,7 @@ class Classification < ApplicationRecord
     tag = Tag.in_my_region.find_by_name(Classification.name2tag(name, parent_id, ns))
     return if tag.nil?
 
-    tag.taggings.delete_all
-    tag.delete
+    tag.destroy
   end
 
   def delete_tags_and_entries

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -142,6 +142,26 @@ class MiqGroup < ApplicationRecord
     self.filters[type.to_s] = filter
   end
 
+  def self.remove_tag_from_all_managed_filters(tag)
+    all.each do |miq_group|
+      miq_group.remove_tag_from_managed_filter(tag)
+      miq_group.save if miq_group.filters_changed?
+    end
+  end
+
+  def remove_tag_from_managed_filter(filter_to_remove)
+    if get_managed_filters.present?
+      *category, _tag = filter_to_remove.split("/")
+      category = category.join("/")
+      self.filters["managed"].each do |filter|
+        next unless filter.first.starts_with?(category)
+        next unless filter.include?(filter_to_remove)
+        filter.delete(filter_to_remove)
+      end
+      self.filters["managed"].reject!(&:empty?)
+    end
+  end
+
   def set_managed_filters(filter)
     set_filters("managed", filter)
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,8 @@ class Tag < ApplicationRecord
   virtual_has_one :category,       :class_name => "Classification"
   virtual_has_one :categorization, :class_name => "Hash"
 
+  before_destroy :remove_from_managed_filters
+
   def self.to_tag(name, options = {})
     File.join(Tag.get_namespace(options), name)
   end
@@ -142,6 +144,10 @@ class Tag < ApplicationRecord
   end
 
   private
+
+  def remove_from_managed_filters
+    MiqGroup.remove_tag_from_all_managed_filters(name)
+  end
 
   def name_path
     @name_path ||= name.sub(%r{^/[^/]*/}, "")

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -4,6 +4,26 @@ describe MiqGroup do
       @miq_group = FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator")
     end
 
+    describe ".remove_tag_from_all_managed_filters" do
+      let(:other_miq_group) { FactoryGirl.create(:miq_group) }
+      let(:filters) { [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"], ["/managed/my_name/test"]] }
+
+      before do
+        @miq_group.set_managed_filters(filters)
+        other_miq_group.set_managed_filters(filters)
+        [@miq_group, other_miq_group].each(&:save)
+      end
+
+      it "removes managed filter from all groups" do
+        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(filters) }
+
+        MiqGroup.remove_tag_from_all_managed_filters("/managed/my_name/test")
+
+        expected_filters = [["/managed/prov_max_memory/test", "/managed/prov_max_memory/1024"]]
+        MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(expected_filters) }
+      end
+    end
+
     context "#get_filters" do
       it "normal" do
         expected = {:test => "test filter"}

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -88,4 +88,25 @@ describe Tag do
       expect(Tag.find_by_classification_name("test_entry", nil, ns).name).to eq("#{ns}/test_entry")
     end
   end
+
+  describe "#destroy" do
+    let(:miq_group)       { FactoryGirl.create(:miq_group) }
+    let(:other_miq_group) { FactoryGirl.create(:miq_group) }
+    let(:filters)         { [["/managed/prov_max_memory/test"], ["/managed/my_name/test"]] }
+    let(:tag)             { FactoryGirl.create(:tag, :name => "/managed/my_name/test") }
+
+    before :each do
+      miq_group.set_managed_filters(filters)
+      other_miq_group.set_managed_filters(filters)
+      [miq_group, other_miq_group].each(&:save)
+    end
+
+    it "destroys tag and remove it from all groups's managed filters" do
+      tag.destroy
+
+      expected_filters = [["/managed/prov_max_memory/test"]]
+      MiqGroup.all.each { |group| expect(group.get_managed_filters).to match_array(expected_filters) }
+      expect(Tag.all).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
scenario:
1. Assign any tag filter to user's group.
2. Remove this tag: Configure->Configuration->Settings->Region-> tab ... Tags
results: filter tag is still stored in user's group managed filter

cc @jrafanie 