### PR TITLE
[api] Remove rack-test as dependency of api specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,8 @@ RSpec.configure do |config|
     ApplicationController.handle_exceptions = false if %w(controller requests).include?(example.metadata[:type])
   end
 
+  config.before(:each, :rest_api => true) { init_api_spec_env }
+
   config.after(:each) do
     EvmSpecHelper.clear_caches
   end

--- a/spec/support/api_spec_setup.rb
+++ b/spec/support/api_spec_setup.rb
@@ -1,7 +1,0 @@
-RSpec.shared_context "api request specs", :rest_api => true do
-  include Rack::Test::Methods
-  before { init_api_spec_env }
-  def app
-    Vmdb::Application
-  end
-end


### PR DESCRIPTION
Mixing request specs with rack-test made things a bit confusing -
e.g. knowing whether to use `response` or `last_response`,
etc.. Removing rack-test helped clear this up.

***

@miq-bot add-label api, refactoring, test