### PR TITLE
Rbac target scopes

### DIFF
--- a/app/controllers/api_controller/features.rb
+++ b/app/controllers/api_controller/features.rb
@@ -77,11 +77,7 @@ class ApiController
     end
 
     def resource_search_by_criteria(criteria, search_val, klass)
-      Rbac.search(
-        :targets        => Array(klass.send("find_by_#{criteria}", search_val)),
-        :user           => @auth_user_obj,
-        :results_format => :objects
-      ).first.first
+      Rbac.filtered(klass.where(criteria => search_val), :user => @auth_user_obj).first
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2473,10 +2473,7 @@ class ApplicationController < ActionController::Base
       raise msg
     end
 
-    Rbac.search(:class          => db,
-                :conditions     => ["#{db.table_name}.id = ?", id],
-                :user           => current_user,
-                :results_format => :objects).first.first ||
+    Rbac.filtered(db, :conditions => ["#{db.table_name}.id = ?", id], :user => current_user).first ||
       raise("User '#{current_userid}' is not authorized to access '#{ui_lookup(:model => db.to_s)}' record id '#{id}'")
   end
 

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -270,6 +270,7 @@ module MiqReport::Generator
       # Basic report
       # Daily and Hourly for: C&U main reports go through here too
       ext_options[:only_cols] += conditions.columns_for_sql if conditions # Add cols references in expression to ensure they are present for evaluation
+      # NOTE: using search to get user property "managed", otherwise this is overkill
       results, attrs = Rbac.search(
         options.merge(
           :class            => db,

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -111,7 +111,7 @@ class MiqSchedule < ApplicationRecord
     # Let RBAC evaluate the filter's MiqExpression, and return the first value (the target ids)
     my_filter = get_filter
     return [] if my_filter.nil?
-    Rbac.search(:class => towhat, :filter => my_filter).first
+    Rbac.filtered(towhat, :filter => my_filter)
   end
 
   def get_targets
@@ -124,8 +124,7 @@ class MiqSchedule < ApplicationRecord
       return []
     end
 
-    targets, attrs = Rbac.search(:class => towhat, :filter => my_filter, :results_format => :objects)
-    targets
+    Rbac.filtered(towhat, :filter => my_filter)
   end
 
   def get_filter

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -317,7 +317,7 @@ module Rbac
                                             "use [] to get an empty result back. nil will return all records",
                                             caller(0)) unless Rails.env.production?
     end
-    if objects.present?
+    if objects.respond_to?(:all) || objects.present?
       Rbac.search(options.merge(:targets => objects, :results_format => :objects)).first
     else
       objects

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -461,9 +461,9 @@ module Rbac
     ids_clause             = nil
     target_ids             = nil
 
-    if targets.nil? || targets.kind_of?(Array) && targets.empty?
+    if targets.nil?
       scope = apply_scope(klass, scope)
-    elsif targets.kind_of?(Array) && !targets.empty?
+    elsif targets.kind_of?(Array)
       if targets.first.kind_of?(Numeric)
         target_ids = targets
       else

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -317,11 +317,7 @@ module Rbac
                                             "use [] to get an empty result back. nil will return all records",
                                             caller(0)) unless Rails.env.production?
     end
-    if objects.respond_to?(:all) || objects.present?
-      Rbac.search(options.merge(:targets => objects, :results_format => :objects)).first
-    else
-      objects
-    end
+    Rbac.search(options.merge(:targets => objects, :results_format => :objects, :empty_means_empty => true)).first
   end
 
   def self.find_via_descendants(descendants, method_name, klass)
@@ -427,6 +423,8 @@ module Rbac
     # later: search(:targets => [],  :class => Vm) returns []
     #        search(:targets => nil, :class => Vm) will always search Vms
     if options.key?(:targets) && options[:targets].kind_of?(Array) && options[:targets].empty?
+      return [], {:total_count => 0} if options[:empty_means_empty]
+
       Vmdb::Deprecation.deprecation_warning(":targets => []", "use :targets => nil to search all records",
                                             caller(0)) unless Rails.env.production?
       options[:targets] = nil

--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -436,7 +436,7 @@ module Rbac
     # => list if ids - :class is required for this format.
     # => list of objects
     # results are returned in the same format as the targets. for empty targets, the default result format is a list of ids.
-    targets           = options.delete(:targets) || []
+    targets           = options.delete(:targets)
 
     # Support for using named_scopes in search. Supports scopes with or without args:
     # Example without args: :named_scope => :in_my_region
@@ -461,9 +461,9 @@ module Rbac
     ids_clause             = nil
     target_ids             = nil
 
-    unless targets.empty?
+    unless targets.nil? || targets.empty?
       if targets.first.kind_of?(Numeric)
-        target_ids       = targets
+        target_ids = targets
       else
         target_ids       = targets.collect(&:id)
         klass            = targets.first.class.base_class unless klass.respond_to?(:find)
