### PR TITLE
[PoC] Asynchronous notifications using ActionCable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ bin/*
 
 # config/
 config/apache
+config/cable.yml
 config/database.yml*
 config/vmdb.yml.db
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "rails",                           "~> 5.0.x", :git => "git://github.com/rai
 gem "rails-controller-testing",        :require => false
 gem "activemodel-serializers-xml",     :require => false # required by draper: https://github.com/drapergem/draper/issues/697
 gem "activerecord-session_store",      "~>0.1.2", :require => false
+gem "actioncable"
+gem "coffee-rails"
 gem "websocket-driver",                "~>0.6.3"
 
 gem "config",                          "~>1.1.0", :git => "git://github.com/ManageIQ/config.git", :branch => "overwrite_arrays"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -75,3 +75,4 @@
 //= require resizable_sidebar
 //= require xml_display
 //= require miq_c3
+//= require cable

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,0 +1,5 @@
+//= require action_cable
+//= require_self
+//= require_tree ./channels
+
+ManageIQ.notifications = ActionCable.createConsumer('/ws/notifications');

--- a/app/assets/javascripts/channels/notification.js
+++ b/app/assets/javascripts/channels/notification.js
@@ -1,0 +1,45 @@
+ManageIQ.notification = ManageIQ.notifications.subscriptions.create("NotificationChannel", {
+  connected: function () {},
+  disconnected: function () {},
+  received: function (data) {
+    var _this = this;
+    var level2class = {
+      error:   'danger',
+      warning: 'warning',
+      info:    'info',
+      success: 'success'
+    };
+
+    var level2icon = {
+      error:   'error-circle-o',
+      warning: 'warning-triangle-o',
+      info:    'info',
+      success: 'ok'
+    };
+
+    var toast = $('<div>')
+      .addClass('toast-pf toast-pf-max-width toast-pf-top-right alert alert-dismissable col-xs-12')
+      .addClass('alert-' + level2class[data.level]);
+    var button = $('<div>')
+      .addClass('close')
+      .attr('type', 'button')
+      .data('dismiss', 'alert')
+      .attr('aria-hidden', true)
+      .append($('<span>').addClass('pficon pficon-close'));
+    var icon = $('<span>').addClass('pficon pficon-' + level2icon[data.level]);
+
+    toast.append(button, icon, data.message);
+    $('body').prepend(toast);
+
+    var dismissMessage = function () {
+      toast.remove();
+    };
+
+    button.click(function () {
+      dismissMessage();
+      _this.perform('mark', data);
+    });
+
+    setTimeout(dismissMessage, 3000);
+  }
+});

--- a/app/assets/javascripts/miq_global.js
+++ b/app/assets/javascripts/miq_global.js
@@ -72,5 +72,6 @@ if (! window.ManageIQ) {
       processing: false, // is a request currently being processed?
       queue: [], // a queue of pending requests
     },
+    notifications: null, // asynchronous notifications endpoint
   };
 }

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,26 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    # TODO: what if the user is not logged in
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    # TODO: Do we need really to enter to the database?
+    def find_verified_user
+      User.find_by(:userid => userid_from_session)
+    end
+
+    # TODO: What if the session store is different?
+    def userid_from_session
+      cache = Vmdb::Application.config.session_options[:cache]
+      servers = cache.instance_variable_get(:@servers)
+      options = cache.instance_variable_get(:@options)
+      client = Dalli::Client.new(servers, options)
+      client.get(cookies['_vmdb_session'])['userid']
+    end
+  end
+end

--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -1,0 +1,13 @@
+class NotificationChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "notifications_#{current_user.id}" if current_user
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+
+  def mark(data)
+    current_user.notifications.find(data['id'].to_i).update_attribute(:seen, true)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,14 @@ class ApplicationController < ActionController::Base
   before_action :get_global_session_data, :except => [:resize_layout, :window_sizes, :authenticate]
   before_action :set_user_time_zone, :except => [:window_sizes]
   before_action :set_gettext_locale, :except => [:window_sizes]
+  before_action :allow_websocket
   after_action :set_global_session_data, :except => [:resize_layout, :window_sizes]
+
+  def allow_websocket
+    proto = request.ssl? ? 'wss' : 'ws'
+    override_content_security_policy_directives(:connect_src => ["'self'", "#{proto}://#{request.env['HTTP_HOST']}"])
+  end
+  private :allow_websocket
 
   def reset_toolbar
     @toolbars = {}

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,18 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+
+  after_commit :push_async, :on => :create
+
+  validates :level, :inclusion => %w(success info warning error), :presence => true
+  validates :message, :presence => true
+
+  scope :unread, -> { where(:seen => false) }
+
+  default_value_for :seen, false
+
+  private
+
+  def push_async
+    ActionCable.server.broadcast("notifications_#{user_id}", :id => id, :level => level, :message => message)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_reports, :dependent => :nullify
   has_many   :service_orders, :dependent => :nullify
+  has_many   :notifications, :dependent => :destroy
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :admin, -> { where(:userid => "admin") }

--- a/bin/setup
+++ b/bin/setup
@@ -32,6 +32,9 @@ Dir.chdir APP_ROOT do
   unless File.exist?("config/database.yml")
     system "cp config/database.pg.yml config/database.yml"
   end
+  unless File.exist?("config/cable.yml")
+    system "cp config/cable.yml.sample config/cable.yml"
+  end
   unless File.exist?("certs/v2_key")
     system "cp certs/v2_key.dev certs/v2_key"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'action_view/railtie'
 require 'action_mailer/railtie'
 require 'active_job/railtie'
 require 'sprockets/railtie'
+require 'action_cable/engine'
 
 if defined?(Bundler)
   Bundler.require *Rails.groups(:assets => %w(development test))

--- a/config/cable.yml.sample
+++ b/config/cable.yml.sample
@@ -1,0 +1,8 @@
+production:
+  adapter: postgresql
+
+development:
+  adapter: postgresql
+
+test:
+  adapter: postgresql

--- a/db/migrate/20160623080805_create_notifications.rb
+++ b/db/migrate/20160623080805_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[5.0]
+  def change
+    create_table :notifications do |t|
+      t.references :user, :foreign_key => true, :type => :bigint
+      t.string :level
+      t.text :message
+      t.boolean :seen
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -39,10 +39,13 @@ class WebsocketServer
 
   def call(env)
     if WebSocket::Driver.websocket?(env)
-      exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
-      return not_found if exp.nil?
-
-      init_proxy(env, exp[1])
+      if env['REQUEST_URI'] =~ %r{^/ws/notifications}
+        ActionCable.server.call(env)
+      else
+        exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
+        return not_found if exp.nil?
+        init_proxy(env, exp[1])
+      end
 
       [-1, {}, []]
     else

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notification, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
So this PR implements an asynchronous notification solution. Basically if you create a new `Notification` database record, a callback function sends a notification to the client using ActionCable. The client is listening for notifications on its channel and displays them using PatternFly toast.
 
![yzisrqqaaf](https://cloud.githubusercontent.com/assets/649130/16299231/81eaac00-3939-11e6-993e-dc92903dcca7.gif)

Saving to the database is necessary because it is not guaranteed that the user is logged in. In the future, these database records can be disabled in the [notification drawer](http://rawgit.com/patternfly/patternfly/master/tests/notifications-drawer.html) also provided by the PatternFly guys.

Known issue when displaying multiple notifications at the same time:
https://github.com/patternfly/patternfly/issues/323

**ActionCable uses Redis by default! So make sure that you run bin/setup to copy the sample configuration which uses PostgreSQL!**