### PR TITLE
Remove secureheaders global config deprecation

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,4 +1,4 @@
-SecureHeaders::Configuration.configure do |config|
+SecureHeaders::Configuration.default do |config|
   config.hsts = {
     :max_age            => 20.years.to_i,
     :include_subdomains => false


### PR DESCRIPTION
The global configuration method `configure` is now deprecated in favor of `default`. Removes deprecation warning and preps for a future 3.x upgrade.

Sorry @Fryguy, should have caught this in review of #6801.