### PR TITLE
Menu redesign: add middle level to menu definition.

### DIFF
--- a/app/presenters/menu/item.rb
+++ b/app/presenters/menu/item.rb
@@ -19,5 +19,9 @@ module Menu
       else                  href
       end
     end
+
+    def leaf?
+      true
+    end
   end
 end

--- a/app/presenters/menu/section.rb
+++ b/app/presenters/menu/section.rb
@@ -5,7 +5,7 @@ module Menu
     end
 
     def features
-      Array(items).collect(&:feature).compact
+      Array(items).collect { |el| el.try(:feature) || el.try(:features) }.flatten.compact
     end
 
     def visible?
@@ -21,6 +21,10 @@ module Menu
       when :big_iframe then "/dashboard/iframe?sid=#{id}"
       else                  "/dashboard/maintab/?tab=#{id}"
       end
+    end
+
+    def leaf?
+      false
     end
   end
 end


### PR DESCRIPTION
This commit allows adding middle level sections to menu definition.

Such as:
```
def services_menu_section
  Menu::Section.new(:svc, N_("Services"), [
    Menu::Section.new(:svc, N_("Services submenu"), [
      Menu::Item.new('services', N_('My Services'), 'service', ...
```

This is just the definition part so that work can continue on other parts.