### PR TITLE
Fix the display name of the MW-Manager as indicated in #6715

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,7 @@ en:
       ManageIQ::Providers::InfraManager:                                    Infrastructure Provider
       ManageIQ::Providers::InfraManager::Vm:                                Virtual Machine
       ManageIQ::Providers::InfraManager::Template:                          Template
+      ManageIQ::Providers::MiddlewareManager:                               Middleware Manager
       ManageIQ::Providers::Openstack::InfraManager:                         Infrastructure Provider (Openstack)
       ManageIQ::Providers::Microsoft::InfraManager:                         Infrastructure Provider (Microsoft)
       ManageIQ::Providers::Redhat::InfraManager:                            Infrastructure Provider (Redhat)


### PR DESCRIPTION
This was `ManageIQ/Providers/Middleware Manager`, automatically determined from the class name as the translation was (gone) missing.
@miq-bot add_label providers/hawkular
@miq-bot add_label ui

@martinpovolny can you please review?