### PR TITLE
removed incoming as default destination folder for anonymous ftp

### DIFF
--- a/app/models/file_depot_ftp_anonymous.rb
+++ b/app/models/file_depot_ftp_anonymous.rb
@@ -1,24 +1,10 @@
 class FileDepotFtpAnonymous < FileDepotFtp
   def self.requires_credentials?
+    true
+  end
+
+  def requires_support_case?
     false
-  end
-
-  def remove_file(_file)
-    _log.info("Removing log file not supported on this depot type")
-  end
-
-  private
-
-  def create_directory_structure(_path)
-    nil
-  end
-
-  def file_exists?(_file)
-    false
-  end
-
-  def destination_path
-    Pathname.new("incoming")
   end
 
   def login_credentials

--- a/spec/models/file_depot_ftp_anonymous_spec.rb
+++ b/spec/models/file_depot_ftp_anonymous_spec.rb
@@ -1,13 +1,6 @@
 describe FileDepotFtpAnonymous do
-  before :each do
-    @ftpAnonymous = FileDepotFtpAnonymous.new
-  end
-
-
-  it "should require credentials with account anonymous" do
+  it "should require credentials for anonymous" do
     expect(FileDepotFtpAnonymous.requires_credentials?).to eq true
-    ss = FileDepotFtpAnonymous.new.login_credentials
-    expect(ss[0]).to eq "anonymous"
+    expect(FileDepotFtpAnonymous.new.login_credentials[0]).to eq "anonymous"
   end
-
 end

--- a/spec/models/file_depot_ftp_anonymous_spec.rb
+++ b/spec/models/file_depot_ftp_anonymous_spec.rb
@@ -1,0 +1,13 @@
+describe FileDepotFtpAnonymous do
+  before :each do
+    @ftpAnonymous = FileDepotFtpAnonymous.new
+  end
+
+
+  it "should require credentials with account anonymous" do
+    expect(FileDepotFtpAnonymous.requires_credentials?).to eq true
+    ss = FileDepotFtpAnonymous.new.login_credentials
+    expect(ss[0]).to eq "anonymous"
+  end
+
+end


### PR DESCRIPTION
Fixed several issues with anonymous ftp:
1. removed 'incoming' as default destination folder
2. allow creation of subfolders on destination server
3. supply account name  

https://bugzilla.redhat.com/show_bug.cgi?id=1307019