### PR TITLE
C3 charts

### DIFF
--- a/app/assets/javascripts/miq_application.js
+++ b/app/assets/javascripts/miq_application.js
@@ -1510,6 +1510,12 @@ function add_expanding_icon(element){
     element.find('.pull-right').append( "<a onclick='toggle_expansion(this)'> <i class='fa fa-angle-right'></i>" );
 }
 
+function chartData(type, data, data2) {
+  var config = _.cloneDeep(ManageIQ.charts.c3config[type]);
+  return _.defaultsDeep({}, config, data, data2);
+}
+
+
 $( document ).ready(function() {
     check_for_ellipsis();
 });

--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -52,7 +52,7 @@
   c3mixins.pfDataColorFunction = {
     data: {
       color: function (color, d) {
-        return pfColors[d.index];
+        return pfColors[d.index % pfColors.length];
       }
     }
   };

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -194,7 +194,6 @@ class ApplicationController < ActionController::Base
       response.headers["Cache-Control"] = "cache, must-revalidate"
       response.headers["Pragma"] = "public"
     end
-
     rpt.to_chart(@settings[:display][:reporttheme], true, MiqReport.graph_options(params[:width], params[:height]))
     render Charting.render_format => rpt.chart
   end

--- a/app/helpers/c3_helper.rb
+++ b/app/helpers/c3_helper.rb
@@ -20,9 +20,9 @@ EOJ
     content_tag(:div, '', :id => chart_id) +
       javascript_tag(<<-EOJ)
 $.get("#{url}").success(function(data) {
-  var config = ManageIQ.charts.c3config[data.miqChart];
-  var chart = c3.generate(_.defaultsDeep(config, data, { bindto: "##{chart_id}" }));
+  var chart = c3.generate(chartData(data.miqChart, data, { bindto: "##{chart_id}" }));
   ManageIQ.charts.c3["#{chart_id}"] = chart;
+  miqSparkleOff();
 });
 EOJ
   end
@@ -33,8 +33,7 @@ EOJ
     content_tag(:div, '', :id => chart_id) +
       javascript_tag(<<-EOJ)
 var data = #{data.to_json};
-var config = ManageIQ.charts.c3config['#{data[:miqChart]}'];
-var chart = c3.generate(_.defaultsDeep(config, data, { bindto: "##{chart_id}" }));
+var chart = c3.generate(chartMerge('#{data[:miqChart]}', data, { bindto: "##{chart_id}" }));
 ManageIQ.charts.c3["#{chart_id}"] = chart;
 EOJ
   end

--- a/app/views/report/_form_chart_sample.html.haml
+++ b/app/views/report/_form_chart_sample.html.haml
@@ -15,5 +15,4 @@
                         :rand   => "#{rand(999_999_999)}"),
                         :id => 'my_chart', :bgcolor => '#f2f2f2', :width => 400, :height => 250)
       - elsif Charting.backend == :c3
-        -# TODO
-        = c3chart_sample
+        = chart_remote('report', :action => 'sample_chart', :id => "my_chart")

--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -39,7 +39,19 @@ class C3Charting < Charting
   end
 
   def sample_chart(_options, _report_theme)
-    # TODO: implement sample charts
+    sample = {
+      :data => {
+        :columns => [
+          ['data1', 30, 200, 100, 400, 150, 250],
+          ['data2', 50, 20, 10, 40, 15, 25],
+          ['data3', 10, 25, 10, 250, 10, 30]
+        ],
+      },
+      :miqChart => _options[:graph_type]
+    }
+    sample[:data][:groups] = [['data1','data2', 'data3']] if _options[:graph_type].include? 'Stacked'
+    sample
+
   end
 
   def js_load_statement(delayed = false)
@@ -71,5 +83,7 @@ class C3Charting < Charting
     ["Columns, Stacked (2D)", "StackedColumn"],
     ["Donut (2D)",            "Donut"],
     ["Pie (2D)",              "Pie"],
+    ["Line (2D)",             "Line"],
+    ["Area (2D)",             "Area"],
   ]
 end

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -9,6 +9,12 @@ module ReportFormatter
       C3Series
     end
 
