### PR TITLE
Rails 4 should handle remove_index

### DIFF
--- a/db/migrate/20160114111114_delete_network_router_id_from_floating_ips.rb
+++ b/db/migrate/20160114111114_delete_network_router_id_from_floating_ips.rb
@@ -1,6 +1,5 @@
 class DeleteNetworkRouterIdFromFloatingIps < ActiveRecord::Migration
   def change
-    remove_index :floating_ips, :column => :network_router_id
     remove_column :floating_ips, :network_router_id, :bigint
   end
 end

--- a/db/migrate/20160114153948_delete_cloud_network_id_from_network_ports.rb
+++ b/db/migrate/20160114153948_delete_cloud_network_id_from_network_ports.rb
@@ -1,6 +1,5 @@
 class DeleteCloudNetworkIdFromNetworkPorts < ActiveRecord::Migration
   def change
-    remove_index :network_ports, :column => :cloud_network_id
     remove_column :network_ports, :cloud_network_id, :bigint
   end
 end


### PR DESCRIPTION
Rails 4 should handle remove_index when we remove_column,
we don't need to manually write it.