### PR TITLE
Clear zone if automate role not enabled.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -29,7 +29,7 @@ module MiqAeEngine
       :class_name  => 'MiqAeEngine',
       :method_name => 'deliver',
       :args        => [args],
-      :zone        => MiqServer.my_zone,
+      :zone        => MiqServer.my_server.has_active_role?('automate') ? MiqServer.my_zone : nil,
       :role        => 'automate',
       :msg_timeout => 60.minutes
     }.merge(options)

--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_multi_spec.rb
@@ -18,6 +18,7 @@ describe "MultipleStateMachineSteps" do
     @state_class3        = 'SM3'
     @state_instance      = 'MY_STATE_INSTANCE'
     @fqname              = '/SPEC_DOMAIN/NS1/SM1/MY_STATE_INSTANCE'
+    @miq_server      = FactoryGirl.create(:miq_server)
     @user                = FactoryGirl.create(:user_with_group)
     @method_params       = {'ae_result'     => {:datatype => 'string', 'default_value' => 'ok'},
                             'ae_next_state' => {:datatype => 'string'},
@@ -31,6 +32,7 @@ describe "MultipleStateMachineSteps" do
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
     allow(MiqServer).to receive(:my_zone).and_return('default')
+    allow(MiqServer).to receive(:my_server).and_return(@miq_server)
     clear_domain
     setup_model
   end

--- a/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
+++ b/spec/automation/unit/engine_validation/miq_ae_state_machine_retry_spec.rb
@@ -12,6 +12,7 @@ describe "MiqAeStateMachineRetry" do
     @root_class      = "TOP_OF_THE_WORLD"
     @root_instance   = "EVEREST"
     @user            = FactoryGirl.create(:user_with_group)
+    @miq_server      = FactoryGirl.create(:miq_server)
     @automate_args   = {:namespace        => @namespace,
                         :class_name       => @root_class,
                         :instance_name    => @root_instance,
@@ -20,6 +21,7 @@ describe "MiqAeStateMachineRetry" do
                         :tenant_id        => @user.current_tenant.id,
                         :automate_message => 'create'}
     allow(MiqServer).to receive(:my_zone).and_return('default')
+    allow(MiqServer).to receive(:my_server).and_return(@miq_server)
     clear_domain
   end
 

--- a/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
+++ b/spec/lib/miq_automation_engine/miq_ae_engine_spec.rb
@@ -156,7 +156,7 @@ module MiqAeEngineSpec
             q = MiqQueue.first
             expect(q.class_name).to eq('MiqAeEngine')
             expect(q.method_name).to eq('deliver')
-            expect(q.zone).to eq(MiqServer.my_zone)
+            expect(q.zone).to be_nil
             expect(q.role).to eq('automate')
             expect(q.msg_timeout).to eq(60.minutes)
 
@@ -175,6 +175,39 @@ module MiqAeEngineSpec
               :ae_state_retries => @ae_state_retries,
             }
             expect(q.args.first).to eq(args)
+          end
+
+          it "with defaults, automate role, valid zone" do
+            allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => true)
+            object_type = @ems.class.name
+            object_id   = @ems.id
+            expect(call_automate(object_type, object_id)).to eq(@ws)
+
+            expect(MiqQueue.count).to eq(1)
+            expect(MiqQueue.first).to have_attributes(
+              :class_name  => 'MiqAeEngine',
+              :method_name => 'deliver',
+              :zone        => MiqServer.my_zone,
+              :role        => 'automate',
+              :msg_timeout => 60.minutes,
+            )
+          end
+
+          it "with defaults, no automate role, nil zone" do
+            allow_any_instance_of(MiqServer).to receive_messages(:has_active_role? => false)
+            object_type = @ems.class.name
+            object_id   = @ems.id
+            expect(call_automate(object_type, object_id)).to eq(@ws)
+
+            expect(MiqQueue.count).to eq(1)
+
+            expect(MiqQueue.first).to have_attributes(
+              :class_name  => 'MiqAeEngine',
+              :method_name => 'deliver',
+              :zone        => nil,
+              :role        => 'automate',
+              :msg_timeout => 60.minutes,
+            )
           end
         end
       end

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -3,6 +3,7 @@ describe ResourceAction do
     let(:user) { FactoryGirl.create(:user_with_group) }
     let(:zone_name) { "default" }
     let(:ra) { FactoryGirl.create(:resource_action) }
+    let(:miq_server) { FactoryGirl.create(:miq_server) }
     let(:q_args) do
       {
         :namespace        => nil,
@@ -30,6 +31,7 @@ describe ResourceAction do
 
     before do
       allow(MiqServer).to receive(:my_zone).and_return(zone_name)
+      allow(MiqServer).to receive(:my_server).and_return(miq_server)
     end
 
     context 'with no target' do


### PR DESCRIPTION
Customer with multi zone environment experiencing problem when calling for service retirement. MiqAeEngine.deliver for the retirement work was stuck on the queue with a zone=UI. Current zone(UI) does not have automate role enabled. Changed code to clear zone if the automate role not enabled.
     
https://bugzilla.redhat.com/show_bug.cgi?id=1302107