### PR TITLE
Require logging for the LOGFILE constant in console utilities

### DIFF
--- a/gems/pending/appliance_console/utilities.rb
+++ b/gems/pending/appliance_console/utilities.rb
@@ -2,6 +2,7 @@
 # TODO: Further refactor these unrelated methods.
 require "util/postgres_admin"
 require "awesome_spawn"
+require "appliance_console/logging"
 
 module ApplianceConsole
   module Utilities


### PR DESCRIPTION
During the first boot database creation this was causing errors of the form:
`Create region failed with error - Error: NameError with message: uninitialized constant ApplianceConsole::Utilities::LOGFILE.`

Appears to be caused by c8dafe4c726bed39057a521a2c9122703d1f2c6f