### PR TITLE
Update Bunny gem

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -55,7 +55,7 @@ if RbConfig::CONFIG["host_os"].include?("linux")
   end
 end
 
-gem "bunny", "~>1.0.4", :require => false
+gem "bunny", "~>2.1.0", :require => false
 
 group :appliance do
   gem "highline", "~> 1.6.21", :require => false  # Needed for the appliance_console


### PR DESCRIPTION
Update Bunny gem, the old gem couldn't handle reconnect when
amqp service got restarted.

Seems like new bunny works the same, so no changes in using it
are needed.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1222005