### PR TITLE
[WIP] Disallow editing name of tags

### DIFF
--- a/app/views/ops/_classification_entry.html.haml
+++ b/app/views/ops/_classification_entry.html.haml
@@ -24,11 +24,8 @@
           "data-method"         => :post,
           'data-click_url'      => {:url => "#{url}"}.to_json}
           %i.fa.fa-save.fa-lg
-      %td
-        = text_field("entry", "name",
-          :maxlength => MAX_NAME_LEN,
-          "value"    => entry.name,
-          :style     => "width: 100%;")
+      %td{:style => "cursor:default"}
+        = entry.name
       %td
         = text_field("entry", "description",
           :maxlength => MAX_DESC_LEN,
@@ -40,7 +37,7 @@
       %td
         %button.btn.btn-default
           %i.fa.fa-plus.fa-lg
-      %td
+      %td{:style => "min-width: 100px"}
         = _("<New Entry>")
       %td= _("<Click on this row to create a new entry>")
   - else
@@ -51,7 +48,7 @@
                                            :confirm => _("Deleting the '%s' entry will also unassign it from all items, are you sure?") % entry.name),
                                            :title => _("Click to delete this entry")}
           %i.fa.fa-minus.fa-lg
-      %td{:onclick => remote_function(:url => {:action => 'ce_select', :id => entry.id, :field => "name"}), :title => _("Click to update this entry")}
+      %td{:style => "cursor: default"}
         = entry.name
       %td{:onclick => remote_function(:url => {:action => 'ce_select', :id => entry.id, :field => "description"}), :title => _("Click to update this entry")}
         = entry.description


### PR DESCRIPTION
name of tag is basically identifier and it should not be changeable
because is it stored in managed filters as string. Description
is field which is visible in UI in whole app (MiqPolicy, group's filters,..).

before
![screen shot 2016-02-19 at 16 56 06](https://cloud.githubusercontent.com/assets/14937244/13180756/18b73314-d72a-11e5-86a9-e8740df7beb0.png)


after
![screen shot 2016-02-19 at 16 51 23](https://cloud.githubusercontent.com/assets/14937244/13180767/2016ea78-d72a-11e5-86ad-04de70388fb8.png)

thanks @himdel 
cc @h-kataria @jrafanie 

