### PR TITLE
[api] Fixes sort_by attribute check when classes instances are not referenced yet.

### DIFF
--- a/app/controllers/api_controller/parameters.rb
+++ b/app/controllers/api_controller/parameters.rb
@@ -131,9 +131,11 @@ class ApiController
       orders = String(params['sort_order']).split(",")
       options = String(params['sort_options']).split(",")
       params['sort_by'].split(",").zip(orders).collect do |attr, order|
-        raise BadRequestError,
-              "#{attr} is not a valid attribute for #{klass.name}" if !klass.method_defined?(attr) && attr != "id"
-        sort_directive(attr, order, options)
+        if klass.respond_to?(attr) || klass.attribute_method?(attr) || klass.method_defined?(attr) || attr == "id"
+          sort_directive(attr, order, options)
+        else
+          raise BadRequestError, "#{attr} is not a valid attribute for #{klass.name}"
+        end
       end.compact
     end
 

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -280,6 +280,12 @@ describe ApiController do
   describe "Querying vms" do
     before { api_basic_authorize }
 
+    it "and sorted by name succeeeds with unreferenced class" do
+      run_get vms_url, :sort_by => "name", :expand => "resources"
+
+      expect_query_result(:vms, 0, 0)
+    end
+
     it "is supported without expanding resources" do
       create_vms_by_name(%w(aa bb))
 


### PR DESCRIPTION
Fixed an issue where sort_by attributes are not seen as valid when a class instance is not yet referenced.

Fixes Issue #6878