### PR TITLE
Fix the links from relations of the MW-provider integration.

### DIFF
--- a/app/controllers/ems_common.rb
+++ b/app/controllers/ems_common.rb
@@ -92,6 +92,7 @@ module EmsCommon
     [Container, ContainerReplicator, ContainerNode, ContainerGroup,
      ContainerService, ContainerImage, ContainerRoute,
      ContainerProject, ContainerImageRegistry, AvailabilityZone,
+     MiddlewareServer, MiddlewareDeployment,
      CloudTenant, CloudVolume, Flavor, SecurityGroup,].detect do |klass|
       name = klass.name.underscore.pluralize
       [display_name, session_display].include?(name)


### PR DESCRIPTION
This was in the very original work, but got lost during too many rebases onto master.