### PR TITLE
Redirect user to appropriate screen when rbac access is not allowed.

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,3 +1,4 @@
+= render :partial => "layouts/flash_msg"
 - if  @layout == "dashboard" && (controller.action_name == "show" || controller.action_name == "change_tab")
   .row#modules
     .col-md-4#col1{:style => "position: relative; min-height: 50px;"}

--- a/spec/controllers/vm_common_spec.rb
+++ b/spec/controllers/vm_common_spec.rb
@@ -42,4 +42,40 @@ describe VmOrTemplateController do
       expect(assigns(:flash_array).first[:level]).to eq(:error)
     end
   end
+
+  context "#show" do
+    before :each do
+      allow(User).to receive(:server_timezone).and_return("UTC")
+      allow_any_instance_of(described_class).to receive(:set_user_time_zone)
+      allow(controller).to receive(:check_privileges).and_return(true)
+      EvmSpecHelper.seed_specific_product_features("vandt_accord", "vms_instances_filter_accord")
+      @vm = FactoryGirl.create(:vm_vmware)
+    end
+
+    it "redirects user to explorer that they have access to" do
+      feature = MiqProductFeature.find_all_by_identifier(["vandt_accord"])
+      login_as FactoryGirl.create(:user, :features => feature)
+      controller.instance_variable_set(:@sb, {})
+      get :show, :params => {:id => @vm.id}
+      expect(response).to redirect_to(:controller => "vm_infra", :action => 'explorer')
+    end
+
+    it "redirects user to Workloads explorer when user does not have access to Infra Explorer" do
+      feature = MiqProductFeature.find_all_by_identifier(["vms_instances_filter_accord"])
+      login_as FactoryGirl.create(:user, :features => feature)
+      controller.instance_variable_set(:@sb, {})
+      get :show, :params => {:id => @vm.id}
+      expect(response).to redirect_to(:controller => "vm_or_template", :action => 'explorer')
+    end
+
+    it "redirects user back to the url they came from when user does not have access to any of VM Explorers" do
+      feature = MiqProductFeature.find_all_by_identifier(["dashboard_show"])
+      login_as FactoryGirl.create(:user, :features => feature)
+      controller.instance_variable_set(:@sb, {})
+      request.env["HTTP_REFERER"] = "http://localhost:3000/dashboard/show"
+      get :show, :params => {:id => @vm.id}
+      expect(response).to redirect_to(:controller => "dashboard", :action => 'show')
+      expect(assigns(:flash_array).first[:message]).to include("is not authorized to access")
+    end
+  end
 end


### PR DESCRIPTION
When clicking on a link to go to a VM summary screen from dashboard widgets redirect user to Workloads explorer when user is not allowed to see Infrastructure/Virtual Machines or Cloud/Instances explorer based upon record type. Redirect user back to Dashboard with a flash message when user does not have access to any of the VM accordions in VM* explorers.

https://bugzilla.redhat.com/show_bug.cgi?id=1309473
https://bugzilla.redhat.com/show_bug.cgi?id=1309737

@dclarizio please review

screenshots:
Redirect user to Services/Workloads when user does not have access to appropriate accordions Infrastructure/Virtual Machines
![redirected_to_workloads](https://cloud.githubusercontent.com/assets/3450808/13229622/ee1706fa-d96f-11e5-9f04-a2bd48709bb8.png)


Redirect user to back to dashboard with flash message when user does not have access to appropriate accordions  in Services/Workloads & Infrastructure/Virtual Machines
![redirect_back_to_dashboard](https://cloud.githubusercontent.com/assets/3450808/13229628/f3b70d8a-d96f-11e5-92e3-6421a6bdb84b.png)
