### PR TITLE
Adding inclusion of VirtualAttributes module to ActsAsArModel class

### DIFF
--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -117,15 +117,30 @@ class ActsAsArModel
   end
 
   include FakeAttributeStore
-  include VirtualAttributes
+  include VirtualFields
 
   include AttributeBag
+
+  def self.instances_are_derived?
+    true
+  end
+
+  def self.reflect_on_association(name)
+    virtual_reflection(name)
+  end
 
   def initialize(values = {})
     super()
     self.attributes = values
   end
 
+  #
+  # Reflection methods
+  #
+
+  def self.reflections
+    @reflections ||= {}
+  end
 
   #
   # Find routines

--- a/spec/models/miq_expression/model_details_spec.rb
+++ b/spec/models/miq_expression/model_details_spec.rb
@@ -82,6 +82,11 @@ describe MiqExpression do
         result = described_class.model_details("Service", :typ => "all", :include_model => false, :include_tags => true)
         expect(result.map(&:first)).to include("My Company Tags : Auto Approve - Max CPU")
       end
+
+      it "Supports classes derived form ActsAsArModel" do
+        result = described_class.model_details("Chargeback", :typ => "all", :include_model => false, :include_tags => true)
+        expect(result.map(&:first)[0]).to eq(" CPU Total Cost")
+      end
     end
   end
 


### PR DESCRIPTION
This fixes issue #6847

This was broken by the rails 5 upgrade moving/reorganizing of the VirtualAttributes and VirtualFields modules here:  22153f42007a0fc68b22c8f2c1cf37334ca6544a