### PR TITLE
Updated secure_headers gem to 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "outfielding-jqplot-rails",       "= 1.0.8"
 gem "puma",                           "~>2.13"
 gem "recursive-open-struct",          "~>0.6.1"
 gem "responders",                     "~>2.0"
-gem "secure_headers",                 "~>2.5.2"
+gem "secure_headers",                 "~>3.0.0"
 gem "spice-html5-rails"
 #gem "thin",                           "~>1.6.0"  # Used by rails server through rack
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,8 +57,6 @@ class ApplicationController < ActionController::Base
     @toolbars = {}
   end
 
-  ensure_security_headers
-
   # Convert Controller Name to Actual Model
   # Examples:
   #   CimBaseStorageExtentController => CimBaseStorageExtent

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -11,10 +11,9 @@ class DashboardController < ApplicationController
     redirect_to :action => 'show'
   end
 
-  skip_before_action :set_csp_header, :only => :iframe # FIXME: only frame-src
-  skip_before_action :set_x_frame_options_header, :only => :iframe
-
   def iframe
+    override_content_security_policy_directives(:frame_src => ['*'])
+    override_x_frame_options('')
     @layout = nil
     if params[:id].present?
       item = Menu::Manager.item(params[:id])

--- a/app/controllers/vm_common.rb
+++ b/app/controllers/vm_common.rb
@@ -127,6 +127,10 @@ module VmCommon
   private :websocket_use_ssl?
 
   def launch_html5_console
+    # Since the virtual console opens multiple ports, we need to specify * here!
+    # After the WebSocket proxying/multiplexing is done on port 443, use the following line as an override:
+    # override_content_security_policy_directives(:connect_src => ["'self'", "wss://#{request.env['SERVER_NAME']}"]
+    override_content_security_policy_directives(:connect_src => ['*'])
     password, host_address, host_port, _proxy_address, _proxy_port, protocol, ssl = @sb[:html5]
 
     case protocol

--- a/app/controllers/vm_infra_controller.rb
+++ b/app/controllers/vm_infra_controller.rb
@@ -9,8 +9,6 @@ class VmInfraController < ApplicationController
   after_action :cleanup_action
   after_action :set_session_data
 
-  skip_before_action :set_csp_header, :only => :launch_html5_console
-
   def self.table_name
     @table_name ||= "vm_infra"
   end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -4,7 +4,7 @@ SecureHeaders::Configuration.default do |config|
   config.x_content_type_options = "nosniff"
   config.x_xss_protection = "1; mode=block"
   config.csp = {
-    :enforce     => true,
+    :report_only => false,
     :default_src => ["'self'"],
     :frame_src   => ["'self'"],
     :connect_src => ["'self'"],


### PR DESCRIPTION
Overriding the `connect-src` CSP is just a partial solution and after all our WebSocket connections are proxied through `:443`, it should be updated.