### PR TITLE
Fix Volume page crash on undefined method `creation_timestamp'

### DIFF
--- a/app/helpers/persistent_volume_helper/textual_summary.rb
+++ b/app/helpers/persistent_volume_helper/textual_summary.rb
@@ -28,10 +28,6 @@ module PersistentVolumeHelper::TextualSummary
     @record.name
   end
 
-  def textual_creation_timestamp
-    format_timezone(@record.creation_timestamp)
-  end
-
   def textual_resource_version
     @record.resource_version
   end


### PR DESCRIPTION
Removes creation timestamp method from Persistent Volumes textual summary which currently raises an error following these changes:
-Add manageiq created_on timestamp for container entities: https://github.com/ManageIQ/manageiq/pull/6265
-Refactor: containers entities summary helper: https://github.com/ManageIQ/manageiq/pull/6281 
