### PR TITLE
fix secure_headers xss_protection deprecation

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,14 +1,8 @@
 SecureHeaders::Configuration.default do |config|
-  config.hsts = {
-    :max_age            => 20.years.to_i,
-    :include_subdomains => false
-  }
+  config.hsts = "max-age=#{20.years.to_i}",
   config.x_frame_options = 'SAMEORIGIN'
   config.x_content_type_options = "nosniff"
-  config.x_xss_protection = {
-    :value => 1,
-    :mode  => 'block'
-  }
+  config.x_xss_protection = "1; mode=block"
   config.csp = {
     :enforce     => true,
     :default_src => ["'self'"],


### PR DESCRIPTION
```
[DEPRECATION] secure_headers 3.0 will only accept string values for XXssProtection config
```

followed example on https://github.com/twitter/secureheaders
`includeSubDomains` is false by default so unneeded per [owasp.org](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security#Examples)

/cc @chrisarcand Here you go
/cc @Fryguy FYI