@@ -489,6 +489,9 @@ module Rbac
 
     if klass.respond_to?(:find)
       targets, total_count, auth_count = find_targets_with_rbac(klass, scope, user_filters, find_options, user || miq_group)
+    elsif targets.nil? # tmp
+      targets = []
+      total_count = auth_count = 0
     else
       total_count = targets.length
       auth_count  = targets.length

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -80,7 +80,7 @@ module VimPerformanceAnalysis
         elsif topts[:compute_tags]
           search_options[:tag_filters] = {"managed" => topts[:compute_tags]}
         end
-        @compute, _attrs = Rbac.search(search_options)
+        @compute = Rbac.filtered(nil, search_options)
 
         MiqPreloader.preload(@compute, :storages)
         stores = @compute.collect { |c| storages_for_compute_target(c) }.flatten.uniq

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -508,9 +508,7 @@ class TreeBuilder
 
   def self.rbac_has_visible_descendants?(o, type)
     target_ids = o.descendant_ids(:of_type => type).transpose.last
-    return false if target_ids.blank?
-    results, _attrs = Rbac.search(:targets => target_ids, :class => type.constantize)
-    results.length > 0
+    Rbac.filtered(target_ids, :class => type.constantize).present?
   end
   private_class_method :rbac_has_visible_descendants?
 

--- a/app/presenters/tree_builder.rb
+++ b/app/presenters/tree_builder.rb
@@ -508,7 +508,7 @@ class TreeBuilder
 
   def self.rbac_has_visible_descendants?(o, type)
     target_ids = o.descendant_ids(:of_type => type).transpose.last
-    Rbac.filtered(target_ids, :class => type.constantize).present?
+    !target_ids.nil? && Rbac.filtered(target_ids, :class => type.constantize).present?
   end
   private_class_method :rbac_has_visible_descendants?
 

--- a/app/presenters/tree_builder_vms_and_templates.rb
+++ b/app/presenters/tree_builder_vms_and_templates.rb
@@ -54,8 +54,7 @@ class TreeBuilderVmsAndTemplates < FullTreeBuilder
   def prune_rbac(tree)
     vms = extract_vms(tree).uniq
 
-    allowed_vm_ids, _attrs = Rbac.search(:targets => vms, :results_format => :ids)
-    allowed_vm_ids = Set.new(allowed_vm_ids)
+    allowed_vm_ids = Set.new(Rbac.filtered(vms).map(&:id)) # results_format == :ids
 
     prune_filtered_vms(tree, allowed_vm_ids)
     prune_empty_folders(tree)

--- a/spec/controllers/application_controller/explorer_spec.rb
+++ b/spec/controllers/application_controller/explorer_spec.rb
@@ -43,8 +43,9 @@ describe VmInfraController do
         user.current_group.set_managed_filters([["/managed/service_level/gold"]])
         login_as user
 
-        expect(Rbac).to receive(:search).with(:targets => [ems_folder], :results_format => :objects).and_call_original
-
+        expect(Rbac).to receive(:search).with(:targets           => [ems_folder],
+                                              :empty_means_empty => true,
+                                              :results_format    => :objects).and_call_original
         controller.send(:rbac_filtered_objects, [ems_folder], :match_via_descendants => "VmOrTemplate")
       end
     end

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -53,10 +53,9 @@ describe MiqSearch do
   end
 
   describe "#filtered" do
-    # TODO: return matched_vms
     it "works with models" do
       all_vms
-      expect { vm_location_search.filtered(Vm).first }.to raise_error(NoMethodError)
+      expect(vm_location_search.filtered(Vm)).to match_array(matched_vms)
     end
 
     it "works with scopes" do

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -68,10 +68,9 @@ describe MiqSearch do
       expect(vm_location_search.filtered(partial_vms)).to match_array(partial_matched_vms)
     end
 
-    # TODO: return matched_vms
-    it "brings back all for no target" do
+    it "brings back all for unspecified target" do
       all_vms
-      expect(vm_location_search.filtered(nil)).to eq(nil)
+      expect(vm_location_search.filtered(nil)).to match_array(matched_vms)
     end
 
     it "brings back empty array for empty arrays" do

--- a/spec/models/rbac_spec.rb
+++ b/spec/models/rbac_spec.rb
@@ -32,7 +32,7 @@ describe Rbac do
         it "with :user finds #{klass}" do
           owned_resource = FactoryGirl.create(factory_name, :tenant => owner_tenant)
           _other_resource = FactoryGirl.create(factory_name, :tenant => other_tenant)
-          results = Rbac.search(:class => klass, :results_format => :objects, :user => owner_user).first
+          results = Rbac.filtered(klass, :user => owner_user)
           expect(results).to match_array [owned_resource]
         end
       end


### PR DESCRIPTION
1. Use `Rbac.filtered` when we do not need to get the counts from `Rbac.search`.
2. Have `Rbac.{filtered,search}` support scopes

/cc @matthewd here we go :)