### PR TITLE
Allow erb in database.yml with ENV[ERB_IN_CONFIG]

### DIFF
--- a/config/environments/patches/database_configuration.rb
+++ b/config/environments/patches/database_configuration.rb
@@ -14,7 +14,7 @@ Rails::Application::Configuration.module_eval do
         require "erb"
 
         data = yaml.read
-        data = ERB.new(data).result unless Rails.env.production?
+        data = ERB.new(data).result if !Rails.env.production? || ENV['ERB_IN_CONFIG']
 
         begin
           data = YAML.load(data) || {}


### PR DESCRIPTION
I'm finding myself wanting erb in my database.yml more and more
Especially since I'm

Is this still considered a security risk since people have to access the system as root to write this?

/cc @Fryguy This is more of a place holder for a conversation
/cc @jrafanie @chessbyte FYI