+    CONVERT_TYPES = {
+      "ColumnThreed"         => "Column",
+      "ParallelThreedColumn" => "Column",
+      "StackedThreedColumn"  => "StackedColumn",
+      "PieThreed"            => "Pie"
+    }
     def add_series(label, data)
       @counter ||= 0
       @counter += 1
@@ -35,11 +41,10 @@ module ReportFormatter
     # report building methods
     def build_document_header
       super
+      type = c3_convert_type("#{mri.graph[:type]}")
       mri.chart = {
-        :miqChart => "#{mri.graph[:type]}",
-        :data     => {
-          :columns => []
-        }
+        :miqChart => type,
+        :data     => {:columns => []}
       }
 
       if chart_is_2d?
@@ -54,6 +59,10 @@ module ReportFormatter
       if chart_is_stacked?
         mri.chart[:data][:groups] = [[]]
       end
+    end
+
+    def c3_convert_type(type)
+      CONVERT_TYPES[type] || type
     end
 
     def chart_is_2d?

--- a/lib/report_formatter/chart_common.rb
+++ b/lib/report_formatter/chart_common.rb
@@ -21,7 +21,6 @@ module ReportFormatter
 
     def build_document_body
       return no_records_found_chart if mri.table.nil? || mri.table.data.blank?
-
       # find the highest chart value and set the units accordingly for large disk values (identified by GB in units)
       maxcols = 8
       divider = 1

--- a/spec/lib/report_formater/jqplot_formater_charting_counts_spec.rb
+++ b/spec/lib/report_formater/jqplot_formater_charting_counts_spec.rb
@@ -1,6 +1,10 @@
 include ReportsSpecHelper
 
 describe ReportFormatter::JqplotFormatter do
+  before(:each) do
+    allow(Charting).to receive(:backend).and_return(:jqplot)
+    allow(Charting).to receive(:format).and_return(:jqplot)
+  end
   context '#build_reporting_chart_dim2' do
     it 'builds a stacked chart' do
       report = MiqReport.new(

--- a/spec/lib/report_formater/jqplot_formater_spec.rb
+++ b/spec/lib/report_formater/jqplot_formater_spec.rb
@@ -1,6 +1,10 @@
 include ReportsSpecHelper
 
 describe ReportFormatter::JqplotFormatter do
+  before(:each) do
+    allow(Charting).to receive(:backend).and_return(:jqplot)
+    allow(Charting).to receive(:format).and_return(:jqplot)
+  end
   context '#build_numeric_chart_grouped' do
     [true, false].each do |other|
       it "builds 2d numeric charts from summaries #{other ? 'with' : 'without'} 'other'" do


### PR DESCRIPTION
Add c3 charts functionality:
#6692 implement chart samples for report editor
#6693 implement replacements for less important chart types
Charts colors now cycling if there are more records then available colors. In next PR ill add new colors and change existing according to patterfly. Also change its order because i think that light blue, dark blue and green arent the most contrast colors in spectrum.

here are pictures of c3 sample charts:
![firefox_screenshot_2016-03-03t10-16-58 660z](https://cloud.githubusercontent.com/assets/9535558/13491251/a9316d90-e131-11e5-8258-7f0d953d9cad.png)
![firefox_screenshot_2016-03-03t12-52-44 370z](https://cloud.githubusercontent.com/assets/9535558/13494866/5d84b044-e147-11e5-9168-d79dd454804d.png)
![firefox_screenshot_2016-03-03t10-17-14 241z](https://cloud.githubusercontent.com/assets/9535558/13491255/ae2d521e-e131-11e5-9818-531bf417160d.png)
![firefox_screenshot_2016-03-03t12-52-54 153z](https://cloud.githubusercontent.com/assets/9535558/13494870/635e394a-e147-11e5-8273-bd0ad56dbfec.png)

![firefox_screenshot_2016-03-03t10-17-32 196z](https://cloud.githubusercontent.com/assets/9535558/13491257/ae336460-e131-11e5-951d-20f7b2195188.png)
![firefox_screenshot_2016-03-03t10-17-38 708z](https://cloud.githubusercontent.com/assets/9535558/13491258/ae33a808-e131-11e5-9698-98485d61d213.png)

