### PR TITLE
Update rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,7 +65,6 @@ TrivialAccessors:
 # Enabled/Disabled
 #
 AllCops:
-  RunRailsCops: true
   Exclude:
     - config/toolbar_strings.rb
     - gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
@@ -93,13 +92,15 @@ ParallelAssignment:
   Enabled: false
 PerlBackrefs:
   Enabled: false
+Rails:
+  Enabled: true
 ReadWriteAttribute:
   AutoCorrect: false
 RescueModifier:
   AutoCorrect: false
 SingleLineBlockParams:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 SpecialGlobalVars:
   AutoCorrect: false
@@ -107,7 +108,9 @@ StringLiterals:
   Enabled: false
 StringLiteralsInInterpolation:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
+  Enabled: false
+TrailingCommaInArguments:
   Enabled: false
 WhileUntilModifier:
   Enabled: false


### PR DESCRIPTION
Certain rubocop configuration options don't work in the latest
version (0.37.2, of time of writing), and cause rubocop to error.

***

I anticipate this causing some issues synchronizing the bot, and then any other projects that depend on the bot, but opening this to get the ball rolling/discussion