### PR TITLE
C3 charts new chart types

### DIFF
--- a/app/assets/javascripts/miq_c3_config.js
+++ b/app/assets/javascripts/miq_c3_config.js
@@ -196,6 +196,52 @@
       c3mixins.pfColorPattern,
       c3mixins.legendOnRightSide,
       c3mixins.noTooltip
+    ),
+
+    Line: _.defaultsDeep({
+        data: {
+          type: 'line'
+        },
+        line: {
+          label: {
+            format: percentLabelFormat
+          },
+          expand: false
+        }
+      },
+      c3mixins.pfColorPattern,
+      c3mixins.legendOnRightSide,
+      c3mixins.noTooltip
+    ),
+    Area: _.defaultsDeep({
+        data: {
+          type: 'area'
+        },
+        area: {
+          label: {
+            format: percentLabelFormat
+          },
+          expand: false
+        }
+      },
+      c3mixins.pfColorPattern,
+      c3mixins.legendOnRightSide,
+      c3mixins.noTooltip
+    ),
+    StackedArea: _.defaultsDeep({
+        data: {
+          type: 'area'
+        },
+        area: {
+          label: {
+            format: percentLabelFormat
+          },
+          expand: false
+        }
+      },
+      c3mixins.pfColorPattern,
+      c3mixins.legendOnRightSide,
+      c3mixins.noTooltip
     )
   };
 })(ManageIQ);

--- a/app/helpers/c3_helper.rb
+++ b/app/helpers/c3_helper.rb
@@ -33,7 +33,7 @@ EOJ
     content_tag(:div, '', :id => chart_id) +
       javascript_tag(<<-EOJ)
 var data = #{data.to_json};
-var chart = c3.generate(chartMerge('#{data[:miqChart]}', data, { bindto: "##{chart_id}" }));
+var chart = c3.generate(chartData('#{data[:miqChart]}', data, { bindto: "##{chart_id}" }));
 ManageIQ.charts.c3["#{chart_id}"] = chart;
 EOJ
   end

--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -51,7 +51,6 @@ class C3Charting < Charting
     }
     sample[:data][:groups] = [['data1','data2', 'data3']] if _options[:graph_type].include? 'Stacked'
     sample
-
   end
 
   def js_load_statement(delayed = false)

--- a/lib/charting/c3_charting.rb
+++ b/lib/charting/c3_charting.rb
@@ -84,5 +84,6 @@ class C3Charting < Charting
     ["Pie (2D)",              "Pie"],
     ["Line (2D)",             "Line"],
     ["Area (2D)",             "Area"],
+    ["Area, Stacked (2D)",    "StackedArea"],
   ]
 end

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -4,17 +4,19 @@ module ReportFormatter
     include ChartCommon
     renders :c3, :for => ReportRenderer
 
-    CONVERT_TYPES = {
-      "ColumnThreed"         => "Column",
-      "ParallelThreedColumn" => "Column",
-      "StackedThreedColumn"  => "StackedColumn",
-      "PieThreed"            => "Pie"
-    }
     # series handling methods
     def series_class
       C3Series
     end
 
+    CONVERT_TYPES = {
+      "ColumnThreed"         => "Column",
+      "ParallelThreedColumn" => "Column",
+      "StackedThreedColumn"  => "StackedColumn",
+      "PieThreed"            => "Pie",
+      "AreaThreed"           => "Area",
+      "StackedAreaThreed"    => "StackedArea"
+    }
     def add_series(label, data)
       @counter ||= 0
       @counter += 1

--- a/lib/report_formatter/c3.rb
+++ b/lib/report_formatter/c3.rb
@@ -4,17 +4,17 @@ module ReportFormatter
     include ChartCommon
     renders :c3, :for => ReportRenderer
 
-    # series handling methods
-    def series_class
-      C3Series
-    end
-
     CONVERT_TYPES = {
       "ColumnThreed"         => "Column",
       "ParallelThreedColumn" => "Column",
       "StackedThreedColumn"  => "StackedColumn",
       "PieThreed"            => "Pie"
     }
+    # series handling methods
+    def series_class
+      C3Series
+    end
+
     def add_series(label, data)
       @counter ||= 0
       @counter += 1


### PR DESCRIPTION
Add more C3 chart types: line, area, stacked area.
#6691

![firefox_screenshot_2016-03-03t12-38-24 148z](https://cloud.githubusercontent.com/assets/9535558/13494568/535328fa-e145-11e5-8396-a3d24031973d.png)
![firefox_screenshot_2016-03-03t12-38-32 753z](https://cloud.githubusercontent.com/assets/9535558/13494570/535b5fde-e145-11e5-8c88-4c0df3d252d8.png)
![firefox_screenshot_2016-03-03t12-38-39 913z](https://cloud.githubusercontent.com/assets/9535558/13494569/53573bca-e145-11e5-9b59-b471443e57b1.png)
