### PR TITLE
Enable processing provider events for policy.

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -14,7 +14,7 @@ class MiqEvent < EventStream
     }
   }
 
-  SUPPORTED_POLICY_AND_ALERT_CLASSES = [Host, VmOrTemplate, Storage, EmsCluster, ResourcePool, MiqServer]
+  SUPPORTED_POLICY_AND_ALERT_CLASSES = [Host, VmOrTemplate, Storage, EmsCluster, ResourcePool, MiqServer, ExtManagementSystem]
 
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})
     # Target may have been deleted if it's a worker

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -123,6 +123,16 @@ describe MiqEvent do
         expect(MiqEvent).to receive(:raise_event_for_children).never
         MiqEvent.first.process_evm_event
       end
+
+      it "will do policy for provider events" do
+        event = 'ems_auth_changed'
+        ems = FactoryGirl.create(:ext_management_system)
+        FactoryGirl.create(:miq_event_definition, :name => event)
+        FactoryGirl.create(:miq_event, :event_type => event, :target => ems)
+
+        expect(MiqPolicy).to receive(:enforce_policy).with(ems, event, :type => ems.class.name)
+        MiqEvent.first.process_evm_event
+      end
     end
 
     context ".raise_event_for_children" do


### PR DESCRIPTION
Add ExtManagementSystem to the list of SUPPORTED_POLICY_AND_ALERT_CLASSES to enable processing provider events for policy.

https://bugzilla.redhat.com/show_bug.cgi?id=991474