### PR TITLE
i18n: support for localized report views and product features

### DIFF
--- a/app/controllers/application_controller/timelines.rb
+++ b/app/controllers/application_controller/timelines.rb
@@ -347,6 +347,7 @@ module ApplicationController::Timelines
       when "Hourly"
         tl_rpt = @tl_options[:tl_show] == "timeline" ? "tl_events_hourly" : "tl_policy_events_hourly"
         @report = tl_get_rpt(tl_rpt)
+        @report.headers.map! { |header| _(header) }
         mm, dd, yy = @tl_options[:hourly_date].split("/")
         from_dt = create_time_in_utc("#{yy}-#{mm}-#{dd} 00:00:00", session[:user_tz]) # Get tz 12am in user's time zone
         to_dt = create_time_in_utc("#{yy}-#{mm}-#{dd} 23:59:59", session[:user_tz])   # Get tz 11pm in user's time zone
@@ -367,6 +368,7 @@ module ApplicationController::Timelines
       when "Daily"
         tl_rpt = @tl_options[:tl_show] == "timeline" ? "tl_events_daily" : "tl_policy_events_daily"
         @report = tl_get_rpt(tl_rpt)
+        @report.headers.map! { |header| _(header) }
         from = Date.parse(@tl_options[:daily_date]) - @tl_options[:days].to_i
         from_dt = create_time_in_utc("#{from.year}-#{from.month}-#{from.day} 00:00:00", session[:user_tz])  # Get tz 12am in user's time zone
         mm, dd, yy = @tl_options[:daily_date].split("/")

--- a/app/controllers/miq_capacity_controller.rb
+++ b/app/controllers/miq_capacity_controller.rb
@@ -684,6 +684,7 @@ class MiqCapacityController < ApplicationController
       bottleneck_tl_to_xml
     else
       @sb[:bottlenecks][:report] = MiqReport.new(YAML.load(File.open("#{TIMELINES_FOLDER}/miq_reports/tl_bottleneck_events.yaml")))
+      @sb[:bottlenecks][:report].headers.map! { |header| _(header) }
       @sb[:bottlenecks][:report].tz = @sb[:bottlenecks][:tl_options][:tz] # Set the new timezone
       @title = @sb[:bottlenecks][:report].title
 

--- a/app/controllers/ops_controller/analytics.rb
+++ b/app/controllers/ops_controller/analytics.rb
@@ -50,6 +50,7 @@ module OpsController::Analytics
     typ, id = get_rtype_rid
     fname = "analytics.yaml"
     @sb[:analytics_rpt] = MiqReport.new(YAML.load(File.open("#{OPS_REPORTS_FOLDER}/#{fname}")))
+    @sb[:analytics_rpt].headers.map! { |header| _(header) }
     @sb[:analytics_rpt].title = @sb[:analytics_rpt].name = @sb[:rpt_title]
     @sb[:analytics_rpt].db_options = {:options => {:resource_type => typ, :resource_id => id}, :rpt_type => "analytics"}
     # @sb[:analytics_rpt].generate_table

--- a/app/controllers/ops_controller/rbac_tree.rb
+++ b/app/controllers/ops_controller/rbac_tree.rb
@@ -17,8 +17,8 @@ class OpsController
       root_node = {
         :key      => "#{@role.id ? to_cid(@role.id) : "new"}__#{root_feature}",
         :icon     => ActionController::Base.helpers.image_path('100/feature_node.png'),
-        :title    => root[:name],
-        :tooltip  => root[:description] || root[:name],
+        :title    => _(root[:name]),
+        :tooltip  => _(root[:description]) || _(root[:name]),
         :addClass => "cfme-cursor-default",
         :expand   => true,
         :select   => @role_features.include?(root_feature)
@@ -40,7 +40,7 @@ class OpsController
         t_node = {
           :key     => "#{@role.id ? to_cid(@role.id) : "new"}___tab_#{feature_title}",
           :icon    => ActionController::Base.helpers.image_path('100/feature_node.png'),
-          :title   => feature_title,
+          :title   => _(feature_title),
           :tooltip => _("%{title} Main Tab") % {:title => feature_title}
         }
 
@@ -83,8 +83,8 @@ class OpsController
         f_node = {
           :key     => "#{@role.id ? to_cid(@role.id) : "new"}__#{feature}",
           :icon    => ActionController::Base.helpers.image_path("100/feature_#{details[:feature_type]}.png"),
-          :title   => details[:name],
-          :tooltip => details[:description] || details[:name]
+          :title   => _(details[:name]),
+          :tooltip => _(details[:description]) || _(details[:name])
         }
         f_node[:hideCheckbox] = true if details[:protected]
 

--- a/app/views/layouts/_list_grid.html.haml
+++ b/app/views/layouts/_list_grid.html.haml
@@ -49,7 +49,7 @@
           - if h[:sort]
             %a{:href => '#',
                :onclick => "miqGridSort(#{h[:col_idx] + 1})"}
-              = h[:text]
+              = _(h[:text])
           - else
             = h[:text]
 

--- a/app/views/layouts/gtl/_list.html.haml
+++ b/app/views/layouts/gtl/_list.html.haml
@@ -40,7 +40,7 @@
             -# Replaced to exclude non-view table fields from sorting
             - if i == @sortcol
               %th{:class => (@sortdir == "ASC") ? "sorting_asc" : "sorting_desc"}
-                = link_to(h(h),
+                = link_to(h(_(h)),
                   {:action => action_url, :sort_choice => h},
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,
@@ -48,7 +48,7 @@
                   :remote                => true)
             - else
               %th
-                = link_to(h(h),
+                = link_to(h(_(h)),
                   {:action => action_url, :sort_choice => h},
                   "data-miq_sparkle_on"  => true,
                   "data-miq_sparkle_off" => true,

--- a/app/views/layouts/gtl/_tile.html.haml
+++ b/app/views/layouts/gtl/_tile.html.haml
@@ -32,7 +32,7 @@
               - (1..4).each do |i|
                 - if view.headers.length > i
                   %dt
-                    = "#{h(view.headers[i])}: "
+                    = "#{h(_(view.headers[i]))}: "
                   %dd
                     - col = view.col_order[i]
                     - if row[col].kind_of?(Time) && !row[col].nil? && row[col] != ""

--- a/config/locales/manageiq.pot
+++ b/config/locales/manageiq.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: manageiq 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-19 14:51+0100\n"
-"PO-Revision-Date: 2016-02-19 14:51+0100\n"
+"POT-Creation-Date: 2016-03-03 16:17+0100\n"
+"PO-Revision-Date: 2016-03-03 16:17+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid " # of Days"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:646 ../../app/controllers/miq_policy_controller.rb:649
+#: ../../app/controllers/miq_policy_controller.rb:648 ../../app/controllers/miq_policy_controller.rb:651
 msgid " %{model} Assignments"
 msgstr ""
 
@@ -30,8 +30,116 @@ msgstr ""
 msgid " %{name} from %{value} to %{parameters} "
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1420 ../../app/controllers/container_controller.rb:225
-msgid " (Names with \"%s\")"
+#: ../../app/controllers/ops_controller/diagnostics.rb:1089
+msgid " (%{priority}active, PID=%{number})"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:1093
+msgid " (%{priority}available, PID=%{number})"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:1097
+msgid " (%{priority}unavailable)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:508
+msgid " (Active)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:295 ../../app/controllers/vm_common.rb:301 ../../app/controllers/vm_common.rb:307 ../../app/controllers/vm_common.rb:313 ../../app/controllers/storage_controller.rb:70 ../../app/controllers/ems_cluster_controller.rb:114 ../../app/controllers/ems_cluster_controller.rb:121 ../../app/controllers/ems_cluster_controller.rb:128 ../../app/controllers/ems_cluster_controller.rb:135
+msgid " (All %{tables})"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:104
+msgid " (All %{title})"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:107
+msgid " (All Descendant %{table}(s))"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:82
+msgid " (All Resource Pools)"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:37
+msgid " (All VMs - Tree View)"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:44
+msgid " (All VMs)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1205 ../../app/controllers/vm_common.rb:1207
+msgid " (Analysis History)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:280
+msgid " (Compliance History - Last %{number} Checks)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:250
+msgid " (Container)"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:44
+msgid " (Dashboard)"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:57
+msgid " (Direct %{title})"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:263
+msgid " (Genealogy)"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:28
+msgid " (Hosts & Clusters)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:748
+msgid " (Inactive)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:277
+msgid " (Latest Compliance Check)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1501 ../../app/controllers/container_controller.rb:223
+msgid " (Names with \"%{text}\")"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:244
+msgid " (Networks)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:247
+msgid " (OS Information)"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:22
+msgid " (Properties)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:253
+msgid " (Resources)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:435
+msgid " (Selected)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:256
+msgid " (Snapshots)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:239 ../../app/controllers/vm_common.rb:359 ../../app/controllers/vm_common.rb:363 ../../app/controllers/ems_common.rb:18 ../../app/controllers/ems_cluster_controller.rb:32
+msgid " (Summary)"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:25
+msgid " (VMs & Templates)"
 msgstr ""
 
 #: ../../app/views/ops/_settings_list_tab.html.haml:27
@@ -40,6 +148,30 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:217
 msgid " * Multiple UI workers can not be configured with session store as memory"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:172
+msgid " Build %{number}"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:494
+msgid " Day"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:494
+msgid " Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:572
+msgid " EVM Server Main Configuration"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:493
+msgid " Hour"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:493
+msgid " Hours"
 msgstr ""
 
 #: ../../app/presenters/widget_presenter.rb:72
@@ -62,6 +194,22 @@ msgstr ""
 msgid " Valid numeric quota value required "
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:495
+msgid " Week"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:495
+msgid " Weeks"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:52 ../../app/controllers/ems_cluster_controller.rb:65 ../../app/controllers/ems_cluster_controller.rb:78
+msgid " in this Cluster"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:115
+msgid " on this "
+msgstr ""
+
 #: ../../app/views/miq_policy/_profile_list.html.haml:6 ../../app/views/miq_policy/_event_list.html.haml:8 ../../app/views/miq_policy/_policy_list.html.haml:4 ../../app/views/miq_policy/_condition_list.html.haml:8 ../../app/views/miq_policy/_alert_profile_list.html.haml:6
 msgid " that match the entered search string"
 msgstr ""
@@ -70,27 +218,35 @@ msgstr ""
 msgid "\"#{db}Performance.#{c}\""
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1831
+#: ../../app/controllers/vm_common.rb:1912
 msgid "\"%{action}\" for %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1912
+#: ../../app/controllers/application_controller/ci_processing.rb:1926
 msgid "\"%{datastore_name}\": cannot be removed, has vms or hosts"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1961
+#: ../../app/controllers/miq_ae_class_controller.rb:1963
 msgid "\"%{field}\" %{model} cannot be deleted"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:381
+#: ../../app/controllers/host_controller.rb:81
+msgid "\"%{name} (Compliance History - Last #{number} Checks)\""
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:383
 msgid "\"%{name}\": Global %{model} cannot be deleted"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:385
+#: ../../app/controllers/configuration_controller.rb:387
 msgid "\"%{name}\": In use by %{rep_count}, cannot be deleted"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:275 ../../app/controllers/application_controller.rb:1592 ../../app/controllers/miq_task_controller.rb:257 ../../app/controllers/application_controller/ci_processing.rb:1675 ../../app/controllers/application_controller/ci_processing.rb:1684 ../../app/controllers/application_controller/ci_processing.rb:1824
+#: ../../app/helpers/storage_helper/textual_summary.rb:196
+msgid "\"%{number} (#{percentage}% of Used Space, %{files})\""
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:279 ../../app/controllers/application_controller.rb:1592 ../../app/controllers/miq_task_controller.rb:257 ../../app/controllers/application_controller/ci_processing.rb:1689 ../../app/controllers/application_controller/ci_processing.rb:1698 ../../app/controllers/application_controller/ci_processing.rb:1838
 msgid "\"%{record}\": %{task} successfully initiated"
 msgstr ""
 
@@ -98,7 +254,7 @@ msgstr ""
 msgid "\"%{record}\": Analysis successfully initiated"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1822
+#: ../../app/controllers/application_controller/ci_processing.rb:1836
 msgid "\"%{record}\": Refresh successfully initiated"
 msgstr ""
 
@@ -106,24 +262,37 @@ msgstr ""
 msgid "\"%{task_description}\" was executed"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1686
+#: ../../app/controllers/application_controller/ci_processing.rb:1700
 msgid "\"%{task}\": not available for %{hostname}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1677
+#: ../../app/controllers/application_controller/ci_processing.rb:1691
 msgid "\"%{task}\": not supported for %{hostname}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1091
+#: ../../app/controllers/catalog_controller.rb:1086
 msgid "\"%{type}\" is not a valid Orchestration Template type"
 msgstr ""
 
-#: ../../app/controllers/ems_infra_controller.rb:63
-msgid "\"Unable to initiate scaling, obtaining of status failed: #{ex}\""
+#: ../../app/helpers/vm_helper/textual_summary.rb:743
+msgid "\"Show Details of Compliance Check on #{format_timezone(date)}\""
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:218
+msgid "\"User '#{current_userid}' is not authorized to access '#{ui_lookup(:table => controller_name)}'\""
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../yaml_strings.rb:3249
+msgid "% Free Space"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:168 ../../app/views/vm_common/_right_size.html.haml:252 ../../app/views/vm_common/_right_size.html.haml:335
 msgid "% Savings"
+msgstr ""
+
+#: ../../app/controllers/report_controller/dashboards.rb:240
+msgid "%Dashboards for \"%{name}\""
 msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:180
@@ -136,14 +305,6 @@ msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:169
 msgid "%s  Ending with"
-msgstr ""
-
-#: ../../app/controllers/ems_cluster_controller.rb:221
-msgid "%s (All %s)"
-msgstr ""
-
-#: ../../app/controllers/host_controller.rb:95
-msgid "%s (All cloud tenants present on this host)"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_alert_profile.rb:32
@@ -172,7 +333,7 @@ msgstr ""
 msgid "%s Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:420 ../../app/controllers/catalog_controller.rb:1820
+#: ../../app/controllers/miq_ae_customization_controller.rb:410
 msgid "%s Group Reorder"
 msgstr ""
 
@@ -196,14 +357,6 @@ msgstr[1] ""
 msgid "%s Policies"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1784
-msgid "%s Policy Assignment"
-msgstr ""
-
-#: ../../app/controllers/vm_common.rb:1775 ../../app/controllers/vm_common.rb:1779
-msgid "%s Policy Simulation"
-msgstr ""
-
 #: ../../app/views/report/_form_filter_chargeback.html.haml:194 ../../app/views/report/_form_filter_chargeback.html.haml:196
 msgid "%s Week"
 msgid_plural "%s Weeks"
@@ -214,11 +367,11 @@ msgstr[1] ""
 msgid "%s bytes"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:206
+#: ../../app/controllers/miq_ae_class_controller.rb:200
 msgid "%s domain: Current version - %s, Available version - %s"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:202
+#: ../../app/views/vm_common/_config.html.haml:199
 msgid "%s has no network adapters"
 msgstr ""
 
@@ -226,31 +379,19 @@ msgstr ""
 msgid "%s has no snapshots"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports/editor.rb:981
-msgid "%s is currently being used in the Display Filter"
-msgstr ""
-
-#: ../../app/controllers/miq_ae_customization_controller.rb:500 ../../app/controllers/miq_ae_tools_controller.rb:357 ../../app/controllers/miq_ae_tools_controller.rb:358 ../../app/controllers/report_controller/widgets.rb:741 ../../app/controllers/report_controller/menus.rb:73 ../../app/controllers/report_controller/reports.rb:226 ../../app/controllers/vm_common.rb:567 ../../app/controllers/storage_manager_controller.rb:83 ../../app/controllers/storage_manager_controller.rb:90 ../../app/controllers/storage_manager_controller.rb:119 ../../app/controllers/ops_controller/settings/ldap.rb:175 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:112 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:115 ../../app/controllers/pxe_controller/iso_datastores.rb:49 ../../app/controllers/pxe_controller/pxe_image_types.rb:166 ../../app/controllers/pxe_controller/pxe_servers.rb:296 ../../app/controllers/pxe_controller/pxe_servers.rb:299 ../../app/controllers/pxe_controller/pxe_servers.rb:302 ../../app/controllers/pxe_controller/pxe_servers.rb:306 ../../app/controllers/pxe_controller/pxe_servers.rb:309 ../../app/controllers/pxe_controller/pxe_servers.rb:312 ../../app/controllers/application_controller/buttons.rb:323 ../../app/controllers/application_controller/buttons.rb:327
+#: ../../app/controllers/miq_ae_customization_controller.rb:490 ../../app/controllers/miq_ae_tools_controller.rb:357 ../../app/controllers/miq_ae_tools_controller.rb:358 ../../app/controllers/application_controller/buttons.rb:323 ../../app/controllers/application_controller/buttons.rb:327
 msgid "%s is required"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports.rb:229
-msgid "%s must be configured"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:232 ../../app/controllers/report_controller/reports.rb:323 ../../app/controllers/report_controller/reports.rb:365 ../../app/controllers/ems_common.rb:532 ../../app/controllers/ems_common.rb:535
+#: ../../app/controllers/report_controller/reports.rb:326
 msgid "%s must be numeric"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:356 ../../app/controllers/report_controller/dashboards.rb:349 ../../app/controllers/report_controller/widgets.rb:724 ../../app/controllers/report_controller/widgets.rb:733 ../../app/controllers/report_controller/widgets.rb:737 ../../app/controllers/report_controller/schedules.rb:231 ../../app/controllers/report_controller/reports.rb:242 ../../app/controllers/report_controller/reports.rb:247 ../../app/controllers/report_controller/reports.rb:252 ../../app/controllers/report_controller/reports.rb:256 ../../app/controllers/application_controller/buttons.rb:331
+#: ../../app/controllers/miq_ae_tools_controller.rb:356 ../../app/controllers/application_controller/buttons.rb:331
 msgid "%s must be selected"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:343
-msgid "%s must be unique for this group"
-msgstr ""
-
-#: ../../app/controllers/repository_controller.rb:295 ../../app/controllers/repository_controller.rb:322 ../../app/controllers/report_controller/widgets.rb:100 ../../app/controllers/report_controller/saved_reports.rb:94 ../../app/controllers/report_controller/schedules.rb:83 ../../app/controllers/report_controller/schedules.rb:108 ../../app/controllers/storage_manager_controller.rb:425 ../../app/controllers/mixins/containers_common_mixin.rb:162 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:225 ../../app/controllers/pxe_controller/iso_datastores.rb:117 ../../app/controllers/pxe_controller/pxe_image_types.rb:110 ../../app/controllers/pxe_controller/pxe_servers.rb:137 ../../app/helpers/application_helper.rb:1058
+#: ../../app/controllers/mixins/containers_common_mixin.rb:162
 msgid "%s no longer exists"
 msgstr ""
 
@@ -262,31 +403,11 @@ msgstr ""
 msgid "%s record no longer exists"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:891
-msgid "%s saved"
-msgstr ""
-
-#: ../../app/controllers/report_controller/menus.rb:213
-msgid "%s set to default"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:338
-msgid "%s tab is not available unless a sort field has been selected"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:353
-msgid "%s tab is not available unless at least 1 time field has been selected"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:308 ../../app/controllers/report_controller/reports.rb:312 ../../app/controllers/report_controller/reports.rb:327 ../../app/controllers/report_controller/reports.rb:332 ../../app/controllers/report_controller/reports.rb:336 ../../app/controllers/report_controller/reports.rb:343 ../../app/controllers/report_controller/reports.rb:369 ../../app/controllers/report_controller/reports.rb:381
-msgid "%s tab is not available until at least 1 field has been selected"
-msgstr ""
-
 #: ../../app/views/layouts/angular/_form_buttons_verify_angular.html.haml:3
 msgid "%s to validate against, Username and matching password fields are needed to perform verification of credentials"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:555 ../../app/controllers/vm_common.rb:877 ../../app/controllers/application_controller/ci_processing.rb:756 ../../app/controllers/application_controller/dialog_runner.rb:22
+#: ../../app/controllers/application_controller/ci_processing.rb:756 ../../app/controllers/application_controller/dialog_runner.rb:22
 msgid "%s was cancelled by the user"
 msgstr ""
 
@@ -294,15 +415,15 @@ msgstr ""
 msgid "%s with %s Tags"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1823
+#: ../../app/controllers/vm_common.rb:1904
 msgid "%{action} \"%{item_name}\" for %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:187
+#: ../../app/controllers/provider_foreman_controller.rb:183
 msgid "%{action} %{model} was cancelled by the user"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar_builder.rb:1082
+#: ../../app/helpers/application_helper/toolbar_builder.rb:1081
 msgid "%{approval_states} requests cannot be deleted"
 msgstr ""
 
@@ -310,28 +431,60 @@ msgstr ""
 msgid "%{button_name} Button not yet implemented"
 msgstr ""
 
-#: ../../app/controllers/report_controller/menus.rb:76 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:464 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:485
-msgid "%{field} '%{value}' is already in use"
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:61
+msgid "%{children} (%{count})"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:334
-msgid "%{field} cannot contain \"%{character}\""
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:55
+msgid "%{children} (0)"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:728
+msgid "%{description} category Scan"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:745
+msgid "%{description} registry Scan"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:464 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:485
+msgid "%{field} '%{value}' is already in use"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_ems_infra.html.haml:30
 msgid "%{hosts} & %{clusters}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:299
+#: ../../app/controllers/ops_controller/settings/rhn.rb:303
 msgid "%{item} has been initiated for the selected Servers"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:266 ../../app/controllers/host_controller.rb:473
+msgid "%{key} changed to %{value}"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:1621
 msgid "%{labels} are not in the current region and will be skipped"
 msgstr ""
 
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:115 ../../app/helpers/host_helper/textual_summary.rb:537 ../../app/helpers/ems_infra_helper/textual_summary.rb:157
+msgid "%{label} Credentials"
+msgstr ""
+
 #: ../../app/controllers/application_controller.rb:1619
 msgid "%{label} is not in the current region and will be skipped"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:199
+msgid "%{log_description} log downloaded"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:799 ../../app/controllers/ops_controller.rb:805
+msgid "%{message} %{key}:[%{old_value}] to [new_value]"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:794
+msgid "%{message} %{key}:[*] to [*]"
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:18
@@ -346,11 +499,11 @@ msgstr ""
 msgid "%{models} no longer exists"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:985
+#: ../../app/controllers/provider_foreman_controller.rb:937
 msgid "%{model}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:551 ../../app/controllers/ops_controller.rb:570 ../../app/controllers/ops_controller.rb:584 ../../app/controllers/ops_controller.rb:595 ../../app/controllers/ops_controller.rb:606 ../../app/controllers/ops_controller.rb:652 ../../app/controllers/ops_controller.rb:660 ../../app/controllers/chargeback_controller.rb:473 ../../app/controllers/chargeback_controller.rb:487 ../../app/controllers/chargeback_controller.rb:522 ../../app/controllers/report_controller/dashboards.rb:260 ../../app/controllers/report_controller/saved_reports.rb:23 ../../app/controllers/report_controller/schedules.rb:523 ../../app/controllers/report_controller/reports.rb:32 ../../app/controllers/report_controller/reports.rb:196 ../../app/controllers/miq_policy_controller/events.rb:116 ../../app/controllers/miq_policy_controller/policies.rb:240 ../../app/controllers/miq_policy_controller/miq_actions.rb:426 ../../app/controllers/miq_policy_controller/alerts.rb:592 ../../app/controllers/miq_policy_controller/alert_profiles.rb:345 ../../app/controllers/miq_policy_controller/conditions.rb:243 ../../app/controllers/miq_policy_controller/policy_profiles.rb:154 ../../app/controllers/vm_common.rb:1362 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:114 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1375 ../../app/controllers/service_controller.rb:238 ../../app/controllers/service_controller.rb:251 ../../app/controllers/container_controller.rb:211 ../../app/controllers/catalog_controller.rb:1629 ../../app/controllers/catalog_controller.rb:1656 ../../app/controllers/catalog_controller.rb:1659 ../../app/controllers/catalog_controller.rb:1707 ../../app/controllers/ops_controller/db.rb:210 ../../app/controllers/ops_controller/db.rb:224 ../../app/controllers/ops_controller/ops_rbac.rb:882 ../../app/controllers/ops_controller/ops_rbac.rb:885 ../../app/controllers/ops_controller/ops_rbac.rb:888 ../../app/controllers/ops_controller/ops_rbac.rb:892 ../../app/controllers/ops_controller/analytics.rb:43 ../../app/controllers/pxe_controller.rb:169 ../../app/controllers/pxe_controller.rb:173 ../../app/controllers/pxe_controller.rb:175 ../../app/controllers/pxe_controller.rb:187 ../../app/controllers/pxe_controller.rb:191 ../../app/controllers/pxe_controller.rb:202 ../../app/controllers/pxe_controller.rb:216 ../../app/controllers/report_controller.rb:429 ../../app/controllers/report_controller.rb:454 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:257 ../../app/controllers/pxe_controller/iso_datastores.rb:315 ../../app/controllers/pxe_controller/iso_datastores.rb:318 ../../app/controllers/pxe_controller/pxe_image_types.rb:222 ../../app/controllers/pxe_controller/pxe_servers.rb:490 ../../app/controllers/pxe_controller/pxe_servers.rb:493 ../../app/controllers/pxe_controller/pxe_servers.rb:496 ../../app/controllers/provider_foreman_controller.rb:570 ../../app/controllers/provider_foreman_controller.rb:574 ../../app/controllers/provider_foreman_controller.rb:612 ../../app/controllers/provider_foreman_controller.rb:639 ../../app/controllers/provider_foreman_controller.rb:979 ../../app/controllers/miq_policy_controller.rb:613 ../../app/controllers/miq_policy_controller.rb:644 ../../app/controllers/miq_policy_controller.rb:682 ../../app/controllers/miq_policy_controller.rb:693 ../../app/controllers/miq_policy_controller.rb:704 ../../app/controllers/miq_policy_controller.rb:712 ../../app/controllers/application_controller/buttons.rb:948 ../../app/controllers/application_controller/buttons.rb:990
+#: ../../app/controllers/ops_controller.rb:577 ../../app/controllers/ops_controller.rb:596 ../../app/controllers/ops_controller.rb:610 ../../app/controllers/ops_controller.rb:621 ../../app/controllers/ops_controller.rb:632 ../../app/controllers/ops_controller.rb:678 ../../app/controllers/ops_controller.rb:686 ../../app/controllers/chargeback_controller.rb:472 ../../app/controllers/chargeback_controller.rb:486 ../../app/controllers/chargeback_controller.rb:521 ../../app/controllers/report_controller/schedules.rb:527 ../../app/controllers/report_controller/reports.rb:32 ../../app/controllers/report_controller/reports.rb:197 ../../app/controllers/miq_policy_controller/events.rb:116 ../../app/controllers/miq_policy_controller/policies.rb:240 ../../app/controllers/miq_policy_controller/miq_actions.rb:426 ../../app/controllers/miq_policy_controller/alerts.rb:592 ../../app/controllers/miq_policy_controller/alert_profiles.rb:345 ../../app/controllers/miq_policy_controller/conditions.rb:243 ../../app/controllers/miq_policy_controller/policy_profiles.rb:154 ../../app/controllers/vm_common.rb:1427 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:114 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1375 ../../app/controllers/service_controller.rb:233 ../../app/controllers/service_controller.rb:246 ../../app/controllers/container_controller.rb:209 ../../app/controllers/catalog_controller.rb:1624 ../../app/controllers/catalog_controller.rb:1651 ../../app/controllers/catalog_controller.rb:1654 ../../app/controllers/catalog_controller.rb:1704 ../../app/controllers/ops_controller/db.rb:210 ../../app/controllers/ops_controller/db.rb:224 ../../app/controllers/ops_controller/ops_rbac.rb:883 ../../app/controllers/ops_controller/ops_rbac.rb:886 ../../app/controllers/ops_controller/ops_rbac.rb:889 ../../app/controllers/ops_controller/ops_rbac.rb:893 ../../app/controllers/pxe_controller.rb:153 ../../app/controllers/pxe_controller.rb:157 ../../app/controllers/pxe_controller.rb:159 ../../app/controllers/pxe_controller.rb:171 ../../app/controllers/pxe_controller.rb:175 ../../app/controllers/pxe_controller.rb:186 ../../app/controllers/pxe_controller.rb:200 ../../app/controllers/report_controller.rb:425 ../../app/controllers/report_controller.rb:450 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:258 ../../app/controllers/pxe_controller/iso_datastores.rb:315 ../../app/controllers/pxe_controller/iso_datastores.rb:318 ../../app/controllers/pxe_controller/pxe_image_types.rb:222 ../../app/controllers/pxe_controller/pxe_servers.rb:490 ../../app/controllers/pxe_controller/pxe_servers.rb:493 ../../app/controllers/pxe_controller/pxe_servers.rb:496 ../../app/controllers/provider_foreman_controller.rb:522 ../../app/controllers/provider_foreman_controller.rb:526 ../../app/controllers/provider_foreman_controller.rb:564 ../../app/controllers/provider_foreman_controller.rb:591 ../../app/controllers/provider_foreman_controller.rb:931 ../../app/controllers/miq_policy_controller.rb:613 ../../app/controllers/miq_policy_controller.rb:646 ../../app/controllers/miq_policy_controller.rb:684 ../../app/controllers/miq_policy_controller.rb:695 ../../app/controllers/miq_policy_controller.rb:706 ../../app/controllers/miq_policy_controller.rb:714 ../../app/controllers/application_controller/buttons.rb:948 ../../app/controllers/application_controller/buttons.rb:990
 msgid "%{model} \"%{name}\""
 msgstr ""
 
@@ -362,23 +515,23 @@ msgstr ""
 msgid "%{model} \"%{name}\" already exists"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:971
+#: ../../app/controllers/vm_common.rb:1032
 msgid "%{model} \"%{name}\" successfully added to Service \"%{to_name}\""
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:166
+#: ../../app/controllers/provider_foreman_controller.rb:162
 msgid "%{model} \"%{name}\" was %{action}"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:72 ../../app/controllers/chargeback_controller.rb:163 ../../app/controllers/report_controller/reports/editor.rb:62 ../../app/controllers/report_controller/schedules.rb:239 ../../app/controllers/miq_policy_controller/policies.rb:63 ../../app/controllers/miq_policy_controller/policies.rb:109 ../../app/controllers/miq_policy_controller/miq_actions.rb:46 ../../app/controllers/miq_policy_controller/alerts.rb:26 ../../app/controllers/miq_policy_controller/alert_profiles.rb:54 ../../app/controllers/miq_policy_controller/conditions.rb:61 ../../app/controllers/miq_policy_controller/policy_profiles.rb:54 ../../app/controllers/miq_ae_class_controller.rb:683 ../../app/controllers/miq_ae_class_controller.rb:1232 ../../app/controllers/miq_ae_class_controller.rb:1270 ../../app/controllers/miq_ae_class_controller.rb:1299 ../../app/controllers/storage_manager_controller.rb:101 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:279 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:226 ../../app/controllers/catalog_controller.rb:390 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/ops_controller/settings/tags.rb:84 ../../app/controllers/ops_controller/settings/zones.rb:35 ../../app/controllers/host_controller.rb:255 ../../app/controllers/configuration_controller.rb:518 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:59 ../../app/controllers/pxe_controller/pxe_image_types.rb:54 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/application_controller/buttons.rb:387 ../../app/controllers/application_controller/buttons.rb:474
+#: ../../app/controllers/repository_controller.rb:73 ../../app/controllers/chargeback_controller.rb:135 ../../app/controllers/report_controller/reports/editor.rb:62 ../../app/controllers/report_controller/schedules.rb:243 ../../app/controllers/miq_policy_controller/policies.rb:63 ../../app/controllers/miq_policy_controller/policies.rb:109 ../../app/controllers/miq_policy_controller/miq_actions.rb:46 ../../app/controllers/miq_policy_controller/alerts.rb:26 ../../app/controllers/miq_policy_controller/alert_profiles.rb:54 ../../app/controllers/miq_policy_controller/conditions.rb:61 ../../app/controllers/miq_policy_controller/policy_profiles.rb:54 ../../app/controllers/miq_ae_class_controller.rb:677 ../../app/controllers/miq_ae_class_controller.rb:1226 ../../app/controllers/miq_ae_class_controller.rb:1264 ../../app/controllers/miq_ae_class_controller.rb:1293 ../../app/controllers/storage_manager_controller.rb:102 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:279 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:226 ../../app/controllers/catalog_controller.rb:919 ../../app/controllers/ops_controller/settings/tags.rb:88 ../../app/controllers/ops_controller/settings/zones.rb:35 ../../app/controllers/host_controller.rb:287 ../../app/controllers/configuration_controller.rb:521 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:128 ../../app/controllers/pxe_controller/iso_datastores.rb:59 ../../app/controllers/pxe_controller/pxe_image_types.rb:54 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/application_controller/buttons.rb:387 ../../app/controllers/application_controller/buttons.rb:474
 msgid "%{model} \"%{name}\" was added"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:125 ../../app/controllers/chargeback_controller.rb:187 ../../app/controllers/report_controller/dashboards.rb:82 ../../app/controllers/report_controller/widgets.rb:63 ../../app/controllers/report_controller/reports/editor.rb:61 ../../app/controllers/report_controller/schedules.rb:238 ../../app/controllers/report_controller/reports.rb:33 ../../app/controllers/miq_policy_controller/policies.rb:62 ../../app/controllers/miq_policy_controller/miq_actions.rb:45 ../../app/controllers/miq_policy_controller/alerts.rb:25 ../../app/controllers/miq_policy_controller/alert_profiles.rb:53 ../../app/controllers/miq_policy_controller/conditions.rb:60 ../../app/controllers/miq_policy_controller/policy_profiles.rb:53 ../../app/controllers/vm_common.rb:1075 ../../app/controllers/miq_ae_class_controller.rb:632 ../../app/controllers/miq_ae_class_controller.rb:1016 ../../app/controllers/miq_ae_class_controller.rb:1110 ../../app/controllers/miq_ae_class_controller.rb:1163 ../../app/controllers/storage_manager_controller.rb:192 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:281 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:228 ../../app/controllers/service_controller.rb:161 ../../app/controllers/catalog_controller.rb:389 ../../app/controllers/catalog_controller.rb:631 ../../app/controllers/catalog_controller.rb:924 ../../app/controllers/catalog_controller.rb:1009 ../../app/controllers/catalog_controller.rb:1063 ../../app/controllers/catalog_controller.rb:1110 ../../app/controllers/ops_controller/settings/tags.rb:105 ../../app/controllers/ops_controller/settings/ldap.rb:62 ../../app/controllers/ops_controller/settings/ldap.rb:192 ../../app/controllers/ops_controller/settings/zones.rb:34 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:269 ../../app/controllers/ops_controller/settings/schedules.rb:75 ../../app/controllers/ops_controller/ops_rbac.rb:132 ../../app/controllers/ops_controller/ops_rbac.rb:732 ../../app/controllers/ops_controller/settings.rb:180 ../../app/controllers/host_controller.rb:346 ../../app/controllers/configuration_controller.rb:579 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:127 ../../app/controllers/pxe_controller/iso_datastores.rb:182 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:202 ../../app/controllers/pxe_controller/pxe_servers.rb:254 ../../app/controllers/ems_common.rb:153 ../../app/controllers/ems_common.rb:260 ../../app/controllers/ems_cloud_controller.rb:53 ../../app/controllers/ems_cloud_controller.rb:105 ../../app/controllers/application_controller/buttons.rb:352 ../../app/controllers/application_controller/buttons.rb:530
+#: ../../app/controllers/repository_controller.rb:126 ../../app/controllers/chargeback_controller.rb:159 ../../app/controllers/report_controller/widgets.rb:63 ../../app/controllers/report_controller/reports/editor.rb:61 ../../app/controllers/report_controller/schedules.rb:242 ../../app/controllers/report_controller/reports.rb:33 ../../app/controllers/miq_policy_controller/policies.rb:62 ../../app/controllers/miq_policy_controller/miq_actions.rb:45 ../../app/controllers/miq_policy_controller/alerts.rb:25 ../../app/controllers/miq_policy_controller/alert_profiles.rb:53 ../../app/controllers/miq_policy_controller/conditions.rb:60 ../../app/controllers/miq_policy_controller/policy_profiles.rb:53 ../../app/controllers/vm_common.rb:1137 ../../app/controllers/miq_ae_class_controller.rb:626 ../../app/controllers/miq_ae_class_controller.rb:1010 ../../app/controllers/miq_ae_class_controller.rb:1104 ../../app/controllers/miq_ae_class_controller.rb:1157 ../../app/controllers/storage_manager_controller.rb:194 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:281 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:228 ../../app/controllers/catalog_controller.rb:597 ../../app/controllers/catalog_controller.rb:919 ../../app/controllers/catalog_controller.rb:1004 ../../app/controllers/catalog_controller.rb:1058 ../../app/controllers/catalog_controller.rb:1105 ../../app/controllers/ops_controller/settings/tags.rb:109 ../../app/controllers/ops_controller/settings/ldap.rb:62 ../../app/controllers/ops_controller/settings/ldap.rb:192 ../../app/controllers/ops_controller/settings/zones.rb:34 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:269 ../../app/controllers/ops_controller/settings/schedules.rb:75 ../../app/controllers/ops_controller/ops_rbac.rb:132 ../../app/controllers/ops_controller/ops_rbac.rb:733 ../../app/controllers/ops_controller/settings.rb:180 ../../app/controllers/host_controller.rb:379 ../../app/controllers/configuration_controller.rb:585 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:128 ../../app/controllers/pxe_controller/iso_datastores.rb:182 ../../app/controllers/pxe_controller/pxe_servers.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:202 ../../app/controllers/pxe_controller/pxe_servers.rb:254 ../../app/controllers/ems_common.rb:157 ../../app/controllers/ems_common.rb:265 ../../app/controllers/ems_cloud_controller.rb:53 ../../app/controllers/ems_cloud_controller.rb:106 ../../app/controllers/application_controller/buttons.rb:352 ../../app/controllers/application_controller/buttons.rb:530
 msgid "%{model} \"%{name}\" was saved"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:567 ../../app/controllers/storage_manager_controller.rb:483 ../../app/controllers/ontap_file_share_controller.rb:81 ../../app/controllers/ems_common.rb:835 ../../app/controllers/application_controller/ci_processing.rb:981 ../../app/controllers/application_controller/ci_processing.rb:1579
+#: ../../app/controllers/miq_request_controller.rb:567 ../../app/controllers/storage_manager_controller.rb:496 ../../app/controllers/ontap_file_share_controller.rb:81 ../../app/controllers/ems_common.rb:850 ../../app/controllers/application_controller/ci_processing.rb:970 ../../app/controllers/application_controller/ci_processing.rb:1593
 msgid "%{model} \"%{name}\": %{task} successfully initiated"
 msgstr ""
 
@@ -386,19 +539,23 @@ msgstr ""
 msgid "%{model} \"%{name}\": Create Logical Disk successfully initiated"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:273 ../../app/controllers/report_controller/reports.rb:104 ../../app/controllers/miq_request_controller.rb:565 ../../app/controllers/storage_manager_controller.rb:478 ../../app/controllers/ops_controller/settings/tags.rb:22 ../../app/controllers/ops_controller/settings/zones.rb:73 ../../app/controllers/ops_controller/diagnostics.rb:718 ../../app/controllers/ems_common.rb:830 ../../app/controllers/miq_task_controller.rb:254 ../../app/controllers/application_controller/ci_processing.rb:979 ../../app/controllers/application_controller/buttons.rb:161 ../../app/controllers/application_controller/buttons.rb:239
+#: ../../app/controllers/repository_controller.rb:277 ../../app/controllers/report_controller/reports.rb:105 ../../app/controllers/miq_request_controller.rb:565 ../../app/controllers/storage_manager_controller.rb:491 ../../app/controllers/ops_controller/settings/tags.rb:26 ../../app/controllers/ops_controller/settings/zones.rb:72 ../../app/controllers/ops_controller/diagnostics.rb:738 ../../app/controllers/ems_common.rb:845 ../../app/controllers/miq_task_controller.rb:254 ../../app/controllers/application_controller/ci_processing.rb:995 ../../app/controllers/application_controller/buttons.rb:161 ../../app/controllers/application_controller/buttons.rb:239
 msgid "%{model} \"%{name}\": Delete successful"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:269 ../../app/controllers/report_controller/reports.rb:97 ../../app/controllers/miq_request_controller.rb:560 ../../app/controllers/storage_manager_controller.rb:470 ../../app/controllers/ops_controller/diagnostics.rb:708 ../../app/controllers/miq_task_controller.rb:248
+#: ../../app/controllers/miq_request_controller.rb:560 ../../app/controllers/ops_controller/diagnostics.rb:728 ../../app/controllers/miq_task_controller.rb:248
 msgid "%{model} \"%{name}\": Error during '%{task}': "
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:680 ../../app/controllers/ems_common.rb:822 ../../app/controllers/application_controller/ci_processing.rb:971 ../../app/controllers/application_controller/ci_processing.rb:1542 ../../app/controllers/application_controller/ci_processing.rb:1573 ../../app/controllers/application_controller/ci_processing.rb:1815
+#: ../../app/controllers/catalog_controller.rb:650 ../../app/controllers/ems_common.rb:836 ../../app/controllers/application_controller/ci_processing.rb:1556 ../../app/controllers/application_controller/ci_processing.rb:1587 ../../app/controllers/application_controller/ci_processing.rb:1829
 msgid "%{model} \"%{name}\": Error during '%{task}': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:514 ../../app/controllers/application_controller/ci_processing.rb:1639
+#: ../../app/controllers/application_controller/ci_processing.rb:966
+msgid "%{model} \"%{name}\": Error during '%{task}': %{error_msg}"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:271 ../../app/controllers/storage_manager_controller.rb:478 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:514 ../../app/controllers/application_controller/ci_processing.rb:1653
 msgid "%{model} \"%{name}\": Error during '%{task}': %{message}"
 msgstr ""
 
@@ -406,55 +563,63 @@ msgstr ""
 msgid "%{model} \"%{name}\": Error during 'Analysis': "
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:688
+#: ../../app/controllers/application_controller/filter.rb:690
 msgid "%{model} \"%{name}\": Error during 'delete': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:570
-msgid "%{model} \"%{name}\": Error during 'save': %{error_message}"
+#: ../../app/controllers/report_controller/reports.rb:97
+msgid "%{model} \"%{name}\": Error during 'miq_report_delete': %{message}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:674
+#: ../../app/controllers/application_controller/ci_processing.rb:998
+msgid "%{model} \"%{name}\": Error during delete: %{error_msg}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/analytics.rb:43
+msgid "%{model} \"Enterprise\""
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:547 ../../app/controllers/ops_controller/settings/schedules.rb:548
+msgid "%{model} Analysis"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:676
 msgid "%{model} Condition \"%{name}\""
-msgstr ""
-
-#: ../../app/controllers/report_controller/dashboards.rb:240
-msgid "%{model} for \"%{name}\""
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:920
 msgid "%{model} for \"%{record}\""
 msgstr ""
 
-#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:265
+#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:266
 msgid "%{model} for %{group} \"%{name}\""
-msgstr ""
-
-#: ../../app/controllers/report_controller/menus.rb:233
-msgid "%{model} for role \"%{role}\" was saved"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/alert_profiles.rb:36 ../../app/controllers/miq_policy_controller/policy_profiles.rb:36
 msgid "%{model} must contain at least one %{field}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:112 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:412
+#: ../../app/controllers/report_controller/widgets.rb:100 ../../app/controllers/report_controller/schedules.rb:83 ../../app/controllers/report_controller/schedules.rb:112 ../../app/controllers/miq_policy_controller/alert_profiles.rb:112 ../../app/controllers/storage_manager_controller.rb:428 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:412 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:226 ../../app/controllers/pxe_controller/iso_datastores.rb:117 ../../app/controllers/pxe_controller/pxe_image_types.rb:110 ../../app/controllers/pxe_controller/pxe_servers.rb:137 ../../app/helpers/application_helper.rb:1064
 msgid "%{model} no longer exists"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:642
+#: ../../app/controllers/application_controller/filter.rb:644
 msgid "%{model} search \"%{name}\" was saved"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:678
+#: ../../app/controllers/application_controller/filter.rb:680
 msgid "%{model} search \"%{name}\" was successfully loaded"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:700
+#: ../../app/controllers/application_controller/filter.rb:702
 msgid "%{model} search \"%{name}\": Delete successful"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:874 ../../app/controllers/application_controller/ci_processing.rb:1548
+#: ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:26 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:34 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:57
+msgid "%{model}: %{name}"
+msgstr ""
+
+#: ../../app/controllers/application_controller/ci_processing.rb:874 ../../app/controllers/application_controller/ci_processing.rb:1562
 msgid "%{model}: %{task} successfully initiated"
 msgstr ""
 
@@ -462,15 +627,139 @@ msgstr ""
 msgid "%{model}: Restart successfully initiated"
 msgstr ""
 
+#: ../../app/controllers/availability_zone_controller.rb:38 ../../app/controllers/flavor_controller.rb:29
+msgid "%{name} (%{table}(s))"
+msgstr ""
+
+#: ../../app/controllers/cloud_volume_snapshot_controller.rb:53 ../../app/controllers/cloud_volume_controller.rb:40
+msgid "%{name} (All %{children})"
+msgstr ""
+
+#: ../../app/controllers/cim_instance_controller.rb:136 ../../app/controllers/storage_controller.rb:77 ../../app/controllers/storage_controller.rb:84 ../../app/controllers/storage_controller.rb:91 ../../app/controllers/host_controller.rb:120 ../../app/controllers/host_controller.rb:137 ../../app/controllers/host_controller.rb:144 ../../app/controllers/host_controller.rb:151 ../../app/controllers/host_controller.rb:158
+msgid "%{name} (All %{tables})"
+msgstr ""
+
+#: ../../app/controllers/cloud_tenant_controller.rb:68 ../../app/controllers/ems_cluster_controller.rb:241
+msgid "%{name} (All %{titles})"
+msgstr ""
+
+#: ../../app/controllers/cloud_volume_controller.rb:57 ../../app/controllers/host_controller.rb:94 ../../app/controllers/availability_zone_controller.rb:46 ../../app/controllers/cloud_tenant_controller.rb:86 ../../app/controllers/flavor_controller.rb:37
+msgid "%{name} (All %{title})"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:24
+msgid "%{name} (All Registered %{title})"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:39
+msgid "%{name} (All Registered Hosts)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:114
+msgid "%{name} (All Resource Pools)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:108
+msgid "%{name} (All cloud tenants present on this host)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:40
+msgid "%{name} (Devices)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:292
+msgid "%{name} (Disks)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:78
+msgid "%{name} (Latest Compliance Check)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:52
+msgid "%{name} (Network)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:44
+msgid "%{name} (OS Information)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:87
+msgid "%{name} (Storage Adapters)"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:252 ../../app/controllers/cloud_volume_snapshot_controller.rb:44 ../../app/controllers/cim_instance_controller.rb:121 ../../app/controllers/cloud_volume_controller.rb:33 ../../app/controllers/host_controller.rb:35 ../../app/controllers/availability_zone_controller.rb:26 ../../app/controllers/cloud_tenant_controller.rb:54 ../../app/controllers/flavor_controller.rb:24
+msgid "%{name} (Summary)"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:48
+msgid "%{name} (VM Monitor Information)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:286 ../../app/controllers/cim_instance_controller.rb:128 ../../app/controllers/storage_controller.rb:65 ../../app/controllers/host_controller.rb:58 ../../app/controllers/availability_zone_controller.rb:33 ../../app/controllers/ems_common.rb:47 ../../app/controllers/ems_cluster_controller.rb:93
+msgid "%{name} Capacity & Utilization"
+msgstr ""
+
+#: ../../app/controllers/alert_controller.rb:25
+msgid "%{name} RSS Feeds"
+msgstr ""
+
+#: ../../app/helpers/container_summary_helper.rb:125 ../../app/helpers/textual_summary_helper.rb:43
+msgid "%{name} Tags"
+msgstr ""
+
+#: ../../app/controllers/dashboard_controller.rb:706
+msgid "%{name} dashboard for user %{id} in group id %{current_group_id}"
+msgstr ""
+
 #: ../../app/controllers/ops_controller/settings/common.rb:385
 msgid "%{name} file saved"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:221
+#: ../../app/controllers/report_controller/reports/editor.rb:981
+msgid "%{name} is currently being used in the Display Filter"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:225
 msgid "%{name} is required"
 msgstr ""
 
-#: ../../app/controllers/application_controller.rb:2547
+#: ../../app/controllers/storage_manager_controller.rb:498 ../../app/controllers/ems_common.rb:852
+msgid "%{name}: '%{task}' successfully initiated"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:493 ../../app/controllers/ems_common.rb:847
+msgid "%{name}: Delete successful"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:484 ../../app/controllers/ems_common.rb:839
+msgid "%{name}: Error during '%{task}': %{message}"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:178
+msgid "%{number} (%{percentage}% of Used Space, ${files})"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:213 ../../app/helpers/storage_helper/textual_summary.rb:229 ../../app/helpers/storage_helper/textual_summary.rb:245
+msgid "%{number} (%{percentage}% of Used Space, %{files})"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:117
+msgid "%{number} (Virtual to Real Ratio: %{ration})"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:110
+msgid "%{number} (Virtual to Real Ratio: %{ratio})"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:506
+msgid "%{number} Hours Ago"
+msgstr ""
+
+#: ../../app/helpers/container_service_helper/textual_summary.rb:61
+msgid "%{protocol} port %{port} to pods on target port:'%{target_port}'"
+msgstr ""
+
+#: ../../app/controllers/application_controller.rb:2546
 msgid "%{record_name} no longer exists in the database"
 msgstr ""
 
@@ -478,7 +767,7 @@ msgstr ""
 msgid "%{record} - \"%{button_text}\""
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:315 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:83 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1345 ../../app/controllers/ems_common.rb:859 ../../app/controllers/ems_common.rb:890 ../../app/controllers/ems_common.rb:923 ../../app/controllers/miq_policy_controller.rb:265 ../../app/controllers/application_controller/ci_processing.rb:1211 ../../app/controllers/application_controller/ci_processing.rb:1279 ../../app/controllers/application_controller/ci_processing.rb:1604 ../../app/controllers/application_controller/ci_processing.rb:1767 ../../app/controllers/application_controller/ci_processing.rb:1855 ../../app/controllers/application_controller/ci_processing.rb:1919 ../../app/controllers/application_controller/ci_processing.rb:1947
+#: ../../app/controllers/chargeback_controller.rb:292 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:83 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1345 ../../app/controllers/ems_common.rb:874 ../../app/controllers/ems_common.rb:905 ../../app/controllers/ems_common.rb:938 ../../app/controllers/miq_policy_controller.rb:265 ../../app/controllers/application_controller/ci_processing.rb:1225 ../../app/controllers/application_controller/ci_processing.rb:1293 ../../app/controllers/application_controller/ci_processing.rb:1618 ../../app/controllers/application_controller/ci_processing.rb:1781 ../../app/controllers/application_controller/ci_processing.rb:1869 ../../app/controllers/application_controller/ci_processing.rb:1933 ../../app/controllers/application_controller/ci_processing.rb:1961
 msgid "%{record} no longer exists"
 msgstr ""
 
@@ -486,43 +775,47 @@ msgstr ""
 msgid "%{role} on %{model}: %{name} [%{id}]"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:536 ../../app/controllers/ops_controller/settings/ldap.rb:121 ../../app/controllers/ops_controller/settings/ldap.rb:297 ../../app/controllers/ops_controller/settings/schedules.rb:183 ../../app/controllers/ops_controller/diagnostics.rb:695
+#: ../../app/helpers/storage_helper/textual_summary.rb:36
+msgid "%{storage} Type"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_region.rb:35 ../../app/presenters/tree_builder_region.rb:40
+msgid "%{tables} (Click to open)"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1865
+msgid "%{table} Policy Assignment"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1856 ../../app/controllers/vm_common.rb:1860
+msgid "%{table} Policy Simulation"
+msgstr ""
+
+#: ../../app/controllers/miq_request_controller.rb:536 ../../app/controllers/ops_controller/settings/ldap.rb:121 ../../app/controllers/ops_controller/settings/ldap.rb:297 ../../app/controllers/ops_controller/settings/schedules.rb:184 ../../app/controllers/ops_controller/diagnostics.rb:715
 msgid "%{table} no longer exists"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports.rb:317 ../../app/controllers/report_controller/reports.rb:359
-msgid "%{tab} tab is not available until %{field} field has been selected"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:320 ../../app/controllers/report_controller/reports.rb:362 ../../app/controllers/report_controller/reports.rb:374
-msgid "%{tab} tab is not available until %{field} has been configured"
-msgstr ""
-
-#: ../../app/controllers/vm_common.rb:1732
+#: ../../app/controllers/vm_common.rb:1813
 msgid "%{task} %{model}"
 msgstr ""
 
-#: ../../app/controllers/service_controller.rb:179 ../../app/controllers/catalog_controller.rb:583
-msgid "%{task} %{model} \"%{name}\""
-msgstr ""
-
-#: ../../app/controllers/application_controller.rb:2611
+#: ../../app/controllers/application_controller.rb:2610
 msgid "%{task} does not apply to at least one of the selected %{model}"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:74
+#: ../../app/controllers/provider_foreman_controller.rb:78
 msgid "%{task} initiated for %{count_model}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1305
-msgid "%{task} initiated for %{count_model} (%{controller}) from the CFME Database"
+#: ../../app/controllers/application_controller/ci_processing.rb:1319
+msgid "%{task} initiated for %{count_model} (%{controller})"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:256 ../../app/controllers/repository_controller.rb:292 ../../app/controllers/repository_controller.rb:317 ../../app/controllers/repository_controller.rb:327 ../../app/controllers/storage_manager_controller.rb:454 ../../app/controllers/ems_common.rb:796 ../../app/controllers/miq_task_controller.rb:161 ../../app/controllers/miq_task_controller.rb:191 ../../app/controllers/miq_task_controller.rb:218 ../../app/controllers/application_controller/ci_processing.rb:1659
+#: ../../app/controllers/repository_controller.rb:258 ../../app/controllers/storage_manager_controller.rb:457 ../../app/controllers/ems_common.rb:802 ../../app/controllers/miq_task_controller.rb:161 ../../app/controllers/miq_task_controller.rb:191 ../../app/controllers/miq_task_controller.rb:218 ../../app/controllers/application_controller/ci_processing.rb:1673
 msgid "%{task} initiated for %{count_model} from the CFME Database"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1270
+#: ../../app/controllers/application_controller/ci_processing.rb:1284
 msgid "%{task} initiated for %{model} from the CFME Database"
 msgstr ""
 
@@ -538,19 +831,39 @@ msgstr ""
 msgid "%{title_for_hosts} & %{title_for_clusters}"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:360
+msgid "%{title} '%{description}'"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/common.rb:1220
+msgid "%{title} (current)"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:201
+msgid "%{title} Default VNC Port Range"
+msgstr ""
+
 #: ../../app/controllers/application_controller/ci_processing.rb:868
 msgid "%{title} Discovery returned: %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/rbac_tree.rb:44
+msgid "%{title} Main Tab"
 msgstr ""
 
 #: ../../app/views/ops/_rbac_tenant_details.html.haml:8
 msgid "%{type} Information"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:311 ../../app/controllers/chargeback_controller.rb:328 ../../app/controllers/chargeback_controller.rb:442 ../../app/controllers/chargeback_controller.rb:453 ../../app/controllers/report_controller/widgets.rb:267 ../../app/controllers/miq_policy_controller/policies.rb:228 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:121 ../../app/controllers/report_controller.rb:461 ../../app/controllers/report_controller.rb:481 ../../app/controllers/miq_policy_controller.rb:626 ../../app/controllers/miq_policy_controller.rb:953
+#: ../../app/controllers/host_controller.rb:735
+msgid "%{type} Storage Adapter: %{name}"
+msgstr ""
+
+#: ../../app/controllers/chargeback_controller.rb:286 ../../app/controllers/chargeback_controller.rb:308 ../../app/controllers/chargeback_controller.rb:441 ../../app/controllers/chargeback_controller.rb:452 ../../app/controllers/report_controller/widgets.rb:267 ../../app/controllers/miq_policy_controller/policies.rb:228 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:121 ../../app/controllers/report_controller.rb:457 ../../app/controllers/report_controller.rb:477 ../../app/controllers/miq_policy_controller.rb:626 ../../app/controllers/miq_policy_controller.rb:955
 msgid "%{typ} %{model}"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:447 ../../app/controllers/report_controller/widgets.rb:273 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39
+#: ../../app/controllers/chargeback_controller.rb:446 ../../app/controllers/report_controller/widgets.rb:273 ../../app/controllers/ops_controller/analytics.rb:33 ../../app/controllers/ops_controller/analytics.rb:39
 msgid "%{typ} %{model} \"%{name}\""
 msgstr ""
 
@@ -578,15 +891,27 @@ msgstr ""
 msgid "%{typ} Request was re-submitted, you will be notified when your %{title} are ready"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1667 ../../app/controllers/catalog_controller.rb:1672
+#: ../../app/controllers/catalog_controller.rb:1669
 msgid "%{typ} in %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:362 ../../app/controllers/miq_ae_tools_controller.rb:363 ../../app/controllers/miq_policy_controller/miq_actions.rb:392 ../../app/controllers/miq_policy_controller/miq_actions.rb:393 ../../app/controllers/miq_policy_controller.rb:1036 ../../app/controllers/miq_policy_controller.rb:1038 ../../app/controllers/miq_policy_controller.rb:1040 ../../app/controllers/miq_policy_controller.rb:1041 ../../app/controllers/miq_policy_controller.rb:1043 ../../app/controllers/miq_policy_controller.rb:1045 ../../app/controllers/miq_policy_controller.rb:1047
+#: ../../app/controllers/catalog_controller.rb:1662
+msgid "%{typ} in %{model} \"Unassigned\""
+msgstr ""
+
+#: ../../app/controllers/miq_ae_tools_controller.rb:362 ../../app/controllers/miq_ae_tools_controller.rb:363 ../../app/controllers/miq_policy_controller/miq_actions.rb:392 ../../app/controllers/miq_policy_controller/miq_actions.rb:393 ../../app/controllers/miq_policy_controller.rb:1038 ../../app/controllers/miq_policy_controller.rb:1040 ../../app/controllers/miq_policy_controller.rb:1042 ../../app/controllers/miq_policy_controller.rb:1043 ../../app/controllers/miq_policy_controller.rb:1045 ../../app/controllers/miq_policy_controller.rb:1047 ../../app/controllers/miq_policy_controller.rb:1049
 msgid "%{val} missing for %{field}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:69
+#: ../../app/controllers/storage_manager_controller.rb:460
+msgid "'%{task}' successfully initiated for %{items}"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:806
+msgid "'%{task}' successfully initiated for %{table}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:77
 msgid "'%{type}' Worker restart initiated successfully"
 msgstr ""
 
@@ -600,6 +925,10 @@ msgstr ""
 
 #: ../../app/views/vm_common/_snapshots_desc.html.haml:41
 msgid "(%s bytes)"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:508 ../../app/helpers/vm_helper/textual_summary.rb:606
+msgid "(%{value}) * Overallocated"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20 ../../app/views/configuration/_timeprofile_days_hours.html.haml:68
@@ -750,6 +1079,10 @@ msgstr ""
 msgid "* Only a single value can be assigned from these Tag Categories"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/common.rb:154
+msgid "* Passwords don't match."
+msgstr ""
+
 #: ../../app/views/report/_form_columns_performance.html.haml:6
 msgid "* Performance Interval"
 msgstr ""
@@ -810,8 +1143,52 @@ msgstr ""
 msgid "* Style \"If\" conditions are evaluated top to bottom for each column"
 msgstr ""
 
-#: ../../app/controllers/auth_key_pair_cloud_controller.rb:71
+#: ../../app/controllers/ems_common.rb:112 ../../app/controllers/ems_cluster_controller.rb:50 ../../app/controllers/ems_cluster_controller.rb:63 ../../app/controllers/ems_cluster_controller.rb:76
+msgid "* You are not authorized to view "
+msgstr ""
+
+#: ../../app/controllers/cloud_volume_snapshot_controller.rb:61 ../../app/controllers/cloud_volume_controller.rb:48 ../../app/controllers/cloud_volume_controller.rb:65 ../../app/controllers/auth_key_pair_cloud_controller.rb:71
 msgid "* You are not authorized to view %{children} on this %{model}"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:31
+msgid "* You are not authorized to view other %{items} on this Host"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:33
+msgid "* You are not authorized to view other %{item} on this Host"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:128
+msgid "* You are not authorized to view other %{tables} on this Host"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:131
+msgid "* You are not authorized to view other %{table} on this Host"
+msgstr ""
+
+#: ../../app/controllers/availability_zone_controller.rb:53 ../../app/controllers/availability_zone_controller.rb:73 ../../app/controllers/cloud_tenant_controller.rb:75 ../../app/controllers/cloud_tenant_controller.rb:93 ../../app/controllers/flavor_controller.rb:44 ../../app/controllers/flavor_controller.rb:47
+msgid "* You are not authorized to view other %{titles} on this %{tables}"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:101
+msgid "* You are not authorized to view other %{titles} on this Host"
+msgstr ""
+
+#: ../../app/controllers/availability_zone_controller.rb:56 ../../app/controllers/availability_zone_controller.rb:76 ../../app/controllers/cloud_tenant_controller.rb:78 ../../app/controllers/cloud_tenant_controller.rb:96
+msgid "* You are not authorized to view other %{title} on this %{tables}"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:103
+msgid "* You are not authorized to view other %{title} on this Host"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:48
+msgid "* You are not authorized to view other Host on this %{table}"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:45
+msgid "* You are not authorized to view other Hosts on this %{table}"
 msgstr ""
 
 #: ../../app/views/layouts/_adv_search_body.html.haml:73
@@ -822,6 +1199,18 @@ msgstr ""
 msgid "1 - Select a Reference VM."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:400
+msgid "1 Day Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:346
+msgid "1 Hour"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:331
+msgid "1 Week"
+msgstr ""
+
 #: ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "1 Week Ago"
 msgstr ""
@@ -830,16 +1219,64 @@ msgstr ""
 msgid "1 Week before retirement"
 msgstr ""
 
-#: ../../app/views/miq_policy/_alert_details.html.haml:193
+#: ../../app/helpers/ui_constants.rb:342 ../../app/views/miq_policy/_alert_details.html.haml:193
 msgid "10 Minutes"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:297
+msgid "12 Hours"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:516
+msgid "14 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:343
+msgid "15 Minutes"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_instructions.html.haml:22
 msgid "2 - Specify the VM Options to define the source of the values used for the plan calculations."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:284
+msgid "2 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:401 ../../app/helpers/ui_constants.rb:510
+msgid "2 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:292
+msgid "2 Hours"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:307
+msgid "2 Months"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:528
+msgid "2 Months Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:536
+msgid "2 Quarters Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:301 ../../app/helpers/ui_constants.rb:332
+msgid "2 Weeks"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:521
+msgid "2 Weeks Ago"
+msgstr ""
+
 #: ../../app/views/shared/views/_retire.html.haml:49
 msgid "2 Weeks before retirement"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:543
+msgid "2 Years Ago"
 msgstr ""
 
 #: ../../app/views/miq_task/_tasks_options.html.haml:59
@@ -850,19 +1287,233 @@ msgstr ""
 msgid "3 - Specify Target Options to qualify target %s or %s."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:285
+msgid "3 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:402 ../../app/helpers/ui_constants.rb:511
+msgid "3 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:293
+msgid "3 Hours"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:308
+msgid "3 Months"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:529
+msgid "3 Months Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:537
+msgid "3 Quarters Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:302 ../../app/helpers/ui_constants.rb:333
+msgid "3 Weeks"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:522
+msgid "3 Weeks Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:544
+msgid "3 Years Ago"
+msgstr ""
+
 #: ../../app/views/shared/views/_retire.html.haml:49
 msgid "30 Days before retirement"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:344
+msgid "30 Minutes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../yaml_strings.rb:3454
+msgid "32 Bit Architecture"
+msgstr ""
+
+#: ../../app/helpers/flavor_helper/textual_summary.rb:46
+msgid "32 Bit Architecture "
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_instructions.html.haml:42
 msgid "4 - Change the Trend Options used to calculate the daily trends, if desired."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:286
+msgid "4 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:403 ../../app/helpers/ui_constants.rb:512
+msgid "4 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:294
+msgid "4 Hours"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:309
+msgid "4 Months"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:530
+msgid "4 Months Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:538
+msgid "4 Quarters Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:303 ../../app/helpers/ui_constants.rb:334
+msgid "4 Weeks"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:523
+msgid "4 Weeks Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:545
+msgid "4 Years Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:345
+msgid "45 Minutes"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_instructions.html.haml:52
 msgid "5 - Press the Submit button."
 msgstr ""
 
-#: ../../app/presenters/tree_builder_instances.rb:21 ../../app/presenters/tree_builder_vandt.rb:15
+#: ../../app/helpers/ui_constants.rb:287
+msgid "5 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:404 ../../app/helpers/ui_constants.rb:513
+msgid "5 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:310
+msgid "5 Months"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:288
+msgid "6 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:405 ../../app/helpers/ui_constants.rb:514
+msgid "6 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:295
+msgid "6 Hours"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:311
+msgid "6 Months"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:531
+msgid "6 Months Ago"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../yaml_strings.rb:3456
+msgid "64 Bit Architecture"
+msgstr ""
+
+#: ../../app/helpers/flavor_helper/textual_summary.rb:51
+msgid "64 Bit Architecture "
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:515
+msgid "7 Days Ago"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:296
+msgid "8 Hours"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:415
+msgid ": All UI Tasks"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:411
+msgid ": Analysis Profiles"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:438
+msgid ": Automate"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:423
+msgid ": Configuration"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:440
+msgid ": Control"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:431
+msgid ": Instances"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:449
+msgid ": Login"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:417
+msgid ": My UI Tasks"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:442
+msgid ": Optimize"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:427
+msgid ": PXE"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:413
+msgid ": Policy Simulation"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:419
+msgid ": RSS"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:444
+msgid ": Requests"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:407
+msgid ": Servers"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:447
+msgid ": Storage - %{tables}"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:421
+msgid ": Storage - Storage Managers"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:409
+msgid ": VM Usage"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:433
+msgid ": Virtual Machines"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:435
+msgid ": Workloads"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_instances.rb:21 ../../app/presenters/tree_builder_images.rb:21 ../../app/presenters/tree_builder_vandt.rb:15
 msgid "<Archived>"
 msgstr ""
 
@@ -906,16 +1557,24 @@ msgstr ""
 msgid "<No chart>"
 msgstr ""
 
-#: ../../app/presenters/tree_builder_instances.rb:22 ../../app/presenters/tree_builder_vandt.rb:16
+#: ../../app/controllers/vm_common.rb:322 ../../app/controllers/vm_common.rb:366
+msgid "<No notes have been entered for this VM>"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_instances.rb:22 ../../app/presenters/tree_builder_images.rb:22 ../../app/presenters/tree_builder_vandt.rb:16
 msgid "<Orphaned>"
 msgstr ""
 
-#: ../../app/helpers/container_service_helper/textual_summary.rb:22 ../../app/helpers/container_service_helper/textual_summary.rb:60
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:112 ../../app/helpers/host_helper/textual_summary.rb:534 ../../app/helpers/ems_infra_helper/textual_summary.rb:154
+msgid "<Unknown>"
+msgstr ""
+
+#: ../../app/helpers/container_service_helper/textual_summary.rb:22 ../../app/helpers/container_service_helper/textual_summary.rb:59
 msgid "<Unnamed>"
 msgstr ""
 
 #: ../../app/controllers/report_controller/widgets.rb:729
-msgid "A %s must be selected"
+msgid "A %{type} must be selected"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/alerts.rb:533
@@ -926,19 +1585,27 @@ msgstr ""
 msgid "A Red Hat subscription that covers your product"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:86
+#: ../../app/controllers/report_controller/widgets.rb:724 ../../app/controllers/report_controller/schedules.rb:235
+msgid "A Report must be selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:253 ../../app/controllers/miq_policy_controller/alert_profiles.rb:86
 msgid "A Tag Category must be selected"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:1285
+#: ../../app/controllers/report_controller/reports.rb:257
+msgid "A Tag must be selected"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:1290
 msgid "A User Group must be assigned a Role"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:998
+#: ../../app/controllers/ops_controller/ops_rbac.rb:999
 msgid "A User must be assigned to a Group"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1445
+#: ../../app/controllers/application_controller/filter.rb:1336
 msgid "A check field must be chosen to commit this expression element"
 msgstr ""
 
@@ -946,27 +1613,47 @@ msgstr ""
 msgid "A condition must contain a valid expression."
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1369
+#: ../../app/controllers/application_controller/filter.rb:1260
 msgid "A field must be chosen to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1442
+#: ../../app/controllers/application_controller/filter.rb:1333
 msgid "A find field must be chosen to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1422
+#: ../../app/controllers/application_controller/filter.rb:1313
 msgid "A registry key name must be entered to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1424
+#: ../../app/controllers/application_controller/filter.rb:1315
 msgid "A registry value name must be entered to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1408
+#: ../../app/controllers/ops_controller/settings/schedules.rb:590
+msgid "A single Cluster"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:599
+msgid "A single Datastore"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:582
+msgid "A single Host"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:573
+msgid "A single Template"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:563
+msgid "A single VM"
+msgstr ""
+
+#: ../../app/controllers/application_controller/filter.rb:1299
 msgid "A tag category must be chosen to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1410
+#: ../../app/controllers/application_controller/filter.rb:1301
 msgid "A tag value must be chosen to commit this expression element"
 msgstr ""
 
@@ -974,8 +1661,28 @@ msgstr ""
 msgid "A valid expression must be present"
 msgstr ""
 
-#: ../../app/controllers/ems_infra_controller.rb:79
+#: ../../app/controllers/ems_infra_controller.rb:80
 msgid "A value must be changed or provider will not be scaled."
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:45
+msgid "A0 - 841mm x 1189mm"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:46
+msgid "A1 - 594mm x 841mm"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:47
+msgid "A2 - 420mm x 594mm"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:48
+msgid "A3 - 297mm x 420mm"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:49
+msgid "A4 - 210mm x 297mm (default)"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_field.html.haml:31 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:20
@@ -986,7 +1693,7 @@ msgstr ""
 msgid "AM:"
 msgstr ""
 
-#: ../../app/views/layouts/_multi_auth_credentials.html.haml:25 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:21
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:111 ../../app/helpers/ems_infra_helper/textual_summary.rb:153 ../../app/views/layouts/_multi_auth_credentials.html.haml:25 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:21
 msgid "AMQP"
 msgstr ""
 
@@ -998,7 +1705,7 @@ msgstr ""
 msgid "API Authentication failed"
 msgstr ""
 
-#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:218 ../../app/views/shared/views/ems_common/_form.html.haml:62
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:45 ../../app/helpers/ems_infra_helper/textual_summary.rb:39 ../../app/views/shared/views/ems_common/angular/_form.html.haml:218 ../../app/views/shared/views/ems_common/_form.html.haml:62
 msgid "API Port"
 msgstr ""
 
@@ -1010,16 +1717,40 @@ msgstr ""
 msgid "Abandon changes?"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:165
+#: ../../app/helpers/ui_constants.rb:408
+msgid "Aborting"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:165 ../yaml_strings.rb:1384
 msgid "About"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:869 ../../app/controllers/ops_controller/ops_rbac.rb:872 ../../app/controllers/ops_controller/ops_rbac.rb:875 ../../app/controllers/ops_controller/ops_rbac.rb:878
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/ops_controller.rb:215 ../yaml_strings.rb:1240
+msgid "Access Control"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:870 ../../app/controllers/ops_controller/ops_rbac.rb:873 ../../app/controllers/ops_controller/ops_rbac.rb:876 ../../app/controllers/ops_controller/ops_rbac.rb:879
 msgid "Access Control %{model}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:895
+#: ../../app/controllers/ops_controller/ops_rbac.rb:896
 msgid "Access Control %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:467
+msgid "Access Control %{text}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1242
+msgid "Access Control Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:589
+msgid "Access Everything under Resource Pools"
 msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:220
@@ -1034,28 +1765,66 @@ msgstr ""
 msgid "Access Key ID and matching Secret Access Key fields are needed to perform verification of credentials"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#: ../yaml_strings.rb:3887
+msgid "Access Modes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2105
+msgid "Access Rules for Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2021
+msgid "Access Rules for Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2257
+msgid "Access Rules for Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2143
+msgid "Access Rules for Virtual Machines"
+msgstr ""
+
 #: ../../app/controllers/ops_controller/rbac_tree.rb:31
 msgid "Access Rules for all Virtual Machines"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_form.html.haml:84
+#: ../../app/helpers/pxe_helper/textual_summary.rb:16 ../../app/views/pxe/_pxe_form.html.haml:84
 msgid "Access URL"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:4
+msgid "Access to Everything"
 msgstr ""
 
 #: ../../app/views/layouts/_exception_contents.html.haml:21
 msgid "Accessing Management Engine from multiple tabs or windows of the same browser on a single machine."
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:10
+msgid "Accordions"
+msgstr ""
+
 #: ../../app/views/ops/rhn/_info_subscribed.html.haml:45 ../model_attributes.rb:2
 msgid "Account"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/Group.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.acctid
-#: ../dictionary_strings.rb:151
+#: ../yaml_strings.rb:3105 ../dictionary_strings.rb:151
 msgid "Account ID"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:44 ../../app/views/vm_common/_config.html.haml:234
+#: ../../app/views/vm_common/_config.html.haml:44 ../../app/views/vm_common/_config.html.haml:231
 msgid "Account Policies"
 msgstr ""
 
@@ -1108,13 +1877,19 @@ msgstr ""
 msgid "Account|Name"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAction.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAction
-#: ../../app/views/ops/_schedule_form.html.haml:86 ../../app/views/ops/_schedule_show.html.haml:29 ../../app/views/shared/buttons/_ab_form.html.haml:27 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_sandt_tree_show.html.haml:234 ../dictionary_strings.rb:1493
+#: ../../app/views/ops/_schedule_form.html.haml:86 ../../app/views/ops/_schedule_show.html.haml:29 ../../app/views/shared/buttons/_ab_form.html.haml:27 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_sandt_tree_show.html.haml:234 ../yaml_strings.rb:3277 ../dictionary_strings.rb:1493
 msgid "Action"
 msgstr ""
 
 #: ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_sandt_tree_show.html.haml:233
 msgid "Action Order"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqActionSet.yaml
+#: ../yaml_strings.rb:3616
+msgid "Action Sets"
 msgstr ""
 
 #: ../../app/views/miq_policy/_action_details.html.haml:42
@@ -1125,8 +1900,15 @@ msgstr ""
 msgid "Action Type must be selected"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqActionSet.yaml
+#: ../yaml_strings.rb:3618
+msgid "ActionSet"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqAction.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAction (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1134 ../../app/views/miq_policy/_policy_details.html.haml:351 ../dictionary_strings.rb:1495
+#: ../../app/controllers/miq_policy_controller.rb:1136 ../../app/views/miq_policy/_policy_details.html.haml:351 ../yaml_strings.rb:903 ../dictionary_strings.rb:1495
 msgid "Actions"
 msgstr ""
 
@@ -1134,9 +1916,14 @@ msgstr ""
 msgid "Actions for Policy Event \"%{events}\" were saved"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
+#. TRANSLATORS: file: product/views/MiqPolicy.yaml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.active
 #. TRANSLATORS: en.yml key: dictionary.column.enabled
-#: ../../app/views/ops/_schedule_form.html.haml:70 ../../app/views/ops/_schedule_show.html.haml:19 ../../app/views/ops/_diagnostics_replication_tab.html.haml:39 ../../app/views/report/_widget_show.html.haml:42 ../../app/views/report/_widget_form.html.haml:54 ../../app/views/report/_show_schedule.html.haml:19 ../../app/views/report/_schedule_form.html.haml:51 ../../app/views/report/_report_info.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:43 ../../app/views/miq_policy/_policy_details.html.haml:49 ../../app/views/miq_policy/_policy_details.html.haml:66 ../dictionary_strings.rb:157 ../dictionary_strings.rb:387
+#: ../../app/helpers/ui_constants.rb:412 ../../app/views/ops/_schedule_form.html.haml:70 ../../app/views/ops/_schedule_show.html.haml:19 ../../app/views/ops/_diagnostics_replication_tab.html.haml:39 ../../app/views/report/_widget_show.html.haml:42 ../../app/views/report/_widget_form.html.haml:54 ../../app/views/report/_show_schedule.html.haml:19 ../../app/views/report/_schedule_form.html.haml:51 ../../app/views/report/_report_info.html.haml:134 ../../app/views/miq_policy/_alert_details.html.haml:43 ../../app/views/miq_policy/_policy_details.html.haml:49 ../../app/views/miq_policy/_policy_details.html.haml:66 ../yaml_strings.rb:2862 ../dictionary_strings.rb:157 ../dictionary_strings.rb:387
 msgid "Active"
 msgstr ""
 
@@ -1163,7 +1950,8 @@ msgstr ""
 msgid "Activity Sample - Timestamp (Day/Time)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_edit_view.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:35 ../../app/views/storage_manager/_form.html.haml:240 ../../app/views/layouts/_x_edit_buttons.html.haml:46 ../../app/views/layouts/_x_edit_buttons.html.haml:141 ../../app/views/layouts/_edit_to_email.html.haml:92 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/vm_common/_add_to_service.html.haml:49 ../../app/views/configuration/_timeprofile_form.html.haml:117 ../../app/views/shared/views/ems_common/_form.html.haml:181
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_edit_view.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:35 ../../app/views/storage_manager/_form.html.haml:240 ../../app/views/layouts/_x_edit_buttons.html.haml:46 ../../app/views/layouts/_x_edit_buttons.html.haml:141 ../../app/views/layouts/_edit_to_email.html.haml:92 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:15 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/layouts/_edit_buttons.html.haml:52 ../../app/views/vm_common/_add_to_service.html.haml:49 ../../app/views/configuration/_timeprofile_form.html.haml:117 ../../app/views/shared/views/ems_common/_form.html.haml:181 ../yaml_strings.rb:308
 msgid "Add"
 msgstr ""
 
@@ -1171,24 +1959,254 @@ msgstr ""
 msgid "Add (enter manually)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:13
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:167
+msgid "Add Atomic Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:998
+msgid "Add Automate Class"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:962
+msgid "Add Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1012
+msgid "Add Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1024
+msgid "Add Automate Method"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:988
+msgid "Add Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1065
+msgid "Add Box"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1067
+msgid "Add Box to Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1113
+msgid "Add Button"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1103
+msgid "Add Button Group"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:71
+msgid "Add Capabilities"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:204
+msgid "Add Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:159
+msgid "Add Composite Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1959
+msgid "Add Container"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1053
+msgid "Add Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1069
+msgid "Add Element"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1071
+msgid "Add Element to Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:13 ../yaml_strings.rb:1214
 msgid "Add Host Analysis Profile"
+msgstr ""
+
+#: ../../app/controllers/ems_cloud_controller.rb:118
+msgid "Add New %{tables}"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:131 ../../app/controllers/ems_common.rb:167
+msgid "Add New %{table}"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:267 ../../app/controllers/host_controller.rb:298
+msgid "Add New Host"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:69 ../../app/controllers/storage_manager_controller.rb:112
+msgid "Add New Storage Manager"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:503 ../../app/controllers/configuration_controller.rb:515
+msgid "Add New Time Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:217
+msgid "Add Orchestration Template"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/tenant_center.rb:18
 msgid "Add Project to this Tenant"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:967
-msgid "Add VM \"%s\" to a Service was cancelled by the user"
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2005
+msgid "Add Provider"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:18
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1087
+msgid "Add Provisioning Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1579
+msgid "Add System Image Types"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1061
+msgid "Add Tab"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1063
+msgid "Add Tab to Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1157
+msgid "Add Time Profiles"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1028
+msgid "Add VM \"%{name}\" to a Service was cancelled by the user"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:18 ../yaml_strings.rb:1216
 msgid "Add VM Analysis Profile"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1021
+msgid "Add VM to a Service"
 msgstr ""
 
 #: ../../app/views/vm_common/_add_to_service.html.haml:49
 msgid "Add VM to the selected Service"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:808
+msgid "Add a Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:310
+msgid "Add a Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:206
+msgid "Add a Composite Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:161
+msgid "Add a Composite Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:879
+msgid "Add a Condition"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1961
+msgid "Add a Container"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1848
+msgid "Add a Container Image Registry"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1787
+msgid "Add a Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1812
+msgid "Add a Container Replicator"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1897
+msgid "Add a Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1664
+msgid "Add a Containers Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:756
+msgid "Add a Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1279
+msgid "Add a Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:576
+msgid "Add a Host / Node"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1732
+msgid "Add a Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1688
+msgid "Add a Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1710
+msgid "Add a Middleware Server"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/conditions_center.rb:12
@@ -1315,15 +2333,91 @@ msgstr ""
 msgid "Add a New item"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1870
+msgid "Add a Persistent Volume"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1761
+msgid "Add a Pod"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:856
+msgid "Add a Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:909
+msgid "Add a Policy Action"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:936
+msgid "Add a Policy Alert"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:921
+msgid "Add a Policy Alert Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:842
+msgid "Add a Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2007
+msgid "Add a Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:713
+msgid "Add a Report"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:655
+msgid "Add a Repository"
+msgstr ""
+
 #: ../../app/views/catalog/_form_resources_info.html.haml:17
 msgid "Add a Resource"
 msgstr ""
 
-#: ../../app/views/layouts/_edit_to_email.html.haml:50
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1299
+msgid "Add a Role"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:736
+msgid "Add a Schedule"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1312
+msgid "Add a Tenant/Project"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/layouts/_edit_to_email.html.haml:50 ../yaml_strings.rb:1257
 msgid "Add a User"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:710 ../../app/controllers/provider_foreman_controller.rb:807
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:780
+msgid "Add a Widget"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1234
+msgid "Add a Zone"
+msgstr ""
+
+#: ../../app/controllers/provider_foreman_controller.rb:662 ../../app/controllers/provider_foreman_controller.rb:759
 msgid "Add a new %s Provider"
 msgstr ""
 
@@ -1427,15 +2521,54 @@ msgstr ""
 msgid "Add a widget"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1562
+msgid "Add an Customization Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1598
+msgid "Add an ISO Datastore"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:451
+msgid "Add an Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1539
+msgid "Add an PXE Server"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1516
+msgid "Add an Storage Manager"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:671
+msgid "Add and Remove Dashboard Widgets"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:669
+msgid "Add and Remove a Widget"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/tenant_center.rb:12
 msgid "Add child Tenant to this Tenant"
 msgstr ""
 
-#: ../../app/controllers/ems_cloud_controller.rb:134
+#: ../../app/controllers/configuration_controller.rb:347
+msgid "Add new Time Profile"
+msgstr ""
+
+#: ../../app/controllers/ems_cloud_controller.rb:136
 msgid "Add of %{model} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:63 ../../app/controllers/report_controller/dashboards.rb:62 ../../app/controllers/report_controller/widgets.rb:47 ../../app/controllers/report_controller/reports/editor.rb:33 ../../app/controllers/report_controller/schedules.rb:217 ../../app/controllers/miq_ae_class_controller.rb:650 ../../app/controllers/storage_manager_controller.rb:79 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:197 ../../app/controllers/ops_controller/settings/ldap.rb:162 ../../app/controllers/host_controller.rb:245 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:101 ../../app/controllers/pxe_controller/iso_datastores.rb:43 ../../app/controllers/pxe_controller/pxe_image_types.rb:31 ../../app/controllers/pxe_controller/pxe_servers.rb:48 ../../app/controllers/application_controller/miq_request_methods.rb:66 ../../app/views/shared/views/ems_common/_form.html.haml:188
+#: ../../app/controllers/miq_ae_class_controller.rb:644 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:197 ../../app/controllers/application_controller/miq_request_methods.rb:66 ../../app/views/shared/views/ems_common/_form.html.haml:188
 msgid "Add of new %s was cancelled by the user"
 msgstr ""
 
@@ -1447,7 +2580,7 @@ msgstr ""
 msgid "Add of new %{models} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/alert_profiles.rb:11 ../../app/controllers/miq_policy_controller/conditions.rb:13 ../../app/controllers/catalog_controller.rb:96 ../../app/controllers/catalog_controller.rb:613 ../../app/controllers/ops_controller/settings/tags.rb:40 ../../app/controllers/ops_controller/settings/ldap.rb:36 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:222 ../../app/controllers/ops_controller/settings/schedules.rb:41 ../../app/controllers/ops_controller/ops_rbac.rb:106
+#: ../../app/controllers/repository_controller.rb:63 ../../app/controllers/report_controller/widgets.rb:47 ../../app/controllers/report_controller/reports/editor.rb:33 ../../app/controllers/report_controller/schedules.rb:221 ../../app/controllers/miq_policy_controller/alert_profiles.rb:11 ../../app/controllers/miq_policy_controller/conditions.rb:13 ../../app/controllers/storage_manager_controller.rb:79 ../../app/controllers/catalog_controller.rb:97 ../../app/controllers/catalog_controller.rb:579 ../../app/controllers/ops_controller/settings/tags.rb:44 ../../app/controllers/ops_controller/settings/ldap.rb:36 ../../app/controllers/ops_controller/settings/ldap.rb:162 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:222 ../../app/controllers/ops_controller/settings/schedules.rb:41 ../../app/controllers/ops_controller/ops_rbac.rb:106 ../../app/controllers/host_controller.rb:276 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:101 ../../app/controllers/pxe_controller/iso_datastores.rb:43 ../../app/controllers/pxe_controller/pxe_image_types.rb:31 ../../app/controllers/pxe_controller/pxe_servers.rb:48
 msgid "Add of new %{model} was cancelled by the user"
 msgstr ""
 
@@ -1455,7 +2588,7 @@ msgstr ""
 msgid "Add of new %{name} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1215 ../../app/controllers/miq_ae_class_controller.rb:1247 ../../app/controllers/miq_ae_class_controller.rb:1288 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:239 ../../app/controllers/configuration_controller.rb:484
+#: ../../app/controllers/miq_ae_class_controller.rb:1209 ../../app/controllers/miq_ae_class_controller.rb:1241 ../../app/controllers/miq_ae_class_controller.rb:1282 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:239 ../../app/controllers/configuration_controller.rb:487
 msgid "Add of new %{record} was cancelled by the user"
 msgstr ""
 
@@ -1463,8 +2596,12 @@ msgstr ""
 msgid "Add of new %{table} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:360
+#: ../../app/controllers/catalog_controller.rb:321
 msgid "Add of new Catalog Bundle was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/report_controller/dashboards.rb:62
+msgid "Add of new Dashboard was cancelled by the user"
 msgstr ""
 
 #: ../../app/views/report/_menu_form1.html.haml:45
@@ -1475,8 +2612,24 @@ msgstr ""
 msgid "Add this %s"
 msgstr ""
 
+#: ../../app/controllers/dashboard_controller.rb:244
+msgid "Add this Chart Widget"
+msgstr ""
+
 #: ../../app/views/ops/_ldap_server_entry.html.haml:7
 msgid "Add this LDAP Server"
+msgstr ""
+
+#: ../../app/controllers/dashboard_controller.rb:242
+msgid "Add this Menu Widget"
+msgstr ""
+
+#: ../../app/controllers/dashboard_controller.rb:243
+msgid "Add this RSS Feed Widget"
+msgstr ""
+
+#: ../../app/controllers/dashboard_controller.rb:245
+msgid "Add this Report Widget"
 msgstr ""
 
 #: ../../app/views/storage_manager/_form.html.haml:240
@@ -1491,23 +2644,27 @@ msgstr ""
 msgid "Add this entry"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:647 ../../app/controllers/miq_ae_customization_controller.rb:414 ../../app/controllers/miq_ae_customization_controller.rb:418 ../../app/controllers/miq_ae_customization_controller.rb:433 ../../app/controllers/miq_ae_customization_controller.rb:470 ../../app/controllers/vm_common.rb:1804 ../../app/controllers/miq_ae_class_controller.rb:567 ../../app/controllers/miq_ae_class_controller.rb:712 ../../app/controllers/miq_ae_class_controller.rb:747 ../../app/controllers/miq_ae_class_controller.rb:787 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/catalog_controller.rb:280 ../../app/controllers/catalog_controller.rb:1178 ../../app/controllers/catalog_controller.rb:1327 ../../app/controllers/catalog_controller.rb:1377 ../../app/controllers/catalog_controller.rb:1814 ../../app/controllers/catalog_controller.rb:1818 ../../app/controllers/pxe_controller.rb:167 ../../app/controllers/pxe_controller.rb:185 ../../app/controllers/pxe_controller.rb:199 ../../app/controllers/pxe_controller.rb:215 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:716 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:729 ../../app/controllers/report_controller.rb:744
+#: ../../app/controllers/ops_controller.rb:673 ../../app/controllers/miq_ae_customization_controller.rb:404 ../../app/controllers/miq_ae_customization_controller.rb:408 ../../app/controllers/miq_ae_customization_controller.rb:423 ../../app/controllers/miq_ae_customization_controller.rb:460 ../../app/controllers/miq_ae_class_controller.rb:561 ../../app/controllers/miq_ae_class_controller.rb:706 ../../app/controllers/miq_ae_class_controller.rb:741 ../../app/controllers/miq_ae_class_controller.rb:781 ../../app/controllers/miq_ae_class_controller.rb:2439
 msgid "Adding a new %s"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:709
+#: ../../app/controllers/miq_policy_controller.rb:711
 msgid "Adding a new %{alerts}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:636
+#: ../../app/controllers/miq_policy_controller.rb:638
 msgid "Adding a new %{model_name} %{mode} Policy"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:639
+#: ../../app/controllers/miq_policy_controller.rb:641
 msgid "Adding a new %{model_name} Policy"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:546 ../../app/controllers/ops_controller.rb:566 ../../app/controllers/ops_controller.rb:579 ../../app/controllers/ops_controller.rb:590 ../../app/controllers/ops_controller.rb:601 ../../app/controllers/miq_policy_controller.rb:667
+#: ../../app/controllers/pxe_controller.rb:169 ../../app/controllers/pxe_controller.rb:199
+msgid "Adding a new %{models}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:572 ../../app/controllers/ops_controller.rb:592 ../../app/controllers/ops_controller.rb:605 ../../app/controllers/ops_controller.rb:616 ../../app/controllers/ops_controller.rb:627 ../../app/controllers/vm_common.rb:1885 ../../app/controllers/catalog_controller.rb:240 ../../app/controllers/catalog_controller.rb:1173 ../../app/controllers/catalog_controller.rb:1322 ../../app/controllers/pxe_controller.rb:151 ../../app/controllers/pxe_controller.rb:183 ../../app/controllers/report_controller.rb:709 ../../app/controllers/report_controller.rb:717 ../../app/controllers/report_controller.rb:726 ../../app/controllers/report_controller.rb:741 ../../app/controllers/miq_policy_controller.rb:669
 msgid "Adding a new %{model}"
 msgstr ""
 
@@ -1515,20 +2672,49 @@ msgstr ""
 msgid "Adding a new %{name}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:610 ../../app/controllers/miq_policy_controller.rb:686 ../../app/controllers/miq_policy_controller.rb:701
+#: ../../app/controllers/miq_policy_controller.rb:610 ../../app/controllers/miq_policy_controller.rb:688 ../../app/controllers/miq_policy_controller.rb:703
 msgid "Adding a new %{record}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:558
+#: ../../app/controllers/catalog_controller.rb:1812
+msgid "Adding a new Button"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1818
+msgid "Adding a new Button Group"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1372
+msgid "Adding a new Catalog Bundle"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:584
 msgid "Adding a new Category"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:792
+#: ../../app/controllers/catalog_controller.rb:762
 msgid "Adding a new Orchestration Template"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:823
-msgid "Adding a new Service Dialog from Orchestration Template \"%s\""
+#: ../../app/controllers/catalog_controller.rb:793
+msgid "Adding a new Service Dialog from Orchestration Template \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/report_controller.rb:695
+msgid "Adding a new dashboard"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:473
+msgid "Adding copy of '%{description}'"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3602
+msgid "Address"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:325
+msgid "Adhoc DB Backup at %{time}"
 msgstr ""
 
 #: ../../app/views/alert/_rss_list.html.haml:24
@@ -1543,18 +2729,23 @@ msgstr ""
 msgid "Advanced Search"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1669
+#: ../../app/controllers/vm_common.rb:1750
 msgid "Advanced Setting"
 msgid_plural "Advanced Settings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:238
+#: ../../app/controllers/host_controller.rb:241 ../../app/helpers/vm_cloud_helper/textual_summary.rb:129 ../../app/helpers/host_helper/textual_summary.rb:491 ../../app/helpers/vm_infra_helper/textual_summary.rb:158 ../../app/helpers/vm_helper/textual_summary.rb:192 ../../app/views/layouts/listnav/_host.html.haml:238
 msgid "Advanced Settings"
 msgstr ""
 
 #: ../model_attributes.rb:14
 msgid "Advanced setting"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AdvancedSetting.yaml
+#: ../yaml_strings.rb:2889
+msgid "AdvancedSetting"
 msgstr ""
 
 #: ../model_attributes.rb:15
@@ -1601,7 +2792,7 @@ msgstr ""
 msgid "AdvancedSetting|Value"
 msgstr ""
 
-#: ../../app/views/shared/views/_ownership.html.haml:77
+#: ../../app/views/shared/views/_ownership.html.haml:76
 msgid "Affected Items"
 msgstr ""
 
@@ -1609,8 +2800,54 @@ msgstr ""
 msgid "Affected VMs"
 msgstr ""
 
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#: ../yaml_strings.rb:2425
+msgid "Age of Last Message to Process"
+msgstr ""
+
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#: ../yaml_strings.rb:2423
+msgid "Age of Next Message to Process"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:458 ../../app/helpers/vm_infra_helper/textual_summary.rb:596 ../../app/helpers/vm_helper/textual_summary.rb:693
+msgid "Agent Address"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:463 ../../app/helpers/vm_infra_helper/textual_summary.rb:601 ../../app/helpers/vm_helper/textual_summary.rb:698
+msgid "Agent Port"
+msgstr ""
+
+#: ../../app/helpers/storage_manager_helper/textual_summary.rb:23
+msgid "Agent Type"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:57
+msgid "Aggregate %{title} CPU Cores"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:43
+msgid "Aggregate %{title} CPU Resources"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:53
+msgid "Aggregate %{title} CPUs"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:48
+msgid "Aggregate %{title} Memory"
+msgstr ""
+
 #: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:26
 msgid "Aggregate (free space)"
+msgstr ""
+
+#: ../../app/helpers/ems_container_helper/textual_summary.rb:68
+msgid "Aggregate Node CPU Cores"
+msgstr ""
+
+#: ../../app/helpers/ems_container_helper/textual_summary.rb:62
+msgid "Aggregate Node Memory"
 msgstr ""
 
 #: ../../app/controllers/ontap_storage_system_controller.rb:126
@@ -1631,8 +2868,9 @@ msgstr ""
 msgid "Alert Profile \"%{alert_profile}\" assignments succesfully saved"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAlertSet (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1135 ../../app/views/miq_policy/_alert_profile_folders.html.haml:24 ../dictionary_strings.rb:1523
+#: ../../app/controllers/miq_policy_controller.rb:1137 ../../app/views/miq_policy/_alert_profile_folders.html.haml:24 ../yaml_strings.rb:915 ../dictionary_strings.rb:1523
 msgid "Alert Profiles"
 msgstr ""
 
@@ -1640,8 +2878,10 @@ msgstr ""
 msgid "Alert Selection"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAlert (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1136 ../../app/views/miq_policy/_export.html.haml:105 ../../app/views/miq_policy/_alert_profile_details.html.haml:39 ../dictionary_strings.rb:1519
+#: ../../app/controllers/miq_policy_controller.rb:1138 ../../app/views/miq_policy/_export.html.haml:105 ../../app/views/miq_policy/_alert_profile_details.html.haml:39 ../yaml_strings.rb:930 ../dictionary_strings.rb:1519
 msgid "Alerts"
 msgstr ""
 
@@ -1653,20 +2893,16 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:82 ../../app/controllers/chargeback_controller.rb:83 ../../app/controllers/chargeback_controller.rb:84 ../../app/controllers/chargeback_controller.rb:439 ../../app/controllers/chargeback_controller.rb:455 ../../app/controllers/chargeback_controller.rb:466 ../../app/controllers/report_controller/dashboards.rb:217 ../../app/controllers/report_controller/dashboards.rb:237 ../../app/controllers/report_controller/widgets.rb:247 ../../app/controllers/report_controller/widgets.rb:261 ../../app/controllers/report_controller/menus.rb:739 ../../app/controllers/report_controller/saved_reports.rb:130 ../../app/controllers/report_controller/schedules.rb:52 ../../app/controllers/vm_common.rb:1373 ../../app/controllers/vm_common.rb:1389 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1366 ../../app/controllers/service_controller.rb:247 ../../app/controllers/container_controller.rb:208 ../../app/controllers/catalog_controller.rb:1646 ../../app/controllers/catalog_controller.rb:1649 ../../app/controllers/pxe_controller.rb:162 ../../app/controllers/pxe_controller.rb:182 ../../app/controllers/pxe_controller.rb:214 ../../app/controllers/report_controller.rb:157 ../../app/controllers/report_controller.rb:501 ../../app/controllers/pxe_controller/iso_datastores.rb:307 ../../app/controllers/pxe_controller/pxe_image_types.rb:216 ../../app/controllers/pxe_controller/pxe_servers.rb:482
+#: ../../app/controllers/chargeback_controller.rb:465 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1366
 msgid "All %s"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:625 ../../app/controllers/provider_foreman_controller.rb:648
+#: ../../app/controllers/provider_foreman_controller.rb:577 ../../app/controllers/provider_foreman_controller.rb:600
 msgid "All %s Configured Systems"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:583 ../../app/controllers/provider_foreman_controller.rb:656
+#: ../../app/controllers/provider_foreman_controller.rb:535 ../../app/controllers/provider_foreman_controller.rb:608
 msgid "All %s Providers"
-msgstr ""
-
-#: ../../app/controllers/ems_cluster_controller.rb:235
-msgid "All %s with %s"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:107
@@ -1677,11 +2913,11 @@ msgstr ""
 msgid "All %{items}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/policies.rb:232 ../../app/controllers/miq_policy_controller/conditions.rb:228 ../../app/controllers/miq_policy_controller/conditions.rb:236 ../../app/controllers/miq_policy_controller/policy_profiles.rb:146 ../../app/controllers/ops_controller/db.rb:189 ../../app/controllers/miq_policy_controller.rb:605
+#: ../../app/presenters/tree_builder.rb:140 ../../app/controllers/chargeback_controller.rb:54 ../../app/controllers/chargeback_controller.rb:438 ../../app/controllers/report_controller/dashboards.rb:237 ../../app/controllers/report_controller/widgets.rb:261 ../../app/controllers/report_controller/menus.rb:740 ../../app/controllers/report_controller/schedules.rb:52 ../../app/controllers/miq_policy_controller/policies.rb:232 ../../app/controllers/miq_policy_controller/conditions.rb:228 ../../app/controllers/miq_policy_controller/conditions.rb:236 ../../app/controllers/miq_policy_controller/policy_profiles.rb:146 ../../app/controllers/vm_common.rb:1467 ../../app/controllers/service_controller.rb:242 ../../app/controllers/container_controller.rb:206 ../../app/controllers/catalog_controller.rb:1641 ../../app/controllers/catalog_controller.rb:1644 ../../app/controllers/ops_controller/db.rb:189 ../../app/controllers/pxe_controller.rb:146 ../../app/controllers/pxe_controller.rb:166 ../../app/controllers/pxe_controller.rb:198 ../../app/controllers/report_controller.rb:153 ../../app/controllers/report_controller.rb:497 ../../app/controllers/pxe_controller/iso_datastores.rb:307 ../../app/controllers/pxe_controller/pxe_image_types.rb:216 ../../app/controllers/pxe_controller/pxe_servers.rb:482 ../../app/controllers/miq_policy_controller.rb:605
 msgid "All %{models}"
 msgstr ""
 
-#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:250
+#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:251
 msgid "All %{model} - %{group}"
 msgstr ""
 
@@ -1693,12 +2929,35 @@ msgstr ""
 msgid "All %{tables}"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:620 ../../app/controllers/miq_policy_controller.rb:623 ../../app/controllers/miq_policy_controller.rb:960 ../../app/controllers/miq_policy_controller.rb:968 ../../app/controllers/miq_policy_controller.rb:975
+#: ../../app/controllers/ems_cluster_controller.rb:255
+msgid "All %{titles} with %{name}"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1439
+msgid "All %{title}"
+msgstr ""
+
+#: ../../app/controllers/miq_policy_controller.rb:620 ../../app/controllers/miq_policy_controller.rb:623 ../../app/controllers/miq_policy_controller.rb:629 ../../app/controllers/miq_policy_controller.rb:962 ../../app/controllers/miq_policy_controller.rb:970 ../../app/controllers/miq_policy_controller.rb:977
 msgid "All %{typ} %{model}"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:86 ../../app/helpers/ems_cluster_helper/textual_summary.rb:63
-msgid "All (%s)"
+#: ../../app/helpers/host_helper/textual_summary.rb:89 ../../app/helpers/ems_cluster_helper/textual_summary.rb:74
+msgid "All (%{number})"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:73
+msgid "All Accordions under Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:30
+msgid "All Accordions under Virtual Machines"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:12
+msgid "All Accordions under Workloads"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_action.rb:17
@@ -1713,27 +2972,40 @@ msgstr ""
 msgid "All Alerts"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:96
+#: ../../app/controllers/chargeback_controller.rb:55 ../../app/controllers/chargeback_controller.rb:454
+msgid "All Assignments"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:145
 msgid "All Catalog Items"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:99
+#: ../../app/presenters/tree_builder.rb:148
 msgid "All Catalogs"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:588
+msgid "All Clusters"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:589
+msgid "All Clusters for %{table}"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_condition.rb:18
 msgid "All Conditions"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:64 ../../app/controllers/provider_foreman_controller.rb:660
+#: ../../app/presenters/tree_builder.rb:109 ../../app/controllers/provider_foreman_controller.rb:612
 msgid "All Configured Systems"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:62 ../../app/presenters/tree_builder.rb:63
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:107 ../../app/presenters/tree_builder.rb:108 ../../app/controllers/container_controller.rb:190 ../yaml_strings.rb:1943
 msgid "All Containers"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:68
+#: ../../app/presenters/tree_builder.rb:113 ../../app/controllers/report_controller/dashboards.rb:217
 msgid "All Dashboards"
 msgstr ""
 
@@ -1741,7 +3013,19 @@ msgstr ""
 msgid "All Datastore customizations will be lost. Are you sure you want to reset all classes and instances to default?"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:72 ../../app/presenters/tree_builder.rb:80
+#: ../../app/controllers/ops_controller/settings/schedules.rb:596
+msgid "All Datastores"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:598
+msgid "All Datastores for %{table}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:597
+msgid "All Datastores for Host"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:121 ../../app/presenters/tree_builder.rb:129
 msgid "All Dialogs"
 msgstr ""
 
@@ -1749,27 +3033,39 @@ msgstr ""
 msgid "All Events"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:86
+#: ../../app/controllers/storage_controller.rb:186 ../../app/helpers/storage_helper/textual_summary.rb:164 ../../app/views/layouts/listnav/_storage.html.haml:86
 msgid "All Files"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:79
+#: ../../app/presenters/tree_builder_report_dashboards.rb:25
+msgid "All Groups"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:579
+msgid "All Hosts"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:580 ../../app/controllers/ops_controller/settings/schedules.rb:581
+msgid "All Hosts for %{table}"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:128
 msgid "All ISO Datastores"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:78
+#: ../../app/presenters/tree_builder.rb:127
 msgid "All Images"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:75
+#: ../../app/presenters/tree_builder.rb:124
 msgid "All Images by Provider that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:77
+#: ../../app/presenters/tree_builder.rb:126
 msgid "All Instances"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:76
+#: ../../app/presenters/tree_builder.rb:125
 msgid "All Instances by Provider that I can see"
 msgstr ""
 
@@ -1777,11 +3073,16 @@ msgstr ""
 msgid "All Object Types"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:81
+#: ../../app/presenters/tree_builder.rb:130
 msgid "All Orchestration Templates"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:86
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1173
+msgid "All Other Tasks"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:135
 msgid "All PXE Servers"
 msgstr ""
 
@@ -1793,36 +3094,64 @@ msgstr ""
 msgid "All Policy Profiles"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:87
+#: ../../app/controllers/alert_controller.rb:22
+msgid "All RSS Feeds"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:136
 msgid "All Reports"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:97
+#: ../../app/controllers/chargeback_controller.rb:56
+msgid "All Saved Chargeback Reports"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:146 ../../app/controllers/report_controller/saved_reports.rb:132
 msgid "All Saved Reports"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:98
+#: ../../app/presenters/tree_builder.rb:147
 msgid "All Schedules"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:100 ../../app/presenters/tree_builder.rb:101
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:149 ../../app/presenters/tree_builder.rb:150 ../yaml_strings.rb:235
 msgid "All Services"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:85
+#: ../../app/presenters/tree_builder.rb:134
 msgid "All System Image Types"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:104 ../../app/views/layouts/listnav/_ems_cluster.html.haml:65
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#: ../../app/presenters/tree_builder.rb:153 ../../app/controllers/ops_controller/settings/schedules.rb:569 ../../app/helpers/ems_cluster_helper/textual_summary.rb:163 ../../app/views/layouts/listnav/_ems_cluster.html.haml:65 ../yaml_strings.rb:3521
 msgid "All Templates"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:106
+#: ../../app/presenters/tree_builder.rb:155
 msgid "All Templates & Images"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:570 ../../app/controllers/ops_controller/settings/schedules.rb:571
+msgid "All Templates for %{table}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:572
+msgid "All Templates for Host"
 msgstr ""
 
 #: ../../app/views/miq_task/_tasks_options.html.haml:44 ../../app/views/configuration/_timeprofile_form.html.haml:45
 msgid "All Users"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1169
+msgid "All VM Analysis Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2017
+msgid "All VM and Instance Access Rules"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_condition.rb:25
@@ -1833,27 +3162,36 @@ msgstr ""
 msgid "All VMDB Indexes"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:103 ../../app/views/layouts/listnav/_resource_pool.html.haml:50 ../../app/views/layouts/listnav/_ems_cluster.html.haml:58 ../../app/views/miq_capacity/_planning_options.html.haml:16
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#: ../../app/presenters/tree_builder.rb:152 ../../app/controllers/ops_controller/settings/schedules.rb:559 ../../app/helpers/ems_cluster_helper/textual_summary.rb:151 ../../app/helpers/resource_pool_helper/textual_summary.rb:99 ../../app/views/layouts/listnav/_resource_pool.html.haml:50 ../../app/views/layouts/listnav/_ems_cluster.html.haml:58 ../../app/views/miq_capacity/_planning_options.html.haml:16 ../yaml_strings.rb:3519
 msgid "All VMs"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:105
+#: ../../app/presenters/tree_builder.rb:154
 msgid "All VMs & Instances"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:102
+#: ../../app/presenters/tree_builder.rb:151 ../../app/controllers/vm_common.rb:1441 ../../app/controllers/vm_common.rb:1469
 msgid "All VMs & Templates"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:102
+#: ../../app/presenters/tree_builder.rb:151
 msgid "All VMs & Templates that I can see"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:58 ../../app/views/layouts/listnav/_ems_cluster.html.haml:72
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:173 ../../app/helpers/resource_pool_helper/textual_summary.rb:109 ../../app/views/layouts/listnav/_resource_pool.html.haml:58 ../../app/views/layouts/listnav/_ems_cluster.html.haml:72
 msgid "All VMs (Tree View)"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:108
+#: ../../app/controllers/ops_controller/settings/schedules.rb:560 ../../app/controllers/ops_controller/settings/schedules.rb:561
+msgid "All VMs for %{table}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:562
+msgid "All VMs for Host"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:157 ../../app/controllers/report_controller/widgets.rb:247
 msgid "All Widgets"
 msgstr ""
 
@@ -1865,7 +3203,7 @@ msgstr ""
 msgid "All attributes"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:148 ../../app/controllers/chargeback_controller.rb:268 ../../app/controllers/chargeback_controller.rb:347 ../../app/controllers/report_controller/dashboards.rb:44 ../../app/controllers/report_controller/dashboards.rb:103 ../../app/controllers/report_controller/widgets.rb:84 ../../app/controllers/report_controller/menus.rb:206 ../../app/controllers/report_controller/reports/editor.rb:84 ../../app/controllers/report_controller/schedules.rb:263 ../../app/controllers/miq_policy_controller/events.rb:17 ../../app/controllers/miq_policy_controller/policies.rb:23 ../../app/controllers/miq_policy_controller/miq_actions.rb:23 ../../app/controllers/miq_policy_controller/alerts.rb:43 ../../app/controllers/miq_policy_controller/alert_profiles.rb:22 ../../app/controllers/miq_policy_controller/alert_profiles.rb:102 ../../app/controllers/miq_policy_controller/conditions.rb:25 ../../app/controllers/miq_policy_controller/policy_profiles.rb:22 ../../app/controllers/vm_common.rb:906 ../../app/controllers/vm_common.rb:910 ../../app/controllers/vm_common.rb:1093 ../../app/controllers/miq_ae_class_controller.rb:638 ../../app/controllers/miq_ae_class_controller.rb:1026 ../../app/controllers/miq_ae_class_controller.rb:1074 ../../app/controllers/miq_ae_class_controller.rb:1119 ../../app/controllers/miq_ae_class_controller.rb:1175 ../../app/controllers/miq_ae_class_controller.rb:1511 ../../app/controllers/miq_ae_class_controller.rb:1551 ../../app/controllers/miq_ae_class_controller.rb:1723 ../../app/controllers/storage_manager_controller.rb:210 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:298 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:255 ../../app/controllers/catalog_controller.rb:108 ../../app/controllers/catalog_controller.rb:414 ../../app/controllers/catalog_controller.rb:651 ../../app/controllers/catalog_controller.rb:1021 ../../app/controllers/ops_controller/settings/tags.rb:123 ../../app/controllers/ops_controller/settings/ldap.rb:90 ../../app/controllers/ops_controller/settings/ldap.rb:251 ../../app/controllers/ops_controller/settings/zones.rb:53 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:338 ../../app/controllers/ops_controller/settings/cap_and_u.rb:44 ../../app/controllers/ops_controller/settings/schedules.rb:108 ../../app/controllers/ops_controller/settings/common.rb:503 ../../app/controllers/ops_controller/ops_rbac.rb:155 ../../app/controllers/ops_controller/ops_rbac.rb:222 ../../app/controllers/ops_controller/ops_rbac.rb:435 ../../app/controllers/ops_controller/ops_rbac.rb:605 ../../app/controllers/ops_controller/ops_rbac.rb:702 ../../app/controllers/ops_controller/settings.rb:188 ../../app/controllers/host_controller.rb:390 ../../app/controllers/configuration_controller.rb:282 ../../app/controllers/configuration_controller.rb:540 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:144 ../../app/controllers/pxe_controller/iso_datastores.rb:77 ../../app/controllers/pxe_controller/iso_datastores.rb:205 ../../app/controllers/pxe_controller/pxe_image_types.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:87 ../../app/controllers/pxe_controller/pxe_servers.rb:225 ../../app/controllers/pxe_controller/pxe_servers.rb:276 ../../app/controllers/ems_common.rb:285 ../../app/controllers/application_controller/explorer.rb:180 ../../app/controllers/application_controller/tags.rb:151 ../../app/controllers/application_controller/ci_processing.rb:171 ../../app/controllers/application_controller/ci_processing.rb:176 ../../app/controllers/application_controller/dialog_runner.rb:69 ../../app/controllers/application_controller/automate.rb:115 ../../app/controllers/application_controller/buttons.rb:50 ../../app/controllers/application_controller/buttons.rb:407 ../../app/controllers/application_controller/buttons.rb:551 ../../app/controllers/application_controller/policy_support.rb:36 ../../app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js:64 ../../app/assets/javascripts/controllers/ops/log_collection_form_controller.js:105 ../../app/assets/javascripts/controllers/ops/tenant_form_controller.js:69 ../../app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js:97 ../../app/assets/javascripts/controllers/service/service_form_controller.js:47 ../../app/assets/javascripts/controllers/repository/repository_form_controller.js:56 ../../app/assets/javascripts/controllers/host/host_form_controller.js:145 ../../app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js:174 ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:270
+#: ../../app/controllers/repository_controller.rb:149 ../../app/controllers/chargeback_controller.rb:240 ../../app/controllers/chargeback_controller.rb:329 ../../app/controllers/report_controller/dashboards.rb:44 ../../app/controllers/report_controller/dashboards.rb:103 ../../app/controllers/report_controller/widgets.rb:84 ../../app/controllers/report_controller/menus.rb:207 ../../app/controllers/report_controller/reports/editor.rb:84 ../../app/controllers/report_controller/schedules.rb:267 ../../app/controllers/miq_policy_controller/events.rb:17 ../../app/controllers/miq_policy_controller/policies.rb:23 ../../app/controllers/miq_policy_controller/miq_actions.rb:23 ../../app/controllers/miq_policy_controller/alerts.rb:43 ../../app/controllers/miq_policy_controller/alert_profiles.rb:22 ../../app/controllers/miq_policy_controller/alert_profiles.rb:102 ../../app/controllers/miq_policy_controller/conditions.rb:25 ../../app/controllers/miq_policy_controller/policy_profiles.rb:22 ../../app/controllers/vm_common.rb:967 ../../app/controllers/vm_common.rb:971 ../../app/controllers/vm_common.rb:1155 ../../app/controllers/miq_ae_class_controller.rb:632 ../../app/controllers/miq_ae_class_controller.rb:1020 ../../app/controllers/miq_ae_class_controller.rb:1068 ../../app/controllers/miq_ae_class_controller.rb:1113 ../../app/controllers/miq_ae_class_controller.rb:1169 ../../app/controllers/miq_ae_class_controller.rb:1505 ../../app/controllers/miq_ae_class_controller.rb:1545 ../../app/controllers/miq_ae_class_controller.rb:1725 ../../app/controllers/storage_manager_controller.rb:213 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:298 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:255 ../../app/controllers/catalog_controller.rb:109 ../../app/controllers/catalog_controller.rb:378 ../../app/controllers/catalog_controller.rb:617 ../../app/controllers/catalog_controller.rb:1016 ../../app/controllers/ops_controller/settings/tags.rb:127 ../../app/controllers/ops_controller/settings/ldap.rb:90 ../../app/controllers/ops_controller/settings/ldap.rb:251 ../../app/controllers/ops_controller/settings/zones.rb:53 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:338 ../../app/controllers/ops_controller/settings/cap_and_u.rb:44 ../../app/controllers/ops_controller/settings/schedules.rb:108 ../../app/controllers/ops_controller/settings/common.rb:503 ../../app/controllers/ops_controller/ops_rbac.rb:155 ../../app/controllers/ops_controller/ops_rbac.rb:222 ../../app/controllers/ops_controller/ops_rbac.rb:435 ../../app/controllers/ops_controller/ops_rbac.rb:605 ../../app/controllers/ops_controller/ops_rbac.rb:702 ../../app/controllers/ops_controller/settings.rb:188 ../../app/controllers/host_controller.rb:423 ../../app/controllers/configuration_controller.rb:282 ../../app/controllers/configuration_controller.rb:543 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:145 ../../app/controllers/pxe_controller/iso_datastores.rb:77 ../../app/controllers/pxe_controller/iso_datastores.rb:205 ../../app/controllers/pxe_controller/pxe_image_types.rb:68 ../../app/controllers/pxe_controller/pxe_servers.rb:87 ../../app/controllers/pxe_controller/pxe_servers.rb:225 ../../app/controllers/pxe_controller/pxe_servers.rb:276 ../../app/controllers/ems_common.rb:291 ../../app/controllers/application_controller/explorer.rb:180 ../../app/controllers/application_controller/tags.rb:151 ../../app/controllers/application_controller/ci_processing.rb:171 ../../app/controllers/application_controller/ci_processing.rb:176 ../../app/controllers/application_controller/dialog_runner.rb:69 ../../app/controllers/application_controller/automate.rb:115 ../../app/controllers/application_controller/buttons.rb:50 ../../app/controllers/application_controller/buttons.rb:407 ../../app/controllers/application_controller/buttons.rb:551 ../../app/controllers/application_controller/policy_support.rb:36 ../../app/assets/javascripts/controllers/ops/tenant_quota_form_controller.js:64 ../../app/assets/javascripts/controllers/ops/log_collection_form_controller.js:105 ../../app/assets/javascripts/controllers/ops/tenant_form_controller.js:69 ../../app/assets/javascripts/controllers/provider_foreman/provider_foreman_form_controller.js:97 ../../app/assets/javascripts/controllers/service/service_form_controller.js:47 ../../app/assets/javascripts/controllers/repository/repository_form_controller.js:56 ../../app/assets/javascripts/controllers/host/host_form_controller.js:145 ../../app/assets/javascripts/controllers/ems_common/ems_common_form_controller.js:174 ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:270
 msgid "All changes have been reset"
 msgstr ""
 
@@ -1877,27 +3215,27 @@ msgstr ""
 msgid "All fields are needed to perform verification of Database Settings"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:78
+#: ../../app/presenters/tree_builder.rb:127
 msgid "All of the Images that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:77
+#: ../../app/presenters/tree_builder.rb:126
 msgid "All of the Instances that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:106
+#: ../../app/presenters/tree_builder.rb:155
 msgid "All of the Templates & Images that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:104
+#: ../../app/presenters/tree_builder.rb:153
 msgid "All of the Templates that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:105
+#: ../../app/presenters/tree_builder.rb:154
 msgid "All of the VMs & Instances that I can see"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:103
+#: ../../app/presenters/tree_builder.rb:152
 msgid "All of the VMs that I can see"
 msgstr ""
 
@@ -1905,8 +3243,12 @@ msgstr ""
 msgid "All selected %{labels} are not in the current region"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:188
-msgid "All system services of %s"
+#: ../../app/controllers/host_controller.rb:218
+msgid "All system services of %{name}"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:139
+msgid "Allocated"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.allocated_memory
@@ -1926,8 +3268,26 @@ msgstr ""
 msgid "Allocated Number of Virtual Machines"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#: ../yaml_strings.rb:3016
+msgid "Allocated Size"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.allocated_storage
-#: ../dictionary_strings.rb:171
+#: ../yaml_strings.rb:3784 ../dictionary_strings.rb:171
 msgid "Allocated Storage"
 msgstr ""
 
@@ -1942,6 +3302,10 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.column.allocated_vcpu
 #: ../dictionary_strings.rb:173
 msgid "Allocated vCPU"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:391
+msgid "Allocation"
 msgstr ""
 
 #: ../../app/helpers/application_helper/discover.rb:6 ../../app/views/ops/_settings_authentication_tab.html.haml:55
@@ -1960,6 +3324,10 @@ msgstr ""
 msgid "Amazon access key and secret are needed to validate Amazon Settings"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:248
+msgid "An Owner must be selected"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_details.html.haml:246
 msgid "An alert must contain a valid expression."
 msgstr ""
@@ -1968,12 +3336,18 @@ msgstr ""
 msgid "An internal system error."
 msgstr ""
 
-#: ../../app/helpers/application_helper/tasks.rb:14 ../../app/views/ops/_schedule_show.html.haml:46
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/tasks.rb:14 ../../app/views/ops/_schedule_show.html.haml:46 ../yaml_strings.rb:491
 msgid "Analysis"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/common.rb:605
 msgid "Analysis Affinity was saved"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ScanHistory.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:269 ../../app/helpers/vm_infra_helper/textual_summary.rb:291 ../../app/helpers/vm_helper/textual_summary.rb:389 ../yaml_strings.rb:3320
+msgid "Analysis History"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet
@@ -1985,21 +3359,46 @@ msgstr ""
 msgid "Analysis Profile is required"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ScanItemSet.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ScanItemSet (plural form)
-#: ../../app/views/ops/_settings_details_tab.html.haml:69 ../../app/views/miq_policy/_action_options.html.haml:511 ../../app/views/miq_policy/_action_options.html.haml:520 ../dictionary_strings.rb:1681
+#: ../../app/presenters/tree_builder_ops_settings.rb:22 ../../app/views/ops/_settings_details_tab.html.haml:69 ../../app/views/miq_policy/_action_options.html.haml:511 ../../app/views/miq_policy/_action_options.html.haml:520 ../yaml_strings.rb:1212 ../dictionary_strings.rb:1681
 msgid "Analysis Profiles"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:884 ../../app/controllers/ems_common.rb:895
+#: ../../app/controllers/ems_common.rb:899 ../../app/controllers/ems_common.rb:910
 msgid "Analysis initiated for %{count_model} from the CFME Database"
 msgstr ""
 
-#: ../../app/views/ops/_all_tabs.html.haml:333
+#: ../../app/controllers/ops_controller.rb:223
+msgid "Analytics"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:468
+msgid "Analytics %{text}"
+msgstr ""
+
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#: ../../app/views/ops/_all_tabs.html.haml:333 ../yaml_strings.rb:2413
 msgid "Analytics Report"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/host_center.rb:65 ../../app/helpers/application_helper/toolbar/hosts_center.rb:107
+#: ../../app/controllers/ops_controller/analytics.rb:32
+msgid "Analytics Report for '%{description}'"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/analytics.rb:44
+msgid "Analytics Report for Enterprise"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/host_center.rb:65 ../../app/helpers/application_helper/toolbar/hosts_center.rb:107 ../yaml_strings.rb:528
 msgid "Analyze then Check Compliance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:530
+msgid "Analyze then Check Compliance for Hosts / Nodes"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/hosts_center.rb:106
@@ -2026,6 +3425,20 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.model.FileDepotFtpAnonymous (plural form)
 #: ../dictionary_strings.rb:1365
 msgid "Anonymous FTPs"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3474
+msgid "Ansible Tower Configured System"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:24 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:26
+msgid "Ansible Tower Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#: ../../app/presenters/tree_builder_configuration_manager.rb:25 ../../app/presenters/tree_builder_configuration_manager.rb:27 ../yaml_strings.rb:3470
+msgid "Ansible Tower Providers"
 msgstr ""
 
 #: ../../app/views/pxe/_pxe_image_type_form.html.haml:39
@@ -2056,11 +3469,22 @@ msgstr ""
 msgid "Appliances in this region can be registered with:"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:329 ../../app/helpers/vm_infra_helper/textual_summary.rb:343 ../../app/helpers/vm_helper/textual_summary.rb:441
+msgid "Application"
+msgid_plural "Applications"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#: ../yaml_strings.rb:3429
+msgid "Applications"
+msgstr ""
+
 #: ../../app/views/miq_policy/_action_options.html.haml:102 ../../app/views/miq_policy/_action_details.html.haml:309
 msgid "Applied Tag"
 msgstr ""
 
-#: ../../app/views/miq_request/_prov_options.html.haml:125 ../../app/views/miq_request/_prov_options.html.haml:143 ../../app/views/miq_task/_tasks_options.html.haml:148 ../../app/views/miq_task/_tasks_options.html.haml:165 ../../app/views/layouts/_user_input_filter.html.haml:105 ../../app/views/layouts/_x_edit_buttons.html.haml:54 ../../app/views/layouts/_x_edit_buttons.html.haml:145 ../../app/views/layouts/listnav/_compare_sections.html.haml:180 ../../app/views/layouts/_ae_tree_select.html.haml:70 ../../app/views/layouts/_ae_tree_select.html.haml:91 ../../app/views/layouts/_adv_search_footer.html.haml:27 ../../app/views/layouts/_adv_search_footer.html.haml:30
+#: ../../app/views/miq_request/_prov_options.html.haml:125 ../../app/views/miq_request/_prov_options.html.haml:143 ../../app/views/miq_task/_tasks_options.html.haml:148 ../../app/views/miq_task/_tasks_options.html.haml:165 ../../app/views/layouts/_user_input_filter.html.haml:105 ../../app/views/layouts/_x_edit_buttons.html.haml:54 ../../app/views/layouts/_x_edit_buttons.html.haml:145 ../../app/views/layouts/listnav/_compare_sections.html.haml:176 ../../app/views/layouts/_ae_tree_select.html.haml:70 ../../app/views/layouts/_ae_tree_select.html.haml:91 ../../app/views/layouts/_adv_search_footer.html.haml:27 ../../app/views/layouts/_adv_search_footer.html.haml:30
 msgid "Apply"
 msgstr ""
 
@@ -2068,7 +3492,7 @@ msgstr ""
 msgid "Apply CFME Update"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_compare_sections.html.haml:180 ../../app/views/layouts/listnav/_compare_sections.html.haml:180
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:176 ../../app/views/layouts/listnav/_compare_sections.html.haml:176
 msgid "Apply sections"
 msgstr ""
 
@@ -2080,6 +3504,14 @@ msgstr ""
 msgid "Apply the current filter (Enter)"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:374
+msgid "Apply the good VM custom variable value records"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:376
+msgid "Apply the good import records"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_options.html.haml:143 ../../app/views/miq_task/_tasks_options.html.haml:165
 msgid "Apply the selected filters"
 msgstr ""
@@ -2088,7 +3520,9 @@ msgstr ""
 msgid "Apply this filter"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:159
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:159 ../yaml_strings.rb:3656
 msgid "Approval State"
 msgstr ""
 
@@ -2101,8 +3535,33 @@ msgstr ""
 msgid "Approvals"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:117
+msgid "Approve and Deny"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:119
+msgid "Approve and Deny Requests"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_request_center.rb:31
 msgid "Approve this Request"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:417
+msgid "Approved"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../yaml_strings.rb:3713
+msgid "Approved/Denied By"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../yaml_strings.rb:3671
+msgid "Approved/Denied On"
 msgstr ""
 
 #: ../../app/views/miq_request/_request.html.haml:173 ../../app/views/miq_request/_request_details.html.haml:58
@@ -2113,13 +3572,36 @@ msgstr ""
 msgid "Approved/Denied on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_arch
-#: ../../app/helpers/provider_foreman_helper.rb:88 ../../app/helpers/provider_foreman_helper.rb:169 ../dictionary_strings.rb:997
+#: ../../app/helpers/provider_foreman_helper.rb:88 ../../app/helpers/provider_foreman_helper.rb:169 ../yaml_strings.rb:3024 ../dictionary_strings.rb:997
 msgid "Architecture"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:124
+msgid "Architecture "
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1459
+msgid "Archived %{models}"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_images.rb:21
+msgid "Archived Images"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_instances.rb:21
 msgid "Archived Instances"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1461
+msgid "Archived VMs & Templates"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_vandt.rb:15
@@ -2219,7 +3701,7 @@ msgid "Are you sure you want to delete this item and all of it's children?"
 msgstr ""
 
 #: ../../app/presenters/widget_presenter.rb:58
-msgid "Are you sure you want to remove '%s'from the Dashboard?"
+msgid "Are you sure you want to remove '%{title}'from the Dashboard?"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb:53
@@ -2364,15 +3846,17 @@ msgstr ""
 msgid "Assigning %{hosts} but only have %{hosts_count} hosts available."
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:59 ../../app/views/miq_policy/_alert_profile_assign.html.haml:8
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:104 ../../app/controllers/chargeback_controller.rb:363 ../../app/views/miq_policy/_alert_profile_assign.html.haml:8 ../yaml_strings.rb:816
 msgid "Assignments"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:221
-msgid "At least %{num} %{model} must be selected for %{action}"
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:818
+msgid "Assignments Accordion"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1496
+#: ../../app/controllers/application_controller/ci_processing.rb:1510
 msgid "At least 1 %{model} must be selected for Policy Simulation"
 msgstr ""
 
@@ -2380,7 +3864,7 @@ msgstr ""
 msgid "At least 1 item must be selected for discovery"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:122 ../../app/controllers/miq_policy_controller.rb:40
+#: ../../app/controllers/miq_ae_customization_controller.rb:122 ../../app/controllers/report_controller.rb:217 ../../app/controllers/miq_policy_controller.rb:40
 msgid "At least 1 item must be selected for export"
 msgstr ""
 
@@ -2392,11 +3876,7 @@ msgstr ""
 msgid "At least 2 Analyses must be selected for Drift"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:295
-msgid "At least one %s must be configured"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:236 ../../app/controllers/application_controller/timelines.rb:62 ../../app/controllers/application_controller/timelines.rb:72
+#: ../../app/controllers/application_controller/timelines.rb:62 ../../app/controllers/application_controller/timelines.rb:72
 msgid "At least one %s must be selected"
 msgstr ""
 
@@ -2412,7 +3892,11 @@ msgstr ""
 msgid "At least one Category must be selected"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:494 ../../app/controllers/configuration_controller.rb:552
+#: ../../app/controllers/report_controller/widgets.rb:733
+msgid "At least one Column must be selected"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:497 ../../app/controllers/configuration_controller.rb:556
 msgid "At least one Day must be selected"
 msgstr ""
 
@@ -2420,11 +3904,15 @@ msgstr ""
 msgid "At least one E-mail recipient must be configured"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:497 ../../app/controllers/configuration_controller.rb:555
+#: ../../app/controllers/report_controller/reports.rb:237
+msgid "At least one Field must be selected"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:500 ../../app/controllers/configuration_controller.rb:559
 msgid "At least one Hour must be selected"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:1272
+#: ../../app/controllers/ops_controller/ops_rbac.rb:1277
 msgid "At least one Product Feature must be selected"
 msgstr ""
 
@@ -2436,8 +3924,16 @@ msgstr ""
 msgid "At least one Selection must be checked"
 msgstr ""
 
+#: ../../app/controllers/report_controller/widgets.rb:737
+msgid "At least one Shortcut must be selected"
+msgstr ""
+
 #: ../../app/controllers/miq_policy_controller/miq_actions.rb:418
 msgid "At least one Tag must be selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:299
+msgid "At least one To E-mail address must be configured"
 msgstr ""
 
 #: ../../app/controllers/miq_capacity_controller.rb:98 ../../app/controllers/miq_capacity_controller.rb:239
@@ -2488,12 +3984,20 @@ msgstr ""
 msgid "Attributes with same values"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:898
+msgid "Audit"
+msgstr ""
+
 #: ../../app/views/ops/_all_tabs.html.haml:175
 msgid "Audit Log"
 msgstr ""
 
 #: ../model_attributes.rb:29
 msgid "Audit event"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:188
+msgid "Audit log downloaded"
 msgstr ""
 
 #: ../model_attributes.rb:30
@@ -2526,6 +4030,21 @@ msgstr ""
 
 #: ../model_attributes.rb:37
 msgid "AuditEvent|Userid"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+#: ../yaml_strings.rb:3737
+msgid "Auth Key Pair"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:364
+msgid "Auth Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+#: ../yaml_strings.rb:3739
+msgid "AuthKeyPair"
 msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:7 ../../app/views/ops/_settings_server_tab.html.haml:473 ../../app/views/ops/_all_tabs.html.haml:27 ../model_attributes.rb:38
@@ -2612,8 +4131,9 @@ msgstr ""
 msgid "Automate"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeClass
-#: ../dictionary_strings.rb:1497
+#: ../yaml_strings.rb:994 ../dictionary_strings.rb:1497
 msgid "Automate Class"
 msgstr ""
 
@@ -2627,13 +4147,25 @@ msgstr ""
 msgid "Automate Domain"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeDomain (plural form)
-#: ../dictionary_strings.rb:1503
+#: ../yaml_strings.rb:958 ../dictionary_strings.rb:1503
 msgid "Automate Domains"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:956
+msgid "Automate Explorer"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1119
+msgid "Automate Import/Export"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeInstance
-#: ../dictionary_strings.rb:1505
+#: ../yaml_strings.rb:1008 ../dictionary_strings.rb:1505
 msgid "Automate Instance"
 msgstr ""
 
@@ -2642,8 +4174,14 @@ msgstr ""
 msgid "Automate Instances"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1121
+msgid "Automate Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeMethod
-#: ../dictionary_strings.rb:1509
+#: ../yaml_strings.rb:1020 ../dictionary_strings.rb:1509
 msgid "Automate Method"
 msgstr ""
 
@@ -2652,14 +4190,25 @@ msgstr ""
 msgid "Automate Methods"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace
-#: ../dictionary_strings.rb:1513
+#: ../yaml_strings.rb:984 ../dictionary_strings.rb:1513
 msgid "Automate Namespace"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.MiqAeNamespace (plural form)
 #: ../dictionary_strings.rb:1515
 msgid "Automate Namespaces"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1032
+msgid "Automate Schema"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1040
+msgid "Automate Simulation"
 msgstr ""
 
 #: ../../app/controllers/application_controller/automate.rb:21
@@ -2674,20 +4223,34 @@ msgstr ""
 msgid "Automations Tasks"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/AvailabilityZone.yaml
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone
 #. TRANSLATORS: en.yml key: dictionary.table.availability_zone
-#: ../dictionary_strings.rb:1259 ../dictionary_strings.rb:1753
+#: ../../app/controllers/availability_zone_controller.rb:168 ../yaml_strings.rb:2663 ../dictionary_strings.rb:1259 ../dictionary_strings.rb:1753
 msgid "Availability Zone"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.AvailabilityZone (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.availability_zone (plural form)
-#: ../../app/presenters/menu/default_menu.rb:27 ../../app/views/configuration/_ui_2.html.haml:131 ../dictionary_strings.rb:1261 ../dictionary_strings.rb:1755
+#: ../../app/presenters/menu/default_menu.rb:27 ../../app/views/configuration/_ui_2.html.haml:131 ../yaml_strings.rb:312 ../dictionary_strings.rb:1261 ../dictionary_strings.rb:1755
 msgid "Availability Zones"
 msgstr ""
 
 #: ../model_attributes.rb:53
 msgid "Availability zone"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AvailabilityZone.yaml
+#: ../yaml_strings.rb:3873
+msgid "AvailabilityZone"
 msgstr ""
 
 #: ../model_attributes.rb:54
@@ -2696,6 +4259,14 @@ msgstr ""
 
 #: ../model_attributes.rb:55
 msgid "AvailabilityZone|Name"
+msgstr ""
+
+#: ../../app/controllers/availability_zone_controller.rb:21
+msgid "Availabilty Zones"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:140 ../../app/helpers/vm_cloud_helper/textual_summary.rb:442 ../../app/helpers/vm_cloud_helper/textual_summary.rb:499 ../../app/helpers/host_helper/textual_summary.rb:205 ../../app/helpers/host_helper/textual_summary.rb:397 ../../app/helpers/host_helper/textual_summary.rb:502 ../../app/helpers/ops_helper/textual_summary.rb:139 ../../app/helpers/ems_infra_helper/textual_summary.rb:68 ../../app/helpers/ems_infra_helper/textual_summary.rb:80 ../../app/helpers/vm_infra_helper/textual_summary.rb:168 ../../app/helpers/vm_infra_helper/textual_summary.rb:532 ../../app/helpers/vm_infra_helper/textual_summary.rb:637 ../../app/helpers/vm_helper/textual_summary.rb:202 ../../app/helpers/vm_helper/textual_summary.rb:629 ../../app/helpers/vm_helper/textual_summary.rb:756
+msgid "Available"
 msgstr ""
 
 #: ../../app/views/miq_policy/_alert_profile_details.html.haml:70
@@ -2754,7 +4325,7 @@ msgstr ""
 msgid "Available Widgets:"
 msgstr ""
 
-#: ../../app/views/vm_common/_right_size.html.haml:30
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:665 ../../app/helpers/vm_infra_helper/textual_summary.rb:674 ../../app/helpers/vm_infra_helper/textual_summary.rb:684 ../../app/helpers/vm_infra_helper/textual_summary.rb:695 ../../app/helpers/vm_helper/textual_summary.rb:784 ../../app/helpers/vm_helper/textual_summary.rb:793 ../../app/helpers/vm_helper/textual_summary.rb:803 ../../app/helpers/vm_helper/textual_summary.rb:814 ../../app/views/vm_common/_right_size.html.haml:30
 msgid "Average"
 msgstr ""
 
@@ -2772,8 +4343,46 @@ msgstr ""
 msgid "Averages Based On"
 msgstr ""
 
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2695
+msgid "Avg CPU MHz"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2702
+msgid "Avg Disk I/O KBs (Total Bytes)"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2699
+msgid "Avg Disk Space"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2705
+msgid "Avg Net I/O KBs (Total Bytes)"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2697
+msgid "Avg RAM"
+msgstr ""
+
 #: ../../app/helpers/application_helper/discover.rb:5
 msgid "Azure"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#: ../yaml_strings.rb:2734
+msgid "Azure Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#: ../yaml_strings.rb:2732
+msgid "Azure Orchestration Templates"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure
@@ -2782,7 +4391,7 @@ msgid "Azure Template"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateAzure (plural form)
-#: ../dictionary_strings.rb:1649
+#: ../../app/presenters/tree_builder_orchestration_templates.rb:18 ../../app/presenters/tree_builder_orchestration_templates.rb:20 ../dictionary_strings.rb:1649
 msgid "Azure Templates"
 msgstr ""
 
@@ -2808,6 +4417,10 @@ msgstr ""
 msgid "Back (ABCD...)"
 msgstr ""
 
+#: ../../app/helpers/container_helper/textual_summary.rb:62
+msgid "Backing Ref (Container ID)"
+msgstr ""
+
 #: ../../app/views/ops/_diagnostics_database_tab.html.haml:96
 msgid "Backup Schedules"
 msgstr ""
@@ -2821,12 +4434,28 @@ msgstr ""
 msgid "Base Extents"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1442
+msgid "Base Storage Extents"
+msgstr ""
+
 #: ../../app/views/report/_form_tl_settings.html.haml:23
 msgid "Base Timeline on"
 msgstr ""
 
-#: ../../app/views/report/_report_info.html.haml:66 ../../app/views/miq_policy/_alert_profile_assign.html.haml:17 ../../app/views/miq_policy/_alert_details.html.haml:64
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
+#: ../../app/views/report/_report_info.html.haml:66 ../../app/views/miq_policy/_alert_profile_assign.html.haml:17 ../../app/views/miq_policy/_alert_details.html.haml:64 ../yaml_strings.rb:3699
 msgid "Based On"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:106 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:99
+msgid "Based On Underlying Redundancy"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#: ../yaml_strings.rb:3202
+msgid "Based Volumes"
 msgstr ""
 
 #: ../../app/views/ops/_logs_selected.html.haml:8 ../../app/views/ops/_diagnostics_database_tab.html.haml:12 ../../app/views/miq_ae_customization/_dialog_details.html.haml:18 ../../app/views/chargeback/_cb_rate_edit.html.haml:6 ../../app/views/chargeback/_cb_assignments.html.haml:9 ../../app/views/chargeback/_cb_rate_show.html.haml:7 ../../app/views/shared/buttons/_group_form.html.haml:8 ../../app/views/catalog/_form.html.haml:4 ../../app/views/catalog/_sandt_tree_show.html.haml:8 ../../app/views/catalog/_stcat_form.html.haml:11
@@ -2905,12 +4534,20 @@ msgstr ""
 msgid "BinaryBlob|Size"
 msgstr ""
 
+#: ../../app/helpers/middleware_server_helper/textual_summary.rb:32
+msgid "Bind Address"
+msgstr ""
+
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:356 ../../app/views/ops/_ldap_forest_entries.html.haml:26 ../../app/views/ops/_ldap_domain_form.html.haml:167 ../../app/views/ops/_ldap_domain_show.html.haml:209 ../../app/views/_ldap_domain_form.html.haml:167
 msgid "Bind DN"
 msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:373 ../../app/views/ops/_ldap_forest_entries.html.haml:28 ../../app/views/ops/_ldap_domain_form.html.haml:184 ../../app/views/ops/_ldap_domain_show.html.haml:225 ../../app/views/_ldap_domain_form.html.haml:184
 msgid "Bind Password"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:109
+msgid "Black"
 msgstr ""
 
 #: ../model_attributes.rb:67
@@ -2931,6 +4568,63 @@ msgstr ""
 
 #: ../model_attributes.rb:71
 msgid "BlacklistedEvent|System"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:81 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:74 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:53
+msgid "Block Size"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../../app/helpers/flavor_helper/textual_summary.rb:66 ../yaml_strings.rb:3462
+msgid "Block Storage Based"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3604
+msgid "Blocked By"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:107
+msgid "Blue"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:10
+msgid "Blue Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:9
+msgid "Blue Text"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2351
+msgid "Boolean (Pass/Fail)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2345
+msgid "Boolean (T/F)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2343
+msgid "Boolean (True/False)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2349
+msgid "Boolean (Y/N)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2347
+msgid "Boolean (Yes/No)"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#: ../yaml_strings.rb:3841
+msgid "Bootable?"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_bottlenecks_report.html.haml:13
@@ -2977,7 +4671,8 @@ msgstr ""
 msgid "BottleneckEvent|Timestamp"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:156
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:156 ../yaml_strings.rb:1129
 msgid "Bottlenecks"
 msgstr ""
 
@@ -2999,6 +4694,21 @@ msgstr ""
 
 #: ../../app/views/support/show.html.haml:17
 msgid "Browser Version"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#: ../yaml_strings.rb:3483
+msgid "Build"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3318
+msgid "Build State"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.CustomButton
@@ -3027,6 +4737,11 @@ msgstr ""
 msgid "Button Group Text"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1099
+msgid "Button Groups"
+msgstr ""
+
 #: ../../app/views/shared/buttons/_ab_list.html.haml:166 ../../app/views/shared/buttons/_ab_show.html.haml:35 ../../app/views/shared/buttons/_ab_form.html.haml:69
 msgid "Button Hover Text"
 msgstr ""
@@ -3051,7 +4766,7 @@ msgstr ""
 msgid "Button Text is required"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:193 ../../app/controllers/miq_ae_tools_controller.rb:29 ../../app/controllers/vm_common.rb:20 ../../app/controllers/vm_common.rb:951 ../../app/controllers/miq_request_controller.rb:23 ../../app/controllers/storage_manager_controller.rb:23 ../../app/controllers/orchestration_stack_controller.rb:123 ../../app/controllers/resource_pool_controller.rb:149 ../../app/controllers/cim_instance_controller.rb:83 ../../app/controllers/storage_controller.rb:137 ../../app/controllers/container_controller.rb:49 ../../app/controllers/host_controller.rb:510 ../../app/controllers/configuration_controller.rb:54 ../../app/controllers/availability_zone_controller.rb:118 ../../app/controllers/miq_policy_controller.rb:92 ../../app/controllers/ems_cluster_controller.rb:192 ../../app/controllers/application_controller/filter.rb:48 ../../app/controllers/application_controller/policy_support.rb:151 ../../app/helpers/application_helper.rb:668
+#: ../../app/controllers/repository_controller.rb:194 ../../app/controllers/miq_ae_tools_controller.rb:29 ../../app/controllers/vm_common.rb:20 ../../app/controllers/vm_common.rb:1012 ../../app/controllers/miq_request_controller.rb:23 ../../app/controllers/storage_manager_controller.rb:23 ../../app/controllers/orchestration_stack_controller.rb:123 ../../app/controllers/resource_pool_controller.rb:149 ../../app/controllers/cim_instance_controller.rb:83 ../../app/controllers/storage_controller.rb:160 ../../app/controllers/host_controller.rb:547 ../../app/controllers/configuration_controller.rb:54 ../../app/controllers/availability_zone_controller.rb:135 ../../app/controllers/miq_policy_controller.rb:92 ../../app/controllers/ems_cluster_controller.rb:212 ../../app/controllers/application_controller/filter.rb:50 ../../app/controllers/application_controller/policy_support.rb:151 ../../app/helpers/application_helper.rb:670
 msgid "Button not yet implemented"
 msgstr ""
 
@@ -3059,14 +4774,24 @@ msgstr ""
 msgid "Button not yet implemented %{model_name}:%{action_name}"
 msgstr ""
 
+#: ../../app/controllers/container_controller.rb:50
+msgid "Button not yet implemented %{model}: %{action}"
+msgstr ""
+
 #: ../../app/controllers/application_controller/explorer.rb:138
 msgid "Button not yet implemented %{model}:%{action}"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.CustomButton (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.custom_button (plural form)
-#: ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:50 ../dictionary_strings.rb:1293 ../dictionary_strings.rb:1835
+#: ../../app/controllers/miq_ae_customization_controller.rb:205 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:50 ../yaml_strings.rb:1095 ../dictionary_strings.rb:1293 ../dictionary_strings.rb:1835
 msgid "Buttons"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1097
+msgid "Buttons Accordion"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet
@@ -3075,9 +4800,14 @@ msgstr ""
 msgid "Buttons Group"
 msgstr ""
 
+#: ../../app/controllers/catalog_controller.rb:1821
+msgid "Buttons Group Reorder"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.CustomButtonSet (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.custom_button_set (plural form)
-#: ../dictionary_strings.rb:1297 ../dictionary_strings.rb:1839
+#: ../yaml_strings.rb:1109 ../dictionary_strings.rb:1297 ../dictionary_strings.rb:1839
 msgid "Buttons Groups"
 msgstr ""
 
@@ -3117,15 +4847,19 @@ msgstr ""
 msgid "C & U Data Processors"
 msgstr ""
 
-#: ../../app/views/layouts/_multi_auth_credentials.html.haml:21 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:18
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:110 ../../app/helpers/ems_infra_helper/textual_summary.rb:152 ../../app/views/layouts/_multi_auth_credentials.html.haml:21 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:18
 msgid "C & U Database"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:534
+msgid "C & U Database Login Password and Verify Password fields do not match"
 msgstr ""
 
 #: ../../app/views/ops/_all_tabs.html.haml:140
 msgid "C & U Gap Collection"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:258
+#: ../../app/controllers/ops_controller/diagnostics.rb:270
 msgid "C & U Gap Collection successfully initiated"
 msgstr ""
 
@@ -3134,7 +4868,11 @@ msgstr ""
 msgid "CD/DVD Drives"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:33
+#: ../../app/controllers/ops_controller/diagnostics.rb:892
+msgid "CFME"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:37
 msgid "CFME Appliance restart initiated successfully"
 msgstr ""
 
@@ -3146,7 +4884,11 @@ msgstr ""
 msgid "CFME Log"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:733 ../../app/controllers/ops_controller/diagnostics.rb:751
+#: ../../app/presenters/tree_builder.rb:99 ../../app/presenters/tree_builder.rb:116 ../../app/presenters/tree_builder.rb:118
+msgid "CFME Region: %{region_description} [%{region}]"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:753 ../../app/controllers/ops_controller/diagnostics.rb:771
 msgid "CFME Server \"%{name}\" set as %{priority} for Role \"%{role_description}\""
 msgstr ""
 
@@ -3154,12 +4896,33 @@ msgstr ""
 msgid "CFME Version"
 msgstr ""
 
-#: ../../app/helpers/application_helper/chargeback.rb:5 ../../app/views/vm_common/_right_size.html.haml:39 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:21 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:17
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1444
+msgid "CIM Base Storage Extents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1424
+msgid "CIM Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1388
+msgid "CIM Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1408
+msgid "CIM Storage Volumes"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:49 ../../app/helpers/application_helper/chargeback.rb:5 ../../app/helpers/vm_infra_helper/textual_summary.rb:664 ../../app/helpers/vm_helper/textual_summary.rb:783 ../../app/views/vm_common/_right_size.html.haml:39 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:21 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:13
 msgid "CPU"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.percent_cpu
-#: ../dictionary_strings.rb:711
+#: ../yaml_strings.rb:3911 ../dictionary_strings.rb:711
 msgid "CPU %"
 msgstr ""
 
@@ -3504,7 +5267,7 @@ msgid "CPU - Usage Rate for Collected Intervals 30 Day Low Avg (MHz)"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_affinity
-#: ../dictionary_strings.rb:239
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:142 ../../app/helpers/vm_helper/textual_summary.rb:176 ../dictionary_strings.rb:239
 msgid "CPU Affinity"
 msgstr ""
 
@@ -3513,13 +5276,22 @@ msgstr ""
 msgid "CPU Average Used MHz Trend"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../../app/helpers/flavor_helper/textual_summary.rb:41 ../yaml_strings.rb:3452
+msgid "CPU Cores"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:233
+msgid "CPU Cores Per Socket"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.v_cpu_vr_ratio
 #: ../dictionary_strings.rb:999
 msgid "CPU Cores Virtual to Real Ratio"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_limit
-#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:241
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:163 ../../app/views/vm_common/_config.html.haml:237 ../dictionary_strings.rb:241
 msgid "CPU Limit"
 msgstr ""
 
@@ -3543,27 +5315,28 @@ msgstr ""
 msgid "CPU Max Used MHz Trend"
 msgstr ""
 
-#: ../../app/views/ops/_selected_by_servers.html.haml:128 ../../app/views/ops/_selected_by_roles.html.haml:176 ../../app/views/ops/_server_desc.html.haml:83
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#: ../../app/views/ops/_selected_by_servers.html.haml:128 ../../app/views/ops/_selected_by_roles.html.haml:176 ../../app/views/ops/_server_desc.html.haml:83 ../yaml_strings.rb:3547
 msgid "CPU Percent"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve
-#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:245
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:151 ../../app/views/vm_common/_config.html.haml:237 ../dictionary_strings.rb:245
 msgid "CPU Reserve"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_reserve_expand
-#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:247
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:157 ../../app/views/vm_common/_config.html.haml:237 ../dictionary_strings.rb:247
 msgid "CPU Reserve Expand"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_shares
-#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:249
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:169 ../../app/views/vm_common/_config.html.haml:237 ../dictionary_strings.rb:249
 msgid "CPU Shares"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_shares_level
-#: ../../app/views/vm_common/_config.html.haml:240 ../dictionary_strings.rb:251
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:175 ../../app/views/vm_common/_config.html.haml:237 ../dictionary_strings.rb:251
 msgid "CPU Shares Level"
 msgstr ""
 
@@ -3572,8 +5345,10 @@ msgstr ""
 msgid "CPU Speed"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_time
-#: ../../app/views/ops/_selected_by_servers.html.haml:115 ../../app/views/ops/_selected_by_roles.html.haml:163 ../../app/views/ops/_server_desc.html.haml:73 ../dictionary_strings.rb:257
+#: ../../app/views/ops/_selected_by_servers.html.haml:115 ../../app/views/ops/_selected_by_roles.html.haml:163 ../../app/views/ops/_server_desc.html.haml:73 ../yaml_strings.rb:3550 ../dictionary_strings.rb:257
 msgid "CPU Time"
 msgstr ""
 
@@ -3597,7 +5372,7 @@ msgstr ""
 msgid "CPU Type"
 msgstr ""
 
-#: ../../app/views/vm_common/_right_size.html.haml:67
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:673 ../../app/helpers/vm_helper/textual_summary.rb:792 ../../app/views/vm_common/_right_size.html.haml:67
 msgid "CPU Usage"
 msgstr ""
 
@@ -3609,6 +5384,11 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_used_cost
 #: ../dictionary_strings.rb:1149
 msgid "CPU Used Cost"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2223
+msgid "CPU/Memory Recommendations"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:76 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:67
@@ -3623,6 +5403,11 @@ msgstr ""
 msgid "CPU/Memory Recommendations of this VM"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../../app/helpers/flavor_helper/textual_summary.rb:37 ../yaml_strings.rb:3450
+msgid "CPUs"
+msgstr ""
+
 #: ../../app/views/report/_schedule_email_options.html.haml:50
 msgid "CSV"
 msgstr ""
@@ -3635,7 +5420,8 @@ msgstr ""
 msgid "Can not delete folder, one or more reports in the selected folder are not owned by your group"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_edit_view.rb:28 ../../app/views/storage_manager/_form.html.haml:246 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:70 ../../app/views/ems_cloud/discover.html.haml:61 ../../app/views/ems_cloud/discover.html.haml:61 ../../app/views/miq_request/_prov_form_buttons.html.haml:15 ../../app/views/miq_request/_prov_form_buttons.html.haml:46 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:96 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/layouts/_discover.html.haml:110 ../../app/views/layouts/_discover.html.haml:110 ../../app/views/layouts/_user_input_filter.html.haml:123 ../../app/views/layouts/_x_edit_buttons.html.haml:130 ../../app/views/layouts/_x_edit_buttons.html.haml:173 ../../app/views/layouts/_x_edit_buttons.html.haml:193 ../../app/views/layouts/_x_edit_buttons.html.haml:211 ../../app/views/layouts/_form_buttons.html.haml:82 ../../app/views/layouts/_form_buttons.html.haml:105 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_ae_tree_select.html.haml:79 ../../app/views/layouts/_ae_tree_select.html.haml:93 ../../app/views/layouts/_adv_search_footer.html.haml:99 ../../app/views/layouts/_adv_search_footer.html.haml:118 ../../app/views/layouts/_edit_form_buttons.html.haml:133 ../../app/views/layouts/_edit_form_buttons.html.haml:142 ../../app/views/layouts/_edit_form_buttons.html.haml:176 ../../app/views/layouts/_edit_form_buttons.html.haml:185 ../../app/views/layouts/_x_dialog_buttons.html.haml:46 ../../app/views/layouts/_x_dialog_buttons.html.haml:71 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:37 ../../app/views/vm_common/_reconfigure.html.haml:174 ../../app/views/vm_common/_snap.html.haml:70 ../../app/views/vm_common/_add_to_service.html.haml:56 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/report/_export_widgets.html.haml:68 ../../app/views/ontap_file_share/_create_datastore.html.haml:73 ../../app/views/shared/views/_retire.html.haml:112 ../../app/views/shared/views/_retire.html.haml:112 ../../app/views/shared/views/ems_common/_form.html.haml:187 ../../app/views/miq_policy/_export.html.haml:34
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_edit_view.rb:28 ../../app/views/storage_manager/_form.html.haml:246 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:70 ../../app/views/ems_cloud/discover.html.haml:61 ../../app/views/ems_cloud/discover.html.haml:61 ../../app/views/miq_request/_prov_form_buttons.html.haml:15 ../../app/views/miq_request/_prov_form_buttons.html.haml:46 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:96 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/ems_infra/scaling.html.haml:66 ../../app/views/layouts/_discover.html.haml:110 ../../app/views/layouts/_discover.html.haml:110 ../../app/views/layouts/_user_input_filter.html.haml:123 ../../app/views/layouts/_x_edit_buttons.html.haml:130 ../../app/views/layouts/_x_edit_buttons.html.haml:173 ../../app/views/layouts/_x_edit_buttons.html.haml:193 ../../app/views/layouts/_x_edit_buttons.html.haml:211 ../../app/views/layouts/_form_buttons.html.haml:82 ../../app/views/layouts/_form_buttons.html.haml:105 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:40 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_edit_buttons.html.haml:65 ../../app/views/layouts/_ae_tree_select.html.haml:79 ../../app/views/layouts/_ae_tree_select.html.haml:93 ../../app/views/layouts/_adv_search_footer.html.haml:99 ../../app/views/layouts/_adv_search_footer.html.haml:118 ../../app/views/layouts/_edit_form_buttons.html.haml:133 ../../app/views/layouts/_edit_form_buttons.html.haml:142 ../../app/views/layouts/_edit_form_buttons.html.haml:176 ../../app/views/layouts/_edit_form_buttons.html.haml:185 ../../app/views/layouts/_x_dialog_buttons.html.haml:46 ../../app/views/layouts/_x_dialog_buttons.html.haml:71 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:37 ../../app/views/vm_common/_reconfigure.html.haml:174 ../../app/views/vm_common/_snap.html.haml:70 ../../app/views/vm_common/_add_to_service.html.haml:56 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/configuration/_timeprofile_form.html.haml:125 ../../app/views/report/_export_widgets.html.haml:68 ../../app/views/ontap_file_share/_create_datastore.html.haml:73 ../../app/views/shared/views/_retire.html.haml:112 ../../app/views/shared/views/_retire.html.haml:112 ../../app/views/shared/views/ems_common/_form.html.haml:187 ../../app/views/miq_policy/_export.html.haml:34 ../yaml_strings.rb:1199
 msgid "Cancel"
 msgstr ""
 
@@ -3657,6 +5443,11 @@ msgstr ""
 
 #: ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:36 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:62
 msgid "Cancel Simulation to go back to Button details"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1201
+msgid "Cancel Task"
 msgstr ""
 
 #: ../../app/views/report/_form_columns.html.haml:60
@@ -3695,6 +5486,10 @@ msgstr ""
 msgid "Cancel this provisioning request"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:408
+msgid "Cancelling"
+msgstr ""
+
 #: ../../app/views/dashboard/_widgets_menu.html.haml:14
 msgid "Cannot add a Widget, this Dashboard has been locked by the Administrator"
 msgstr ""
@@ -3707,11 +5502,11 @@ msgstr ""
 msgid "Cannot display binary content"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:615
+#: ../../app/controllers/ops_controller/diagnostics.rb:635
 msgid "Cannot start log collection, a log collection is already in progress within this scope"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:613
+#: ../../app/controllers/ops_controller/diagnostics.rb:633
 msgid "Cannot start log collection, requires a started server"
 msgstr ""
 
@@ -3719,11 +5514,11 @@ msgstr ""
 msgid "Canvas not supported."
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:73 ../../app/views/layouts/listnav/_container_group.html.haml:23 ../../app/views/layouts/listnav/_container_group.html.haml:31 ../../app/views/layouts/listnav/_storage.html.haml:18 ../../app/views/layouts/listnav/_ems_container.html.haml:23 ../../app/views/layouts/listnav/_ems_container.html.haml:31 ../../app/views/layouts/listnav/_ems_cluster.html.haml:26 ../../app/views/layouts/listnav/_container_replicator.html.haml:23 ../../app/views/layouts/listnav/_container_replicator.html.haml:31 ../../app/views/layouts/listnav/_container_node.html.haml:23 ../../app/views/layouts/listnav/_container_node.html.haml:31 ../../app/views/layouts/listnav/_container_service.html.haml:23 ../../app/views/layouts/listnav/_container_service.html.haml:31 ../../app/views/layouts/listnav/_container_project.html.haml:23 ../../app/views/layouts/listnav/_container_project.html.haml:31
+#: ../../app/views/layouts/listnav/_host.html.haml:73 ../../app/views/layouts/listnav/_container_group.html.haml:19 ../../app/views/layouts/listnav/_container_group.html.haml:27 ../../app/views/layouts/listnav/_storage.html.haml:18 ../../app/views/layouts/listnav/_ems_container.html.haml:19 ../../app/views/layouts/listnav/_ems_container.html.haml:27 ../../app/views/layouts/listnav/_ems_cluster.html.haml:26 ../../app/views/layouts/listnav/_container_replicator.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:27 ../../app/views/layouts/listnav/_container_node.html.haml:19 ../../app/views/layouts/listnav/_container_node.html.haml:27 ../../app/views/layouts/listnav/_container_service.html.haml:19 ../../app/views/layouts/listnav/_container_service.html.haml:27 ../../app/views/layouts/listnav/_container_project.html.haml:19 ../../app/views/layouts/listnav/_container_project.html.haml:27
 msgid "Capacity & Utilization"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1769
+#: ../../app/controllers/vm_common.rb:1850
 msgid "Capacity & Utilization data for %{model} \"%{name}\""
 msgstr ""
 
@@ -3970,6 +5765,10 @@ msgstr ""
 msgid "Capacity and Utilization Collection settings saved"
 msgstr ""
 
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:45 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:38 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:35
+msgid "Caption"
+msgstr ""
+
 #: ../../app/views/ops/_settings_co_categories_tab.html.haml:20
 msgid "Capture C & U Data"
 msgstr ""
@@ -3978,10 +5777,19 @@ msgstr ""
 msgid "Capture C & U Data by Tag"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog
 #. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog
-#: ../../app/views/catalog/_form_basic_info.html.haml:54 ../../app/views/catalog/_sandt_tree_show.html.haml:56 ../dictionary_strings.rb:1691 ../dictionary_strings.rb:2085
+#: ../../app/views/catalog/_form_basic_info.html.haml:54 ../../app/views/catalog/_sandt_tree_show.html.haml:56 ../yaml_strings.rb:3735 ../dictionary_strings.rb:1691 ../dictionary_strings.rb:2085
 msgid "Catalog"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:353
+msgid "Catalog Bundle \"%{name}\" was added"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:351
+msgid "Catalog Bundle \"%{name}\" was saved"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.service_template
@@ -3993,15 +5801,25 @@ msgstr ""
 msgid "Catalog Item Type"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ServiceCatalog.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.service_template (plural form)
-#: ../../app/views/configuration/_ui_2.html.haml:49 ../../app/views/catalog/_stcat_tree_show.html.haml:49 ../dictionary_strings.rb:2083
+#: ../../app/controllers/catalog_controller.rb:835 ../../app/controllers/catalog_controller.rb:1974 ../../app/views/configuration/_ui_2.html.haml:49 ../../app/views/catalog/_stcat_tree_show.html.haml:49 ../yaml_strings.rb:143 ../dictionary_strings.rb:2083
 msgid "Catalog Items"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ServiceTemplateCatalog (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.service_template_catalog (plural form)
-#: ../../app/presenters/menu/default_menu.rb:18 ../dictionary_strings.rb:1693 ../dictionary_strings.rb:2087
+#: ../../app/presenters/menu/default_menu.rb:18 ../../app/controllers/catalog_controller.rb:845 ../yaml_strings.rb:188 ../dictionary_strings.rb:1693 ../dictionary_strings.rb:2087
 msgid "Catalogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:137
+msgid "Catalogs Explorer"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.Classification (plural form)
@@ -4009,9 +5827,22 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Classification
-#: ../../app/views/ops/_settings_co_tags_tab.html.haml:15 ../../app/views/ops/_ap_form.html.haml:82 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:517 ../../app/views/layouts/_classify_table.html.haml:11 ../../app/views/layouts/_tag_edit_assignments.html.haml:13 ../dictionary_strings.rb:1275
+#: ../../app/views/ops/_settings_co_tags_tab.html.haml:15 ../../app/views/ops/_ap_form.html.haml:82 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:517 ../../app/views/layouts/_classify_table.html.haml:11 ../../app/views/layouts/_tag_edit_assignments.html.haml:13 ../yaml_strings.rb:3863 ../dictionary_strings.rb:1275
 msgid "Category"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/tags.rb:261
+msgid "Category %{description} [%{name}] record created ("
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/tags.rb:223
+msgid "Category %{description} [%{name}] record deleted"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/tags.rb:276
+msgid "Category %{description} [%{name}] record updated ("
 msgstr ""
 
 #: ../../app/views/ops/_settings_co_categories_tab.html.haml:60
@@ -4087,8 +5918,9 @@ msgstr ""
 msgid "Changing the UI Workers Count will immediately restart the webserver"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.Chargeback
-#: ../../app/presenters/menu/default_menu.rb:9 ../dictionary_strings.rb:1263
+#: ../../app/presenters/menu/default_menu.rb:9 ../../app/controllers/chargeback_controller.rb:839 ../yaml_strings.rb:798 ../dictionary_strings.rb:1263
 msgid "Chargeback"
 msgstr ""
 
@@ -4105,8 +5937,9 @@ msgstr ""
 msgid "Chargeback Rate"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ChargebackRate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ChargebackRate (plural form)
-#: ../dictionary_strings.rb:1269
+#: ../yaml_strings.rb:3853 ../dictionary_strings.rb:1269
 msgid "Chargeback Rates"
 msgstr ""
 
@@ -4219,6 +6052,18 @@ msgstr ""
 msgid "Chart no longer exists"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:551
+msgid "Charts"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:341
+msgid "Charts tab is not available unless a sort field has been selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:339
+msgid "Charts tab is not available until at least 1 field has been selected"
+msgstr ""
+
 #: ../../app/views/ops/_settings_cu_collection_tab.html.haml:61 ../../app/views/ops/_settings_cu_collection_tab.html.haml:120 ../../app/views/layouts/exp_atom/_edit_find.html.haml:151 ../../app/views/miq_ae_class/_class_instances.html.haml:14 ../../app/views/miq_ae_class/_class_methods.html.haml:14 ../../app/views/miq_ae_class/_ns_list.html.haml:15 ../../app/views/miq_ae_class/_ns_details.html.haml:13
 msgid "Check All"
 msgstr ""
@@ -4227,12 +6072,19 @@ msgstr ""
 msgid "Check Any"
 msgstr ""
 
-#: ../../app/helpers/application_helper/tasks.rb:6
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/tasks.rb:6 ../yaml_strings.rb:532
 msgid "Check Compliance"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:92 ../../app/helpers/application_helper/toolbar/host_center.rb:59 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:90 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:68 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:79 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:94 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:103 ../../app/helpers/application_helper/toolbar/vms_center.rb:95 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:129 ../../app/helpers/application_helper/toolbar/hosts_center.rb:98 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:120 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:104 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:69
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:92 ../../app/helpers/application_helper/toolbar/host_center.rb:59 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:90 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:68 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:79 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:94 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:103 ../../app/helpers/application_helper/toolbar/vms_center.rb:95 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:129 ../../app/helpers/application_helper/toolbar/hosts_center.rb:98 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:120 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:104 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:69 ../yaml_strings.rb:2041
 msgid "Check Compliance of Last Known Configuration"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:534
+msgid "Check Compliance of Last Known Configuration for Hosts / Nodes"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:93 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:102
@@ -4267,7 +6119,7 @@ msgstr ""
 msgid "Check Count"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1462
+#: ../../app/controllers/application_controller/filter.rb:1353
 msgid "Check Value Error: %{msg}"
 msgstr ""
 
@@ -4275,7 +6127,7 @@ msgstr ""
 msgid "Check for Updates"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:292
+#: ../../app/controllers/ops_controller/settings/rhn.rb:296
 msgid "Check for updates"
 msgstr ""
 
@@ -4375,12 +6227,47 @@ msgstr ""
 msgid "Choose>"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1495
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#: ../yaml_strings.rb:3410
+msgid "Cim Base Storage Extent"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#: ../yaml_strings.rb:3865
+msgid "Cim Logical Disk"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#: ../yaml_strings.rb:3897
+msgid "Cim Storage Extent"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#: ../yaml_strings.rb:3523
+msgid "Cim Storage Volume"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#: ../yaml_strings.rb:3412
+msgid "CimBaseStorageExtents"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#: ../yaml_strings.rb:3899
+msgid "CimStorageExtents"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1489
 msgid "Class Schema Sequence was saved"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_fields_seq_form.html.haml:19
 msgid "Class Schema Sequencing:"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqAeClass.yaml
+#: ../yaml_strings.rb:3271
+msgid "Classes"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_utilization_options.html.haml:40 ../model_attributes.rb:101
@@ -4523,6 +6410,10 @@ msgstr ""
 msgid "Click to remove this policy"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:505
+msgid "Click to select"
+msgstr ""
+
 #: ../../app/views/catalog/_sandt_tree_show.html.haml:258 ../../app/views/catalog/_stcat_tree_show.html.haml:57
 msgid "Click to this Catalog Item"
 msgstr ""
@@ -4619,6 +6510,16 @@ msgstr ""
 msgid "Client Keys do not match"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2289
+msgid "Clone Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2207
+msgid "Clone VMs"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/template_infras_center.rb:122
 msgid "Clone selected Template"
 msgstr ""
@@ -4643,11 +6544,19 @@ msgstr ""
 msgid "Close any duplicate browser sessions, then select a menu option above."
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#: ../yaml_strings.rb:3504
+msgid "Cloud"
+msgstr ""
+
 #: ../../app/presenters/menu/default_menu.rb:5
 msgid "Cloud Intelligence"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:52
+#. TRANSLATORS: file: product/views/CloudNetwork.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:52 ../yaml_strings.rb:3396
 msgid "Cloud Networks"
 msgstr ""
 
@@ -4656,9 +6565,17 @@ msgstr ""
 msgid "Cloud Networks (Openstack)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/AvailabilityZone.yaml
+#. TRANSLATORS: file: product/views/CloudTenant.yaml
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager
 #. TRANSLATORS: en.yml key: dictionary.table.ems_cloud
-#: ../dictionary_strings.rb:1421 ../dictionary_strings.rb:1841
+#: ../yaml_strings.rb:3211 ../dictionary_strings.rb:1421 ../dictionary_strings.rb:1841
 msgid "Cloud Provider"
 msgstr ""
 
@@ -4677,10 +6594,12 @@ msgstr ""
 msgid "Cloud Provider (Openstack)"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_cloud (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_clouds
-#: ../dictionary_strings.rb:1423 ../dictionary_strings.rb:1843 ../dictionary_strings.rb:1845
+#: ../yaml_strings.rb:270 ../dictionary_strings.rb:1423 ../dictionary_strings.rb:1843 ../dictionary_strings.rb:1845
 msgid "Cloud Providers"
 msgstr ""
 
@@ -4703,8 +6622,22 @@ msgstr ""
 msgid "Cloud Quota"
 msgstr ""
 
+#: ../../app/helpers/vm_helper.rb:28
+msgid "Cloud Subnet"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudTenant.yaml
+#: ../../app/controllers/cloud_tenant_controller.rb:132 ../yaml_strings.rb:3727
+msgid "Cloud Tenant"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:22
 msgid "Cloud Tenant:"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/cloud_tenant_controller.rb:49 ../yaml_strings.rb:332
+msgid "Cloud Tenants"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_openstack_cloud_manager_cloud_tenant
@@ -4712,15 +6645,39 @@ msgstr ""
 msgid "Cloud Tenants (Openstack)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.cloud_volume
-#: ../dictionary_strings.rb:1761
+#: ../yaml_strings.rb:3199 ../dictionary_strings.rb:1761
 msgid "Cloud Volume"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#: ../yaml_strings.rb:3192
+msgid "Cloud Volume Snapshot"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:378
+msgid "Cloud Volume Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.cloud_volume (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.cloud_volumes
-#: ../dictionary_strings.rb:1763 ../dictionary_strings.rb:1765
+#: ../../app/controllers/cloud_volume_controller.rb:28 ../yaml_strings.rb:350 ../dictionary_strings.rb:1763 ../dictionary_strings.rb:1765
 msgid "Cloud Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#: ../yaml_strings.rb:3835
+msgid "Cloud Volumes based on Snapshot"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:43 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:49
+msgid "Cloud Volumes based on Snapshot (%{count})"
 msgstr ""
 
 #: ../model_attributes.rb:111
@@ -4772,8 +6729,18 @@ msgid "CloudFormation Template"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateCfn (plural form)
-#: ../dictionary_strings.rb:1641
+#: ../../app/presenters/tree_builder_orchestration_templates.rb:8 ../../app/presenters/tree_builder_orchestration_templates.rb:10 ../dictionary_strings.rb:1641
 msgid "CloudFormation Templates"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#: ../yaml_strings.rb:3230
+msgid "CloudFormations Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#: ../yaml_strings.rb:3228
+msgid "CloudFormations Orchestration Templates"
 msgstr ""
 
 #: ../../app/views/pxe/_template_form.html.haml:73
@@ -4892,6 +6859,11 @@ msgstr ""
 msgid "CloudSubnet|Status"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CloudTenant.yaml
+#: ../yaml_strings.rb:3729
+msgid "CloudTenant"
+msgstr ""
+
 #: ../model_attributes.rb:145
 msgid "CloudTenant|Description"
 msgstr ""
@@ -4906,6 +6878,18 @@ msgstr ""
 
 #: ../model_attributes.rb:148
 msgid "CloudTenant|Name"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#: ../yaml_strings.rb:3838
+msgid "CloudVolume"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#: ../yaml_strings.rb:3195
+msgid "CloudVolumeSnapshot"
 msgstr ""
 
 #: ../model_attributes.rb:159
@@ -4968,14 +6952,26 @@ msgstr ""
 msgid "Clouds"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.ems_cluster_name
-#: ../../app/helpers/application_helper.rb:1244 ../../app/helpers/application_helper.rb:1257 ../dictionary_strings.rb:383
+#: ../../app/helpers/application_helper.rb:1251 ../../app/helpers/application_helper.rb:1264 ../yaml_strings.rb:2636 ../dictionary_strings.rb:383
 msgid "Cluster"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.EmsCluster
 #. TRANSLATORS: en.yml key: dictionary.table.ems_cluster
-#: ../../app/presenters/tree_builder_utilization.rb:16 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:118 ../../app/helpers/application_helper.rb:1248 ../dictionary_strings.rb:1335 ../dictionary_strings.rb:1847
+#: ../../app/presenters/tree_builder_utilization.rb:16 ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:118 ../../app/helpers/application_helper.rb:1255 ../dictionary_strings.rb:1335 ../dictionary_strings.rb:1847
 msgid "Cluster / Deployment Role"
 msgstr ""
 
@@ -4998,12 +6994,18 @@ msgstr ""
 msgid "Cluster in Datacenter"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1244
+#: ../../app/controllers/ems_cluster_controller.rb:283
+msgid "Cluster: %{name}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#: ../../app/presenters/menu/default_menu.rb:40 ../../app/controllers/ems_cluster_controller.rb:31 ../../app/controllers/ems_cluster_controller.rb:328 ../../app/helpers/ui_constants.rb:351 ../../app/helpers/application_helper.rb:1251 ../yaml_strings.rb:3515
 msgid "Clusters"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.ems_clusters
-#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1248 ../dictionary_strings.rb:1851
+#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1255 ../yaml_strings.rb:465 ../dictionary_strings.rb:1851
 msgid "Clusters / Deployment Roles"
 msgstr ""
 
@@ -5015,8 +7017,18 @@ msgstr ""
 msgid "Collect"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1332
+msgid "Collect All Logs"
+msgstr ""
+
 #: ../../app/views/ops/_ap_form_file.html.haml:17
 msgid "Collect Contents?"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1334
+msgid "Collect Current Logs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:51 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:51 ../../app/views/ops/_all_tabs.html.haml:137 ../../app/views/ops/_all_tabs.html.haml:168
@@ -5059,6 +7071,11 @@ msgstr ""
 msgid "Collect the current logs from the selected #{ui_lookup(:table=>\"zone\")}"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#: ../yaml_strings.rb:3818
+msgid "Collected On"
+msgstr ""
+
 #: ../../app/views/ops/_diagnostics_cu_repair_tab.html.haml:15
 msgid "Collection Options"
 msgstr ""
@@ -5091,7 +7108,23 @@ msgstr ""
 msgid "Column Name"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:250 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:93 ../../app/views/miq_ae_tools/_import_export.html.haml:166 ../../app/views/report/_menu_form1.html.haml:88 ../../app/views/report/_menu_form2.html.haml:168 ../../app/views/report/_export_widgets.html.haml:66 ../../app/views/miq_policy/_export.html.haml:18 ../../app/views/miq_policy/_export.html.haml:24
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2405
+msgid "Comma seperated list"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../../app/helpers/container_helper/textual_summary.rb:66 ../yaml_strings.rb:3612
+msgid "Command"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#: ../yaml_strings.rb:3120
+msgid "Comment"
+msgstr ""
+
+#: ../../app/controllers/report_controller.rb:246 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:93 ../../app/views/miq_ae_tools/_import_export.html.haml:166 ../../app/views/report/_menu_form1.html.haml:88 ../../app/views/report/_menu_form2.html.haml:168 ../../app/views/report/_export_widgets.html.haml:66 ../../app/views/miq_policy/_export.html.haml:18 ../../app/views/miq_policy/_export.html.haml:24
 msgid "Commit"
 msgstr ""
 
@@ -5111,16 +7144,37 @@ msgstr ""
 msgid "Commit report management changes"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1606
+msgid "Common"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1608
+msgid "Common Buttons"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:73
 msgid "Company Name"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:21
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/configuration/_ui_2.html.haml:21 ../yaml_strings.rb:471
 msgid "Compare"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1725
-msgid "Compare %s"
+#: ../../app/controllers/vm_common.rb:1806
+msgid "Compare %{model}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:473
+msgid "Compare List of Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:512
+msgid "Compare List of Hosts / Nodes"
 msgstr ""
 
 #: ../../app/views/configuration/_ui_2.html.haml:21
@@ -5139,6 +7193,26 @@ msgstr ""
 msgid "Compare To"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2113
+msgid "Compare multiple Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2029
+msgid "Compare multiple Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2265
+msgid "Compare multiple Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2151
+msgid "Compare multiple VMs"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:156 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:160
 msgid "Compare selected Templates"
 msgstr ""
@@ -5147,11 +7221,13 @@ msgstr ""
 msgid "Compare selected VMs"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_compare_sections.html.haml:157
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:153
 msgid "Comparison Sections"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:140
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:140 ../yaml_strings.rb:3668
 msgid "Completed"
 msgstr ""
 
@@ -5229,12 +7305,50 @@ msgstr ""
 msgid "Compliance|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#: ../yaml_strings.rb:3002
+msgid "Compliant"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:382 ../../app/helpers/vm_helper/textual_summary.rb:740
+msgid "Compliant as of %{time} Ago"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#: ../yaml_strings.rb:3755
+msgid "Component"
+msgstr ""
+
 #: ../../app/views/ems_container/_main.html.haml:12
 msgid "Component Statuses"
 msgstr ""
 
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:139
+msgid "Compressed Data"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/compare_view.rb:12 ../../app/helpers/application_helper/toolbar/drift_view.rb:12 ../../app/helpers/configuration_helper/configuration_view_helper.rb:43 ../../app/helpers/configuration_helper/configuration_view_helper.rb:48
 msgid "Compressed View"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:143
+msgid "Compression Saved Percentage"
 msgstr ""
 
 #: ../../app/views/chargeback/_assignments_list.html.haml:22
@@ -5245,6 +7359,11 @@ msgstr ""
 msgid "Compute Profile"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#: ../yaml_strings.rb:3859
+msgid "Computer Name"
+msgstr ""
+
 #: ../model_attributes.rb:178
 msgid "Computer system"
 msgstr ""
@@ -5253,8 +7372,9 @@ msgstr ""
 msgid "ComputerSystem|Managed entity type"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Condition.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Condition
-#: ../dictionary_strings.rb:1287 ../model_attributes.rb:180
+#: ../yaml_strings.rb:3777 ../dictionary_strings.rb:1287 ../model_attributes.rb:180
 msgid "Condition"
 msgstr ""
 
@@ -5266,8 +7386,22 @@ msgstr ""
 msgid "Condition Selection"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ConditionSet.yaml
+#: ../yaml_strings.rb:3903
+msgid "Condition Sets"
+msgstr ""
+
 #: ../model_attributes.rb:193
 msgid "Condition set"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:804
+msgid "Condition:"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConditionSet.yaml
+#: ../yaml_strings.rb:3905
+msgid "ConditionSet"
 msgstr ""
 
 #: ../model_attributes.rb:194
@@ -5314,8 +7448,10 @@ msgstr ""
 msgid "ConditionSet|Userid"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Condition.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Condition (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1133 ../../app/views/container_group/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:17 ../../app/views/miq_policy/_policy_details.html.haml:232 ../dictionary_strings.rb:1289
+#: ../../app/controllers/miq_policy_controller.rb:1135 ../../app/views/container_group/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:17 ../../app/views/miq_policy/_policy_details.html.haml:232 ../yaml_strings.rb:873 ../dictionary_strings.rb:1289
 msgid "Conditions"
 msgstr ""
 
@@ -5367,12 +7503,13 @@ msgstr ""
 msgid "Condition|Updated on"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:164 ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/saved_reports_center.rb:14 ../../app/helpers/application_helper/toolbar/saved_report_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_action_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_buttons_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:6 ../../app/helpers/application_helper/toolbar/host_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instances_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:6 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_set_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_method_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:6 ../../app/helpers/application_helper/toolbar/services_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_regions_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:11 ../../app/helpers/application_helper/toolbar/users_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_center.rb:13 ../../app/helpers/application_helper/toolbar/container_service_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:6 ../../app/helpers/application_helper/toolbar/container_center.rb:6 ../../app/helpers/application_helper/toolbar/condition_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_reports_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:6 ../../app/helpers/application_helper/toolbar/chargebacks_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/container_route_center.rb:6 ../../app/helpers/application_helper/toolbar/user_roles_center.rb:6 ../../app/helpers/application_helper/toolbar/user_role_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_region_center.rb:6 ../../app/helpers/application_helper/toolbar/time_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_actions_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:6 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/repository_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:6 ../../app/helpers/application_helper/toolbar/container_project_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_event_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policies_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_fields_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_server_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb:6 ../../app/helpers/application_helper/toolbar/vms_center.rb:6 ../../app/helpers/application_helper/toolbar/container_node_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastore_center.rb:6 ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/conditions_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:6 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:42 ../../app/helpers/application_helper/toolbar/custom_button_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/service_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_image_center.rb:6 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_methods_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:11 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:6 ../../app/helpers/application_helper/toolbar/container_group_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widgets_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_ae_class_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:6 ../../app/helpers/application_helper/toolbar/hosts_center.rb:6 ../../app/helpers/application_helper/toolbar/storages_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:6 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/windows_image_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_type_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_sets_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/repositories_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:74 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:6 ../../app/helpers/application_helper/toolbar/zone_center.rb:6 ../../app/helpers/application_helper/toolbar/dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alerts_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:6 ../../app/helpers/application_helper/toolbar/tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:6 ../../app/helpers/application_helper/toolbar/containers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/container_images_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instance_center.rb:6 ../../app/helpers/application_helper/toolbar/zones_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:11 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:13 ../../app/views/resource_pool/_main.html.haml:14 ../../app/views/vm_cloud/_main.html.haml:32 ../../app/views/host/_main.html.haml:21 ../../app/views/ems_cluster/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:217 ../../app/views/layouts/listnav/_ems_cluster.html.haml:19 ../../app/views/vm_common/_main.html.haml:33 ../../app/views/container_image/_main.html.haml:19 ../model_attributes.rb:205
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:164 ../../app/controllers/ops_controller.rb:822 ../../app/controllers/configuration_controller.rb:848 ../../app/controllers/ems_cluster_controller.rb:89 ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/saved_reports_center.rb:14 ../../app/helpers/application_helper/toolbar/saved_report_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_action_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_buttons_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:6 ../../app/helpers/application_helper/toolbar/host_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instances_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:6 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_set_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_method_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:6 ../../app/helpers/application_helper/toolbar/services_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_regions_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_namespace_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:11 ../../app/helpers/application_helper/toolbar/users_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_center.rb:13 ../../app/helpers/application_helper/toolbar/container_service_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:6 ../../app/helpers/application_helper/toolbar/container_center.rb:6 ../../app/helpers/application_helper/toolbar/condition_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_reports_center.rb:6 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:6 ../../app/helpers/application_helper/toolbar/chargebacks_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/container_route_center.rb:6 ../../app/helpers/application_helper/toolbar/user_roles_center.rb:6 ../../app/helpers/application_helper/toolbar/user_role_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:6 ../../app/helpers/application_helper/toolbar/ldap_region_center.rb:6 ../../app/helpers/application_helper/toolbar/time_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedule_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_actions_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:6 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/repository_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:6 ../../app/helpers/application_helper/toolbar/container_project_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_event_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policies_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_fields_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_server_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplatecatalogs_center.rb:6 ../../app/helpers/application_helper/toolbar/vms_center.rb:6 ../../app/helpers/application_helper/toolbar/container_node_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_datastore_center.rb:6 ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/conditions_center.rb:6 ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:6 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:42 ../../app/helpers/application_helper/toolbar/custom_button_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/service_center.rb:6 ../../app/helpers/application_helper/toolbar/iso_image_center.rb:6 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:6 ../../app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_policy_profile_center.rb:6 ../../app/helpers/application_helper/toolbar/dialog_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_methods_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:11 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:6 ../../app/helpers/application_helper/toolbar/container_group_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widgets_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_ae_class_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:6 ../../app/helpers/application_helper/toolbar/hosts_center.rb:6 ../../app/helpers/application_helper/toolbar/storages_center.rb:6 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:6 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:6 ../../app/helpers/application_helper/toolbar/scan_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/windows_image_center.rb:6 ../../app/helpers/application_helper/toolbar/pxe_image_type_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_widget_sets_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/repositories_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:74 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:6 ../../app/helpers/application_helper/toolbar/customization_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:6 ../../app/helpers/application_helper/toolbar/zone_center.rb:6 ../../app/helpers/application_helper/toolbar/dialogs_center.rb:6 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alerts_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:6 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:6 ../../app/helpers/application_helper/toolbar/tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:6 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:6 ../../app/helpers/application_helper/toolbar/containers_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_alert_profiles_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/container_images_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_ae_instance_center.rb:6 ../../app/helpers/application_helper/toolbar/zones_center.rb:6 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:11 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:13 ../../app/views/resource_pool/_main.html.haml:14 ../../app/views/vm_cloud/_main.html.haml:32 ../../app/views/host/_main.html.haml:21 ../../app/views/ems_cluster/_main.html.haml:19 ../../app/views/layouts/listnav/_host.html.haml:217 ../../app/views/layouts/listnav/_ems_cluster.html.haml:19 ../../app/views/vm_common/_main.html.haml:33 ../../app/views/container_image/_main.html.haml:19 ../yaml_strings.rb:1203 ../model_attributes.rb:205
 msgid "Configuration"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:94
-msgid "Configuration (%s)"
+#: ../../app/helpers/host_helper/textual_summary.rb:97
+msgid "Configuration (%{number})"
 msgstr ""
 
 #: ../../app/views/ops/_settings_advanced_tab.html.haml:38
@@ -5387,15 +7524,16 @@ msgstr ""
 msgid "Configuration Location"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:55
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:55 ../yaml_strings.rb:1977
 msgid "Configuration Management"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:377
+#: ../../app/views/configuration/_ui_2.html.haml:388
 msgid "Configuration Management Configured Systems"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:363
+#: ../../app/views/configuration/_ui_2.html.haml:374
 msgid "Configuration Management Providers"
 msgstr ""
 
@@ -5411,6 +7549,11 @@ msgstr ""
 
 #: ../../app/helpers/provider_foreman_helper.rb:115 ../../app/helpers/provider_foreman_helper.rb:196
 msgid "Configuration Organization"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3472
+msgid "Configuration Profile"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.manageiq_providers_foreman_configuration_manager_configuration_profile
@@ -5432,8 +7575,8 @@ msgstr ""
 msgid "Configuration XML"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:150
-msgid "Configuration files of %s"
+#: ../../app/controllers/host_controller.rb:180
+msgid "Configuration files of nova service"
 msgstr ""
 
 #: ../model_attributes.rb:210
@@ -5476,6 +7619,13 @@ msgstr ""
 msgid "ConfigurationLocation|Title"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2940
+msgid "ConfigurationManagerForeman"
+msgstr ""
+
 #: ../model_attributes.rb:216
 msgid "ConfigurationOrganization|Manager ref"
 msgstr ""
@@ -5490,6 +7640,11 @@ msgstr ""
 
 #: ../model_attributes.rb:219
 msgid "ConfigurationOrganization|Title"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#: ../yaml_strings.rb:3070
+msgid "ConfigurationProfile"
 msgstr ""
 
 #: ../model_attributes.rb:221
@@ -5540,12 +7695,26 @@ msgstr ""
 msgid "Configure Report Columns"
 msgstr ""
 
-#: ../../app/views/provider_foreman/_configuration_profile.html.haml:7 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:36
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/provider_foreman_controller.rb:452 ../../app/views/provider_foreman/_configuration_profile.html.haml:7 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:36 ../yaml_strings.rb:2009
 msgid "Configured Systems"
 msgstr ""
 
 #: ../model_attributes.rb:228
 msgid "Configured system"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3297
+msgid "ConfiguredSystem"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3301
+msgid "ConfiguredSystems"
 msgstr ""
 
 #: ../model_attributes.rb:229
@@ -5600,6 +7769,10 @@ msgstr ""
 msgid "Confirm Secret Access Key"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:71 ../../app/helpers/vm_infra_helper/textual_summary.rb:82 ../../app/helpers/vm_helper/textual_summary.rb:94
+msgid "Connect to this VM in its Region"
+msgstr ""
+
 #: ../../app/views/vm_common/console_spice.html.haml:31
 msgid "Connecting (unencrypted) to: %s"
 msgstr ""
@@ -5608,7 +7781,7 @@ msgstr ""
 msgid "Connection Broker"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:599
+#: ../../app/controllers/ops_controller/diagnostics.rb:614 ../../app/controllers/ops_controller/diagnostics.rb:619
 msgid "Connection Broker cache cleared successfully"
 msgstr ""
 
@@ -5616,32 +7789,81 @@ msgstr ""
 msgid "Connection failed."
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1246 ../../app/controllers/vm_common.rb:1253 ../../app/controllers/vm_common.rb:1266
-msgid "Console access failed: %s"
+#: ../../app/controllers/vm_common.rb:1310 ../../app/controllers/vm_common.rb:1331
+msgid "Console access failed: %{message}"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:149
+#: ../../app/controllers/vm_common.rb:1317
+msgid "Console access failed: Task start failed: ID [%{id}]"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:153
 msgid "Console access failed: proxy errror"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2187
+msgid "Console using MKS"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2195
+msgid "Console using VMRC"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2191
+msgid "Console using VNC"
 msgstr ""
 
 #: ../../app/views/report/_form_consolidate.html.haml:84
 msgid "Consolidating records will not show detail records in the report."
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:311
+msgid "Consolidation tab is not available until at least 1 field has been selected"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:85 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:78 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:57
+msgid "Consumable Blocks"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/Container.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Container
 #. TRANSLATORS: en.yml key: dictionary.table.container
-#: ../../app/controllers/vm_common.rb:1685 ../dictionary_strings.rb:1299 ../dictionary_strings.rb:1773 ../model_attributes.rb:237
+#: ../../app/controllers/vm_common.rb:1766 ../../app/helpers/vm_helper/textual_summary.rb:130 ../yaml_strings.rb:2680 ../dictionary_strings.rb:1299 ../dictionary_strings.rb:1773 ../model_attributes.rb:237
 msgid "Container"
 msgid_plural "Container"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/presenters/menu/default_menu.rb:103
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#: ../../app/presenters/menu/default_menu.rb:103 ../yaml_strings.rb:3788
 msgid "Container Images"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:94
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2669
+msgid "Container Node"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../../app/presenters/menu/default_menu.rb:94 ../yaml_strings.rb:3757
 msgid "Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2676
+msgid "Container Project"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#: ../yaml_strings.rb:3647
+msgid "Container Projects"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Atomic::ContainerManager
@@ -5684,7 +7906,30 @@ msgstr ""
 msgid "Container Providers (Openshift)"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:82
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2683
+msgid "Container Replicator"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#: ../yaml_strings.rb:3653
+msgid "Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerRoute.yaml
+#: ../yaml_strings.rb:3406
+msgid "Container Route"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#: ../yaml_strings.rb:3651
+msgid "Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#: ../../app/presenters/menu/default_menu.rb:82 ../yaml_strings.rb:3577
 msgid "Container Services"
 msgstr ""
 
@@ -5848,6 +8093,16 @@ msgstr ""
 msgid "ContainerGroup|Restart policy"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#: ../yaml_strings.rb:3790
+msgid "ContainerImage"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+#: ../yaml_strings.rb:3048
+msgid "ContainerImageRegistry"
+msgstr ""
+
 #: ../model_attributes.rb:278
 msgid "ContainerImageRegistry|Host"
 msgstr ""
@@ -5870,6 +8125,11 @@ msgstr ""
 
 #: ../model_attributes.rb:276
 msgid "ContainerImage|Tag"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../yaml_strings.rb:3759
+msgid "ContainerNode"
 msgstr ""
 
 #: ../model_attributes.rb:282
@@ -5940,6 +8200,11 @@ msgstr ""
 msgid "ContainerPortConfig|Protocol"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#: ../yaml_strings.rb:3649
+msgid "ContainerProject"
+msgstr ""
+
 #: ../model_attributes.rb:301
 msgid "ContainerProject|Creation timestamp"
 msgstr ""
@@ -5958,6 +8223,11 @@ msgstr ""
 
 #: ../model_attributes.rb:305
 msgid "ContainerProject|Resource version"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#: ../yaml_strings.rb:3641
+msgid "ContainerReplicator"
 msgstr ""
 
 #: ../model_attributes.rb:307
@@ -5984,6 +8254,11 @@ msgstr ""
 msgid "ContainerReplicator|Resource version"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerRoute.yaml
+#: ../yaml_strings.rb:3408
+msgid "ContainerRoute"
+msgstr ""
+
 #: ../model_attributes.rb:314
 msgid "ContainerRoute|Creation timestamp"
 msgstr ""
@@ -6006,6 +8281,11 @@ msgstr ""
 
 #: ../model_attributes.rb:319
 msgid "ContainerRoute|Resource version"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#: ../yaml_strings.rb:3579
+msgid "ContainerService"
 msgstr ""
 
 #: ../model_attributes.rb:328
@@ -6052,11 +8332,24 @@ msgstr ""
 msgid "ContainerService|Session affinity"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Container.yaml
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Container (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.containers
-#: ../../app/presenters/menu/default_menu.rb:77 ../../app/views/configuration/_ui_2.html.haml:75 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:19 ../dictionary_strings.rb:1301 ../dictionary_strings.rb:1775 ../dictionary_strings.rb:1777
+#: ../../app/presenters/menu/default_menu.rb:77 ../../app/views/configuration/_ui_2.html.haml:75 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:19 ../yaml_strings.rb:3371 ../dictionary_strings.rb:1301 ../dictionary_strings.rb:1775 ../dictionary_strings.rb:1777
 msgid "Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2311
+msgid "Containers Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1933
+msgid "Containers Explorer"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager
@@ -6065,11 +8358,17 @@ msgstr ""
 msgid "Containers Provider"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::ContainerManager (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_container (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_containers
-#: ../dictionary_strings.rb:1435 ../dictionary_strings.rb:1879 ../dictionary_strings.rb:1881
+#: ../yaml_strings.rb:3626 ../dictionary_strings.rb:1435 ../dictionary_strings.rb:1879 ../dictionary_strings.rb:1881
 msgid "Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1969
+msgid "Containers Topology"
 msgstr ""
 
 #: ../model_attributes.rb:238
@@ -6204,6 +8503,11 @@ msgstr ""
 msgid "Contents"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#: ../yaml_strings.rb:3814
+msgid "Contents Available"
+msgstr ""
+
 #: ../../app/views/miq_request/_prov_form_buttons.html.haml:21 ../../app/views/miq_request/_prov_form_buttons.html.haml:39 ../../app/views/layouts/_x_edit_buttons.html.haml:78 ../../app/views/layouts/_x_edit_buttons.html.haml:151 ../../app/views/layouts/_edit_form_buttons.html.haml:46 ../../app/views/layouts/_edit_form_buttons.html.haml:46 ../../app/views/layouts/_edit_form_buttons.html.haml:76 ../../app/views/layouts/_edit_form_buttons.html.haml:158 ../../app/views/layouts/_x_dialog_buttons.html.haml:32 ../../app/views/layouts/_x_dialog_buttons.html.haml:65
 msgid "Continue"
 msgstr ""
@@ -6216,23 +8520,139 @@ msgstr ""
 msgid "Control"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:828
+msgid "Control Explorer"
+msgstr ""
+
 #: ../../app/presenters/tree_builder_policy.rb:44
 msgid "Control Policies"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb:7 ../../app/views/layouts/_x_edit_buttons.html.haml:92 ../../app/views/layouts/_x_edit_buttons.html.haml:154
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2411
+msgid "Convert Numbers Larger than 1.0e+15 to Exponential Form"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/miq_ae_tools_simulate_center.rb:7 ../../app/views/layouts/_x_edit_buttons.html.haml:92 ../../app/views/layouts/_x_edit_buttons.html.haml:154 ../yaml_strings.rb:125
 msgid "Copy"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1734
+#: ../../app/controllers/miq_ae_class_controller.rb:1736
 msgid "Copy %{record} was cancelled by the user"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1218
+msgid "Copy Analysis Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1000
+msgid "Copy Automate Class"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1014
+msgid "Copy Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1026
+msgid "Copy Automate Method"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:885
+msgid "Copy Condition to a new Condition assigned to specified Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:883
+msgid "Copy Condition to specified Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1568
+msgid "Copy Customization Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1057
+msgid "Copy Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:221
+msgid "Copy Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1091
+msgid "Copy Provisioning Dialog"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:18
 msgid "Copy Selected Customization Templates"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1575
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1159
+msgid "Copy Time Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:810
+msgid "Copy a Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:881
+msgid "Copy a Condition"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:758
+msgid "Copy a Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:858
+msgid "Copy a Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:938
+msgid "Copy a Policy Alert"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:715
+msgid "Copy a Report"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:127
+msgid "Copy a Request"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1303
+msgid "Copy a Role"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1261
+msgid "Copy a User"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:782
+msgid "Copy a Widget"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1569
 msgid "Copy does not apply to selected %{model}"
 msgstr ""
 
@@ -6240,15 +8660,23 @@ msgstr ""
 msgid "Copy object details for use in a Button"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1028
-msgid "Copy of %{model} \"%{name}\" was cancelled by the user"
+#: ../../app/controllers/chargeback_controller.rb:185 ../../app/controllers/configuration_controller.rb:462
+msgid "Copy of %{description}"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:689
+msgid "Copy of %{name}"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1023
+msgid "Copy of Orchestration Template \"%{name}\" was cancelled by the user"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_request_center.rb:6
 msgid "Copy original Request"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1709
+#: ../../app/controllers/miq_ae_class_controller.rb:1711
 msgid "Copy selected %{record} was saved"
 msgstr ""
 
@@ -6364,11 +8792,11 @@ msgstr ""
 msgid "Copy to same path"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:718
+#: ../../app/controllers/catalog_controller.rb:688
 msgid "Copying %s"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:18
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:14
 msgid "Cores"
 msgstr ""
 
@@ -6378,6 +8806,10 @@ msgstr ""
 
 #: ../../app/views/ops/_diagnostics_savedreports.html.haml:20 ../../app/views/ops/_settings_workers_tab.html.haml:27 ../../app/views/ops/_settings_workers_tab.html.haml:79 ../../app/views/ops/_settings_workers_tab.html.haml:192 ../../app/views/ops/_settings_workers_tab.html.haml:234 ../../app/views/ops/_settings_workers_tab.html.haml:285 ../../app/views/ops/_settings_workers_tab.html.haml:339 ../../app/views/ops/_settings_workers_tab.html.haml:390 ../../app/views/ops/_settings_workers_tab.html.haml:469
 msgid "Count"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:479
+msgid "Count of"
 msgstr ""
 
 #: ../../app/views/report/_form_chart.html.haml:43 ../../app/views/report/_form_chart.html.haml:54 ../../app/views/report/_form_sort.html.haml:78
@@ -6396,6 +8828,16 @@ msgstr ""
 msgid "Create Datastore was cancelled by the user"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1472
+msgid "Create Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1474
+msgid "Create Datastores from File Shares"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:13
 msgid "Create Logical Disk"
 msgstr ""
@@ -6404,11 +8846,22 @@ msgstr ""
 msgid "Create Logical Disk was cancelled by the user"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:12
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1400
+msgid "Create Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1402
+msgid "Create Logical Disks on Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:12 ../yaml_strings.rb:229
 msgid "Create Service Dialog from Orchestration Template"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:592
+#: ../../app/controllers/vm_common.rb:651
 msgid "Create Snapshot for %{model} \"%{name}\" was started"
 msgstr ""
 
@@ -6424,6 +8877,16 @@ msgstr ""
 msgid "Create a new Condition assigned to this Policy"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2303
+msgid "Create a new snapshot for Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2241
+msgid "Create a new snapshot for VMs"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:114 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:117
 msgid "Create a new snapshot for this Template"
 msgstr ""
@@ -6436,6 +8899,11 @@ msgstr ""
 msgid "Create new Orchestration Template"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2239
+msgid "Create new Snapshots"
+msgstr ""
+
 #: ../../app/views/vm_common/_snap.html.haml:63
 msgid "Create snapshot"
 msgstr ""
@@ -6444,7 +8912,28 @@ msgstr ""
 msgid "Created"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:113 ../../app/views/miq_ae_customization/_dialog_info.html.haml:44 ../../app/views/vm_common/_snapshots_desc.html.haml:50 ../../app/views/miq_ae_class/_method_inputs.html.haml:80 ../../app/views/miq_ae_class/_method_form.html.haml:88 ../../app/views/catalog/_ot_tree_show.html.haml:63
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#: ../yaml_strings.rb:3355
+msgid "Created At"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Vsc.yaml
+#: ../yaml_strings.rb:2867
+msgid "Created By"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#. TRANSLATORS: file: product/views/Repository.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#. TRANSLATORS: file: product/views/Service.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#. TRANSLATORS: file: product/views/Vsc.yaml
+#: ../../app/helpers/service_helper/textual_summary.rb:116 ../../app/views/miq_request/_request.html.haml:113 ../../app/views/miq_ae_customization/_dialog_info.html.haml:44 ../../app/views/vm_common/_snapshots_desc.html.haml:50 ../../app/views/miq_ae_class/_method_inputs.html.haml:80 ../../app/views/miq_ae_class/_method_form.html.haml:88 ../../app/views/catalog/_ot_tree_show.html.haml:63 ../yaml_strings.rb:2807
 msgid "Created On"
 msgstr ""
 
@@ -6453,27 +8942,27 @@ msgstr ""
 msgid "Created on Time"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1081
+#: ../../app/controllers/catalog_controller.rb:1076
 msgid "Creation of a new Orchestration Template was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1134
+#: ../../app/controllers/catalog_controller.rb:1129
 msgid "Creation of a new Service Dialog was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:168
+#: ../../app/controllers/ops_controller/settings/rhn.rb:172
 msgid "Credential validation returned: %{message}"
 msgstr ""
 
-#: ../../app/controllers/ems_cloud_controller.rb:83
+#: ../../app/controllers/ems_cloud_controller.rb:84
 msgid "Credential validation was not successful: %s"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:312
+#: ../../app/controllers/ems_common.rb:318
 msgid "Credential validation was not successful: %{details}"
 msgstr ""
 
-#: ../../app/controllers/storage_manager_controller.rb:133 ../../app/controllers/storage_manager_controller.rb:227 ../../app/controllers/ops_controller/settings/rhn.rb:171 ../../app/controllers/ops_controller/settings/ldap.rb:154 ../../app/controllers/host_controller.rb:280 ../../app/controllers/host_controller.rb:417 ../../app/controllers/ems_common.rb:310 ../../app/controllers/provider_foreman_controller.rb:238 ../../app/controllers/ems_cloud_controller.rb:81
+#: ../../app/controllers/storage_manager_controller.rb:134 ../../app/controllers/storage_manager_controller.rb:230 ../../app/controllers/ops_controller/settings/rhn.rb:175 ../../app/controllers/ops_controller/settings/ldap.rb:154 ../../app/controllers/host_controller.rb:312 ../../app/controllers/host_controller.rb:450 ../../app/controllers/ems_common.rb:316 ../../app/controllers/provider_foreman_controller.rb:226 ../../app/controllers/ems_cloud_controller.rb:82
 msgid "Credential validation was successful"
 msgstr ""
 
@@ -6485,8 +8974,17 @@ msgstr ""
 msgid "Credentials - Windows Domain"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:377
+#: ../../app/controllers/host_controller.rb:329
+msgid "Credentials/Settings"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:410
 msgid "Credentials/Settings saved successfully"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2329
+msgid "Currency, 2 Decimals ($1,234.00)"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:164 ../../app/views/vm_common/_right_size.html.haml:248 ../../app/views/vm_common/_right_size.html.haml:331
@@ -6505,8 +9003,9 @@ msgstr ""
 msgid "Current Group"
 msgstr ""
 
-#: ../../app/views/chargeback/_chargeback_rates.html.haml:3
-msgid "Current Rates"
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#: ../yaml_strings.rb:3645
+msgid "Current Replicas"
 msgstr ""
 
 #: ../../app/views/report/_widget_show.html.haml:71
@@ -6515,6 +9014,10 @@ msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_form.html.haml:45
 msgid "Current User"
+msgstr ""
+
+#: ../../app/helpers/container_replicator_helper/textual_summary.rb:29
+msgid "Current pods"
 msgstr ""
 
 #: ../../app/views/layouts/_user_options.html.haml:37
@@ -6538,7 +9041,7 @@ msgstr ""
 msgid "Custom Automation"
 msgstr ""
 
-#: ../../app/views/host/_form.html.haml:97 ../../app/views/vm_common/_form.html.haml:18
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:99 ../../app/helpers/host_helper/textual_summary.rb:123 ../../app/helpers/vm_infra_helper/textual_summary.rb:114 ../../app/helpers/vm_helper/textual_summary.rb:126 ../../app/views/host/_form.html.haml:97 ../../app/views/vm_common/_form.html.haml:18
 msgid "Custom Identifier"
 msgstr ""
 
@@ -6546,15 +9049,15 @@ msgstr ""
 msgid "Custom Image"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:464
-msgid "Custom Image file \"%s\" successfully uploaded"
+#: ../../app/controllers/catalog_controller.rb:428
+msgid "Custom Image file \"%{name}\" successfully uploaded"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:457
-msgid "Custom Image must be a %s file"
+#: ../../app/controllers/catalog_controller.rb:421
+msgid "Custom Image must be a .png or .jpg file"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:451
+#: ../../app/controllers/catalog_controller.rb:415
 msgid "Custom Image successfully removed"
 msgstr ""
 
@@ -6578,7 +9081,7 @@ msgstr ""
 msgid "Custom Logos"
 msgstr ""
 
-#: ../../app/views/report/_export_custom_reports.html.haml:7
+#: ../../app/presenters/tree_builder_report_export.rb:24 ../../app/views/report/_export_custom_reports.html.haml:7
 msgid "Custom Reports"
 msgstr ""
 
@@ -6726,16 +9229,22 @@ msgstr ""
 msgid "CustomButton|Wait for complete"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:136
+#: ../../app/controllers/ops_controller/settings/rhn.rb:140
 msgid "Customer Information successfully saved"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:145
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:145 ../yaml_strings.rb:1042
 msgid "Customization"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_form.html.haml:129
+#: ../../app/helpers/pxe_helper/textual_summary.rb:28 ../../app/views/pxe/_pxe_form.html.haml:129
 msgid "Customization Directory"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1044
+msgid "Customization Explorer"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate
@@ -6743,8 +9252,10 @@ msgstr ""
 msgid "Customization Template"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/CustomizationTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.PxeCustomizationTemplate (plural form)
-#: ../dictionary_strings.rb:1657
+#: ../../app/controllers/pxe_controller.rb:85 ../yaml_strings.rb:1554 ../dictionary_strings.rb:1657
 msgid "Customization Templates"
 msgstr ""
 
@@ -6809,12 +9320,12 @@ msgid "Customize Template"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.dhcp_enabled
-#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:361
+#: ../../app/views/vm_common/_config.html.haml:208 ../dictionary_strings.rb:361
 msgid "DHCP Enabled"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.dhcp_server
-#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:363
+#: ../../app/views/vm_common/_config.html.haml:208 ../dictionary_strings.rb:363
 msgid "DHCP Server"
 msgstr ""
 
@@ -6822,17 +9333,43 @@ msgstr ""
 msgid "DNS"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#: ../../app/helpers/container_group_helper/textual_summary.rb:90 ../yaml_strings.rb:3377
+msgid "DNS Policy"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.dns_server
-#: ../../app/views/vm_common/_config.html.haml:211 ../dictionary_strings.rb:377
+#: ../../app/views/vm_common/_config.html.haml:208 ../dictionary_strings.rb:377
 msgid "DNS Server"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:265
+msgid "DRS Automation Level"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:259
+msgid "DRS Enabled"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:271
+msgid "DRS Migration Threshold"
 msgstr ""
 
 #: ../../app/views/layouts/_tl_options.html.haml:50 ../../app/views/report/_schedule_form_timer.html.haml:20 ../../app/views/report/_form_columns_performance.html.haml:12 ../../app/views/report/_form_columns_performance.html.haml:15
 msgid "Daily"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:6
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:6 ../yaml_strings.rb:661
 msgid "Dashboard"
+msgstr ""
+
+#: ../../app/controllers/report_controller/dashboards.rb:260
+msgid "Dashboard \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/report_controller/dashboards.rb:82
+msgid "Dashboard \"%{name}\" was saved"
 msgstr ""
 
 #: ../../app/controllers/report_controller/dashboards.rb:31
@@ -6843,11 +9380,18 @@ msgstr ""
 msgid "Dashboard View"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:299
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/report_controller.rb:295 ../yaml_strings.rb:768
 msgid "Dashboard Widgets"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:295
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:770
+msgid "Dashboard Widgets Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/report_controller.rb:291 ../yaml_strings.rb:750
 msgid "Dashboards"
 msgstr ""
 
@@ -6855,13 +9399,26 @@ msgstr ""
 msgid "Dashboards:"
 msgstr ""
 
-#: ../../app/views/miq_ae_class/_method_inputs.html.haml:95 ../../app/views/miq_ae_class/_method_form.html.haml:100
+#. TRANSLATORS: file: product/views/RegistryItem.yaml
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:95 ../../app/views/miq_ae_class/_method_form.html.haml:100 ../yaml_strings.rb:3292
 msgid "Data"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:53
+msgid "Data Directory"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:57
+msgid "Data Disk"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.count_of_trend
 #: ../dictionary_strings.rb:237
 msgid "Data Points"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:69 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:62
+msgid "Data Redundancy"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_method_inputs.html.haml:132 ../../app/views/miq_ae_class/_method_form.html.haml:147 ../../app/views/miq_ae_class/_class_fields.html.haml:97
@@ -6880,7 +9437,7 @@ msgstr ""
 msgid "Data type: %s"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:805
+#: ../../app/controllers/miq_ae_class_controller.rb:799
 msgid "Data validated successfully"
 msgstr ""
 
@@ -6888,11 +9445,17 @@ msgstr ""
 msgid "Data:"
 msgstr ""
 
-#: ../../app/views/ops/_settings_database_tab.html.haml:28 ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_all_tabs.html.haml:34 ../../app/views/ops/_all_tabs.html.haml:236 ../../app/views/ops/_settings_workers_tab.html.haml:520
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/ops_controller.rb:227 ../../app/views/ops/_settings_database_tab.html.haml:28 ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_all_tabs.html.haml:34 ../../app/views/ops/_all_tabs.html.haml:236 ../../app/views/ops/_settings_workers_tab.html.haml:520 ../yaml_strings.rb:1376
 msgid "Database"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_show.html.haml:41
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1378
+msgid "Database Accordion"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:556 ../../app/views/ops/_schedule_show.html.haml:41
 msgid "Database Backup"
 msgstr ""
 
@@ -6904,16 +9467,20 @@ msgstr ""
 msgid "Database Backup Settings"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:334
+#: ../../app/controllers/ops_controller/diagnostics.rb:346
 msgid "Database Backup successfully initiated"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:407
+#: ../../app/controllers/ops_controller/diagnostics.rb:419
 msgid "Database Garbage Collection successfully initiated"
 msgstr ""
 
 #: ../../app/views/ops/_diagnostics_database_tab.html.haml:51
 msgid "Database Name"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:469
+msgid "Database []"
 msgstr ""
 
 #: ../model_attributes.rb:377
@@ -6928,13 +9495,29 @@ msgstr ""
 msgid "DatabaseBackup|Name"
 msgstr ""
 
-#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:27 ../../app/views/shared/views/_prov_dialog.html.haml:97
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:126 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:27 ../../app/views/shared/views/_prov_dialog.html.haml:97 ../yaml_strings.rb:3517
 msgid "Datacenter"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:457
+msgid "Datacenters"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/Storage.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Storage
 #. TRANSLATORS: en.yml key: dictionary.table.storage
-#: ../../app/presenters/tree_builder.rb:48 ../../app/presenters/tree_builder.rb:49 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:60 ../../app/views/miq_request/_prov_host_dialog.html.haml:69 ../../app/views/shared/views/_prov_dialog.html.haml:140 ../dictionary_strings.rb:1699 ../dictionary_strings.rb:2091
+#: ../../app/presenters/tree_builder.rb:92 ../../app/presenters/tree_builder.rb:93 ../../app/controllers/miq_ae_class_controller.rb:1640 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:60 ../../app/views/miq_request/_prov_host_dialog.html.haml:69 ../../app/views/shared/views/_prov_dialog.html.haml:140 ../yaml_strings.rb:3241 ../dictionary_strings.rb:1699 ../dictionary_strings.rb:2091
 msgid "Datastore"
 msgstr ""
 
@@ -6952,11 +9535,22 @@ msgstr ""
 msgid "Datastore File"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.StorageFile (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.storage_file (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.storage_files
-#: ../dictionary_strings.rb:1705 ../dictionary_strings.rb:2097 ../dictionary_strings.rb:2099
+#: ../yaml_strings.rb:3336 ../dictionary_strings.rb:1705 ../dictionary_strings.rb:2097 ../dictionary_strings.rb:2099
 msgid "Datastore Files"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#: ../yaml_strings.rb:3893
+msgid "Datastore Non-VM Files"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#: ../yaml_strings.rb:2907
+msgid "Datastore Other VM Files"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_datastore_path
@@ -6972,6 +9566,21 @@ msgstr ""
 msgid "Datastore Space"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+#: ../yaml_strings.rb:3448
+msgid "Datastore VM Memory Files"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#: ../yaml_strings.rb:3749
+msgid "Datastore VM Provisioned Disk Files"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#: ../yaml_strings.rb:3895
+msgid "Datastore VM Snapshot Files"
+msgstr ""
+
 #: ../../app/controllers/miq_ae_tools_controller.rb:124
 msgid "Datastore import was cancelled or is finished"
 msgstr ""
@@ -6985,10 +9594,18 @@ msgid ""
 "Methods updated/added: %{method_stats}"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Storage (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.storage (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.storages
-#: ../dictionary_strings.rb:1701 ../dictionary_strings.rb:2093 ../dictionary_strings.rb:2101
+#: ../yaml_strings.rb:612 ../dictionary_strings.rb:1701 ../dictionary_strings.rb:2093 ../dictionary_strings.rb:2101
 msgid "Datastores"
 msgstr ""
 
@@ -6996,19 +9613,53 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2363
+msgid "Date (M/D)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2355
+msgid "Date (M/D/YY)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2353
+msgid "Date (M/D/YYYY)"
+msgstr ""
+
 #: ../../app/views/miq_request/_request_details.html.haml:71
 msgid "Date Approved/Denied"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.created_at
 #. TRANSLATORS: en.yml key: dictionary.column.created_on
-#: ../dictionary_strings.rb:277 ../dictionary_strings.rb:279
+#: ../yaml_strings.rb:2586 ../dictionary_strings.rb:277 ../dictionary_strings.rb:279
 msgid "Date Created"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../yaml_strings.rb:3847
+msgid "Date Installed"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.display_range
 #: ../dictionary_strings.rb:1161
 msgid "Date Range"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2357
+msgid "Date Range (M/D/Y - M/D/Y)"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#: ../yaml_strings.rb:2601
+msgid "Date Time"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.updated_at
@@ -7017,19 +9668,85 @@ msgstr ""
 msgid "Date Updated"
 msgstr ""
 
-#: ../../app/assets/javascripts/miq_application.js:100
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2371
+msgid "Date/Hour (M/D/Y H AM|PM Z)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2369
+msgid "Date/Hour (M/D/Y H:00 Z)"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#: ../../app/assets/javascripts/miq_application.js:100 ../yaml_strings.rb:3681
 msgid "Date/Time"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:154 ../../app/assets/javascripts/miq_formatters.js:251
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2367
+msgid "Date/Time (M/D/Y H:M:S Z)"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:283 ../../app/views/report/_form_filter_chargeback.html.haml:154 ../../app/assets/javascripts/miq_formatters.js:251
 msgid "Day"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2379
+msgid "Day Full (Monday)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2359
+msgid "Day Range (M/D - M/D)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2361
+msgid "Day Range Start (M/D)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2381
+msgid "Day Short (Mon)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2385
+msgid "Day of Month (27)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2387
+msgid "Day of Month (27th)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2383
+msgid "Day of Week (1)"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:11 ../../app/views/configuration/_ui_4.html.haml:15
 msgid "Days"
 msgstr ""
 
-#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:79 ../../app/views/ops/_settings_co_categories_tab.html.haml:22 ../../app/views/miq_request/_prov_options.html.haml:129 ../../app/views/miq_request/_prov_options.html.haml:163 ../../app/views/miq_task/_tasks_options.html.haml:152 ../../app/views/miq_task/_tasks_options.html.haml:185 ../../app/views/layouts/_container_auth.html.haml:14 ../../app/views/layouts/_x_edit_buttons.html.haml:123 ../../app/views/layouts/_x_edit_buttons.html.haml:165 ../../app/views/layouts/listnav/_show_list.html.haml:23 ../../app/views/layouts/_edit_form_buttons.html.haml:104 ../../app/views/layouts/_edit_form_buttons.html.haml:167 ../../app/views/layouts/_multi_auth_credentials.html.haml:16 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:14 ../../app/views/report/_widget_show.html.haml:53 ../../app/views/report/_form_styling.html.haml:69 ../../app/views/report/_form_styling.html.haml:117
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:147
+msgid "Dedup Percent Saved"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:151
+msgid "Dedup Size Saved"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:155
+msgid "Dedup Size Shared"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqDialog.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:109 ../../app/helpers/host_helper/textual_summary.rb:529 ../../app/helpers/ems_infra_helper/textual_summary.rb:151 ../../app/views/ops/_settings_rhn_edit_tab.html.haml:79 ../../app/views/ops/_settings_co_categories_tab.html.haml:22 ../../app/views/miq_request/_prov_options.html.haml:129 ../../app/views/miq_request/_prov_options.html.haml:163 ../../app/views/miq_task/_tasks_options.html.haml:152 ../../app/views/miq_task/_tasks_options.html.haml:185 ../../app/views/layouts/_container_auth.html.haml:14 ../../app/views/layouts/_x_edit_buttons.html.haml:123 ../../app/views/layouts/_x_edit_buttons.html.haml:165 ../../app/views/layouts/listnav/_show_list.html.haml:23 ../../app/views/layouts/_edit_form_buttons.html.haml:104 ../../app/views/layouts/_edit_form_buttons.html.haml:167 ../../app/views/layouts/_multi_auth_credentials.html.haml:16 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:14 ../../app/views/report/_widget_show.html.haml:53 ../../app/views/report/_form_styling.html.haml:69 ../../app/views/report/_form_styling.html.haml:117 ../yaml_strings.rb:3387
 msgid "Default"
 msgstr ""
 
@@ -7041,11 +9758,16 @@ msgstr ""
 msgid "Default %{model} \"%{name}\" can not be edited"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:69 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:90 ../../app/controllers/ops_controller/ops_rbac.rb:271 ../../app/controllers/ops_controller/ops_rbac.rb:583 ../../app/controllers/configuration_controller.rb:377
+#: ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:69 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:90 ../../app/controllers/ops_controller/ops_rbac.rb:271 ../../app/controllers/ops_controller/ops_rbac.rb:583 ../../app/controllers/configuration_controller.rb:379
 msgid "Default %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:631
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:104 ../../app/helpers/host_helper/textual_summary.rb:524 ../../app/helpers/ems_infra_helper/textual_summary.rb:146
+msgid "Default Authentication"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/configuration_controller.rb:639 ../yaml_strings.rb:1147
 msgid "Default Filters"
 msgstr ""
 
@@ -7053,12 +9775,20 @@ msgstr ""
 msgid "Default Filters saved successfully"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#: ../../app/views/vm_common/_config.html.haml:208
 msgid "Default Gateway"
 msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:284
 msgid "Default Group for Users"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:541
+msgid "Default Host VNC Port Range End must be numeric"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:538
+msgid "Default Host VNC Port Range Start must be numeric"
 msgstr ""
 
 #: ../../app/views/configuration/_ui_1.html.haml:110
@@ -7073,6 +9803,10 @@ msgstr ""
 msgid "Default Locale"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:782
+msgid "Default Password and Verify Password fields do not match"
+msgstr ""
+
 #: ../../app/views/ops/_settings_server_tab.html.haml:213
 msgid "Default Repository SmartProxy"
 msgstr ""
@@ -7081,11 +9815,16 @@ msgstr ""
 msgid "Default Request"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:787
+msgid "Default User ID must be entered if a Remote Login or Web Services User ID is entered"
+msgstr ""
+
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:201 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:434 ../../app/views/miq_ae_class/_method_inputs.html.haml:130 ../../app/views/miq_ae_class/_method_form.html.haml:145 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97
 msgid "Default Value"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:630
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/configuration_controller.rb:638 ../yaml_strings.rb:1143
 msgid "Default Views"
 msgstr ""
 
@@ -7101,36 +9840,222 @@ msgstr ""
 msgid "Delay (mins)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:22 ../../app/helpers/application_helper/tasks.rb:8 ../../app/views/layouts/_adv_search_footer.html.haml:46
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:22 ../../app/helpers/application_helper/tasks.rb:8 ../../app/views/layouts/_adv_search_footer.html.haml:46 ../yaml_strings.rb:129
 msgid "Delete"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:40
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:40 ../yaml_strings.rb:1195
 msgid "Delete All"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:258 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:251 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:134 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:138
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:258 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:251 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:134 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:138 ../yaml_strings.rb:2247
 msgid "Delete All Existing Snapshots"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:31
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2307
+msgid "Delete All Existing Snapshots on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2249
+msgid "Delete All Existing Snapshots on VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1197
+msgid "Delete All Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1222
+msgid "Delete Analysis Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1006
+msgid "Delete Automate Class"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:966
+msgid "Delete Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1018
+msgid "Delete Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1030
+msgid "Delete Automate Method"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:992
+msgid "Delete Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1105
+msgid "Delete Buttons"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1059
+msgid "Delete Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:31 ../yaml_strings.rb:1191
 msgid "Delete Older"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1193
+msgid "Delete Older Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1228
+msgid "Delete Product Updates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1093
+msgid "Delete Provisioning Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:131
+msgid "Delete Requests"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:250 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:243 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:126 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:130
 msgid "Delete Selected Snapshot"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1362
+msgid "Delete Server"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:19 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:19
 msgid "Delete Server #{@record.name} [#{@record.id}]"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:244 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:237 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:120 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:124
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:244 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:237 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:120 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:124 ../yaml_strings.rb:2243
 msgid "Delete Snapshots"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:14
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2305
+msgid "Delete Snapshots on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2245
+msgid "Delete Snapshots on VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/tasks_center.rb:14 ../yaml_strings.rb:1189
 msgid "Delete Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1161
+msgid "Delete Time Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:812
+msgid "Delete a Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:889
+msgid "Delete a Condition"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:760
+msgid "Delete a Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1285
+msgid "Delete a Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:870
+msgid "Delete a Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:913
+msgid "Delete a Policy Action"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:942
+msgid "Delete a Policy Alert"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:927
+msgid "Delete a Policy Alert Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:844
+msgid "Delete a Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:717
+msgid "Delete a Report"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1305
+msgid "Delete a Role"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:689
+msgid "Delete a Saved Report"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:740
+msgid "Delete a Schedule"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1316
+msgid "Delete a Tenant/Project"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1263
+msgid "Delete a User"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:784
+msgid "Delete a Widget"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1238
+msgid "Delete a Zone"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/tasks_center.rb:39
@@ -7173,11 +10098,11 @@ msgstr ""
 msgid "Delete if older than"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:810 ../../app/controllers/ems_common.rb:855 ../../app/controllers/application_controller/ci_processing.rb:1943
+#: ../../app/controllers/repository_controller.rb:296 ../../app/controllers/ems_common.rb:821 ../../app/controllers/ems_common.rb:870 ../../app/controllers/application_controller/ci_processing.rb:1957
 msgid "Delete initiated for %{count_model} from the CFME Database"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1803
+#: ../../app/controllers/application_controller/ci_processing.rb:1817
 msgid "Delete initiated for Datastore from the CFME Database"
 msgid_plural "Delete initiated for Datastores from the CFME Database"
 msgstr[0] ""
@@ -7335,7 +10260,12 @@ msgstr ""
 msgid "Deleting the '%s' entry will also unassign it from all items, are you sure?"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:38 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:38
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:98 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:91
+msgid "Delta Reservation"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:38 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:38 ../yaml_strings.rb:1368
 msgid "Demote Server"
 msgstr ""
 
@@ -7343,8 +10273,26 @@ msgstr ""
 msgid "Demote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to secondary for the #{@record.server_role.description} Role"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:418
+msgid "Denied"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_request_center.rb:38
 msgid "Deny this Request"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../yaml_strings.rb:3150
+msgid "Depend on Group"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../yaml_strings.rb:3146
+msgid "Depend on Service"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.depend_on_group
@@ -7357,11 +10305,20 @@ msgstr ""
 msgid "Depends on Service"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:1246 ../../app/helpers/application_helper.rb:1257
+#: ../../app/helpers/ui_constants.rb:411
+msgid "Deploy Smartproxy"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
+#: ../yaml_strings.rb:3571
+msgid "Deployment Name"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:1253 ../../app/helpers/application_helper.rb:1264
 msgid "Deployment Role"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1246
+#: ../../app/presenters/menu/default_menu.rb:40 ../../app/helpers/application_helper.rb:1253
 msgid "Deployment Roles"
 msgstr ""
 
@@ -7369,12 +10326,16 @@ msgstr ""
 msgid "Depot Name"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:241
+#: ../../app/controllers/ops_controller/settings/schedules.rb:242
 msgid "Depot Settings successfuly validated"
 msgstr ""
 
 #: ../../app/views/pxe/_pxe_form.html.haml:34
 msgid "Depot Type"
+msgstr ""
+
+#: ../../app/controllers/pxe_controller/pxe_servers.rb:299
+msgid "Depot Type is required"
 msgstr ""
 
 #: ../../app/views/layouts/_pagingcontrols.html.haml:48
@@ -7385,11 +10346,61 @@ msgstr ""
 msgid "Descending"
 msgstr ""
 
-#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:29 ../../app/views/ops/_category_form.html.haml:136 ../../app/views/ops/_ldap_region_show.html.haml:31 ../../app/views/ops/_ap_show.html.haml:32 ../../app/views/ops/_settings_details_tab.html.haml:19 ../../app/views/ops/_zone_form.html.haml:37 ../../app/views/ops/_rbac_tenant_details.html.haml:30 ../../app/views/ops/_tenant_form.html.haml:42 ../../app/views/ops/_classification_entries.html.haml:17 ../../app/views/ops/_schedule_form.html.haml:45 ../../app/views/ops/_settings_server_tab.html.haml:675 ../../app/views/ops/_schedule_show.html.haml:9 ../../app/views/ops/_tenant_quota_form.html.haml:27 ../../app/views/ops/_ldap_region_form.html.haml:38 ../../app/views/ops/_rbac_group_details.html.haml:23 ../../app/views/ops/_ap_form.html.haml:40 ../../app/views/ops/_settings_co_categories_tab.html.haml:14 ../../app/views/service/_service_form.html.haml:52 ../../app/views/miq_request/_request.html.haml:87 ../../app/views/miq_request/_ae_prov_show.html.haml:16 ../../app/views/miq_ae_customization/_dialog_info.html.haml:28 ../../app/views/miq_ae_customization/_field_values.html.haml:20 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:13 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:36 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:33 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:31 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:32 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:36 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:52 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/chargeback/_cb_rate_edit.html.haml:15 ../../app/views/chargeback/_cb_rate_edit.html.haml:43 ../../app/views/chargeback/_cb_rate_show.html.haml:15 ../../app/views/chargeback/_cb_rate_show.html.haml:40 ../../app/views/alert/_rss_list.html.haml:41 ../../app/views/vm_common/_snap.html.haml:30 ../../app/views/vm_common/_snapshots_desc.html.haml:15 ../../app/views/vm_common/_form.html.haml:36 ../../app/views/vm_common/_config.html.haml:211 ../../app/views/miq_ae_class/_ns_list.html.haml:22 ../../app/views/miq_ae_class/_ns_list.html.haml:114 ../../app/views/miq_ae_class/_instance_form.html.haml:63 ../../app/views/miq_ae_class/_class_form.html.haml:61 ../../app/views/miq_ae_class/_class_props.html.haml:55 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/configuration/_timeprofile_form.html.haml:19 ../../app/views/report/_widget_show.html.haml:29 ../../app/views/report/_db_list.html.haml:57 ../../app/views/report/_db_list.html.haml:102 ../../app/views/report/_widget_form.html.haml:37 ../../app/views/report/_show_schedule.html.haml:9 ../../app/views/report/_schedule_form.html.haml:35 ../../app/views/report/_report_info.html.haml:129 ../../app/views/report/_report_info.html.haml:248 ../../app/views/catalog/_ot_tree_show.html.haml:24 ../../app/views/catalog/_ot_add.html.haml:34 ../../app/views/catalog/_ot_copy.html.haml:41 ../../app/views/catalog/_svccat_tree_show.html.haml:44 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_stcat_tree_show.html.haml:27 ../../app/views/catalog/_stcat_form.html.haml:43 ../../app/views/catalog/_ot_edit.html.haml:34 ../../app/views/pxe/_template_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:61 ../../app/views/pxe/_pxe_server_details.html.haml:108 ../../app/views/miq_policy/_event_details.html.haml:15 ../../app/views/miq_policy/_event_details.html.haml:226 ../../app/views/miq_policy/_event_details.html.haml:418 ../../app/views/miq_policy/_condition_details.html.haml:20 ../../app/views/miq_policy/_profile_details.html.haml:22 ../../app/views/miq_policy/_alert_profile_details.html.haml:21 ../../app/views/miq_policy/_alert_details.html.haml:23 ../../app/views/miq_policy/_action_details.html.haml:21 ../../app/views/miq_policy/_policy_details.html.haml:24 ../../app/views/miq_policy/_policy_details.html.haml:246 ../../app/views/miq_policy/_policy_details.html.haml:349
+#. TRANSLATORS: file: product/views/AdvancedSetting.yaml
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/ChargebackRate.yaml
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/Condition.yaml
+#. TRANSLATORS: file: product/views/ConditionSet.yaml
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#. TRANSLATORS: file: product/views/CustomizationTemplate.yaml
+#. TRANSLATORS: file: product/views/Dialog.yaml
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#. TRANSLATORS: file: product/views/LdapRegion.yaml
+#. TRANSLATORS: file: product/views/MiqAction.yaml
+#. TRANSLATORS: file: product/views/MiqActionSet.yaml
+#. TRANSLATORS: file: product/views/MiqAeClass.yaml
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
+#. TRANSLATORS: file: product/views/MiqDialog.yaml
+#. TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+#. TRANSLATORS: file: product/views/MiqEvent.yaml
+#. TRANSLATORS: file: product/views/MiqPolicy.yaml
+#. TRANSLATORS: file: product/views/MiqPolicySet.yaml
+#. TRANSLATORS: file: product/views/MiqProvision.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#. TRANSLATORS: file: product/views/Patch.yaml
+#. TRANSLATORS: file: product/views/Policy.yaml
+#. TRANSLATORS: file: product/views/PolicySet.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#. TRANSLATORS: file: product/views/ScanItemSet.yaml
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
+#. TRANSLATORS: file: product/views/Service.yaml
+#. TRANSLATORS: file: product/views/ServiceCatalog.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#. TRANSLATORS: file: product/views/Tenant.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:53 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:43 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:46 ../../app/helpers/pxe_helper/textual_summary.rb:52 ../../app/helpers/pxe_helper/textual_summary.rb:76 ../../app/helpers/pxe_helper/textual_summary.rb:100 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:29 ../../app/views/ops/_settings_evm_servers_tab.html.haml:29 ../../app/views/ops/_category_form.html.haml:136 ../../app/views/ops/_ldap_region_show.html.haml:31 ../../app/views/ops/_ap_show.html.haml:32 ../../app/views/ops/_settings_details_tab.html.haml:19 ../../app/views/ops/_zone_form.html.haml:37 ../../app/views/ops/_rbac_tenant_details.html.haml:30 ../../app/views/ops/_tenant_form.html.haml:42 ../../app/views/ops/_classification_entries.html.haml:17 ../../app/views/ops/_schedule_form.html.haml:45 ../../app/views/ops/_settings_server_tab.html.haml:675 ../../app/views/ops/_schedule_show.html.haml:9 ../../app/views/ops/_tenant_quota_form.html.haml:27 ../../app/views/ops/_ldap_region_form.html.haml:38 ../../app/views/ops/_rbac_group_details.html.haml:23 ../../app/views/ops/_ap_form.html.haml:40 ../../app/views/ops/_settings_co_categories_tab.html.haml:14 ../../app/views/service/_service_form.html.haml:52 ../../app/views/miq_request/_request.html.haml:87 ../../app/views/miq_request/_ae_prov_show.html.haml:16 ../../app/views/miq_ae_customization/_dialog_info.html.haml:28 ../../app/views/miq_ae_customization/_field_values.html.haml:20 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:13 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:36 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:33 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:31 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:32 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:36 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:52 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/chargeback/_cb_rate_edit.html.haml:15 ../../app/views/chargeback/_cb_rate_edit.html.haml:43 ../../app/views/chargeback/_cb_rate_show.html.haml:15 ../../app/views/chargeback/_cb_rate_show.html.haml:40 ../../app/views/alert/_rss_list.html.haml:41 ../../app/views/vm_common/_snap.html.haml:30 ../../app/views/vm_common/_snapshots_desc.html.haml:15 ../../app/views/vm_common/_form.html.haml:36 ../../app/views/vm_common/_config.html.haml:208 ../../app/views/miq_ae_class/_ns_list.html.haml:22 ../../app/views/miq_ae_class/_ns_list.html.haml:114 ../../app/views/miq_ae_class/_instance_form.html.haml:63 ../../app/views/miq_ae_class/_class_form.html.haml:61 ../../app/views/miq_ae_class/_class_props.html.haml:55 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/configuration/_timeprofile_form.html.haml:19 ../../app/views/report/_widget_show.html.haml:29 ../../app/views/report/_db_list.html.haml:57 ../../app/views/report/_db_list.html.haml:102 ../../app/views/report/_widget_form.html.haml:37 ../../app/views/report/_show_schedule.html.haml:9 ../../app/views/report/_schedule_form.html.haml:35 ../../app/views/report/_report_info.html.haml:129 ../../app/views/report/_report_info.html.haml:248 ../../app/views/catalog/_ot_tree_show.html.haml:24 ../../app/views/catalog/_ot_add.html.haml:34 ../../app/views/catalog/_ot_copy.html.haml:41 ../../app/views/catalog/_svccat_tree_show.html.haml:44 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_stcat_tree_show.html.haml:27 ../../app/views/catalog/_stcat_form.html.haml:43 ../../app/views/catalog/_ot_edit.html.haml:34 ../../app/views/pxe/_template_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:61 ../../app/views/pxe/_pxe_server_details.html.haml:108 ../../app/views/miq_policy/_event_details.html.haml:15 ../../app/views/miq_policy/_event_details.html.haml:226 ../../app/views/miq_policy/_event_details.html.haml:418 ../../app/views/miq_policy/_condition_details.html.haml:20 ../../app/views/miq_policy/_profile_details.html.haml:22 ../../app/views/miq_policy/_alert_profile_details.html.haml:21 ../../app/views/miq_policy/_alert_details.html.haml:23 ../../app/views/miq_policy/_action_details.html.haml:21 ../../app/views/miq_policy/_policy_details.html.haml:24 ../../app/views/miq_policy/_policy_details.html.haml:246 ../../app/views/miq_policy/_policy_details.html.haml:349 ../yaml_strings.rb:2795
 msgid "Description"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:149 ../../app/controllers/miq_policy_controller/miq_actions.rb:383 ../../app/controllers/ops_controller/settings/tags.rb:57 ../../app/controllers/ops_controller/settings/zones.rb:22 ../../app/controllers/configuration_controller.rb:491 ../../app/controllers/configuration_controller.rb:549
+#: ../../app/controllers/chargeback_controller.rb:121 ../../app/controllers/miq_policy_controller/miq_actions.rb:383 ../../app/controllers/ops_controller/settings/tags.rb:61 ../../app/controllers/ops_controller/settings/zones.rb:22 ../../app/controllers/configuration_controller.rb:494 ../../app/controllers/configuration_controller.rb:553
 msgid "Description is required"
 msgstr ""
 
@@ -7397,13 +10408,27 @@ msgstr ""
 msgid "Desired"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2648
+msgid "Destination Host"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.dest_host_name
 #: ../dictionary_strings.rb:355
 msgid "Destination Host Name"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2651
+msgid "Destination VM"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.dest_vm_location
-#: ../dictionary_strings.rb:357
+#: ../yaml_strings.rb:2654 ../dictionary_strings.rb:357
 msgid "Destination VM Location"
 msgstr ""
 
@@ -7417,7 +10442,7 @@ msgid "Detail"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.compliance_details
-#: ../../app/views/ops/_all_tabs.html.haml:77 ../../app/views/catalog/_form.html.haml:8 ../../app/views/catalog/_sandt_tree_show.html.haml:12 ../../app/views/miq_capacity/_utilization_tabs.html.haml:7 ../../app/assets/javascripts/miq_policy/import.js:46 ../dictionary_strings.rb:1767
+#: ../../app/controllers/ops_controller.rb:721 ../../app/views/ops/_all_tabs.html.haml:77 ../../app/views/catalog/_form.html.haml:7 ../../app/views/catalog/_sandt_tree_show.html.haml:12 ../../app/views/miq_capacity/_utilization_tabs.html.haml:7 ../../app/assets/javascripts/miq_policy/import.js:46 ../dictionary_strings.rb:1767
 msgid "Details"
 msgstr ""
 
@@ -7429,25 +10454,58 @@ msgstr ""
 msgid "Determine at Run Time"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:120
+msgid "Development"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:89 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:82 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:61
+msgid "Device ID"
+msgstr ""
+
 #: ../../app/views/vm_common/_disks.html.haml:7
 msgid "Device Type"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.guest_devices
-#: ../../app/views/layouts/listnav/_host.html.haml:43 ../../app/views/vm_common/_config.html.haml:113 ../dictionary_strings.rb:1923
+#: ../../app/helpers/host_helper/textual_summary.rb:214 ../../app/views/layouts/listnav/_host.html.haml:43 ../../app/views/vm_common/_config.html.haml:113 ../dictionary_strings.rb:1923
 msgid "Devices"
 msgstr ""
 
-#: ../../app/views/vm_cloud/_main.html.haml:34 ../../app/views/host/_main.html.haml:23 ../../app/views/vm_common/_main.html.haml:39
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/ops_controller.rb:219 ../../app/views/vm_cloud/_main.html.haml:34 ../../app/views/host/_main.html.haml:23 ../../app/views/vm_common/_main.html.haml:39 ../yaml_strings.rb:1324
 msgid "Diagnostics"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:837 ../../app/controllers/ops_controller/diagnostics.rb:863 ../../app/controllers/ops_controller/diagnostics.rb:931
+#: ../../app/controllers/ops_controller/diagnostics.rb:857 ../../app/controllers/ops_controller/diagnostics.rb:883 ../../app/controllers/ops_controller/diagnostics.rb:951
 msgid "Diagnostics %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:833 ../../app/controllers/ops_controller/diagnostics.rb:927
+#: ../../app/controllers/ops_controller/diagnostics.rb:853 ../../app/controllers/ops_controller/diagnostics.rb:947
 msgid "Diagnostics %{model} \"%{name}\" (current)"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:465
+msgid "Diagnostics %{text}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1326
+msgid "Diagnostics Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1360
+msgid "Diagnostics Region Settings"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1328
+msgid "Diagnostics Server Settings"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1372
+msgid "Diagnostics Zone Settings"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.MiqDialog
@@ -7479,7 +10537,7 @@ msgstr ""
 msgid "Dialog group"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1988
+#: ../../app/controllers/catalog_controller.rb:1989
 msgid "Dialog has to be set if Display in Catalog is chosen"
 msgstr ""
 
@@ -7643,9 +10701,16 @@ msgstr ""
 msgid "DialogTab|Position"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Dialog.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqDialog (plural form)
-#: ../dictionary_strings.rb:1527
+#: ../yaml_strings.rb:1047 ../dictionary_strings.rb:1527
 msgid "Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1049
+msgid "Dialogs Accordion"
 msgstr ""
 
 #: ../model_attributes.rb:380
@@ -7660,21 +10725,62 @@ msgstr ""
 msgid "Dialog|Label"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_direct_vms
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:42 ../../app/views/layouts/listnav/_ems_cluster.html.haml:51 ../dictionary_strings.rb:1009
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:141 ../../app/helpers/resource_pool_helper/textual_summary.rb:89 ../../app/views/layouts/listnav/_resource_pool.html.haml:42 ../../app/views/layouts/listnav/_ems_cluster.html.haml:51 ../yaml_strings.rb:3587 ../dictionary_strings.rb:1009
 msgid "Direct VMs"
 msgstr ""
 
-#: ../../app/views/security_group/_main.html.haml:20
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#: ../../app/views/security_group/_main.html.haml:20 ../yaml_strings.rb:3830
 msgid "Direction"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../yaml_strings.rb:3261
+msgid "Directory Hierarchy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:746
+msgid "Disable"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:748
+msgid "Disable a Schedule"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:42 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:42
 msgid "Disable the selected Schedules"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:188
+msgid "Disabled"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#: ../yaml_strings.rb:3513
+msgid "Disabled Run Levels"
+msgstr ""
+
 #: ../../app/views/report/_menu_form1.html.haml:102 ../../app/views/report/_menu_form2.html.haml:180
 msgid "Discard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1075
+msgid "Discard Dialog item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1079
+msgid "Discard Dialog resource"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1073
+msgid "Discard Item"
 msgstr ""
 
 #: ../../app/views/layouts/exp_atom/_editor.html.haml:40 ../../app/views/report/_menu_form1.html.haml:92
@@ -7685,11 +10791,17 @@ msgstr ""
 msgid "Discard report management changes"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1077
+msgid "Discard resource"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/dialog_center.rb:64
 msgid "Discard this new #{@sb[:node_typ].titleize}"
 msgstr ""
 
-#: ../../app/views/layouts/_discover.html.haml:10
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/layouts/_discover.html.haml:10 ../yaml_strings.rb:286
 msgid "Discover"
 msgstr ""
 
@@ -7701,6 +10813,16 @@ msgstr ""
 msgid "Discover #{ui_lookup(:tables=>\"ems_infras\")}"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:288
+msgid "Discover Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:437
+msgid "Discover Infrastructure Providers"
+msgstr ""
+
 #: ../../app/views/ems_cloud/discover.html.haml:12
 msgid "Discover Type"
 msgstr ""
@@ -7709,12 +10831,25 @@ msgstr ""
 msgid "Discover items"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_repository.html.haml:22
+#: ../../app/helpers/vm_helper/textual_summary.rb:211
+msgid "Discovered"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:37 ../../app/helpers/ems_infra_helper/textual_summary.rb:31 ../yaml_strings.rb:3359
+msgid "Discovered IP Address"
+msgstr ""
+
+#: ../../app/helpers/repository_helper/textual_summary.rb:21 ../../app/views/layouts/listnav/_repository.html.haml:22
 msgid "Discovered VMs"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../model_attributes.rb:425
 msgid "Disk"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:57 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:159
+msgid "Disk Count"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_disk_percent_of_used
@@ -7820,6 +10955,10 @@ msgstr ""
 msgid "Disk Space"
 msgstr ""
 
+#: ../../app/helpers/service_helper/textual_summary.rb:61
+msgid "Disk Space Allocated"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.trend_v_derived_storage_used
 #: ../dictionary_strings.rb:979
 msgid "Disk Space Average Trend"
@@ -7856,8 +10995,16 @@ msgstr ""
 msgid "Disk Space Min Used"
 msgstr ""
 
+#: ../../app/helpers/service_helper/textual_summary.rb:66
+msgid "Disk Space Used"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:454 ../../app/helpers/vm_helper/textual_summary.rb:553
+msgid "Disks"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.disks_aligned
-#: ../dictionary_strings.rb:375
+#: ../../app/helpers/vm_helper/textual_summary.rb:545 ../dictionary_strings.rb:375
 msgid "Disks Aligned"
 msgstr ""
 
@@ -7925,11 +11072,526 @@ msgstr ""
 msgid "Disk|Updated on"
 msgstr ""
 
-#: ../../app/views/miq_ae_class/_method_inputs.html.haml:48 ../../app/views/miq_ae_class/_instance_form.html.haml:46 ../../app/views/miq_ae_class/_method_form.html.haml:48 ../../app/views/miq_ae_class/_class_form.html.haml:45 ../../app/views/miq_ae_class/_class_props.html.haml:42 ../../app/views/miq_ae_class/_class_fields.html.haml:97
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:477
+msgid "Display Clusters / Deployment Roles Drift"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1468
+msgid "Display File Shares Utilization"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:518
+msgid "Display Hosts / Nodes Drift"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2115
+msgid "Display Images Drift"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:320
+msgid "Display Individual Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:278
+msgid "Display Individual Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:481
+msgid "Display Individual Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1840
+msgid "Display Individual Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1775
+msgid "Display Individual Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1802
+msgid "Display Individual Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1911
+msgid "Display Individual Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1887
+msgid "Display Individual Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1824
+msgid "Display Individual Container images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1646
+msgid "Display Individual Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:463
+msgid "Display Individual Datacenters"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:620
+msgid "Display Individual Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1466
+msgid "Display Individual File Shares"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:416
+msgid "Display Individual Flavors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1275
+msgid "Display Individual Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:516
+msgid "Display Individual Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2111
+msgid "Display Individual Images related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:431
+msgid "Display Individual Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2027
+msgid "Display Individual Instances related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:372
+msgid "Display Individual Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1486
+msgid "Display Individual Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1430
+msgid "Display Individual Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1724
+msgid "Display Individual Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1672
+msgid "Display Individual Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1698
+msgid "Display Individual Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1622
+msgid "Display Individual Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1862
+msgid "Display Individual Persistent Volume"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1749
+msgid "Display Individual Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:643
+msgid "Display Individual Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:107
+msgid "Display Individual Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:593
+msgid "Display Individual Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1295
+msgid "Display Individual Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:401
+msgid "Display Individual Security Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:386
+msgid "Display Individual Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1450
+msgid "Display Individual Storage Extents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1502
+msgid "Display Individual Storage Managers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1394
+msgid "Display Individual Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1414
+msgid "Display Individual Storage Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2263
+msgid "Display Individual Templates related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:340
+msgid "Display Individual Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1253
+msgid "Display Individual Users"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2149
+msgid "Display Individual VMs related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:358
+msgid "Display Individual Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2031
+msgid "Display Instances Drift"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1175
+msgid "Display Lists of All UI Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1171
+msgid "Display Lists of All VM Analysis Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:318
+msgid "Display Lists of Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:276
+msgid "Display Lists of Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:479
+msgid "Display Lists of Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1838
+msgid "Display Lists of Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1822
+msgid "Display Lists of Container Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1773
+msgid "Display Lists of Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1923
+msgid "Display Lists of Container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1800
+msgid "Display Lists of Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1909
+msgid "Display Lists of Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1885
+msgid "Display Lists of Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1945
+msgid "Display Lists of Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1644
+msgid "Display Lists of Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:461
+msgid "Display Lists of Datacenters"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:618
+msgid "Display Lists of Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1464
+msgid "Display Lists of File Shares"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:414
+msgid "Display Lists of Flavors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1273
+msgid "Display Lists of Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:514
+msgid "Display Lists of Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2109
+msgid "Display Lists of Images related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:429
+msgid "Display Lists of Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2025
+msgid "Display Lists of Instances related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:370
+msgid "Display Lists of Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1484
+msgid "Display Lists of Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1428
+msgid "Display Lists of Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1722
+msgid "Display Lists of Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1670
+msgid "Display Lists of Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1696
+msgid "Display Lists of Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1620
+msgid "Display Lists of Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1860
+msgid "Display Lists of Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1747
+msgid "Display Lists of Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:641
+msgid "Display Lists of Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:103
+msgid "Display Lists of Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:591
+msgid "Display Lists of Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1293
+msgid "Display Lists of Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:399
+msgid "Display Lists of Security Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:384
+msgid "Display Lists of Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1448
+msgid "Display Lists of Storage Extents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1500
+msgid "Display Lists of Storage Managers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1392
+msgid "Display Lists of Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1412
+msgid "Display Lists of Storage Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2299
+msgid "Display Lists of Template Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2261
+msgid "Display Lists of Templates related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:338
+msgid "Display Lists of Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1183
+msgid "Display Lists of UI Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1251
+msgid "Display Lists of Users"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1179
+msgid "Display Lists of VM Analysis Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2235
+msgid "Display Lists of VM Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2147
+msgid "Display Lists of VMs related to a CI"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:356
+msgid "Display Lists of Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1488
+msgid "Display Local File Systems Utilization"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1436
+msgid "Display Logical Disks Utilization Statistics"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/AdvancedSetting.yaml
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#. TRANSLATORS: file: product/views/MiqAeClass.yaml
+#. TRANSLATORS: file: product/views/MiqAeInstance.yaml
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../../app/views/miq_ae_class/_method_inputs.html.haml:48 ../../app/views/miq_ae_class/_instance_form.html.haml:46 ../../app/views/miq_ae_class/_method_form.html.haml:48 ../../app/views/miq_ae_class/_class_form.html.haml:45 ../../app/views/miq_ae_class/_class_props.html.haml:42 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../yaml_strings.rb:2905
 msgid "Display Name"
 msgstr ""
 
-#: ../../app/views/container_topology/show.html.haml:15
+#: ../../app/views/shared/_topology_header.html.haml:9
 msgid "Display Names"
 msgstr ""
 
@@ -7941,8 +11603,139 @@ msgstr ""
 msgid "Display Settings"
 msgstr ""
 
-#: ../../app/views/catalog/_form_basic_info.html.haml:43 ../../app/views/catalog/_sandt_tree_show.html.haml:47
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1452
+msgid "Display Storage Extents Utilization"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1396
+msgid "Display Storage Systems Utilization"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1416
+msgid "Display Storage Volumes Utilization"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2267
+msgid "Display Templates Drift"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:326
+msgid "Display Timelines for Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:282
+msgid "Display Timelines for Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:487
+msgid "Display Timelines for Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1779
+msgid "Display Timelines for Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1947
+msgid "Display Timelines for Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1650
+msgid "Display Timelines for Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:522
+msgid "Display Timelines for Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2119
+msgid "Display Timelines for Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:433
+msgid "Display Timelines for Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2035
+msgid "Display Timelines for Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1674
+msgid "Display Timelines for Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1700
+msgid "Display Timelines for Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1751
+msgid "Display Timelines for Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2271
+msgid "Display Timelines for Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:344
+msgid "Display Timelines for Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2157
+msgid "Display Timelines for VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1927
+msgid "Display Timelines for container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1806
+msgid "Display Timelines for container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2153
+msgid "Display VMs Drift"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#: ../../app/views/catalog/_form_basic_info.html.haml:43 ../../app/views/catalog/_sandt_tree_show.html.haml:47 ../yaml_strings.rb:3733
 msgid "Display in Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1131
+msgid "Display of Bottlenecks data"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1127
+msgid "Display of Planning Data"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1123
+msgid "Display of Utilization Data"
 msgstr ""
 
 #: ../../app/views/shared/buttons/_ab_list.html.haml:158 ../../app/views/shared/buttons/_ab_show.html.haml:27 ../../app/views/shared/buttons/_ab_form.html.haml:55 ../../app/views/shared/buttons/_group_form.html.haml:36
@@ -7973,7 +11766,10 @@ msgstr ""
 msgid "Do you want to promote this Server to primary?  This will replace any existing primary Server for this Role."
 msgstr ""
 
-#: ../../app/helpers/provider_foreman_helper.rb:68 ../../app/views/ops/_settings_server_tab.html.haml:417
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/Group.yaml
+#: ../../app/helpers/provider_foreman_helper.rb:68 ../../app/helpers/provider_foreman_helper.rb:149 ../../app/views/ops/_settings_server_tab.html.haml:417 ../yaml_strings.rb:3117
 msgid "Domain"
 msgstr ""
 
@@ -8009,8 +11805,53 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1336
+msgid "Download Audit Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:695
+msgid "Download CSV Format"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1338
+msgid "Download EVM Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:699
+msgid "Download PDF Format"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1340
+msgid "Download Production Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:697
+msgid "Download Report in CSV Format"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:701
+msgid "Download Report in PDF Format"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:705
+msgid "Download Report in Text Format"
+msgstr ""
+
 #: ../../app/views/layouts/_x_edit_buttons.html.haml:62 ../../app/views/layouts/_x_edit_buttons.html.haml:201
 msgid "Download Report to YAML"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:703
+msgid "Download Text Format"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/gtl_view.rb:43 ../../app/helpers/application_helper/toolbar/report_view.rb:42 ../../app/helpers/application_helper/toolbar/compare_view.rb:33 ../../app/helpers/application_helper/toolbar/miq_capacity_view.rb:20 ../../app/helpers/application_helper/toolbar/x_gtl_view.rb:43 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:19 ../../app/helpers/application_helper/toolbar/drift_view.rb:33
@@ -8073,6 +11914,10 @@ msgstr ""
 msgid "Download these items in text format"
 msgstr ""
 
+#: ../../app/controllers/dashboard_controller.rb:613
+msgid "Download this Timeline data in %{typ} format"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/timeline_center.rb:12
 msgid "Download this Timeline data in CSV format"
 msgstr ""
@@ -8097,7 +11942,11 @@ msgstr ""
 msgid "Download this report in text format"
 msgstr ""
 
-#: ../../app/views/catalog/_ot_tree_show.html.haml:37 ../../app/views/catalog/_ot_add.html.haml:78 ../../app/views/catalog/_ot_copy.html.haml:61 ../../app/views/catalog/_ot_edit.html.haml:55
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#: ../../app/views/catalog/_ot_tree_show.html.haml:37 ../../app/views/catalog/_ot_add.html.haml:78 ../../app/views/catalog/_ot_copy.html.haml:61 ../../app/views/catalog/_ot_edit.html.haml:55 ../yaml_strings.rb:2744
 msgid "Draft"
 msgstr ""
 
@@ -8113,11 +11962,12 @@ msgstr ""
 msgid "Drag/drop Widget \"%s\""
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:21
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/configuration/_ui_2.html.haml:21 ../yaml_strings.rb:475
 msgid "Drift"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1673 ../../app/views/layouts/listnav/_host.html.haml:146 ../../app/views/layouts/listnav/_ems_cluster.html.haml:86
+#: ../../app/controllers/vm_common.rb:1754 ../../app/helpers/vm_cloud_helper/textual_summary.rb:255 ../../app/helpers/host_helper/textual_summary.rb:279 ../../app/helpers/ems_cluster_helper/textual_summary.rb:192 ../../app/helpers/vm_infra_helper/textual_summary.rb:277 ../../app/helpers/vm_helper/textual_summary.rb:375 ../../app/views/layouts/listnav/_host.html.haml:146 ../../app/views/layouts/listnav/_ems_cluster.html.haml:86
 msgid "Drift History"
 msgid_plural "Drift History"
 msgstr[0] ""
@@ -8127,11 +11977,11 @@ msgstr[1] ""
 msgid "Drift Mode"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_compare_sections.html.haml:157
+#: ../../app/views/layouts/listnav/_compare_sections.html.haml:153
 msgid "Drift Sections"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1727
+#: ../../app/controllers/vm_common.rb:1808
 msgid "Drift for %{model} \"%{name}\""
 msgstr ""
 
@@ -8155,6 +12005,10 @@ msgstr ""
 msgid "Driving Event"
 msgstr ""
 
+#: ../../app/helpers/container_helper/textual_summary.rb:78
+msgid "Drop Capabilities"
+msgstr ""
+
 #: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:702
 msgid "Dropdown elements require some entries"
 msgstr ""
@@ -8167,7 +12021,8 @@ msgstr ""
 msgid "E-Mail after Running"
 msgstr ""
 
-#: ../../app/views/layouts/_edit_email.html.haml:1
+#. TRANSLATORS: file: product/views/User.yaml
+#: ../../app/views/layouts/_edit_email.html.haml:1 ../yaml_strings.rb:2720
 msgid "E-mail"
 msgstr ""
 
@@ -8199,7 +12054,7 @@ msgstr ""
 msgid "ESX"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:86
+#: ../../app/helpers/host_helper/textual_summary.rb:502 ../../app/views/layouts/listnav/_host.html.haml:86
 msgid "ESX Logs"
 msgstr ""
 
@@ -8216,6 +12071,10 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.table.server_builds
 #: ../dictionary_strings.rb:2079
 msgid "EVM Builds"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:575
+msgid "EVM Capacity Management Configuration"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.miq_custom_attribute
@@ -8249,6 +12108,26 @@ msgstr ""
 msgid "EVM Owners"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#: ../yaml_strings.rb:3476
+msgid "EVM Server"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#: ../yaml_strings.rb:3679
+msgid "EVM Server Builds"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#: ../yaml_strings.rb:3751
+msgid "EVM Server Maintenance"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#: ../yaml_strings.rb:3478
+msgid "EVM Servers"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.guid
 #: ../dictionary_strings.rb:401
 msgid "EVM Unique ID (Guid)"
@@ -8264,34 +12143,53 @@ msgstr ""
 msgid "EVM Users"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:574
+msgid "EVM Vim Broker Notification Properties"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqWorker
 #. TRANSLATORS: en.yml key: dictionary.table.miq_worker
-#: ../dictionary_strings.rb:1597 ../dictionary_strings.rb:2031
+#: ../yaml_strings.rb:3527 ../dictionary_strings.rb:1597 ../dictionary_strings.rb:2031
 msgid "EVM Worker"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqWorker (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_worker (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_workers
-#: ../dictionary_strings.rb:1599 ../dictionary_strings.rb:2033 ../dictionary_strings.rb:2035
+#: ../yaml_strings.rb:3529 ../dictionary_strings.rb:1599 ../dictionary_strings.rb:2033 ../dictionary_strings.rb:2035
 msgid "EVM Workers"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.zone_name
-#: ../dictionary_strings.rb:1139
+#: ../yaml_strings.rb:3226 ../dictionary_strings.rb:1139
 msgid "EVM Zone"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:70 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:70
+#: ../../app/controllers/ops_controller/diagnostics.rb:177
+msgid "EVM log downloaded"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/configuration_controller.rb:356 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:70 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:70 ../yaml_strings.rb:133
 msgid "Edit"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:712 ../../app/controllers/provider_foreman_controller.rb:810
+#: ../../app/controllers/provider_foreman_controller.rb:664 ../../app/controllers/provider_foreman_controller.rb:762
 msgid "Edit %s Provider"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/alert_profiles.rb:81
 msgid "Edit %{model} assignments cancelled by user"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:278 ../../app/controllers/ems_cloud_controller.rb:66
+msgid "Edit %{table} '%{name}'"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:50
@@ -8318,48 +12216,267 @@ msgstr ""
 msgid "Edit '#{session[:customer_name]}' Tags for this User"
 msgstr ""
 
+#: ../../app/controllers/configuration_controller.rb:545 ../../app/controllers/configuration_controller.rb:563 ../../app/controllers/configuration_controller.rb:578
+msgid "Edit '%{description}'"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_event_center.rb:12
 msgid "Edit Actions for this Policy Event"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1220
+msgid "Edit Analysis Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:163
+msgid "Edit Atomic Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1002
+msgid "Edit Automate Class"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:964
+msgid "Edit Automate Domain"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1016
+msgid "Edit Automate Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1028
+msgid "Edit Automate Method"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:990
+msgid "Edit Automate Namespace"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1036
+msgid "Edit Automate Schema"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_policy_center.rb:12
 msgid "Edit Basic Info, Scope, and Notes"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1744
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:169
+msgid "Edit Button"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1825
 msgid "Edit CFME Server Relationship for %{model} \"%{name}\""
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:200
+msgid "Edit Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:175
+msgid "Edit Catalog Items Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:155
+msgid "Edit Composite Catalog Item"
 msgstr ""
 
 #: ../../app/views/chargeback/_assignments_list.html.haml:9 ../../app/views/chargeback/_assignments_list.html.haml:20 ../../app/views/chargeback/_assignments_list.html.haml:28 ../../app/views/chargeback/_assignments_list.html.haml:33
 msgid "Edit Compute Rate Assignments"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:862
+msgid "Edit Condition Assignment"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1987
+msgid "Edit Configured Systems Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1955
+msgid "Edit Container"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1566
+msgid "Edit Customization Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:628
+msgid "Edit Datastore Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1149
+msgid "Edit Default Filters"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1145
+msgid "Edit Default Views"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1055
+msgid "Edit Dialog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2101
+msgid "Edit EVM Server Relationship"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:900
+msgid "Edit Event"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:866
+msgid "Edit Event Assignment"
+msgstr ""
+
 #: ../../app/controllers/miq_policy_controller/events.rb:9
 msgid "Edit Event cancelled by user"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:95
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1476
+msgid "Edit File Shares Tags"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:326 ../../app/controllers/host_controller.rb:392 ../../app/controllers/host_controller.rb:413
+msgid "Edit Host '%{name}'"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:540
+msgid "Edit Host / Node Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1602
+msgid "Edit ISO Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1604
+msgid "Edit ISO Images on ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2133
+msgid "Edit Image Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2089
+msgid "Edit Instance Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1492
+msgid "Edit Local File Systems Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1342
+msgid "Edit Log Depot Settings"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:103
 msgid "Edit Log Depot settings was cancelled by the user"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1440
+msgid "Edit Logical Disks Tags"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:49 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:48 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:42
 msgid "Edit Management Engine Relationship"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:938
+msgid "Edit Management Engine Relationship was cancelled by the user"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1628
+msgid "Edit Orchestration Stack"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:219
+msgid "Edit Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:227
+msgid "Edit Orchestration Templates Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1545
+msgid "Edit PXE Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:864
+msgid "Edit Policy's Condition assignments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:868
+msgid "Edit Policy's Event assignments"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:35
 msgid "Edit Priority Order  of Domains"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:36
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:36 ../yaml_strings.rb:970
 msgid "Edit Priority Order of Domains"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2001
+msgid "Edit Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1089
+msgid "Edit Provisioning Dialog"
 msgstr ""
 
 #: ../../app/views/ops/_settings_rhn_tab.html.haml:28
 msgid "Edit Registration"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:303
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/report_controller.rb:299 ../yaml_strings.rb:790
 msgid "Edit Report Menus"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:792
+msgid "Edit Report Menus Accordion"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/containers_center.rb:19
@@ -8414,6 +12531,11 @@ msgstr ""
 msgid "Edit Selected #{ui_lookup(:table=>\"persistent_volume\")}"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1004
+msgid "Edit Selected Automate Namespace/Class"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:26
 msgid "Edit Selected Customization Templates"
 msgstr ""
@@ -8462,11 +12584,22 @@ msgstr ""
 msgid "Edit Selected items"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:764
+msgid "Edit Sequence"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1038
+msgid "Edit Sequence of Automate Schema"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_widget_sets_center.rb:18
 msgid "Edit Sequence of Dashboards"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:35
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:35 ../yaml_strings.rb:1283
 msgid "Edit Sequence of User Groups for LDAP Look Up"
 msgstr ""
 
@@ -8474,15 +12607,54 @@ msgstr ""
 msgid "Edit Sequence of User Groups was cancelled by the user"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:15 ../../app/helpers/application_helper/toolbar/vm_center.rb:87 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:46 ../../app/helpers/application_helper/toolbar/host_center.rb:54 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:30 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:85 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:63 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:15 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:46 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:36 ../../app/helpers/application_helper/toolbar/services_center.rb:53 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:15 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:46 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:46 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:72 ../../app/helpers/application_helper/toolbar/container_service_center.rb:53 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:35 ../../app/helpers/application_helper/toolbar/container_center.rb:36 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:45 ../../app/helpers/application_helper/toolbar/container_route_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:15 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/security_group_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:58 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:41 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:86 ../../app/helpers/application_helper/toolbar/repository_center.rb:48 ../../app/helpers/application_helper/toolbar/container_project_center.rb:60 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:47 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:95 ../../app/helpers/application_helper/toolbar/vms_center.rb:87 ../../app/helpers/application_helper/toolbar/container_node_center.rb:60 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:46 ../../app/helpers/application_helper/toolbar/storage_center.rb:37 ../../app/helpers/application_helper/toolbar/flavors_center.rb:15 ../../app/helpers/application_helper/toolbar/container_image_center.rb:29 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:73 ../../app/helpers/application_helper/toolbar/service_center.rb:48 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:46 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:121 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:62 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:53 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:34 ../../app/helpers/application_helper/toolbar/container_group_center.rb:60 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:48 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:13 ../../app/helpers/application_helper/toolbar/flavor_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/container_services_center.rb:46 ../../app/helpers/application_helper/toolbar/hosts_center.rb:90 ../../app/helpers/application_helper/toolbar/storages_center.rb:45 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:44 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:112 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:60 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:73 ../../app/helpers/application_helper/toolbar/repositories_center.rb:66 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:28 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:46 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:52 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:36 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:64 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:60 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:13 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:13 ../../app/helpers/application_helper/toolbar/containers_center.rb:46 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:40 ../../app/helpers/application_helper/toolbar/container_images_center.rb:34 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:51 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:15 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:59
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:245
+msgid "Edit Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1456
+msgid "Edit Storage Extents Tags"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:148 ../../app/controllers/storage_manager_controller.rb:202
+msgid "Edit Storage Manager '%{name}'"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1404
+msgid "Edit Storage Systems Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1420
+msgid "Edit Storage Volumes Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1583
+msgid "Edit System Image Type"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:15 ../../app/helpers/application_helper/toolbar/vm_center.rb:87 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:46 ../../app/helpers/application_helper/toolbar/host_center.rb:54 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:30 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:85 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:63 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:15 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:46 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:36 ../../app/helpers/application_helper/toolbar/configured_system_ansibletower_center.rb:13 ../../app/helpers/application_helper/toolbar/services_center.rb:53 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:15 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:46 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:46 ../../app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb:15 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:31 ../../app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:72 ../../app/helpers/application_helper/toolbar/container_service_center.rb:53 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:35 ../../app/helpers/application_helper/toolbar/configured_systems_center.rb:33 ../../app/helpers/application_helper/toolbar/container_center.rb:36 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:45 ../../app/helpers/application_helper/toolbar/container_route_center.rb:36 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:15 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/security_group_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:13 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:58 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:74 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:41 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:86 ../../app/helpers/application_helper/toolbar/repository_center.rb:48 ../../app/helpers/application_helper/toolbar/container_project_center.rb:60 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:47 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb:13 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:95 ../../app/helpers/application_helper/toolbar/vms_center.rb:87 ../../app/helpers/application_helper/toolbar/container_node_center.rb:60 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:46 ../../app/helpers/application_helper/toolbar/storage_center.rb:37 ../../app/helpers/application_helper/toolbar/flavors_center.rb:15 ../../app/helpers/application_helper/toolbar/container_image_center.rb:29 ../../app/helpers/application_helper/toolbar/configured_system_center.rb:33 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:73 ../../app/helpers/application_helper/toolbar/service_center.rb:48 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:46 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:121 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:62 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:53 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:34 ../../app/helpers/application_helper/toolbar/container_group_center.rb:60 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:48 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:13 ../../app/helpers/application_helper/toolbar/flavor_center.rb:13 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:15 ../../app/helpers/application_helper/toolbar/container_services_center.rb:46 ../../app/helpers/application_helper/toolbar/hosts_center.rb:90 ../../app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb:15 ../../app/helpers/application_helper/toolbar/storages_center.rb:45 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:44 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:112 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:60 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:73 ../../app/helpers/application_helper/toolbar/repositories_center.rb:66 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:28 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:46 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:52 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:36 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:13 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:64 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:60 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:13 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:13 ../../app/helpers/application_helper/toolbar/containers_center.rb:46 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:40 ../../app/helpers/application_helper/toolbar/container_images_center.rb:34 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:51 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:15 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:33 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:59 ../yaml_strings.rb:173
 msgid "Edit Tags"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1800 ../../app/controllers/service_controller.rb:279 ../../app/controllers/container_controller.rb:239
-msgid "Edit Tags for %s"
+#: ../../app/controllers/service_controller.rb:274 ../../app/controllers/container_controller.rb:237
+msgid "Edit Tags for %{model}"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:686
+#: ../../app/controllers/vm_common.rb:1881
+msgid "Edit Tags for %{table}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:500
+msgid "Edit Tags for Clusters / Deployment Roles"
+msgstr ""
+
+#: ../../app/controllers/provider_foreman_controller.rb:638
 msgid "Edit Tags for Configured Systems"
 msgstr ""
 
@@ -8654,7 +12826,7 @@ msgstr ""
 msgid "Edit Tags for this Catalog Item"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:30 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:30 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:32 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:32
+#: ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:30 ../../app/helpers/application_helper/toolbar/configured_system_ansibletower_center.rb:12 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:30 ../../app/helpers/application_helper/toolbar/configured_systems_center.rb:32 ../../app/helpers/application_helper/toolbar/configured_system_center.rb:32 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:32 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:32
 msgid "Edit Tags for this Configured System"
 msgstr ""
 
@@ -8710,27 +12882,420 @@ msgstr ""
 msgid "Edit Tags for this item"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:330
+msgid "Edit Tags of Availability Zone"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:290
+msgid "Edit Tags of Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1852
+msgid "Edit Tags of Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1828
+msgid "Edit Tags of Container Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1791
+msgid "Edit Tags of Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1931
+msgid "Edit Tags of Container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1816
+msgid "Edit Tags of Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1915
+msgid "Edit Tags of Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1901
+msgid "Edit Tags of Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1967
+msgid "Edit Tags of Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1656
+msgid "Edit Tags of Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:420
+msgid "Edit Tags of Flavor"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:439
+msgid "Edit Tags of Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:376
+msgid "Edit Tags of Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1736
+msgid "Edit Tags of Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1680
+msgid "Edit Tags of Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1714
+msgid "Edit Tags of Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1632
+msgid "Edit Tags of Orchestration Stack"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1874
+msgid "Edit Tags of Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1765
+msgid "Edit Tags of Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:647
+msgid "Edit Tags of Repository"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:597
+msgid "Edit Tags of Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:405
+msgid "Edit Tags of Security Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:261
+msgid "Edit Tags of Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:390
+msgid "Edit Tags of Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:348
+msgid "Edit Tags of Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:362
+msgid "Edit Tags of Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2285
+msgid "Edit Template Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1153
+msgid "Edit Time Profiles"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:427
+msgid "Edit User Group Sequence"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1069
+msgid "Edit VM '%{name}''"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2199
+msgid "Edit VM Tags"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1141
+msgid "Edit Visuals"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1549
+msgid "Edit Windows Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:202
+msgid "Edit a Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:814
+msgid "Edit a Chargeback Rate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:306
+msgid "Edit a Cloud Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:157
+msgid "Edit a Composite Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:887
+msgid "Edit a Condition"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1957
+msgid "Edit a Container"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1846
+msgid "Edit a Container Image Registry"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1785
+msgid "Edit a Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1810
+msgid "Edit a Container Replicator"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1895
+msgid "Edit a Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1662
+msgid "Edit a Containers Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:762
+msgid "Edit a Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1281
+msgid "Edit a Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:580
+msgid "Edit a Host / Node"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2139
+msgid "Edit a Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2099
+msgid "Edit a Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1730
+msgid "Edit a Middleware Deployment"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1686
+msgid "Edit a Middleware Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1708
+msgid "Edit a Middleware Server"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1868
+msgid "Edit a Persistent Volume"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1759
+msgid "Edit a Pod"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:860
+msgid "Edit a Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:911
+msgid "Edit a Policy Action"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:940
+msgid "Edit a Policy Alert"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:923
+msgid "Edit a Policy Alert Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:846
+msgid "Edit a Policy Profile"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2003
+msgid "Edit a Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:719
+msgid "Edit a Report"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:659
+msgid "Edit a Repository"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:135
+msgid "Edit a Request"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1301
+msgid "Edit a Role"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:738
+msgid "Edit a Schedule"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2293
+msgid "Edit a Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1314
+msgid "Edit a Tenant/Project"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1259
+msgid "Edit a User"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2219
+msgid "Edit a VM"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:786
+msgid "Edit a Widget"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1236
+msgid "Edit a Zone"
+msgstr ""
+
 #: ../../app/controllers/application_controller.rb:822
 msgid "Edit aborted!  CFME does not support the browser's back button or access from multiple tabs or windows of the same browser.  Please close any duplicate sessions before proceeding."
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:165
+msgid "Edit an Atomic Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:449
+msgid "Edit an Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1547
+msgid "Edit an PXE Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1543
+msgid "Edit an PXE Server"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1520
+msgid "Edit an Storage Manager"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1551
+msgid "Edit an Windows Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:925
+msgid "Edit assignments"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_alert_profile_center.rb:18
 msgid "Edit assignments for this Alert Profile"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:117 ../../app/controllers/report_controller/dashboards.rb:64 ../../app/controllers/report_controller/widgets.rb:49 ../../app/controllers/report_controller/reports/editor.rb:32 ../../app/controllers/report_controller/schedules.rb:219 ../../app/controllers/miq_policy_controller/policies.rb:11 ../../app/controllers/miq_policy_controller/miq_actions.rb:11 ../../app/controllers/miq_policy_controller/alerts.rb:13 ../../app/controllers/miq_policy_controller/alert_profiles.rb:13 ../../app/controllers/miq_policy_controller/conditions.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:13 ../../app/controllers/vm_common.rb:1035 ../../app/controllers/vm_common.rb:1039 ../../app/controllers/miq_ae_class_controller.rb:591 ../../app/controllers/miq_ae_class_controller.rb:998 ../../app/controllers/miq_ae_class_controller.rb:1092 ../../app/controllers/miq_ae_class_controller.rb:1136 ../../app/controllers/storage_manager_controller.rb:180 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:241 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:195 ../../app/controllers/service_controller.rb:149 ../../app/controllers/catalog_controller.rb:93 ../../app/controllers/catalog_controller.rb:358 ../../app/controllers/catalog_controller.rb:610 ../../app/controllers/catalog_controller.rb:980 ../../app/controllers/ops_controller/settings/tags.rb:43 ../../app/controllers/ops_controller/settings/ldap.rb:38 ../../app/controllers/ops_controller/settings/ldap.rb:164 ../../app/controllers/ops_controller/settings/zones.rb:9 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:220 ../../app/controllers/ops_controller/settings/schedules.rb:43 ../../app/controllers/ops_controller/ops_rbac.rb:109 ../../app/controllers/host_controller.rb:333 ../../app/controllers/configuration_controller.rb:531 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:100 ../../app/controllers/pxe_controller/iso_datastores.rb:173 ../../app/controllers/pxe_controller/pxe_image_types.rb:29 ../../app/controllers/pxe_controller/pxe_servers.rb:46 ../../app/controllers/pxe_controller/pxe_servers.rb:193 ../../app/controllers/pxe_controller/pxe_servers.rb:245 ../../app/controllers/ems_common.rb:244 ../../app/controllers/ems_cloud_controller.rb:33 ../../app/controllers/application_controller/buttons.rb:308 ../../app/controllers/application_controller/buttons.rb:433 ../../app/controllers/application_controller/miq_request_methods.rb:178
+#: ../../app/controllers/repository_controller.rb:118 ../../app/controllers/report_controller/widgets.rb:49 ../../app/controllers/report_controller/reports/editor.rb:32 ../../app/controllers/report_controller/schedules.rb:223 ../../app/controllers/miq_policy_controller/policies.rb:11 ../../app/controllers/miq_policy_controller/miq_actions.rb:11 ../../app/controllers/miq_policy_controller/alerts.rb:13 ../../app/controllers/miq_policy_controller/alert_profiles.rb:13 ../../app/controllers/miq_policy_controller/conditions.rb:11 ../../app/controllers/miq_policy_controller/policy_profiles.rb:13 ../../app/controllers/vm_common.rb:1096 ../../app/controllers/vm_common.rb:1100 ../../app/controllers/miq_ae_class_controller.rb:585 ../../app/controllers/miq_ae_class_controller.rb:992 ../../app/controllers/miq_ae_class_controller.rb:1086 ../../app/controllers/miq_ae_class_controller.rb:1130 ../../app/controllers/storage_manager_controller.rb:182 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:241 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:195 ../../app/controllers/catalog_controller.rb:94 ../../app/controllers/catalog_controller.rb:576 ../../app/controllers/ops_controller/settings/tags.rb:47 ../../app/controllers/ops_controller/settings/ldap.rb:38 ../../app/controllers/ops_controller/settings/ldap.rb:164 ../../app/controllers/ops_controller/settings/zones.rb:9 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:220 ../../app/controllers/ops_controller/settings/schedules.rb:43 ../../app/controllers/ops_controller/ops_rbac.rb:109 ../../app/controllers/host_controller.rb:366 ../../app/controllers/configuration_controller.rb:534 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:100 ../../app/controllers/pxe_controller/iso_datastores.rb:173 ../../app/controllers/pxe_controller/pxe_image_types.rb:29 ../../app/controllers/pxe_controller/pxe_servers.rb:46 ../../app/controllers/pxe_controller/pxe_servers.rb:193 ../../app/controllers/pxe_controller/pxe_servers.rb:245 ../../app/controllers/ems_common.rb:249 ../../app/controllers/ems_cloud_controller.rb:33 ../../app/controllers/application_controller/buttons.rb:308 ../../app/controllers/application_controller/buttons.rb:433 ../../app/controllers/application_controller/miq_request_methods.rb:178
 msgid "Edit of %{model} \"%{name}\" was cancelled by the user"
-msgstr ""
-
-#: ../../app/controllers/report_controller/menus.rb:192
-msgid "Edit of %{model} for role \"%{role}\" was cancelled by the user"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/ops_rbac.rb:654
 msgid "Edit of %{name} was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1476
+#: ../../app/controllers/catalog_controller.rb:318
+msgid "Edit of Catalog Bundle \"%{name}\" was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1470
 msgid "Edit of Class Schema Sequence was cancelled by the user"
 msgstr ""
 
@@ -8738,19 +13303,35 @@ msgstr ""
 msgid "Edit of Customer Information was cancelled"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:64
+msgid "Edit of Dashboard \"%{name}\" was cancelled by the user"
+msgstr ""
+
 #: ../../app/controllers/report_controller/dashboards.rb:9
 msgid "Edit of Dashboard Sequence was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1538
+#: ../../app/controllers/catalog_controller.rb:975
+msgid "Edit of Orchestration Template \"%{name}\" was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1532
 msgid "Edit of Priority Order was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:326
-msgid "Edit of credentials for selected %s was cancelled by the user"
+#: ../../app/controllers/report_controller/menus.rb:192
+msgid "Edit of Report Menu for role \"%{role}\" was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1042
+#: ../../app/controllers/service_controller.rb:137
+msgid "Edit of Service \"%{name}\" was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:358
+msgid "Edit of credentials for selected %{models} was cancelled by the user"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1036
 msgid "Edit of schema for %{model} \"%{name}\" was cancelled by the user"
 msgstr ""
 
@@ -8778,6 +13359,11 @@ msgstr ""
 msgid "Edit sequence of Class Schema"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:766
+msgid "Edit sequence of Dashboards"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:14
 msgid "Edit tags for the selected File Shares"
 msgstr ""
@@ -8802,8 +13388,12 @@ msgstr ""
 msgid "Edit tags for the selected Volumes"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:14 ../../app/helpers/application_helper/toolbar/vms_center.rb:86 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:120 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:111 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:95 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:12
+#: ../../app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb:14 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:14 ../../app/helpers/application_helper/toolbar/vms_center.rb:86 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:120 ../../app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb:14 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:111 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:95 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:12
 msgid "Edit tags for the selected items"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb:12
+msgid "Edit tags for this #{ui_lookup(:table=>\"cloud_volume_snapshots\")}"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:12
@@ -8812,6 +13402,10 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:12
 msgid "Edit tags for this Cloud Tenant"
+msgstr ""
+
+#: ../../app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb:12
+msgid "Edit tags for this Key Pair"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:69
@@ -9122,7 +13716,7 @@ msgstr ""
 msgid "Editing"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:712 ../../app/controllers/catalog_controller.rb:1022
+#: ../../app/controllers/catalog_controller.rb:682 ../../app/controllers/catalog_controller.rb:1017
 msgid "Editing %s"
 msgstr ""
 
@@ -9130,11 +13724,11 @@ msgstr ""
 msgid "Editing %s File"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:550 ../../app/controllers/ops_controller.rb:560 ../../app/controllers/ops_controller.rb:569 ../../app/controllers/ops_controller.rb:583 ../../app/controllers/ops_controller.rb:594 ../../app/controllers/ops_controller.rb:605 ../../app/controllers/ops_controller.rb:651 ../../app/controllers/miq_ae_customization_controller.rb:413 ../../app/controllers/miq_ae_customization_controller.rb:417 ../../app/controllers/miq_ae_customization_controller.rb:434 ../../app/controllers/miq_ae_customization_controller.rb:473 ../../app/controllers/report_controller/menus.rb:748 ../../app/controllers/vm_common.rb:1740 ../../app/controllers/miq_ae_class_controller.rb:568 ../../app/controllers/miq_ae_class_controller.rb:713 ../../app/controllers/miq_ae_class_controller.rb:748 ../../app/controllers/miq_ae_class_controller.rb:788 ../../app/controllers/miq_ae_class_controller.rb:2437 ../../app/controllers/service_controller.rb:275 ../../app/controllers/container_controller.rb:234 ../../app/controllers/catalog_controller.rb:1177 ../../app/controllers/catalog_controller.rb:1329 ../../app/controllers/catalog_controller.rb:1379 ../../app/controllers/catalog_controller.rb:1813 ../../app/controllers/catalog_controller.rb:1817 ../../app/controllers/ops_controller/ops_rbac.rb:706 ../../app/controllers/pxe_controller.rb:201 ../../app/controllers/report_controller.rb:702 ../../app/controllers/report_controller.rb:715 ../../app/controllers/report_controller.rb:721 ../../app/controllers/report_controller.rb:728 ../../app/controllers/report_controller.rb:743 ../../app/controllers/report_controller.rb:850 ../../app/controllers/miq_policy_controller.rb:612 ../../app/controllers/miq_policy_controller.rb:643 ../../app/controllers/miq_policy_controller.rb:682 ../../app/controllers/miq_policy_controller.rb:689 ../../app/controllers/miq_policy_controller.rb:703 ../../app/controllers/miq_policy_controller.rb:712
+#: ../../app/controllers/ops_controller.rb:576 ../../app/controllers/ops_controller.rb:586 ../../app/controllers/ops_controller.rb:595 ../../app/controllers/ops_controller.rb:609 ../../app/controllers/ops_controller.rb:620 ../../app/controllers/ops_controller.rb:631 ../../app/controllers/ops_controller.rb:677 ../../app/controllers/miq_ae_customization_controller.rb:403 ../../app/controllers/miq_ae_customization_controller.rb:407 ../../app/controllers/miq_ae_customization_controller.rb:424 ../../app/controllers/miq_ae_customization_controller.rb:463 ../../app/controllers/report_controller/menus.rb:749 ../../app/controllers/vm_common.rb:1821 ../../app/controllers/miq_ae_class_controller.rb:562 ../../app/controllers/miq_ae_class_controller.rb:707 ../../app/controllers/miq_ae_class_controller.rb:742 ../../app/controllers/miq_ae_class_controller.rb:782 ../../app/controllers/miq_ae_class_controller.rb:2439 ../../app/controllers/service_controller.rb:270 ../../app/controllers/container_controller.rb:232 ../../app/controllers/catalog_controller.rb:1172 ../../app/controllers/catalog_controller.rb:1324 ../../app/controllers/ops_controller/ops_rbac.rb:706 ../../app/controllers/pxe_controller.rb:185 ../../app/controllers/report_controller.rb:708 ../../app/controllers/report_controller.rb:714 ../../app/controllers/report_controller.rb:725 ../../app/controllers/report_controller.rb:740 ../../app/controllers/report_controller.rb:847 ../../app/controllers/miq_policy_controller.rb:612 ../../app/controllers/miq_policy_controller.rb:645 ../../app/controllers/miq_policy_controller.rb:684 ../../app/controllers/miq_policy_controller.rb:691 ../../app/controllers/miq_policy_controller.rb:705 ../../app/controllers/miq_policy_controller.rb:714
 msgid "Editing %{model} \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:670
+#: ../../app/controllers/miq_policy_controller.rb:672
 msgid "Editing %{model} Condition \"%{name}\""
 msgstr ""
 
@@ -9142,12 +13736,41 @@ msgstr ""
 msgid "Editing %{model} for \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:699
-msgid "Editing %{model} sequence for \"%{name}\""
+#: ../../app/controllers/catalog_controller.rb:1810
+msgid "Editing Button \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1816
+msgid "Editing Button Group \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1374
+msgid "Editing Catalog Bundle \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/report_controller.rb:695
+msgid "Editing Dashboard \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/report_controller.rb:692
+msgid "Editing Dashboard sequence for \"%{name}\""
 msgstr ""
 
 #: ../../app/views/ops/_log_collection.html.haml:17 ../../app/views/layouts/_edit_log_depot_settings.html.haml:14
 msgid "Editing Log Depot Settings for %{class}: %{display}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:544
+msgid "Editing Log Depot settings"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/ops_rbac.rb:452
+msgid "Editing Sequence of User Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2407
+msgid "Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:6
@@ -9156,6 +13779,14 @@ msgstr ""
 
 #: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:682
 msgid "Element Label is required"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:41 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:31 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:34 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:31 ../yaml_strings.rb:3288
+msgid "Element Name"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:690
@@ -9174,8 +13805,9 @@ msgstr ""
 msgid "Eligible %s "
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.notify_email
-#: ../dictionary_strings.rb:649
+#: ../yaml_strings.rb:3703 ../dictionary_strings.rb:649
 msgid "Email"
 msgstr ""
 
@@ -9185,6 +13817,11 @@ msgstr ""
 
 #: ../model_attributes.rb:462
 msgid "Ems folder"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#: ../yaml_strings.rb:3585
+msgid "EmsCloud"
 msgstr ""
 
 #: ../model_attributes.rb:447
@@ -9247,6 +13884,11 @@ msgstr ""
 msgid "EmsCluster|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#: ../yaml_strings.rb:3628
+msgid "EmsContainer"
+msgstr ""
+
 #: ../model_attributes.rb:463
 msgid "EmsFolder|Created on"
 msgstr ""
@@ -9275,6 +13917,21 @@ msgstr ""
 msgid "EmsFolder|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#: ../yaml_strings.rb:3357
+msgid "EmsInfra"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#: ../yaml_strings.rb:3342
+msgid "EmsMiddleware"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:453 ../../app/helpers/vm_infra_helper/textual_summary.rb:591 ../../app/helpers/vm_helper/textual_summary.rb:688 ../yaml_strings.rb:742
+msgid "Enable"
+msgstr ""
+
 #: ../../app/views/ops/_settings_cu_collection_tab.html.haml:55
 msgid "Enable Collection by %s"
 msgstr ""
@@ -9287,12 +13944,33 @@ msgstr ""
 msgid "Enable Single Sign-On"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:744
+msgid "Enable a Schedule"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:34 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:34
 msgid "Enable the selected Schedules"
 msgstr ""
 
-#: ../../app/views/miq_ae_class/_ns_list.html.haml:24 ../../app/views/miq_ae_class/_ns_list.html.haml:132 ../../app/views/report/_report_info.html.haml:253
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#: ../../app/helpers/host_helper/textual_summary.rb:188 ../../app/views/miq_ae_class/_ns_list.html.haml:24 ../../app/views/miq_ae_class/_ns_list.html.haml:132 ../../app/views/report/_report_info.html.haml:253 ../yaml_strings.rb:3123
 msgid "Enabled"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#: ../yaml_strings.rb:3511
+msgid "Enabled Run Levels"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:65 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:58 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:41
+msgid "Enabled State"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#: ../yaml_strings.rb:3775
+msgid "Enabled run levels"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.end_trend_value
@@ -9304,11 +13982,12 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:245
+#: ../../app/controllers/ops_controller/diagnostics.rb:257
 msgid "End Date cannot be greater than Start Date"
 msgstr ""
 
-#: ../../app/views/security_group/_main.html.haml:20
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#: ../../app/views/security_group/_main.html.haml:20 ../yaml_strings.rb:3828
 msgid "End Port"
 msgstr ""
 
@@ -9320,7 +13999,8 @@ msgstr ""
 msgid "Enter Automation Simulation options on the left and press Submit."
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/host_center.rb:120
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/host_center.rb:120 ../yaml_strings.rb:554
 msgid "Enter Maintenance Mode"
 msgstr ""
 
@@ -9336,8 +14016,16 @@ msgstr ""
 msgid "Enter URL Manually"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:57
+msgid "Enter your Red Hat Network Satellite account information"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:55
+msgid "Enter your Red Hat account information"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.MiqEnterprise
-#: ../../app/presenters/tree_builder.rb:52 ../dictionary_strings.rb:1529
+#: ../../app/presenters/tree_builder.rb:96 ../dictionary_strings.rb:1529
 msgid "Enterprise"
 msgstr ""
 
@@ -9366,7 +14054,11 @@ msgstr ""
 msgid "Entry Point must be given."
 msgstr ""
 
-#: ../../app/helpers/provider_foreman_helper.rb:64 ../../app/views/provider_foreman/_main.html.haml:9 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:9
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../../app/helpers/provider_foreman_helper.rb:64 ../../app/helpers/provider_foreman_helper.rb:145 ../../app/views/provider_foreman/_main.html.haml:9 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:9 ../yaml_strings.rb:3075
 msgid "Environment"
 msgstr ""
 
@@ -9378,15 +14070,15 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: ../../app/controllers/dashboard_controller.rb:769
+#: ../../app/controllers/dashboard_controller.rb:756
 msgid "Error building timeline  %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:722 ../../app/controllers/application_controller/timelines.rb:222 ../../app/controllers/application_controller/timelines.rb:477
+#: ../../app/controllers/miq_capacity_controller.rb:723 ../../app/controllers/application_controller/timelines.rb:222 ../../app/controllers/application_controller/timelines.rb:479
 msgid "Error building timeline %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:108
+#: ../../app/controllers/application_controller/filter.rb:110
 msgid "Error details: %s"
 msgstr ""
 
@@ -9394,16 +14086,36 @@ msgstr ""
 msgid "Error during %{task}: Status [%{status}] Message [%{message}]"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:239 ../../app/controllers/miq_ae_tools_controller.rb:198 ../../app/controllers/vm_common.rb:589 ../../app/controllers/vm_common.rb:975 ../../app/controllers/vm_common.rb:988 ../../app/controllers/vm_common.rb:1072 ../../app/controllers/miq_ae_class_controller.rb:675 ../../app/controllers/miq_ae_class_controller.rb:1101 ../../app/controllers/storage_manager_controller.rb:448 ../../app/controllers/service_controller.rb:159 ../../app/controllers/ops_controller/settings/tags.rb:77 ../../app/controllers/ops_controller/settings/upload.rb:77 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:262 ../../app/controllers/report_controller.rb:80 ../../app/controllers/application_controller/ci_processing.rb:1303
+#: ../../app/controllers/miq_ae_tools_controller.rb:198 ../../app/controllers/miq_ae_class_controller.rb:669 ../../app/controllers/miq_ae_class_controller.rb:1095 ../../app/controllers/application_controller/ci_processing.rb:1317
 msgid "Error during '%s': "
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1702
+#: ../../app/controllers/vm_common.rb:1133
+msgid "Error during '%{name} update': %{message}"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1704
 msgid "Error during '%{record} copy': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1268
+#: ../../app/controllers/storage_manager_controller.rb:454
+msgid "Error during '%{task} ': %{message}"
+msgstr ""
+
+#: ../../app/controllers/application_controller/ci_processing.rb:1282
 msgid "Error during '%{task}': %{error_message}"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:451
+msgid "Error during '%{task}': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:262
+msgid "Error during '%{title}': %{message}"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1036
+msgid "Error during 'Add VM to service': %{message}"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/alert_profiles.rb:49
@@ -9414,19 +14126,23 @@ msgstr ""
 msgid "Error during 'Appliance restart': %{message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:255
+#: ../../app/controllers/ops_controller/diagnostics.rb:267
 msgid "Error during 'C & U Gap Collection': %{message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:628
+#: ../../app/controllers/catalog_controller.rb:594
 msgid "Error during 'Catalog Edit': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:595
+#: ../../app/controllers/ops_controller/diagnostics.rb:611
 msgid "Error during 'Clear Connection Broker cache': %{message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:405
+#: ../../app/controllers/vm_common.rb:647
+msgid "Error during 'Create Snapshot': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:417
 msgid "Error during 'Database Garbage Collection': %{message}"
 msgstr ""
 
@@ -9434,19 +14150,19 @@ msgstr ""
 msgid "Error during 'LDAP Group Look Up': %{message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1059
+#: ../../app/controllers/catalog_controller.rb:1054
 msgid "Error during 'Orchestration Template Copy': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:767
+#: ../../app/controllers/catalog_controller.rb:737
 msgid "Error during 'Orchestration Template Deletion': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1005
+#: ../../app/controllers/catalog_controller.rb:1000
 msgid "Error during 'Orchestration Template Edit': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1106
+#: ../../app/controllers/catalog_controller.rb:1101
 msgid "Error during 'Orchestration Template creation': %{error_message}"
 msgstr ""
 
@@ -9462,15 +14178,19 @@ msgstr ""
 msgid "Error during 'Provisioning': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:356
+#: ../../app/controllers/chargeback_controller.rb:338
 msgid "Error during 'Rate assignments': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:278
+#: ../../app/controllers/vm_common.rb:1049
+msgid "Error during 'Remove VM from service': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:290
 msgid "Error during 'Reset/synchronization process': %{message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1288
+#: ../../app/controllers/catalog_controller.rb:1283
 msgid "Error during 'Resource Add': %{error_message}"
 msgstr ""
 
@@ -9478,24 +14198,32 @@ msgstr ""
 msgid "Error during 'Save Tags': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:124
+#: ../../app/controllers/ops_controller/diagnostics.rb:132
 msgid "Error during 'Save': %{message}"
+msgstr ""
+
+#: ../../app/controllers/service_controller.rb:146
+msgid "Error during 'Service Edit': %{message}"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:538
 msgid "Error during 'Validate': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:239 ../../app/controllers/ops_controller/diagnostics.rb:149
+#: ../../app/controllers/ops_controller/settings/schedules.rb:240 ../../app/controllers/ops_controller/diagnostics.rb:157
 msgid "Error during 'Validate': %{message}"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1226 ../../app/controllers/miq_ae_class_controller.rb:1263 ../../app/controllers/configuration_controller.rb:510 ../../app/controllers/application_controller/buttons.rb:498
+#: ../../app/controllers/miq_ae_class_controller.rb:1220 ../../app/controllers/miq_ae_class_controller.rb:1257 ../../app/controllers/configuration_controller.rb:513 ../../app/controllers/application_controller/buttons.rb:498
 msgid "Error during 'add': %{error_message}"
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:393
 msgid "Error during 'add': %{field_name} %{error_name}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/tags.rb:81
+msgid "Error during 'add': %{message}"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings.rb:21
@@ -9506,11 +14234,19 @@ msgstr ""
 msgid "Error during 'edit': %{field_name} %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:618 ../../app/controllers/miq_ae_class_controller.rb:1009 ../../app/controllers/miq_ae_class_controller.rb:1055 ../../app/controllers/miq_ae_class_controller.rb:1151
+#: ../../app/controllers/repository_controller.rb:240
+msgid "Error during 'refresh': %{message}"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:612 ../../app/controllers/miq_ae_class_controller.rb:1003 ../../app/controllers/miq_ae_class_controller.rb:1049 ../../app/controllers/miq_ae_class_controller.rb:1145
 msgid "Error during 'save': %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:65
+#: ../../app/controllers/ops_controller/settings/upload.rb:77 ../../app/controllers/report_controller.rb:80
+msgid "Error during 'upload': %{message}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:69
 msgid "Error during 'workers restart': %{message}"
 msgstr ""
 
@@ -9518,11 +14254,11 @@ msgstr ""
 msgid "Error during Analysis Affinity save: %{message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1094
+#: ../../app/controllers/catalog_controller.rb:1089
 msgid "Error during Orchestration Template creation: new template content cannot be empty"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:419
+#: ../../app/controllers/ops_controller/diagnostics.rb:431
 msgid "Error during Orphaned Records delete for user %{id}: %{message}"
 msgstr ""
 
@@ -9568,11 +14304,11 @@ msgstr ""
 msgid "Error executing: \"%{task_description}\" %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:301
+#: ../../app/controllers/ops_controller/settings/rhn.rb:305
 msgid "Error occured when queuing action: %{message}"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:809
+#: ../../app/controllers/miq_ae_class_controller.rb:803
 msgid "Error on line %{line_num}: %{err_txt}"
 msgstr ""
 
@@ -9592,7 +14328,7 @@ msgstr ""
 msgid "Error when adding a new tenant: %{message}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1147
+#: ../../app/controllers/catalog_controller.rb:1142
 msgid "Error when creating a Service Dialog from Orchestration Template: %{error_message}"
 msgstr ""
 
@@ -9604,6 +14340,10 @@ msgstr ""
 msgid "Error when saving tenant quota: %{message}"
 msgstr ""
 
+#: ../../app/controllers/dashboard_controller.rb:499
+msgid "Error: Authentication failed"
+msgstr ""
+
 #: ../../app/controllers/miq_ae_tools_controller.rb:152
 msgid "Error: Datastore import file upload expired"
 msgstr ""
@@ -9612,19 +14352,19 @@ msgstr ""
 msgid "Error: ImportFileUpload expired"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:289 ../../app/controllers/report_controller/schedules.rb:6 ../../app/controllers/vm_common.rb:1170 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:23 ../../app/controllers/mixins/vm_show_mixin.rb:105 ../../app/controllers/provider_foreman_controller.rb:400 ../../app/helpers/application_helper.rb:1059
+#: ../../app/controllers/chargeback_controller.rb:261 ../../app/controllers/report_controller/schedules.rb:6 ../../app/controllers/vm_common.rb:1233 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:23 ../../app/controllers/mixins/vm_show_mixin.rb:105 ../../app/controllers/provider_foreman_controller.rb:384 ../../app/helpers/application_helper.rb:1065
 msgid "Error: Record no longer exists in the database"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:257
+#: ../../app/controllers/report_controller.rb:253
 msgid "Error: Widget import file upload expired"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:242
+#: ../../app/controllers/report_controller.rb:238
 msgid "Error: the file uploaded contains no widgets"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:57 ../../app/controllers/report_controller.rb:240
+#: ../../app/controllers/miq_ae_customization_controller.rb:57 ../../app/controllers/report_controller.rb:236
 msgid "Error: the file uploaded is not of the supported format"
 msgstr ""
 
@@ -9632,10 +14372,21 @@ msgstr ""
 msgid "Errors in Management Engine can be caused by:"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqEvent.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition
 #. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition
-#: ../dictionary_strings.rb:1533 ../dictionary_strings.rb:1975
+#: ../yaml_strings.rb:3697 ../dictionary_strings.rb:1533 ../dictionary_strings.rb:1975
 msgid "Event"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+#: ../yaml_strings.rb:3745
+msgid "Event Action"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+#: ../yaml_strings.rb:3743
+msgid "Event Actions"
 msgstr ""
 
 #: ../../app/views/miq_policy/_event_details.html.haml:30
@@ -9646,7 +14397,16 @@ msgstr ""
 msgid "Event Groups"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1675 ../../app/views/ops/_ap_form.html.haml:78 ../../app/views/ops/_ap_form.html.haml:91
+#: ../../app/helpers/ui_constants.rb:573
+msgid "Event Handler Configuration"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#: ../yaml_strings.rb:3857
+msgid "Event Id"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1756 ../../app/views/ops/_ap_form.html.haml:78 ../../app/views/ops/_ap_form.html.haml:91
 msgid "Event Log"
 msgid_plural "Event Logs"
 msgstr[0] ""
@@ -9658,6 +14418,11 @@ msgstr ""
 
 #: ../../app/views/ops/_ap_show.html.haml:132
 msgid "Event Log Items"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:442 ../../app/helpers/vm_infra_helper/textual_summary.rb:532 ../../app/helpers/vm_helper/textual_summary.rb:629 ../yaml_strings.rb:3855
+msgid "Event Logs"
 msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:121
@@ -9672,12 +14437,19 @@ msgstr ""
 msgid "Event Selection"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.event_src
-#: ../dictionary_strings.rb:393
+#: ../yaml_strings.rb:2604 ../dictionary_strings.rb:393
 msgid "Event Source"
 msgstr ""
 
-#: ../../app/views/layouts/_tl_options.html.haml:134
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+#: ../../app/views/layouts/_tl_options.html.haml:134 ../yaml_strings.rb:2571
 msgid "Event Type"
 msgstr ""
 
@@ -9693,8 +14465,9 @@ msgstr ""
 msgid "Event name is required"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.notify_evm_event
-#: ../dictionary_strings.rb:651
+#: ../yaml_strings.rb:3707 ../dictionary_strings.rb:651
 msgid "Event on Timeline"
 msgstr ""
 
@@ -9834,13 +14607,340 @@ msgstr ""
 msgid "EventStream|Vm name"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqEvent.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqEventDefinition (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_event_definition (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1132 ../../app/views/miq_policy/_policy_details.html.haml:335 ../dictionary_strings.rb:1535 ../dictionary_strings.rb:1977
+#: ../../app/controllers/miq_policy_controller.rb:1134 ../../app/views/miq_policy/_policy_details.html.haml:335 ../yaml_strings.rb:896 ../dictionary_strings.rb:1535 ../dictionary_strings.rb:1977
 msgid "Events"
 msgstr ""
 
-#: ../../app/controllers/pxe_controller/pxe_customization_templates.rb:264
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2
+msgid "Everything"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2295
+msgid "Everything for Template Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2231
+msgid "Everything for VM Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:145
+msgid "Everything under All Catalog Items Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1939
+msgid "Everything under All Containers Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:179
+msgid "Everything under All Service Catalogs Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:237
+msgid "Everything under All Services Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:366
+msgid "Everything under Auth Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:314
+msgid "Everything under Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:139
+msgid "Everything under Catalogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:190
+msgid "Everything under Catalogs Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:800
+msgid "Everything under Chargeback"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:272
+msgid "Everything under Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:334
+msgid "Everything under Cloud Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:380
+msgid "Everything under Cloud Volume Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:352
+msgid "Everything under Cloud Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:467
+msgid "Everything under Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:875
+msgid "Everything under Conditions Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1205
+msgid "Everything under Configuration"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1979
+msgid "Everything under Configuration Management"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2011
+msgid "Everything under Configured Systems accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1834
+msgid "Everything under Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1818
+msgid "Everything under Container Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1769
+msgid "Everything under Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1919
+msgid "Everything under Container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1796
+msgid "Everything under Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1905
+msgid "Everything under Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1881
+msgid "Everything under Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1935
+msgid "Everything under Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1640
+msgid "Everything under Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1556
+msgid "Everything under Customization Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:663
+msgid "Everything under Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:614
+msgid "Everything under Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:410
+msgid "Everything under Flavors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:508
+msgid "Everything under Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1588
+msgid "Everything under ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:425
+msgid "Everything under Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1718
+msgid "Everything under Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1666
+msgid "Everything under Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1692
+msgid "Everything under Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1135
+msgid "Everything under My Settings"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1616
+msgid "Everything under Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:211
+msgid "Everything under Orchestration Templates Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1524
+msgid "Everything under PXE Explorer"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1529
+msgid "Everything under PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1856
+msgid "Everything under Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1743
+msgid "Everything under Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:852
+msgid "Everything under Policies Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:905
+msgid "Everything under Policy Actions Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:917
+msgid "Everything under Policy Alert Profiles Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:932
+msgid "Everything under Policy Alerts Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:898
+msgid "Everything under Policy Events Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:838
+msgid "Everything under Policy Profiles Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1981
+msgid "Everything under Providers accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:824
+msgid "Everything under RSS"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:679
+msgid "Everything under Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:691
+msgid "Everything under Reports Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:637
+msgid "Everything under Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:95
+msgid "Everything under Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:395
+msgid "Everything under Security Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:233
+msgid "Everything under Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1496
+msgid "Everything under Storage Managers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1573
+msgid "Everything under System Image Types"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1165
+msgid "Everything under Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:820
+msgid "Everything under Timelines"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_pxe_customization_templates.rb:25 ../../app/presenters/tree_builder_pxe_customization_templates.rb:27 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:265
 msgid "Examples (read only)"
 msgstr ""
 
@@ -9852,7 +14952,12 @@ msgstr ""
 msgid "Exists Mode"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/host_center.rb:127
+#: ../../app/helpers/container_helper/textual_summary.rb:42
+msgid "Exit Code"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/host_center.rb:127 ../yaml_strings.rb:558
 msgid "Exit Maintenance Mode"
 msgstr ""
 
@@ -9864,7 +14969,13 @@ msgstr ""
 msgid "Expanded View"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:134 ../../app/presenters/menu/default_menu.rb:143
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#: ../yaml_strings.rb:3125
+msgid "Expires"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:134 ../../app/presenters/menu/default_menu.rb:143 ../yaml_strings.rb:826
 msgid "Explorer"
 msgstr ""
 
@@ -9912,7 +15023,7 @@ msgstr ""
 msgid "Expression (Press the \"Edit\" button to edit the expression)"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1499
+#: ../../app/controllers/application_controller/filter.rb:1390
 msgid "Expression element type must be selected"
 msgstr ""
 
@@ -9984,6 +15095,20 @@ msgstr ""
 msgid "ExtManagementSystem|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+#: ../yaml_strings.rb:2922
+msgid "Extension"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:94 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:87 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:66
+msgid "Extent Status"
+msgstr ""
+
 #: ../../app/views/report/_widget_show.html.haml:173 ../../app/views/report/_widget_form_rss.html.haml:20
 msgid "External"
 msgstr ""
@@ -10000,7 +15125,8 @@ msgstr ""
 msgid "External RSS Feed/URL"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:25 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:25 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:33
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:25 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:25 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:33 ../yaml_strings.rb:2161
 msgid "Extract Running Processes"
 msgstr ""
 
@@ -10020,7 +15146,12 @@ msgstr ""
 msgid "Extract Running Processes for this VM?"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:49
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2163
+msgid "Extract Running Processes of VMs"
+msgstr ""
+
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:147 ../../app/helpers/container_group_helper/textual_summary.rb:49
 msgid "FS Type"
 msgstr ""
 
@@ -10034,20 +15165,29 @@ msgstr ""
 msgid "FTPs"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:468 ../../app/helpers/vm_infra_helper/textual_summary.rb:606 ../../app/helpers/vm_helper/textual_summary.rb:703
+msgid "Fail Open"
+msgstr ""
+
 #: ../../app/views/vm_common/_policy_options.html.haml:54 ../../app/views/miq_policy/_rsop_results.html.haml:57
 msgid "Failed"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:79 ../../app/helpers/ems_cluster_helper/textual_summary.rb:56
-msgid "Failed (%s)"
+#: ../../app/helpers/host_helper/textual_summary.rb:81 ../../app/helpers/ems_cluster_helper/textual_summary.rb:62
+msgid "Failed (%{number})"
 msgstr ""
 
-#: ../../app/controllers/host_controller.rb:185
-msgid "Failed system services of %s"
+#: ../../app/controllers/host_controller.rb:215
+msgid "Failed system services of %{name}"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:388 ../../app/views/report/_show_schedule.html.haml:35 ../../app/views/catalog/_ot_tree_show.html.haml:42 ../../app/views/catalog/_ot_tree_show.html.haml:55
 msgid "False"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiddlewareServer.yaml
+#: ../yaml_strings.rb:3634
+msgid "Feed"
 msgstr ""
 
 #: ../../app/views/alert/_rss_list.html.haml:43
@@ -10058,11 +15198,11 @@ msgstr ""
 msgid "Fetch settings from a schedule"
 msgstr ""
 
-#: ../../app/views/layouts/exp_atom/_editor.html.haml:70 ../../app/views/layouts/exp_atom/_editor.html.haml:81
+#: ../../app/helpers/ui_constants.rb:482 ../../app/views/layouts/exp_atom/_editor.html.haml:70 ../../app/views/layouts/exp_atom/_editor.html.haml:81
 msgid "Field"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1377 ../../app/controllers/application_controller/filter.rb:1398
+#: ../../app/controllers/application_controller/filter.rb:1268 ../../app/controllers/application_controller/filter.rb:1289
 msgid "Field Value Error: %{msg}"
 msgstr ""
 
@@ -10091,19 +15231,33 @@ msgstr ""
 msgid "File Items"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.filename
-#: ../dictionary_strings.rb:395
+#: ../yaml_strings.rb:2915 ../dictionary_strings.rb:395
 msgid "File Name"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.ontap_file_share
-#: ../dictionary_strings.rb:2041
+#: ../yaml_strings.rb:1458 ../dictionary_strings.rb:2041
 msgid "File Shares"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.filesystem_drivers
-#: ../dictionary_strings.rb:1911
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:388 ../../app/helpers/vm_infra_helper/textual_summary.rb:399 ../../app/helpers/vm_helper/textual_summary.rb:498 ../yaml_strings.rb:3129 ../dictionary_strings.rb:1911
 msgid "File System Drivers"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#: ../yaml_strings.rb:3812
+msgid "File Version"
 msgstr ""
 
 #: ../model_attributes.rb:519
@@ -10126,7 +15280,7 @@ msgstr ""
 msgid "FileDepot|Uri"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_server_details.html.haml:33 ../../app/views/pxe/_pxe_form.html.haml:156
+#: ../../app/helpers/pxe_helper/textual_summary.rb:40 ../../app/views/pxe/_pxe_server_details.html.haml:33 ../../app/views/pxe/_pxe_form.html.haml:156
 msgid "Filename"
 msgstr ""
 
@@ -10135,19 +15289,20 @@ msgstr ""
 msgid "Filers"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Filesystem.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Filesystem (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.filesystems
-#: ../../app/controllers/host_controller.rb:145 ../../app/views/layouts/listnav/_host.html.haml:232 ../dictionary_strings.rb:1375 ../dictionary_strings.rb:1913
+#: ../../app/controllers/host_controller.rb:175 ../../app/helpers/vm_cloud_helper/textual_summary.rb:400 ../../app/helpers/host_helper/textual_summary.rb:480 ../../app/helpers/vm_infra_helper/textual_summary.rb:411 ../../app/helpers/vm_helper/textual_summary.rb:510 ../../app/views/layouts/listnav/_host.html.haml:232 ../yaml_strings.rb:3810 ../dictionary_strings.rb:1375 ../dictionary_strings.rb:1913
 msgid "Files"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1679 ../model_attributes.rb:523
+#: ../../app/controllers/vm_common.rb:1760 ../model_attributes.rb:523
 msgid "Filesystem"
 msgid_plural "Filesystems"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/controllers/vm_common.rb:1677
+#: ../../app/controllers/vm_common.rb:1758
 msgid "Filesystem Driver"
 msgid_plural "Filesystem Drivers"
 msgstr[0] ""
@@ -10237,11 +15392,23 @@ msgstr ""
 msgid "Filter Message"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:402
+#: ../../app/controllers/ops_controller/settings/schedules.rb:407
 msgid "Filter must be selected"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:406
+#: ../../app/controllers/report_controller/reports.rb:323
+msgid "Filter tab is not available until Trending Target Limit has been configured"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:320
+msgid "Filter tab is not available until Trending for field has been selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:330
+msgid "Filter tab is not available until at least 1 field has been selected"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:411
 msgid "Filter value must be selected"
 msgstr ""
 
@@ -10249,20 +15416,43 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1455
+#: ../../app/helpers/ui_constants.rb:480
+msgid "Find"
+msgstr ""
+
+#: ../../app/controllers/application_controller/filter.rb:1346
 msgid "Find Value Error: %{msg}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+#: ../yaml_strings.rb:3741
+msgid "Fingerprint"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ScanHistory.yaml
+#: ../../app/helpers/ui_constants.rb:408 ../../app/helpers/ui_constants.rb:413 ../yaml_strings.rb:3327
+msgid "Finished"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:38
+msgid "Finished At"
 msgstr ""
 
 #: ../../app/controllers/miq_task_controller.rb:133
 msgid "Finished Task cannot be cancelled"
 msgstr ""
 
-#: ../../app/views/security_group/_main.html.haml:20 ../../app/views/layouts/listnav/_host.html.haml:209
+#: ../../app/controllers/host_controller.rb:246 ../../app/helpers/host_helper/textual_summary.rb:430 ../../app/views/security_group/_main.html.haml:20 ../../app/views/layouts/listnav/_host.html.haml:209
 msgid "Firewall Rules"
 msgstr ""
 
 #: ../model_attributes.rb:542
 msgid "Firewall rule"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#: ../yaml_strings.rb:3824
+msgid "FirewallRule"
 msgstr ""
 
 #: ../model_attributes.rb:543
@@ -10366,16 +15556,22 @@ msgstr ""
 msgid "Fixed Total Cost"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Flavor
 #. TRANSLATORS: en.yml key: dictionary.table.flavor
-#: ../dictionary_strings.rb:1377 ../dictionary_strings.rb:1915 ../model_attributes.rb:558
+#: ../../app/controllers/flavor_controller.rb:109 ../yaml_strings.rb:2976 ../dictionary_strings.rb:1377 ../dictionary_strings.rb:1915 ../model_attributes.rb:558
 msgid "Flavor"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Flavor.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Flavor (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.flavor (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.flavors
-#: ../../app/presenters/menu/default_menu.rb:30 ../../app/views/configuration/_ui_2.html.haml:159 ../dictionary_strings.rb:1379 ../dictionary_strings.rb:1917 ../dictionary_strings.rb:1919
+#: ../../app/presenters/menu/default_menu.rb:30 ../../app/controllers/flavor_controller.rb:23 ../../app/views/configuration/_ui_2.html.haml:159 ../yaml_strings.rb:408 ../dictionary_strings.rb:1379 ../dictionary_strings.rb:1917 ../dictionary_strings.rb:1919
 msgid "Flavors"
 msgstr ""
 
@@ -10503,6 +15699,14 @@ msgstr ""
 msgid "Folder Name (VMs & Templates) 9"
 msgstr ""
 
+#: ../../app/controllers/report_controller/menus.rb:76
+msgid "Folder name '%{value}' is already in use"
+msgstr ""
+
+#: ../../app/controllers/report_controller/menus.rb:73
+msgid "Folder name is required"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.EmsFolder (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_folder (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_folders
@@ -10514,8 +15718,8 @@ msgstr ""
 msgid "Follow Referrals"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:17
-msgid "For more information, visit the %s documentation."
+#: ../../app/helpers/application_helper.rb:18
+msgid "For more information, visit the %{subject} documentation."
 msgstr ""
 
 #: ../../app/views/support/show.html.haml:84
@@ -10528,11 +15732,16 @@ msgid "Foreman Configured System"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem (plural form)
-#: ../dictionary_strings.rb:1419
+#: ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:19 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:21 ../dictionary_strings.rb:1419
 msgid "Foreman Configured Systems"
 msgstr ""
 
-#: ../../app/views/report/_form_formatting.html.haml:58
+#: ../../app/presenters/tree_builder_configuration_manager.rb:19 ../../app/presenters/tree_builder_configuration_manager.rb:21
+msgid "Foreman Providers"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/RegistryItem.yaml
+#: ../../app/views/report/_form_formatting.html.haml:58 ../yaml_strings.rb:3294
 msgid "Format"
 msgstr ""
 
@@ -10540,9 +15749,26 @@ msgstr ""
 msgid "Format on Summary Row"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:315
+msgid "Formatting tab is not available until at least 1 field has been selected"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:96
+msgid "Free Index Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../../app/helpers/storage_helper/textual_summary.rb:42 ../yaml_strings.rb:3247
+msgid "Free Space"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.v_free_space_percent_of_total
 #: ../dictionary_strings.rb:1013
 msgid "Free Space Percent of Total"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:76
+msgid "Free Space on Volume"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
@@ -10551,6 +15777,10 @@ msgstr ""
 
 #: ../../app/views/layouts/_edit_email.html.haml:35 ../../app/views/miq_policy/_alert_details.html.haml:289
 msgid "From"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:431 ../../app/helpers/vm_infra_helper/textual_summary.rb:522 ../../app/helpers/vm_helper/textual_summary.rb:619
+msgid "From %{time} Ago"
 msgstr ""
 
 #: ../../app/views/layouts/_discover.html.haml:59
@@ -10573,8 +15803,9 @@ msgstr ""
 msgid "Front (...1234)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/User.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.User.name
-#: ../../app/views/ops/_rbac_user_details.html.haml:26 ../dictionary_strings.rb:3
+#: ../../app/helpers/container_image_helper/textual_summary.rb:37 ../../app/views/ops/_rbac_user_details.html.haml:26 ../yaml_strings.rb:2713 ../dictionary_strings.rb:3
 msgid "Full Name"
 msgstr ""
 
@@ -10582,20 +15813,21 @@ msgstr ""
 msgid "Full&#160;Screen"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAeClass.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.fqname
-#: ../dictionary_strings.rb:397
+#: ../yaml_strings.rb:3273 ../dictionary_strings.rb:397
 msgid "Fully Qualified Name"
 msgstr ""
 
-#: ../../app/views/miq_capacity/_planning_options.html.haml:243 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:28
+#: ../../app/views/miq_capacity/_planning_options.html.haml:243 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:24
 msgid "GB"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:34
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:59 ../../app/helpers/container_group_helper/textual_summary.rb:34
 msgid "GCE PD Resource"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1709
+#: ../../app/controllers/vm_common.rb:1790 ../../app/helpers/vm_infra_helper/textual_summary.rb:264 ../../app/helpers/vm_helper/textual_summary.rb:358
 msgid "Genealogy"
 msgid_plural "Genealogy"
 msgstr[0] ""
@@ -10603,6 +15835,16 @@ msgstr[1] ""
 
 #: ../../app/views/configuration/_ui_2.html.haml:18
 msgid "General"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:774
+msgid "Generate Content"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:776
+msgid "Generate Content for a selected Widget"
 msgstr ""
 
 #: ../../app/views/report/_form_preview.html.haml:53
@@ -10637,11 +15879,11 @@ msgstr ""
 msgid "Get User Groups from LDAP"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:35
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:65 ../../app/helpers/container_group_helper/textual_summary.rb:35
 msgid "Git Repository"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:36
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:71 ../../app/helpers/container_group_helper/textual_summary.rb:36
 msgid "Git Revision"
 msgstr ""
 
@@ -10649,11 +15891,11 @@ msgstr ""
 msgid "Global Default"
 msgstr ""
 
-#: ../../app/presenters/tree_builder_vms_filter.rb:21 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:29
+#: ../../app/presenters/tree_builder_containers_filter.rb:23 ../../app/presenters/tree_builder_vms_filter.rb:21 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:29 ../../app/controllers/ops_controller/settings/schedules.rb:565 ../../app/controllers/ops_controller/settings/schedules.rb:575 ../../app/controllers/ops_controller/settings/schedules.rb:584 ../../app/controllers/ops_controller/settings/schedules.rb:592 ../../app/controllers/ops_controller/settings/schedules.rb:601
 msgid "Global Filters"
 msgstr ""
 
-#: ../../app/presenters/tree_builder_vms_filter.rb:21 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:31
+#: ../../app/presenters/tree_builder_containers_filter.rb:25 ../../app/presenters/tree_builder_vms_filter.rb:21 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:31
 msgid "Global Shared Filters"
 msgstr ""
 
@@ -10665,7 +15907,7 @@ msgstr ""
 msgid "Global search:"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:41
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:101 ../../app/helpers/container_group_helper/textual_summary.rb:41
 msgid "Glusterfs Endpoint Name"
 msgstr ""
 
@@ -10677,6 +15919,26 @@ msgstr ""
 msgid "Graph View"
 msgstr ""
 
+#: ../../app/helpers/report_helper.rb:16
+msgid "Gray Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:15
+msgid "Gray Text"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:106
+msgid "Green"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:8
+msgid "Green Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:7
+msgid "Green Text"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/gtl_view.rb:6 ../../app/helpers/application_helper/toolbar/x_gtl_view.rb:6 ../../app/helpers/configuration_helper/configuration_view_helper.rb:72 ../../app/helpers/configuration_helper/configuration_view_helper.rb:78 ../../app/helpers/configuration_helper/configuration_view_helper.rb:84 ../../app/views/configuration/_ui_1.html.haml:113
 msgid "Grid View"
 msgstr ""
@@ -10685,7 +15947,11 @@ msgstr ""
 msgid "Grid/Tile Icons"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1681 ../../app/views/ops/_rbac_user_details.html.haml:158 ../../app/views/chargeback/_cb_rate_edit.html.haml:41 ../../app/views/chargeback/_cb_rate_show.html.haml:38
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#. TRANSLATORS: file: product/views/User.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
+#: ../../app/controllers/vm_common.rb:1762 ../../app/views/ops/_rbac_user_details.html.haml:158 ../../app/views/chargeback/_cb_rate_edit.html.haml:41 ../../app/views/chargeback/_cb_rate_show.html.haml:38 ../yaml_strings.rb:2725
 msgid "Group"
 msgid_plural "Groups"
 msgstr[0] ""
@@ -10703,7 +15969,10 @@ msgstr ""
 msgid "Group by"
 msgstr ""
 
-#: ../../app/views/layouts/_role_visibility.html.haml:71 ../../app/views/layouts/listnav/_host.html.haml:194 ../../app/views/layouts/_item.html.haml:97
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Group.yaml
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#: ../../app/presenters/tree_builder_ops_rbac.rb:27 ../../app/controllers/ops_controller.rb:700 ../../app/controllers/ops_controller.rb:714 ../../app/helpers/vm_cloud_helper/textual_summary.rb:295 ../../app/helpers/host_helper/textual_summary.rb:418 ../../app/helpers/vm_infra_helper/textual_summary.rb:317 ../../app/helpers/vm_helper/textual_summary.rb:415 ../../app/views/layouts/_role_visibility.html.haml:71 ../../app/views/layouts/listnav/_host.html.haml:194 ../../app/views/layouts/_item.html.haml:97 ../yaml_strings.rb:1269
 msgid "Groups"
 msgstr ""
 
@@ -10719,7 +15988,7 @@ msgstr ""
 msgid "Groups in this %{type}"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1683
+#: ../../app/controllers/vm_common.rb:1764
 msgid "Guest Application"
 msgid_plural "Guest Applications"
 msgstr[0] ""
@@ -10866,16 +16135,39 @@ msgstr ""
 msgid "GuestDevice|Uid ems"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:253
+msgid "HA Admit Control"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:247
+msgid "HA Enabled"
+msgstr ""
+
 #: ../../app/views/ops/_ap_form_registry.html.haml:51 ../../app/views/ops/_ap_form_registry.html.haml:87 ../../app/views/ops/_ap_form_registry.html.haml:137
 msgid "HKLM"
 msgstr ""
 
-#: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:111
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#: ../yaml_strings.rb:3421
+msgid "HOT Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#: ../yaml_strings.rb:3419
+msgid "HOT Orchestration Templates"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:211 ../../app/views/ops/_settings_rhn_edit_tab.html.haml:111
 msgid "HTTP Proxy Address"
 msgstr ""
 
 #: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:91
 msgid "HTTP Proxy:"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../../app/helpers/flavor_helper/textual_summary.rb:56 ../yaml_strings.rb:3458
+msgid "HVM (Hardware Virtual Machine)"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:190 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:239
@@ -11023,14 +16315,23 @@ msgstr ""
 msgid "Header"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.health_state_str
-#: ../dictionary_strings.rb:407
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:61 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:51 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:54 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:37 ../yaml_strings.rb:3901 ../dictionary_strings.rb:407
 msgid "Health State"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.health_state
 #: ../dictionary_strings.rb:405
 msgid "Health State Code"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#: ../yaml_strings.rb:3417
+msgid "Health Status"
 msgstr ""
 
 #: ../../app/helpers/ems_container_helper/textual_summary.rb:25
@@ -11043,7 +16344,7 @@ msgid "Heat Template"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplateHot (plural form)
-#: ../dictionary_strings.rb:1645
+#: ../../app/presenters/tree_builder_orchestration_templates.rb:13 ../../app/presenters/tree_builder_orchestration_templates.rb:15 ../dictionary_strings.rb:1645
 msgid "Heat Templates"
 msgstr ""
 
@@ -11055,7 +16356,7 @@ msgstr ""
 msgid "Hide Input Parameters"
 msgstr ""
 
-#: ../../app/views/vm_common/_right_size.html.haml:25
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:665 ../../app/helpers/vm_infra_helper/textual_summary.rb:674 ../../app/helpers/vm_infra_helper/textual_summary.rb:684 ../../app/helpers/vm_infra_helper/textual_summary.rb:695 ../../app/helpers/vm_helper/textual_summary.rb:784 ../../app/helpers/vm_helper/textual_summary.rb:793 ../../app/helpers/vm_helper/textual_summary.rb:803 ../../app/helpers/vm_helper/textual_summary.rb:814 ../../app/views/vm_common/_right_size.html.haml:25
 msgid "High"
 msgstr ""
 
@@ -11063,7 +16364,7 @@ msgstr ""
 msgid "Hint: Press Ctrl-Alt to release the cursor from the guest"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_history.rb:6
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:494 ../../app/helpers/host_helper/textual_summary.rb:392 ../../app/helpers/application_helper/toolbar/x_history.rb:6 ../../app/helpers/vm_infra_helper/textual_summary.rb:632 ../../app/helpers/vm_helper/textual_summary.rb:751
 msgid "History"
 msgstr ""
 
@@ -11072,18 +16373,34 @@ msgstr ""
 msgid "Hit %"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/Group.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.homedir
-#: ../dictionary_strings.rb:409
+#: ../yaml_strings.rb:3109 ../dictionary_strings.rb:409
 msgid "Home Directory"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:1229 ../../app/helpers/application_helper.rb:1253 ../../app/views/ops/_settings_server_tab.html.haml:383 ../../app/views/ops/_settings_workers_tab.html.haml:620 ../../app/views/configuration/_ui_1.html.haml:25 ../model_attributes.rb:638
+#. TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiddlewareServer.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#: ../../app/controllers/ems_common.rb:81 ../../app/helpers/application_helper.rb:1236 ../../app/helpers/application_helper.rb:1260 ../../app/views/ops/_settings_server_tab.html.haml:383 ../../app/views/ops/_settings_workers_tab.html.haml:620 ../../app/views/configuration/_ui_1.html.haml:25 ../yaml_strings.rb:3062 ../model_attributes.rb:638
 msgid "Host"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.Host
 #. TRANSLATORS: en.yml key: dictionary.table.host
-#: ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:116 ../../app/helpers/application_helper.rb:1233 ../dictionary_strings.rb:1381 ../dictionary_strings.rb:1925
+#: ../../app/controllers/miq_ae_customization_controller/custom_buttons.rb:116 ../../app/helpers/application_helper.rb:1240 ../dictionary_strings.rb:1381 ../dictionary_strings.rb:1925
 msgid "Host / Node"
 msgstr ""
 
@@ -11091,6 +16408,14 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.table.host (plural form)
 #: ../dictionary_strings.rb:1383 ../dictionary_strings.rb:1927
 msgid "Host / Nodes"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:546
+msgid "Host Analysis"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:554
+msgid "Host Compliance Check"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_policy.rb:17
@@ -11138,7 +16463,7 @@ msgstr ""
 msgid "Host Selection"
 msgstr ""
 
-#: ../../app/controllers/ontap_file_share_controller.rb:118 ../../app/controllers/miq_policy_controller.rb:1022
+#: ../../app/controllers/ontap_file_share_controller.rb:118 ../../app/controllers/miq_policy_controller.rb:1024
 msgid "Host is required"
 msgstr ""
 
@@ -11150,13 +16475,27 @@ msgstr ""
 msgid "Host service group"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/cap_and_u.rb:320 ../../app/controllers/ops_controller/settings/cap_and_u.rb:362 ../../app/controllers/host_controller.rb:644 ../../app/controllers/host_controller.rb:718
+msgid "Host: %{name}"
+msgstr ""
+
 #: ../model_attributes.rb:669
 msgid "HostServiceGroup|Name"
 msgstr ""
 
-#: ../../app/helpers/provider_configuration_manager_helper.rb:12 ../../app/helpers/provider_foreman_helper.rb:13 ../../app/views/ops/_selected_by_servers.html.haml:22 ../../app/views/ops/_server_desc.html.haml:9 ../../app/views/ops/_ldap_domain_show.html.haml:255 ../../app/views/ops/_settings_server_tab.html.haml:16 ../../app/views/ops/_ldap_server_entries.html.haml:18 ../../app/views/ops/_diagnostics_database_tab.html.haml:35 ../../app/views/storage_manager/_form.html.haml:65 ../../app/views/host/_config.html.haml:47
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:104 ../../app/helpers/provider_configuration_manager_helper.rb:12 ../../app/helpers/storage_manager_helper/textual_summary.rb:15 ../../app/helpers/provider_foreman_helper.rb:13 ../../app/helpers/vm_helper/textual_summary.rb:116 ../../app/views/ops/_selected_by_servers.html.haml:22 ../../app/views/ops/_server_desc.html.haml:9 ../../app/views/ops/_ldap_domain_show.html.haml:255 ../../app/views/ops/_settings_server_tab.html.haml:16 ../../app/views/ops/_ldap_server_entries.html.haml:18 ../../app/views/ops/_diagnostics_database_tab.html.haml:35 ../../app/views/storage_manager/_form.html.haml:65 ../../app/views/host/_config.html.haml:47 ../yaml_strings.rb:3310
 msgid "Hostname"
-msgstr ""
+msgid_plural "Hostnames"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../../app/views/host/_form.html.haml:50 ../../app/views/shared/views/ems_common/angular/_form.html.haml:169
 msgid "Hostname (or IPv4 or IPv6 address)"
@@ -11174,21 +16513,31 @@ msgstr ""
 msgid "Hostname or IPv4/IPv6 address"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:39 ../../app/helpers/application_helper.rb:1229
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#: ../../app/presenters/menu/default_menu.rb:39 ../../app/controllers/host_controller.rb:34 ../../app/controllers/host_controller.rb:861 ../../app/helpers/ui_constants.rb:352 ../../app/helpers/application_helper.rb:1236 ../yaml_strings.rb:3168
 msgid "Hosts"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.hosts
-#: ../../app/presenters/menu/default_menu.rb:39 ../../app/controllers/application_controller/ci_processing.rb:887 ../../app/helpers/application_helper.rb:1233 ../dictionary_strings.rb:1929
+#: ../../app/presenters/menu/default_menu.rb:39 ../../app/controllers/application_controller/ci_processing.rb:887 ../../app/helpers/application_helper.rb:1240 ../yaml_strings.rb:506 ../dictionary_strings.rb:1929
 msgid "Hosts / Nodes"
 msgstr ""
 
-#: ../../app/controllers/ems_cluster_controller.rb:232
-msgid "Hosts with failed %s"
+#: ../../app/controllers/ems_cluster_controller.rb:252
+msgid "Hosts with failed %{name}"
 msgstr ""
 
-#: ../../app/controllers/ems_cluster_controller.rb:229
-msgid "Hosts with running %s"
+#: ../../app/controllers/ems_cluster_controller.rb:249
+msgid "Hosts with running %{name}"
 msgstr ""
 
 #: ../model_attributes.rb:639
@@ -11307,15 +16656,30 @@ msgstr ""
 msgid "Host|Vmm version"
 msgstr ""
 
-#: ../../app/assets/javascripts/miq_formatters.js:251
+#: ../../app/helpers/ui_constants.rb:291 ../../app/assets/javascripts/miq_formatters.js:251
 msgid "Hour"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2375
+msgid "Hour (H AM|PM Z)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2373
+msgid "Hour (H:00 Z)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2377
+msgid "Hour of Day (24)"
 msgstr ""
 
 #: ../../app/views/layouts/_tl_options.html.haml:50 ../../app/views/report/_schedule_form_timer.html.haml:20 ../../app/views/report/_form_columns_performance.html.haml:15
 msgid "Hourly"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:37
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:33
 msgid "Hourly Network Utilization"
 msgstr ""
 
@@ -11339,27 +16703,45 @@ msgstr ""
 msgid "Hyper-V"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.ip_address
 #. TRANSLATORS: en.yml key: dictionary.column.ipaddress
-#: ../../app/helpers/provider_configuration_manager_helper.rb:23 ../../app/helpers/provider_foreman_helper.rb:24 ../../app/views/ops/_selected_by_servers.html.haml:35 ../../app/views/ops/_server_desc.html.haml:19 ../../app/views/ops/_settings_server_tab.html.haml:32 ../../app/views/storage_manager/_form.html.haml:82 ../../app/views/host/_config.html.haml:63 ../dictionary_strings.rb:415 ../dictionary_strings.rb:419
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:94 ../../app/helpers/host_helper/textual_summary.rb:114 ../../app/helpers/ops_helper/textual_summary.rb:41 ../../app/helpers/provider_configuration_manager_helper.rb:23 ../../app/helpers/vm_infra_helper/textual_summary.rb:109 ../../app/helpers/provider_foreman_helper.rb:24 ../../app/helpers/vm_helper/textual_summary.rb:121 ../../app/helpers/container_group_helper/textual_summary.rb:94 ../../app/views/ops/_selected_by_servers.html.haml:35 ../../app/views/ops/_server_desc.html.haml:19 ../../app/views/ops/_settings_server_tab.html.haml:32 ../../app/views/storage_manager/_form.html.haml:82 ../../app/views/host/_config.html.haml:63 ../yaml_strings.rb:3347 ../dictionary_strings.rb:415 ../dictionary_strings.rb:419
 msgid "IP Address"
-msgstr ""
+msgid_plural "IP Addresses"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ../../app/views/miq_request/_prov_host_dialog.html.haml:86 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:53 ../../app/views/shared/views/_prov_dialog.html.haml:339 ../../app/views/shared/views/_prov_dialog.html.haml:373
 msgid "IP Address Information"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.ip_addresses
 #. TRANSLATORS: en.yml key: dictionary.column.ipaddresses
-#: ../dictionary_strings.rb:417 ../dictionary_strings.rb:421
+#: ../yaml_strings.rb:2984 ../dictionary_strings.rb:417 ../dictionary_strings.rb:421
 msgid "IP Addresses"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#: ../../app/helpers/storage_manager_helper/textual_summary.rb:19
+msgid "IP Adress"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#: ../../app/views/vm_common/_config.html.haml:208 ../yaml_strings.rb:3353
 msgid "IPAddress"
 msgstr ""
 
-#: ../../app/helpers/application_helper/discover.rb:9 ../../app/views/layouts/_multi_auth_credentials.html.haml:39 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:37
+#: ../../app/helpers/host_helper/textual_summary.rb:530 ../../app/helpers/application_helper/discover.rb:9 ../../app/views/layouts/_multi_auth_credentials.html.haml:39 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:37
 msgid "IPMI"
 msgstr ""
 
@@ -11367,13 +16749,14 @@ msgstr ""
 msgid "IPMI Credentials"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Host.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.ipmi_enabled
-#: ../dictionary_strings.rb:425
+#: ../yaml_strings.rb:3639 ../dictionary_strings.rb:425
 msgid "IPMI Enabled"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.ipmi_address
-#: ../../app/views/host/_form.html.haml:114 ../dictionary_strings.rb:423
+#: ../../app/helpers/host_helper/textual_summary.rb:118 ../../app/views/host/_form.html.haml:114 ../dictionary_strings.rb:423
 msgid "IPMI IP Address"
 msgstr ""
 
@@ -11381,19 +16764,23 @@ msgstr ""
 msgid "IPMI IP Address, Username and matching password fields are needed to perform verification of credentials"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:802
+msgid "IPMI Password and Verify Password fields do not match"
+msgstr ""
+
 #: ../../app/helpers/provider_configuration_manager_helper.rb:19 ../../app/helpers/provider_foreman_helper.rb:20
 msgid "IPMI Present"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:40
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:95 ../../app/helpers/container_group_helper/textual_summary.rb:40
 msgid "ISCSI Target Lun Number"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:38
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:83 ../../app/helpers/container_group_helper/textual_summary.rb:38
 msgid "ISCSI Target Portal"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:39
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:89 ../../app/helpers/container_group_helper/textual_summary.rb:39
 msgid "ISCSI Target Qualified Name"
 msgstr ""
 
@@ -11407,9 +16794,11 @@ msgstr ""
 msgid "ISO Datastore"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/IsoDatastore.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.IsoDatastore (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.iso_datastore (plural form)
-#: ../dictionary_strings.rb:1391 ../dictionary_strings.rb:1935
+#: ../../app/controllers/pxe_controller.rb:95 ../yaml_strings.rb:1586 ../dictionary_strings.rb:1391 ../dictionary_strings.rb:1935
 msgid "ISO Datastores"
 msgstr ""
 
@@ -11421,8 +16810,13 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.IsoImage (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.iso_image (plural form)
-#: ../../app/views/pxe/_iso_datastore_details.html.haml:16 ../dictionary_strings.rb:1395 ../dictionary_strings.rb:1939
+#: ../../app/presenters/tree_builder_iso_datastores.rb:32 ../../app/presenters/tree_builder_iso_datastores.rb:34 ../../app/views/pxe/_iso_datastore_details.html.haml:16 ../dictionary_strings.rb:1395 ../dictionary_strings.rb:1939
 msgid "ISO Images"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#: ../yaml_strings.rb:3792
+msgid "Id"
 msgstr ""
 
 #: ../../app/views/shared/views/_prov_dialog.html.haml:233
@@ -11437,12 +16831,30 @@ msgstr ""
 msgid "If this widget is new or has just been added to your dashboard, the data is being generated and should be available soon."
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Container.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerImage
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template
 #. TRANSLATORS: en.yml key: dictionary.table.container_image
 #. TRANSLATORS: en.yml key: dictionary.table.template_cloud
-#: ../../app/views/shared/buttons/_ab_list.html.haml:179 ../../app/views/shared/buttons/_ab_show.html.haml:48 ../dictionary_strings.rb:1311 ../dictionary_strings.rb:1429 ../dictionary_strings.rb:1791 ../dictionary_strings.rb:2105
+#: ../../app/views/shared/buttons/_ab_list.html.haml:179 ../../app/views/shared/buttons/_ab_show.html.haml:48 ../yaml_strings.rb:3871 ../dictionary_strings.rb:1311 ../dictionary_strings.rb:1429 ../dictionary_strings.rb:1791 ../dictionary_strings.rb:2105
 msgid "Image"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2103
+msgid "Image Access Rules"
+msgstr ""
+
+#: ../../app/helpers/container_image_helper/textual_summary.rb:33
+msgid "Image Id"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../yaml_strings.rb:3142
+msgid "Image Path"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry (plural form)
@@ -11452,13 +16864,14 @@ msgstr ""
 msgid "Image Registries"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerImageRegistry
 #. TRANSLATORS: en.yml key: dictionary.table.container_image_registry
-#: ../dictionary_strings.rb:1307 ../dictionary_strings.rb:1797
+#: ../yaml_strings.rb:3794 ../dictionary_strings.rb:1307 ../dictionary_strings.rb:1797
 msgid "Image Registry"
 msgstr ""
 
-#: ../../app/views/pxe/_template_form.html.haml:49
+#: ../../app/helpers/pxe_helper/textual_summary.rb:104 ../../app/views/pxe/_template_form.html.haml:49
 msgid "Image Type"
 msgstr ""
 
@@ -11466,25 +16879,54 @@ msgstr ""
 msgid "Image shown at 25% of actual size"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+#: ../yaml_strings.rb:3046
+msgid "ImageRegistries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerImage (plural form)
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Template (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_image (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_images
 #. TRANSLATORS: en.yml key: dictionary.table.template_cloud (plural form)
-#: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:42 ../../app/views/configuration/_ui_2.html.haml:187 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:59 ../dictionary_strings.rb:1313 ../dictionary_strings.rb:1431 ../dictionary_strings.rb:1793 ../dictionary_strings.rb:1795 ../dictionary_strings.rb:2107
+#: ../../app/controllers/vm_cloud_controller.rb:36 ../../app/controllers/ems_common.rb:55 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:42 ../../app/views/configuration/_ui_2.html.haml:187 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:59 ../yaml_strings.rb:87 ../dictionary_strings.rb:1313 ../dictionary_strings.rb:1431 ../dictionary_strings.rb:1793 ../dictionary_strings.rb:1795 ../dictionary_strings.rb:2107
 msgid "Images"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:75
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:89
+msgid "Images Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:124 ../../app/controllers/vm_cloud_controller.rb:26 ../yaml_strings.rb:79
 msgid "Images by Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:81
+msgid "Images by Provider Accordion"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:473 ../../app/helpers/vm_infra_helper/textual_summary.rb:611 ../../app/helpers/vm_helper/textual_summary.rb:708
+msgid "Immutable VM"
 msgstr ""
 
 #: ../../app/views/ops/_ldap_server_entry.html.haml:7 ../../app/views/ops/_ldap_server_entry.html.haml:44 ../../app/views/ops/_all_tabs.html.haml:96 ../../app/views/miq_ae_customization/_dialog_import_export.html.haml:24 ../../app/views/report/_export_custom_reports.html.haml:12 ../../app/views/report/_export_widgets.html.haml:80 ../../app/views/miq_policy/_export.html.haml:9
 msgid "Import"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:136 ../../app/presenters/menu/default_menu.rb:146 ../../app/presenters/tree_builder.rb:74 ../../app/controllers/report_controller.rb:709
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:136 ../../app/presenters/menu/default_menu.rb:146 ../../app/presenters/tree_builder.rb:123 ../../app/controllers/report_controller.rb:702 ../yaml_strings.rb:794
 msgid "Import / Export"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:796
+msgid "Import / Export Accordion"
 msgstr ""
 
 #: ../../app/views/miq_ae_tools/_import_export.html.haml:95
@@ -11515,7 +16957,7 @@ msgstr ""
 msgid "Import file cannot be empty"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller.rb:54 ../../app/controllers/miq_ae_tools_controller.rb:172 ../../app/controllers/report_controller.rb:238 ../../app/controllers/miq_policy_controller.rb:193
+#: ../../app/controllers/miq_ae_customization_controller.rb:54 ../../app/controllers/miq_ae_tools_controller.rb:172 ../../app/controllers/report_controller.rb:234 ../../app/controllers/miq_policy_controller.rb:193
 msgid "Import file was uploaded successfully"
 msgstr ""
 
@@ -11527,13 +16969,18 @@ msgstr ""
 msgid "Import validation complete: %{good_record}, %{bad_record}"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:307
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/miq_ae_customization_controller.rb:209 ../../app/controllers/report_controller.rb:303 ../yaml_strings.rb:948
 msgid "Import/Export"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.owned_by_current_ldap_group
 #: ../dictionary_strings.rb:685
 msgid "In My LDAP Group?"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:139
+msgid "In Use"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_form.html.haml:110
@@ -11552,11 +16999,11 @@ msgstr ""
 msgid "Incorrect UNC path"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:6 ../../app/views/pxe/_pxe_server_details.html.haml:112
+#: ../../app/helpers/pxe_helper/textual_summary.rb:88 ../../app/views/ops/_db_info.html.haml:6 ../../app/views/pxe/_pxe_server_details.html.haml:112
 msgid "Index"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:200 ../../app/views/ops/_all_tabs.html.haml:289
+#: ../../app/presenters/tree_builder_ops_vmdb.rb:49 ../../app/presenters/tree_builder_ops_vmdb.rb:51 ../../app/views/ops/_db_info.html.haml:200 ../../app/views/ops/_all_tabs.html.haml:289
 msgid "Indexes"
 msgstr ""
 
@@ -11568,12 +17015,20 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:327
+msgid "Info/Settings"
+msgstr ""
+
 #: ../../app/views/storage/_main.html.haml:9
 msgid "Information for Registered VMs"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:42 ../../app/views/configuration/_ui_2.html.haml:243
+#: ../../app/presenters/menu/default_menu.rb:42 ../../app/views/configuration/_ui_2.html.haml:254
 msgid "Infrastructure"
+msgstr ""
+
+#: ../../app/helpers/container_node_helper/textual_summary.rb:70
+msgid "Infrastructure Machine ID"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager
@@ -11602,10 +17057,12 @@ msgstr ""
 msgid "Infrastructure Provider (Vmware)"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_infra (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_infras
-#: ../dictionary_strings.rb:1439 ../dictionary_strings.rb:1873 ../dictionary_strings.rb:1875
+#: ../yaml_strings.rb:423 ../dictionary_strings.rb:1439 ../dictionary_strings.rb:1873 ../dictionary_strings.rb:1875
 msgid "Infrastructure Providers"
 msgstr ""
 
@@ -11641,11 +17098,28 @@ msgstr ""
 msgid "Inherit Tags Settings"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1689
+#. TRANSLATORS: file: product/views/MiqAeClass.yaml
+#: ../yaml_strings.rb:3275
+msgid "Inherits From"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1770
 msgid "Init Process"
 msgid_plural "Init Processes"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:344 ../../app/helpers/vm_infra_helper/textual_summary.rb:358 ../../app/helpers/vm_helper/textual_summary.rb:457
+msgid "Init Processes"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:412
+msgid "Initialized"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:407
+msgid "Initializing"
+msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:96 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:105
 msgid "Initiate Check Compliance of the last known configuration for the selected Templates?"
@@ -11675,7 +17149,8 @@ msgstr ""
 msgid "Initiate Check Compliance of the last known configuration for this item?"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_performance.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_performance.rb:6
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_performance.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_performance.rb:6 ../yaml_strings.rb:1610
 msgid "Initiate refresh of recent C&U data"
 msgstr ""
 
@@ -11691,10 +17166,24 @@ msgstr ""
 msgid "Input Parameters"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../yaml_strings.rb:3851
+msgid "Installed"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm
 #. TRANSLATORS: en.yml key: dictionary.table.vm_cloud
-#: ../dictionary_strings.rb:1425 ../dictionary_strings.rb:2117
+#: ../../app/helpers/container_group_helper/textual_summary.rb:101 ../../app/helpers/container_node_helper/textual_summary.rb:78 ../dictionary_strings.rb:1425 ../dictionary_strings.rb:2117
 msgid "Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2019
+msgid "Instance Access Rules"
+msgstr ""
+
+#: ../../app/helpers/ontap_file_share_helper/textual_summary.rb:47
+msgid "Instance ID"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:126
@@ -11705,19 +17194,50 @@ msgstr ""
 msgid "Instance Type:"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:71
+msgid "Instance Views"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/AvailabilityZone.yaml
+#. TRANSLATORS: file: product/views/CloudTenant.yaml
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqAeInstance.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::CloudManager::Vm (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.vm_cloud (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.vm_clouds
-#: ../../app/presenters/menu/default_menu.rb:32 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:32 ../../app/views/layouts/listnav/_security_group.html.haml:34 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38 ../../app/views/miq_ae_class/_class_instances.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:8 ../../app/views/miq_ae_class/_all_tabs.html.haml:35 ../../app/views/miq_ae_class/_class_props.html.haml:68 ../../app/views/configuration/_ui_2.html.haml:173 ../dictionary_strings.rb:1427 ../dictionary_strings.rb:2119 ../dictionary_strings.rb:2121
+#: ../../app/presenters/menu/default_menu.rb:32 ../../app/controllers/vm_cloud_controller.rb:31 ../../app/controllers/ems_common.rb:52 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:28 ../../app/views/layouts/listnav/_security_group.html.haml:30 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38 ../../app/views/miq_ae_class/_class_instances.html.haml:5 ../../app/views/miq_ae_class/_all_tabs.html.haml:8 ../../app/views/miq_ae_class/_all_tabs.html.haml:35 ../../app/views/miq_ae_class/_class_props.html.haml:68 ../../app/views/configuration/_ui_2.html.haml:173 ../yaml_strings.rb:69 ../dictionary_strings.rb:1427 ../dictionary_strings.rb:2119 ../dictionary_strings.rb:2121
 msgid "Instances"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:27 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:33
+#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:23 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:29
 msgid "Instances (%s)"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:76
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:83
+msgid "Instances Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#: ../yaml_strings.rb:3507
+msgid "Instances and Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:125 ../../app/controllers/vm_cloud_controller.rb:21 ../yaml_strings.rb:75
 msgid "Instances by Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:77
+msgid "Instances by Provider Accordion"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:461 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:559 ../../app/assets/javascripts/miq_application.js:101 ../../app/assets/javascripts/miq_application.js:102 ../../app/assets/javascripts/miq_application.js:105
@@ -11732,8 +17252,9 @@ msgstr ""
 msgid "Internal RSS Feed"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.interval
-#: ../../app/views/layouts/_tl_options.html.haml:45 ../../app/views/layouts/_perf_options.html.haml:11 ../../app/views/report/_report_info.html.haml:139 ../dictionary_strings.rb:1215
+#: ../../app/views/layouts/_tl_options.html.haml:45 ../../app/views/layouts/_perf_options.html.haml:11 ../../app/views/report/_report_info.html.haml:139 ../yaml_strings.rb:3217 ../dictionary_strings.rb:1215
 msgid "Interval"
 msgstr ""
 
@@ -11747,6 +17268,22 @@ msgstr ""
 
 #: ../../lib/report_formatter/chart_common.rb:568
 msgid "Invalid chart definition"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:171
+msgid "Is Compression Enabled"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:175
+msgid "Is Inconsistent"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:179
+msgid "Is Invalid"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:183
+msgid "Is Unrecoverable"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_is_a_template
@@ -11787,6 +17324,11 @@ msgstr ""
 
 #: ../model_attributes.rb:674
 msgid "Job"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Job.yaml
+#: ../yaml_strings.rb:3877
+msgid "Jobs"
 msgstr ""
 
 #: ../model_attributes.rb:675
@@ -11877,7 +17419,7 @@ msgstr ""
 msgid "Job|Zone"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:39 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:40 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:47 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:48 ../../app/assets/javascripts/miq_application.js:106
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:35 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:36 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:43 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:44 ../../app/assets/javascripts/miq_application.js:106
 msgid "KBps"
 msgstr ""
 
@@ -11885,15 +17427,30 @@ msgstr ""
 msgid "KVM"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_server_details.html.haml:63
+#: ../../app/helpers/pxe_helper/textual_summary.rb:60 ../../app/views/pxe/_pxe_server_details.html.haml:63
 msgid "Kernel"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1687
+#: ../../app/controllers/vm_common.rb:1768
 msgid "Kernel Driver"
 msgid_plural "Kernel Drivers"
 msgstr[0] ""
 msgstr[1] ""
+
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:373 ../../app/helpers/vm_infra_helper/textual_summary.rb:385 ../../app/helpers/vm_helper/textual_summary.rb:484 ../yaml_strings.rb:3731
+msgid "Kernel Drivers"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../yaml_strings.rb:3763
+msgid "Kernel Version"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+#: ../yaml_strings.rb:3468
+msgid "Key"
+msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud
 #: ../../app/controllers/auth_key_pair_cloud_controller.rb:91 ../dictionary_strings.rb:1747
@@ -11902,7 +17459,7 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_cloud (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.auth_key_pair_clouds
-#: ../../app/presenters/menu/default_menu.rb:34 ../../app/views/configuration/_ui_2.html.haml:229 ../dictionary_strings.rb:1749 ../dictionary_strings.rb:1751
+#: ../../app/presenters/menu/default_menu.rb:34 ../../app/helpers/vm_cloud_helper/textual_summary.rb:319 ../../app/views/configuration/_ui_2.html.haml:226 ../dictionary_strings.rb:1749 ../dictionary_strings.rb:1751
 msgid "Key Pairs"
 msgstr ""
 
@@ -11914,8 +17471,13 @@ msgstr ""
 msgid "Kickstart"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2331
+msgid "Kilobytes per Second (10 KBps)"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.table.ldap
-#: ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279 ../dictionary_strings.rb:1947
+#: ../../app/presenters/tree_builder_ops_settings.rb:26 ../../app/views/ops/_settings_authentication_tab.html.haml:55 ../../app/views/ops/_ldap_server_entry.html.haml:25 ../../app/views/ops/_ldap_server_entry.html.haml:66 ../../app/views/ops/_ldap_server_entry.html.haml:125 ../../app/views/ops/_ldap_domain_show.html.haml:279 ../dictionary_strings.rb:1947
 msgid "LDAP"
 msgstr ""
 
@@ -12014,12 +17576,17 @@ msgstr ""
 msgid "LDAPs"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:771
+msgid "LUN: %{name}"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.table.ontap_storage_volume
 #: ../dictionary_strings.rb:2057
 msgid "LUNs"
 msgstr ""
 
-#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:15 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:14 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:15
+#. TRANSLATORS: file: product/views/Dialog.yaml
+#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:15 ../../app/views/miq_ae_customization/_dialog_info_form.html.haml:14 ../../app/views/miq_ae_customization/_dialog_tab_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_group_form.html.haml:13 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:15 ../yaml_strings.rb:3875
 msgid "Label"
 msgstr ""
 
@@ -12083,7 +17650,7 @@ msgstr ""
 msgid "Large Trees"
 msgstr ""
 
-#: ../../app/views/ops/_db_summary.html.haml:14
+#: ../../app/helpers/ops_helper/textual_summary.rb:108 ../../app/views/ops/_db_summary.html.haml:14
 msgid "Largest Tables"
 msgstr ""
 
@@ -12099,12 +17666,20 @@ msgstr ""
 msgid "Last 1000 lines from the Automation log"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:38
+#: ../../app/helpers/ui_constants.rb:421
+msgid "Last 24 Hours"
+msgstr ""
+
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:34
 msgid "Last 24 hours"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:20 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:30 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:46
+#: ../../app/helpers/ui_constants.rb:423 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:16 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:26 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:42
 msgid "Last 30 Days"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:422
+msgid "Last 7 Days"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.last_scan_attempt_on
@@ -12112,13 +17687,51 @@ msgstr ""
 msgid "Last Analysis Attempt On"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/Storage.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.last_scan_on
-#: ../dictionary_strings.rb:431
+#: ../yaml_strings.rb:3044 ../dictionary_strings.rb:431
 msgid "Last Analysis Time"
+msgstr ""
+
+#: ../../app/helpers/vm_helper/textual_summary.rb:215
+msgid "Last Analyzed"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:518 ../../app/helpers/vm_infra_helper/textual_summary.rb:655 ../../app/helpers/vm_helper/textual_summary.rb:774
+msgid "Last Boot Time"
 msgstr ""
 
 #: ../../app/views/ops/rhn/_server_table.html.haml:94
 msgid "Last Checked for updates"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#: ../yaml_strings.rb:3314
+msgid "Last Checkin"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:66
+msgid "Last Collection"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.last_compliance (plural form)
@@ -12131,20 +17744,89 @@ msgstr ""
 msgid "Last Compliance History"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#: ../yaml_strings.rb:3540
+msgid "Last Heartbeat"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:505
+msgid "Last Hour"
+msgstr ""
+
 #: ../../app/views/ops/_logs_selected.html.haml:24
 msgid "Last Log Collection"
 msgstr ""
 
-#: ../../app/views/ops/_logs_selected.html.haml:35 ../../app/views/ops/rhn/_server_table.html.haml:100 ../../app/views/miq_request/_request.html.haml:100 ../../app/views/miq_request/_request_details.html.haml:108
+#. TRANSLATORS: file: product/views/User.yaml
+#: ../yaml_strings.rb:2730
+msgid "Last Logoff"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/User.yaml
+#: ../yaml_strings.rb:2728
+msgid "Last Logon"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqProvision.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#: ../../app/views/ops/_logs_selected.html.haml:35 ../../app/views/ops/rhn/_server_table.html.haml:100 ../../app/views/miq_request/_request.html.haml:100 ../../app/views/miq_request/_request_details.html.haml:108 ../yaml_strings.rb:3334
 msgid "Last Message"
 msgstr ""
 
-#: ../../app/helpers/ems_middleware_helper/textual_summary.rb:31
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#: ../yaml_strings.rb:3820
+msgid "Last Modified"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+#: ../yaml_strings.rb:2936
+msgid "Last Modified Time"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:527
+msgid "Last Month"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:535
+msgid "Last Quarter"
+msgstr ""
+
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:128 ../../app/helpers/ems_middleware_helper/textual_summary.rb:31 ../../app/helpers/ems_infra_helper/textual_summary.rb:185 ../../app/helpers/ems_container_helper/textual_summary.rb:87
 msgid "Last Refresh"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_show.html.haml:94 ../../app/views/report/_widget_show.html.haml:96 ../../app/views/report/_show_schedule.html.haml:92 ../../app/views/report/_report_info.html.haml:144
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2962
+msgid "Last Refresh Date"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/IsoDatastore.yaml
+#. TRANSLATORS: file: product/views/PxeServer.yaml
+#: ../../app/helpers/pxe_helper/textual_summary.rb:32 ../../app/helpers/pxe_helper/textual_summary.rb:132 ../yaml_strings.rb:3833
+msgid "Last Refreshed On"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#: ../../app/views/ops/_schedule_show.html.haml:94 ../../app/views/report/_widget_show.html.haml:96 ../../app/views/report/_show_schedule.html.haml:92 ../../app/views/report/_report_info.html.haml:144 ../yaml_strings.rb:3219
 msgid "Last Run Time"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:61
+msgid "Last Start Time"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:54
+msgid "Last State"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.last_sync_on
@@ -12156,12 +17838,22 @@ msgstr ""
 msgid "Last Transition Time"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:126 ../../app/views/miq_request/_request_details.html.haml:31
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:126 ../../app/views/miq_request/_request_details.html.haml:31 ../yaml_strings.rb:3674
 msgid "Last Update"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.last_update_status_str
-#: ../dictionary_strings.rb:437
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:114 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:59 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:107 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:55 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:74 ../../app/helpers/storage_manager_helper/textual_summary.rb:35 ../yaml_strings.rb:3185 ../dictionary_strings.rb:437
 msgid "Last Update Status"
 msgstr ""
 
@@ -12174,16 +17866,20 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:178
+#: ../../app/helpers/ui_constants.rb:520 ../../app/views/report/_form_filter_chargeback.html.haml:178
 msgid "Last Week"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:479
-msgid "Last selected %s no longer exists"
+#: ../../app/helpers/ui_constants.rb:542
+msgid "Last Year"
 msgstr ""
 
 #: ../../app/controllers/application_controller/explorer.rb:238
 msgid "Last selected %{record_name} no longer exists"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:535
+msgid "Last selected Snapshot no longer exists"
 msgstr ""
 
 #: ../model_attributes.rb:709
@@ -12276,6 +17972,11 @@ msgstr ""
 
 #: ../model_attributes.rb:728
 msgid "LdapGroup|Whencreated"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/LdapRegion.yaml
+#: ../yaml_strings.rb:3127
+msgid "LdapRegion"
 msgstr ""
 
 #: ../model_attributes.rb:730
@@ -12394,11 +18095,12 @@ msgstr ""
 msgid "Leave all options unchecked to show the original column value from the first record in the group."
 msgstr ""
 
-#: ../../app/views/ops/_ap_form_nteventlog.html.haml:17 ../../app/views/layouts/_tl_options.html.haml:181
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:17 ../../app/views/layouts/_tl_options.html.haml:181 ../yaml_strings.rb:3861
 msgid "Level"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:101 ../../app/helpers/application_helper/toolbar/host_center.rb:74 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:38 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:99 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:77 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:83 ../../app/helpers/application_helper/toolbar/services_center.rb:64 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:115 ../../app/helpers/application_helper/toolbar/vms_center.rb:107 ../../app/helpers/application_helper/toolbar/service_center.rb:57 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:141 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:45 ../../app/helpers/application_helper/toolbar/hosts_center.rb:119 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:116 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:78 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:6 ../../app/views/service/_svcs_show.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:9 ../../app/views/orchestration_stack/_main.html.haml:9 ../../app/views/vm_common/_main.html.haml:9
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:101 ../../app/helpers/application_helper/toolbar/host_center.rb:74 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:38 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:6 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:99 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:77 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:83 ../../app/helpers/application_helper/toolbar/services_center.rb:64 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:6 ../../app/helpers/application_helper/toolbar/configured_systems_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:115 ../../app/helpers/application_helper/toolbar/vms_center.rb:107 ../../app/helpers/application_helper/toolbar/configured_system_center.rb:6 ../../app/helpers/application_helper/toolbar/service_center.rb:57 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:141 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:45 ../../app/helpers/application_helper/toolbar/hosts_center.rb:119 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:116 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:78 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:6 ../../app/views/service/_svcs_show.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:9 ../../app/views/orchestration_stack/_main.html.haml:9 ../../app/views/vm_common/_main.html.haml:9
 msgid "Lifecycle"
 msgstr ""
 
@@ -12438,6 +18140,14 @@ msgstr ""
 msgid "Lifespan"
 msgstr ""
 
+#: ../../app/helpers/report_helper.rb:12
+msgid "Light Blue Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:11
+msgid "Light Blue Text"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_summary.html.haml:11
 msgid "Limit Chart to"
 msgstr ""
@@ -12450,9 +18160,15 @@ msgstr ""
 msgid "Limit Request Ratio"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.linux_initprocesses
-#: ../dictionary_strings.rb:1963
+#: ../yaml_strings.rb:3509 ../dictionary_strings.rb:1963
 msgid "Linux Init Processes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:101
+msgid "List"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/gtl_view.rb:20 ../../app/helpers/application_helper/toolbar/x_gtl_view.rb:20 ../../app/helpers/configuration_helper/configuration_view_helper.rb:74 ../../app/helpers/configuration_helper/configuration_view_helper.rb:80 ../../app/helpers/configuration_helper/configuration_view_helper.rb:86 ../../app/views/configuration/_ui_1.html.haml:113
@@ -12483,6 +18199,18 @@ msgstr ""
 msgid "Loading ..."
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/Group.yaml
+#: ../yaml_strings.rb:3113
+msgid "Local"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1478
+msgid "Local File System"
+msgstr ""
+
 #: ../../app/views/configuration/_ui_1.html.haml:145
 msgid "Locale"
 msgstr ""
@@ -12495,12 +18223,32 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:980
+msgid "Lock"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:982
+msgid "Lock Domain"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:28
 msgid "Lock this Domain"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:972
+msgid "Lock/Unlock"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:974
+msgid "Lock/Unlock Domain"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.admin_disabled
-#: ../dictionary_strings.rb:159
+#: ../../app/helpers/host_helper/textual_summary.rb:188 ../dictionary_strings.rb:159
 msgid "Lockdown Mode"
 msgstr ""
 
@@ -12508,15 +18256,16 @@ msgstr ""
 msgid "Locked"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:137 ../../app/presenters/menu/default_menu.rb:147 ../../app/views/ops/_all_tabs.html.haml:180
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:137 ../../app/presenters/menu/default_menu.rb:147 ../../app/views/ops/_all_tabs.html.haml:180 ../yaml_strings.rb:952
 msgid "Log"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:130
+#: ../../app/controllers/ops_controller/diagnostics.rb:138
 msgid "Log Depot Settings were saved"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:151
+#: ../../app/controllers/ops_controller/diagnostics.rb:159
 msgid "Log Depot Settings were validated"
 msgstr ""
 
@@ -12528,11 +18277,15 @@ msgstr ""
 msgid "Log Level"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:621
+#: ../../app/controllers/host_controller.rb:811
+msgid "Log Wrap Size must be numeric and greater than zero"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:641
 msgid "Log collection error returned: %{error_message}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:623
+#: ../../app/controllers/ops_controller/diagnostics.rb:643
 msgid "Log collection for CFME %{object_type} %{name} has been initiated"
 msgstr ""
 
@@ -12592,6 +18345,16 @@ msgstr ""
 msgid "Logging into"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1422
+msgid "Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../yaml_strings.rb:3717
+msgid "Logical Resource"
+msgstr ""
+
 #: ../../app/views/dashboard/login.html.haml:103 ../../app/views/dashboard/login.html.haml:103
 msgid "Login"
 msgstr ""
@@ -12604,7 +18367,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_tools_controller.rb:38 ../../app/controllers/miq_ae_tools_controller.rb:50 ../../app/controllers/ops_controller/diagnostics.rb:194 ../../app/controllers/ops_controller/diagnostics.rb:205 ../../app/controllers/ops_controller/diagnostics.rb:216 ../../app/controllers/ops_controller/diagnostics.rb:871 ../../app/controllers/ops_controller/diagnostics.rb:877 ../../app/controllers/ops_controller/diagnostics.rb:883 ../../app/controllers/miq_policy_controller.rb:326 ../../app/controllers/miq_policy_controller.rb:341
+#: ../../app/controllers/miq_ae_tools_controller.rb:38 ../../app/controllers/miq_ae_tools_controller.rb:50 ../../app/controllers/ops_controller/diagnostics.rb:206 ../../app/controllers/ops_controller/diagnostics.rb:217 ../../app/controllers/ops_controller/diagnostics.rb:228 ../../app/controllers/ops_controller/diagnostics.rb:891 ../../app/controllers/ops_controller/diagnostics.rb:897 ../../app/controllers/ops_controller/diagnostics.rb:903 ../../app/controllers/miq_policy_controller.rb:326 ../../app/controllers/miq_policy_controller.rb:341
 msgid "Logs for this CFME Server are not available for viewing"
 msgstr ""
 
@@ -12612,12 +18375,16 @@ msgstr ""
 msgid "Long Description"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/tags.rb:60
+#: ../../app/controllers/ops_controller/settings/tags.rb:64
 msgid "Long Description is required"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_field.html.haml:139
 msgid "Lookup"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:665 ../../app/helpers/vm_infra_helper/textual_summary.rb:674 ../../app/helpers/vm_infra_helper/textual_summary.rb:684 ../../app/helpers/vm_infra_helper/textual_summary.rb:695 ../../app/helpers/vm_helper/textual_summary.rb:784 ../../app/helpers/vm_helper/textual_summary.rb:793 ../../app/helpers/vm_helper/textual_summary.rb:803 ../../app/helpers/vm_helper/textual_summary.rb:814
+msgid "Low"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.mac_address
@@ -12648,6 +18415,10 @@ msgstr ""
 msgid "Mac address"
 msgstr ""
 
+#: ../../app/helpers/container_node_helper/textual_summary.rb:65
+msgid "Machine ID"
+msgstr ""
+
 #: ../../app/views/miq_ae_class/_method_inputs.html.haml:7 ../../app/views/miq_ae_class/_instance_form.html.haml:5 ../../app/views/miq_ae_class/_method_form.html.haml:6
 msgid "Main Info"
 msgstr ""
@@ -12660,8 +18431,19 @@ msgstr ""
 msgid "Manage Accordions & Folders"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:77 ../../app/helpers/application_helper/toolbar/host_center.rb:49 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:75 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:53 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:59 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:30 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:64 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:36 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:70 ../../app/helpers/application_helper/toolbar/repository_center.rb:43 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:79 ../../app/helpers/application_helper/toolbar/vms_center.rb:71 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:65 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:105 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:54 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:48 ../../app/helpers/application_helper/toolbar/hosts_center.rb:82 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:36 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:80 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:65 ../../app/helpers/application_helper/toolbar/repositories_center.rb:58 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:54 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:54
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:752
+msgid "Manage Dashboard Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:77 ../../app/helpers/application_helper/toolbar/host_center.rb:49 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:75 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:53 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:59 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:30 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:64 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:36 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:70 ../../app/helpers/application_helper/toolbar/repository_center.rb:43 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:79 ../../app/helpers/application_helper/toolbar/vms_center.rb:71 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:65 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:105 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:54 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:48 ../../app/helpers/application_helper/toolbar/hosts_center.rb:82 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:36 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:96 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:80 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:65 ../../app/helpers/application_helper/toolbar/repositories_center.rb:58 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:54 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:54 ../yaml_strings.rb:292
 msgid "Manage Policies"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:536
+msgid "Manage Policies for Hosts / Nodes"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:64
@@ -12724,7 +18506,53 @@ msgstr ""
 msgid "Manage Policies for this item"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/tenant_center.rb:29
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:294
+msgid "Manage Policies of Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:441
+msgid "Manage Policies of Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:649
+msgid "Manage Policies of Repository"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:599
+msgid "Manage Policies of Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:495
+msgid "Manage Policies on Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2125
+msgid "Manage Policies on Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2043
+msgid "Manage Policies on Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2277
+msgid "Manage Policies on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2165
+msgid "Manage Policies on VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/tenant_center.rb:29 ../yaml_strings.rb:1318
 msgid "Manage Quotas"
 msgstr ""
 
@@ -12736,12 +18564,59 @@ msgstr ""
 msgid "Manage Reports"
 msgstr ""
 
-#: ../../app/controllers/ops_controller.rb:659
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1320
+msgid "Manage Tenant Quotas"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:685
 msgid "Manage quotas for %{model} \"%{name}\""
 msgstr ""
 
 #: ../../app/controllers/ops_controller/ops_rbac.rb:189
 msgid "Manage quotas for %{model} \"%{name}\" was cancelled by the user"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:108
+msgid "ManageIQ-Blue"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:71
+msgid "Managed "
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:97
+msgid "Managed %{tables}"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:81
+msgid "Managed Hosts"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:86
+msgid "Managed VMs"
+msgstr ""
+
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:136 ../../app/helpers/ems_infra_helper/textual_summary.rb:193 ../../app/helpers/ems_container_helper/textual_summary.rb:77
+msgid "Managed by Zone"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../../app/helpers/storage_helper/textual_summary.rb:108 ../yaml_strings.rb:3255
+msgid "Managed/Registered VMs"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../../app/helpers/storage_helper/textual_summary.rb:112 ../yaml_strings.rb:3257
+msgid "Managed/Unregistered VMs"
+msgstr ""
+
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:49 ../../app/helpers/service_helper/textual_summary.rb:45 ../../app/helpers/vm_cloud_helper/textual_summary.rb:145 ../../app/helpers/host_helper/textual_summary.rb:247 ../../app/helpers/ems_infra_helper/textual_summary.rb:61 ../../app/helpers/vm_infra_helper/textual_summary.rb:173 ../../app/helpers/vm_helper/textual_summary.rb:207
+msgid "Management Engine GUID"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:952
+msgid "Management Engine Relationship saved"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.EmsEvent
@@ -12750,8 +18625,9 @@ msgstr ""
 msgid "Management Event"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.notify_automate
-#: ../dictionary_strings.rb:647
+#: ../yaml_strings.rb:3709 ../dictionary_strings.rb:647
 msgid "Management Event Raised"
 msgstr ""
 
@@ -12764,6 +18640,14 @@ msgstr ""
 
 #: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:19 ../../app/views/miq_request/_prov_host_dialog.html.haml:18 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:18 ../../app/views/shared/views/_prov_dialog.html.haml:19
 msgid "Manager"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:394
+msgid "Manual Input"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:143
+msgid "Manufacturer / Model"
 msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:642
@@ -12783,6 +18667,20 @@ msgstr ""
 msgid "Max Concurrent"
 msgstr ""
 
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#: ../yaml_strings.rb:2711
+msgid "Max Disk Space"
+msgstr ""
+
+#: ../../app/helpers/container_node_helper/textual_summary.rb:55
+msgid "Max Pods Capacity"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#: ../yaml_strings.rb:2709
+msgid "Max RAM"
+msgstr ""
+
 #: ../../app/views/miq_ae_class/_instance_fields.html.haml:27 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97
 msgid "Max Retries"
 msgstr ""
@@ -12799,21 +18697,40 @@ msgstr ""
 msgid "Max active VM Scans"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../yaml_strings.rb:3800
+msgid "Maximum"
+msgstr ""
+
 #: ../../app/helpers/provider_foreman_helper.rb:96 ../../app/helpers/provider_foreman_helper.rb:177
 msgid "Medium"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2333
+msgid "Megahertz (12 Mhz)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2335
+msgid "Megahertz Avg (12.1 Mhz)"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_service.html.haml:24 ../../app/views/layouts/listnav/_service.html.haml:30
 msgid "Member VMs (%s)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.mem_cpu
-#: ../../app/helpers/application_helper/chargeback.rb:8 ../../app/views/miq_request/_reconfigure_show.html.haml:17 ../../app/views/vm_common/_reconfigure.html.haml:14 ../../app/views/vm_common/_right_size.html.haml:95 ../../app/views/vm_common/_right_size.html.haml:208 ../../app/views/vm_common/_right_size.html.haml:292 ../../app/views/vm_common/_right_size.html.haml:375 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:27 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:27 ../dictionary_strings.rb:533
+#: ../../app/helpers/service_helper/textual_summary.rb:53 ../../app/helpers/host_helper/textual_summary.rb:238 ../../app/helpers/application_helper/chargeback.rb:8 ../../app/helpers/vm_infra_helper/textual_summary.rb:462 ../../app/helpers/vm_infra_helper/textual_summary.rb:683 ../../app/helpers/vm_helper/textual_summary.rb:561 ../../app/helpers/vm_helper/textual_summary.rb:802 ../../app/helpers/container_node_helper/textual_summary.rb:51 ../../app/views/miq_request/_reconfigure_show.html.haml:17 ../../app/views/vm_common/_reconfigure.html.haml:14 ../../app/views/vm_common/_right_size.html.haml:95 ../../app/views/vm_common/_right_size.html.haml:208 ../../app/views/vm_common/_right_size.html.haml:292 ../../app/views/vm_common/_right_size.html.haml:375 ../../app/views/miq_capacity/_utilization_report.html.haml:33 ../../app/views/miq_capacity/_utilization_summary.html.haml:18 ../../app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js:27 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:23 ../yaml_strings.rb:3404 ../dictionary_strings.rb:533
 msgid "Memory"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.percent_memory
-#: ../dictionary_strings.rb:713
+#: ../yaml_strings.rb:3909 ../dictionary_strings.rb:713
 msgid "Memory %"
 msgstr ""
 
@@ -13197,7 +19114,7 @@ msgstr ""
 msgid "Memory Average Used Trend"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:133 ../../app/views/vm_common/_config.html.haml:237
 msgid "Memory Limit"
 msgstr ""
 
@@ -13226,23 +19143,24 @@ msgstr ""
 msgid "Memory Max Used Trend"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:121 ../../app/views/vm_common/_config.html.haml:237
 msgid "Memory Reserve"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:127 ../../app/views/vm_common/_config.html.haml:237
 msgid "Memory Reserve Expand"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:139 ../../app/views/vm_common/_config.html.haml:237
 msgid "Memory Shares"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:240
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:145 ../../app/views/vm_common/_config.html.haml:237
 msgid "Memory Shares Level"
 msgstr ""
 
-#: ../../app/views/ops/_selected_by_servers.html.haml:102 ../../app/views/ops/_selected_by_roles.html.haml:150 ../../app/views/ops/_server_desc.html.haml:63 ../../app/views/miq_policy/_action_options.html.haml:221 ../../app/views/miq_policy/_action_details.html.haml:294 ../../app/views/miq_capacity/_planning_options.html.haml:194 ../../app/views/miq_capacity/_planning_options.html.haml:356 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:34 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:85
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#: ../../app/views/ops/_selected_by_servers.html.haml:102 ../../app/views/ops/_selected_by_roles.html.haml:150 ../../app/views/ops/_server_desc.html.haml:63 ../../app/views/miq_policy/_action_options.html.haml:221 ../../app/views/miq_policy/_action_details.html.haml:294 ../../app/views/miq_capacity/_planning_options.html.haml:194 ../../app/views/miq_capacity/_planning_options.html.haml:356 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:34 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:85 ../yaml_strings.rb:3545
 msgid "Memory Size"
 msgstr ""
 
@@ -13256,8 +19174,10 @@ msgstr ""
 msgid "Memory Total Cost"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.memory_size
-#: ../../app/views/ops/_selected_by_servers.html.haml:89 ../../app/views/ops/_selected_by_roles.html.haml:137 ../../app/views/ops/_server_desc.html.haml:53 ../../app/views/vm_common/_right_size.html.haml:123 ../dictionary_strings.rb:551
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:694 ../../app/helpers/vm_helper/textual_summary.rb:813 ../../app/views/ops/_selected_by_servers.html.haml:89 ../../app/views/ops/_selected_by_roles.html.haml:137 ../../app/views/ops/_server_desc.html.haml:53 ../../app/views/vm_common/_right_size.html.haml:123 ../yaml_strings.rb:3543 ../dictionary_strings.rb:551
 msgid "Memory Usage"
 msgstr ""
 
@@ -13280,6 +19200,10 @@ msgstr ""
 msgid "Memory must be an integer"
 msgstr ""
 
+#: ../../app/helpers/service_helper/textual_summary.rb:71
+msgid "Memory on Disk"
+msgstr ""
+
 #: ../../app/views/ops/_settings_workers_tab.html.haml:47 ../../app/views/ops/_settings_workers_tab.html.haml:99 ../../app/views/ops/_settings_workers_tab.html.haml:130 ../../app/views/ops/_settings_workers_tab.html.haml:161 ../../app/views/ops/_settings_workers_tab.html.haml:254 ../../app/views/ops/_settings_workers_tab.html.haml:305 ../../app/views/ops/_settings_workers_tab.html.haml:359 ../../app/views/ops/_settings_workers_tab.html.haml:410 ../../app/views/ops/_settings_workers_tab.html.haml:441 ../../app/views/ops/_settings_workers_tab.html.haml:489
 msgid "Memory threshold"
 msgstr ""
@@ -13292,8 +19216,19 @@ msgstr ""
 msgid "Menu Shortcuts"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:553
+msgid "Menus"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#. TRANSLATORS: file: product/views/ScanHistory.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_message
-#: ../../app/views/miq_request/_ae_prov_show.html.haml:20 ../../app/views/layouts/_ae_resolve_options.html.haml:42 ../../app/views/miq_ae_class/_instance_fields.html.haml:31 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/report/_widget_show.html.haml:106 ../../app/views/shared/buttons/_ab_show.html.haml:98 ../../app/assets/javascripts/miq_policy/import.js:47 ../dictionary_strings.rb:1021
+#: ../../app/helpers/container_helper/textual_summary.rb:50 ../../app/views/miq_request/_ae_prov_show.html.haml:20 ../../app/views/layouts/_ae_resolve_options.html.haml:42 ../../app/views/miq_ae_class/_instance_fields.html.haml:31 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/report/_widget_show.html.haml:106 ../../app/views/shared/buttons/_ab_show.html.haml:98 ../../app/assets/javascripts/miq_policy/import.js:47 ../yaml_strings.rb:2581 ../dictionary_strings.rb:1021
 msgid "Message"
 msgstr ""
 
@@ -13303,6 +19238,16 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_import_tab.html.haml:3 ../../app/views/ops/_settings_import_tags_tab.html.haml:6
 msgid "Messages"
+msgstr ""
+
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#: ../yaml_strings.rb:2421
+msgid "Messages Being Processed"
+msgstr ""
+
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#: ../yaml_strings.rb:2419
+msgid "Messages Ready to Process"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_all_tabs.html.haml:44
@@ -13846,9 +19791,10 @@ msgstr ""
 msgid "Middleware Deployment"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.middleware_deployment (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.middleware_deployments
-#: ../dictionary_strings.rb:1897 ../dictionary_strings.rb:1899
+#: ../../app/controllers/middleware_deployment_controller.rb:29 ../yaml_strings.rb:3569 ../dictionary_strings.rb:1897 ../dictionary_strings.rb:1899
 msgid "Middleware Deployments"
 msgstr ""
 
@@ -13857,9 +19803,10 @@ msgstr ""
 msgid "Middleware Provider"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.ems_middleware (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.ems_middlewares
-#: ../dictionary_strings.rb:1885 ../dictionary_strings.rb:1887
+#: ../yaml_strings.rb:3340 ../dictionary_strings.rb:1885 ../dictionary_strings.rb:1887
 msgid "Middleware Providers"
 msgstr ""
 
@@ -13868,10 +19815,36 @@ msgstr ""
 msgid "Middleware Server"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiddlewareServer.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.middleware_server (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.middleware_servers
-#: ../../app/controllers/middleware_server_controller.rb:29 ../dictionary_strings.rb:1891 ../dictionary_strings.rb:1893
+#: ../../app/controllers/middleware_server_controller.rb:29 ../yaml_strings.rb:3630 ../dictionary_strings.rb:1891 ../dictionary_strings.rb:1893
 msgid "Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1973
+msgid "Middleware Topology"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1716
+msgid "MiddlewareDeployment"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1690
+msgid "MiddlewareServer"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2213
+msgid "Migrate VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2215
+msgid "Migrate VMs to another Host/Datastore"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:170
@@ -13895,8 +19868,42 @@ msgstr ""
 msgid "Min"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../yaml_strings.rb:3798
+msgid "Minimum"
+msgstr ""
+
 #: ../../app/assets/javascripts/miq_formatters.js:251
 msgid "Minute"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqDialog.yaml
+#: ../yaml_strings.rb:3567
+msgid "Miq Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+#: ../yaml_strings.rb:2589
+msgid "Miq Event Description"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+#: ../yaml_strings.rb:2592
+msgid "Miq Policy Description"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#: ../yaml_strings.rb:2821
+msgid "Miq Reports"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#: ../yaml_strings.rb:3380
+msgid "Miq Widgets"
 msgstr ""
 
 #: ../model_attributes.rb:908
@@ -15679,6 +21686,336 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:121
+msgid "Modify"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:996
+msgid "Modify Automate Class"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:181
+msgid "Modify Available Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1101
+msgid "Modify Button Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1111
+msgid "Modify Buttons"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:194
+msgid "Modify Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:149
+msgid "Modify Catalog Items"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:300
+msgid "Modify Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:502
+msgid "Modify Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:877
+msgid "Modify Conditions"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1842
+msgid "Modify Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1781
+msgid "Modify Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1891
+msgid "Modify Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1949
+msgid "Modify Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1658
+msgid "Modify Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1560
+msgid "Modify Customization Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:667
+msgid "Modify Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:754
+msgid "Modify Dashboards"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:630
+msgid "Modify Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1051
+msgid "Modify Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:960
+msgid "Modify Domain"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1277
+msgid "Modify Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:574
+msgid "Modify Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1596
+msgid "Modify ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2135
+msgid "Modify Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:445
+msgid "Modify Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1010
+msgid "Modify Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2091
+msgid "Modify Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1022
+msgid "Modify Method"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1726
+msgid "Modify Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1682
+msgid "Modify Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1704
+msgid "Modify Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1137
+msgid "Modify My Settings"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:986
+msgid "Modify Namespace"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1624
+msgid "Modify Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:215
+msgid "Modify Orchestration Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1537
+msgid "Modify PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1864
+msgid "Modify Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1755
+msgid "Modify Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:854
+msgid "Modify Policies"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:907
+msgid "Modify Policy Actions"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:919
+msgid "Modify Policy Alert Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:934
+msgid "Modify Policy Alerts"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:840
+msgid "Modify Policy Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1226
+msgid "Modify Product Updates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1995
+msgid "Modify Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1085
+msgid "Modify Provisioning Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:711
+msgid "Modify Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:653
+msgid "Modify Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:123
+msgid "Modify Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:601
+msgid "Modify Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1297
+msgid "Modify Role"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:687
+msgid "Modify Saved Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:734
+msgid "Modify Schedules"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1034
+msgid "Modify Schema"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:243
+msgid "Modify Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1514
+msgid "Modify Storage Managers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1577
+msgid "Modify System Image Types"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1185
+msgid "Modify Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2287
+msgid "Modify Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1310
+msgid "Modify Tenant/Project"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1155
+msgid "Modify Time Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1255
+msgid "Modify User"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2201
+msgid "Modify VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:778
+msgid "Modify Widgets"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1232
+msgid "Modify Zones"
+msgstr ""
+
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
 msgid "Monday"
 msgstr ""
@@ -15687,8 +22024,33 @@ msgstr ""
 msgid "Monitoring"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:154
+#: ../../app/helpers/ui_constants.rb:306 ../../app/views/report/_form_filter_chargeback.html.haml:154
 msgid "Month"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2393
+msgid "Month Full (January)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2395
+msgid "Month Short (Jan)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2389
+msgid "Month and Year (January 2011)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2391
+msgid "Month and Year Short (Jan 11)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2397
+msgid "Month of Year (12)"
 msgstr ""
 
 #: ../../app/views/report/_schedule_form_timer.html.haml:20
@@ -15751,7 +22113,7 @@ msgstr ""
 msgid "Move selected field up"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:40 ../../app/views/report/_column_lists.html.haml:98
+#: ../../app/views/report/_column_lists.html.haml:40 ../../app/views/report/_column_lists.html.haml:95
 msgid "Move selected fields %{where}"
 msgstr ""
 
@@ -15824,7 +22186,11 @@ msgstr ""
 msgid "Multiple Host Access"
 msgstr ""
 
-#: ../../app/presenters/tree_builder_vms_filter.rb:22 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:34 ../../app/views/layouts/listnav/_show_list.html.haml:38
+#: ../../app/presenters/tree_builder.rb:142
+msgid "My %{models}"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_vms_filter.rb:22 ../../app/presenters/tree_builder_configuration_manager_configured_systems.rb:34 ../../app/controllers/ops_controller/settings/schedules.rb:566 ../../app/controllers/ops_controller/settings/schedules.rb:576 ../../app/controllers/ops_controller/settings/schedules.rb:585 ../../app/controllers/ops_controller/settings/schedules.rb:593 ../../app/controllers/ops_controller/settings/schedules.rb:602 ../../app/views/layouts/listnav/_show_list.html.haml:38
 msgid "My Filters"
 msgstr ""
 
@@ -15832,15 +22198,17 @@ msgstr ""
 msgid "My Personal Filters"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:17 ../../app/views/configuration/_ui_2.html.haml:49
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:17 ../../app/controllers/service_controller.rb:398 ../../app/views/configuration/_ui_2.html.haml:49 ../yaml_strings.rb:231
 msgid "My Services"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:162
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:162 ../yaml_strings.rb:1133
 msgid "My Settings"
 msgstr ""
 
-#: ../../app/views/miq_policy/_policy_details.html.haml:82 ../../app/views/miq_policy/_policy_details.html.haml:97
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:103 ../../app/helpers/vm_cloud_helper/textual_summary.rb:321 ../../app/helpers/vm_cloud_helper/textual_summary.rb:518 ../../app/helpers/vm_cloud_helper/textual_summary.rb:524 ../../app/helpers/host_helper/textual_summary.rb:147 ../../app/helpers/host_helper/textual_summary.rb:205 ../../app/helpers/host_helper/textual_summary.rb:225 ../../app/helpers/host_helper/textual_summary.rb:229 ../../app/helpers/host_helper/textual_summary.rb:234 ../../app/helpers/host_helper/textual_summary.rb:240 ../../app/helpers/ems_infra_helper/textual_summary.rb:68 ../../app/helpers/ems_infra_helper/textual_summary.rb:80 ../../app/helpers/vm_infra_helper/textual_summary.rb:119 ../../app/helpers/vm_infra_helper/textual_summary.rb:123 ../../app/helpers/vm_infra_helper/textual_summary.rb:456 ../../app/helpers/vm_infra_helper/textual_summary.rb:457 ../../app/helpers/vm_infra_helper/textual_summary.rb:464 ../../app/helpers/vm_infra_helper/textual_summary.rb:465 ../../app/helpers/vm_infra_helper/textual_summary.rb:486 ../../app/helpers/vm_infra_helper/textual_summary.rb:487 ../../app/helpers/vm_infra_helper/textual_summary.rb:494 ../../app/helpers/vm_infra_helper/textual_summary.rb:495 ../../app/helpers/vm_infra_helper/textual_summary.rb:502 ../../app/helpers/vm_infra_helper/textual_summary.rb:504 ../../app/helpers/vm_infra_helper/textual_summary.rb:655 ../../app/helpers/vm_infra_helper/textual_summary.rb:660 ../../app/helpers/vm_helper/textual_summary.rb:153 ../../app/helpers/vm_helper/textual_summary.rb:157 ../../app/helpers/vm_helper/textual_summary.rb:555 ../../app/helpers/vm_helper/textual_summary.rb:556 ../../app/helpers/vm_helper/textual_summary.rb:563 ../../app/helpers/vm_helper/textual_summary.rb:564 ../../app/helpers/vm_helper/textual_summary.rb:585 ../../app/helpers/vm_helper/textual_summary.rb:586 ../../app/helpers/vm_helper/textual_summary.rb:593 ../../app/helpers/vm_helper/textual_summary.rb:594 ../../app/helpers/vm_helper/textual_summary.rb:601 ../../app/helpers/vm_helper/textual_summary.rb:603 ../../app/helpers/vm_helper/textual_summary.rb:774 ../../app/helpers/vm_helper/textual_summary.rb:779 ../../app/helpers/container_node_helper/textual_summary.rb:41 ../../app/helpers/container_node_helper/textual_summary.rb:49 ../../app/helpers/container_node_helper/textual_summary.rb:56 ../../app/helpers/container_node_helper/textual_summary.rb:61 ../../app/helpers/container_node_helper/textual_summary.rb:66 ../../app/helpers/container_node_helper/textual_summary.rb:71 ../../app/helpers/container_node_helper/textual_summary.rb:92 ../../app/helpers/container_node_helper/textual_summary.rb:96 ../../app/helpers/container_node_helper/textual_summary.rb:100 ../../app/helpers/container_node_helper/textual_summary.rb:105 ../../app/helpers/container_node_helper/textual_summary.rb:113 ../../app/views/miq_policy/_policy_details.html.haml:82 ../../app/views/miq_policy/_policy_details.html.haml:97
 msgid "N/A"
 msgstr ""
 
@@ -15849,7 +22217,7 @@ msgstr ""
 msgid "NFS"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:37
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:77 ../../app/helpers/container_group_helper/textual_summary.rb:37
 msgid "NFS Server"
 msgstr ""
 
@@ -15865,7 +22233,118 @@ msgstr ""
 msgid "NTP Servers"
 msgstr ""
 
-#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/helpers/ems_container_helper/textual_summary.rb:25 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_db_info.html.haml:15 ../../app/views/ops/_db_info.html.haml:118 ../../app/views/ops/_db_info.html.haml:213 ../../app/views/ops/_ap_form_nteventlog.html.haml:13 ../../app/views/ops/_settings_evm_servers_tab.html.haml:13 ../../app/views/ops/_category_form.html.haml:118 ../../app/views/ops/_ldap_region_show.html.haml:18 ../../app/views/ops/_ldap_region_show.html.haml:71 ../../app/views/ops/_ap_show.html.haml:16 ../../app/views/ops/_ap_show.html.haml:94 ../../app/views/ops/_zone_form.html.haml:16 ../../app/views/ops/_rbac_tenant_details.html.haml:17 ../../app/views/ops/_rbac_tenant_details.html.haml:93 ../../app/views/ops/_rbac_tenant_details.html.haml:125 ../../app/views/ops/_tenant_form.html.haml:17 ../../app/views/ops/_ap_form_file.html.haml:15 ../../app/views/ops/_ldap_domain_form.html.haml:16 ../../app/views/ops/_classification_entries.html.haml:15 ../../app/views/ops/_schedule_form.html.haml:19 ../../app/views/ops/_ldap_domain_show.html.haml:16 ../../app/views/ops/_ldap_region_form.html.haml:19 ../../app/views/ops/_rbac_role_details.html.haml:25 ../../app/views/ops/_ap_form.html.haml:20 ../../app/views/ops/_settings_co_categories_tab.html.haml:12 ../../app/views/provider_foreman/_form.html.haml:18 ../../app/views/service/_service_form.html.haml:27 ../../app/views/storage_manager/_form.html.haml:23 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:12 ../../app/views/repository/_form.html.haml:16 ../../app/views/host/_form.html.haml:25 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:17 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:20 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:35 ../../app/views/_ldap_domain_form.html.haml:16 ../../app/views/chargeback/_cb_assignments.html.haml:72 ../../app/views/chargeback/_reports_list.html.haml:58 ../../app/views/vm_common/_snap.html.haml:17 ../../app/views/miq_ae_class/_method_inputs.html.haml:32 ../../app/views/miq_ae_class/_ns_list.html.haml:20 ../../app/views/miq_ae_class/_ns_list.html.haml:95 ../../app/views/miq_ae_class/_instance_form.html.haml:27 ../../app/views/miq_ae_class/_instance_form.html.haml:87 ../../app/views/miq_ae_class/_instance_fields.html.haml:15 ../../app/views/miq_ae_class/_method_form.html.haml:31 ../../app/views/miq_ae_class/_method_form.html.haml:143 ../../app/views/miq_ae_class/_class_form.html.haml:27 ../../app/views/miq_ae_class/_class_props.html.haml:29 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_timeprofile_form.html.haml:160 ../../app/views/report/_schedule_form.html.haml:17 ../../app/views/report/_report_list.html.haml:48 ../../app/views/report/_report_list.html.haml:87 ../../app/views/report/_report_list.html.haml:123 ../../app/views/report/_db_show.html.haml:14 ../../app/views/report/_db_form.html.haml:20 ../../app/views/report/_report_info.html.haml:124 ../../app/views/ontap_file_share/_create_datastore.html.haml:18 ../../app/views/shared/views/ems_common/angular/_form.html.haml:13 ../../app/views/shared/views/ems_common/_form.html.haml:18 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_ot_tree_show.html.haml:11 ../../app/views/catalog/_ot_add.html.haml:14 ../../app/views/catalog/_ot_copy.html.haml:21 ../../app/views/catalog/_svccat_tree_show.html.haml:28 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_stcat_tree_show.html.haml:11 ../../app/views/catalog/_stcat_form.html.haml:20 ../../app/views/catalog/_ot_edit.html.haml:14 ../../app/views/pxe/_pxe_image_type_form.html.haml:17 ../../app/views/pxe/_template_form.html.haml:15 ../../app/views/pxe/_iso_datastore_details.html.haml:24 ../../app/views/pxe/_pxe_server_details.html.haml:59 ../../app/views/pxe/_pxe_server_details.html.haml:106 ../../app/views/pxe/_pxe_form.html.haml:17 ../../app/views/miq_policy/_action_details.html.haml:76 ../../app/views/miq_capacity/_planning_summary.html.haml:49
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/AdvancedSetting.yaml
+#. TRANSLATORS: file: product/views/AvailabilityZone.yaml
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CloudNetwork.yaml
+#. TRANSLATORS: file: product/views/CloudTenant.yaml
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#. TRANSLATORS: file: product/views/ConditionSet.yaml
+#. TRANSLATORS: file: product/views/Container.yaml
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#. TRANSLATORS: file: product/views/ContainerRoute.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#. TRANSLATORS: file: product/views/CustomizationTemplate.yaml
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#. TRANSLATORS: file: product/views/Group.yaml
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/IsoDatastore.yaml
+#. TRANSLATORS: file: product/views/LdapRegion.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#. TRANSLATORS: file: product/views/MiqActionSet.yaml
+#. TRANSLATORS: file: product/views/MiqAeInstance.yaml
+#. TRANSLATORS: file: product/views/MiqDialog.yaml
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/MiqUserRole.yaml
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
+#. TRANSLATORS: file: product/views/Patch.yaml
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#. TRANSLATORS: file: product/views/Policy.yaml
+#. TRANSLATORS: file: product/views/PolicySet.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#. TRANSLATORS: file: product/views/PxeImageType.yaml
+#. TRANSLATORS: file: product/views/PxeServer.yaml
+#. TRANSLATORS: file: product/views/RegistryItem.yaml
+#. TRANSLATORS: file: product/views/Repository.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#. TRANSLATORS: file: product/views/ScanItemSet.yaml
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
+#. TRANSLATORS: file: product/views/Service.yaml
+#. TRANSLATORS: file: product/views/ServiceCatalog.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#. TRANSLATORS: file: product/views/Storage.yaml
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#. TRANSLATORS: file: product/views/Tenant.yaml
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+#. TRANSLATORS: file: product/views/Vsc.yaml
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:37 ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/helpers/ops_helper/textual_summary.rb:37 ../../app/helpers/ops_helper/textual_summary.rb:101 ../../app/helpers/ops_helper/textual_summary.rb:109 ../../app/helpers/ops_helper/textual_summary.rb:117 ../../app/helpers/ops_helper/textual_summary.rb:139 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:27 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:30 ../../app/helpers/container_helper/textual_summary.rb:121 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:27 ../../app/helpers/pxe_helper/textual_summary.rb:48 ../../app/helpers/pxe_helper/textual_summary.rb:72 ../../app/helpers/pxe_helper/textual_summary.rb:96 ../../app/helpers/pxe_helper/textual_summary.rb:116 ../../app/helpers/pxe_helper/textual_summary.rb:140 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:17 ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/helpers/provider_foreman_helper.rb:127 ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/helpers/ems_container_helper/textual_summary.rb:25 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_db_info.html.haml:15 ../../app/views/ops/_db_info.html.haml:118 ../../app/views/ops/_db_info.html.haml:213 ../../app/views/ops/_ap_form_nteventlog.html.haml:13 ../../app/views/ops/_settings_evm_servers_tab.html.haml:13 ../../app/views/ops/_category_form.html.haml:118 ../../app/views/ops/_ldap_region_show.html.haml:18 ../../app/views/ops/_ldap_region_show.html.haml:71 ../../app/views/ops/_ap_show.html.haml:16 ../../app/views/ops/_ap_show.html.haml:94 ../../app/views/ops/_zone_form.html.haml:16 ../../app/views/ops/_rbac_tenant_details.html.haml:17 ../../app/views/ops/_rbac_tenant_details.html.haml:93 ../../app/views/ops/_rbac_tenant_details.html.haml:125 ../../app/views/ops/_tenant_form.html.haml:17 ../../app/views/ops/_ap_form_file.html.haml:15 ../../app/views/ops/_ldap_domain_form.html.haml:16 ../../app/views/ops/_classification_entries.html.haml:15 ../../app/views/ops/_schedule_form.html.haml:19 ../../app/views/ops/_ldap_domain_show.html.haml:16 ../../app/views/ops/_ldap_region_form.html.haml:19 ../../app/views/ops/_rbac_role_details.html.haml:25 ../../app/views/ops/_ap_form.html.haml:20 ../../app/views/ops/_settings_co_categories_tab.html.haml:12 ../../app/views/provider_foreman/_form.html.haml:18 ../../app/views/service/_service_form.html.haml:27 ../../app/views/storage_manager/_form.html.haml:23 ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:12 ../../app/views/repository/_form.html.haml:16 ../../app/views/host/_form.html.haml:25 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:17 ../../app/views/miq_ae_customization/_old_dialogs_details.html.haml:20 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:35 ../../app/views/_ldap_domain_form.html.haml:16 ../../app/views/chargeback/_cb_assignments.html.haml:72 ../../app/views/chargeback/_reports_list.html.haml:58 ../../app/views/vm_common/_snap.html.haml:17 ../../app/views/miq_ae_class/_method_inputs.html.haml:32 ../../app/views/miq_ae_class/_ns_list.html.haml:20 ../../app/views/miq_ae_class/_ns_list.html.haml:95 ../../app/views/miq_ae_class/_instance_form.html.haml:27 ../../app/views/miq_ae_class/_instance_form.html.haml:87 ../../app/views/miq_ae_class/_instance_fields.html.haml:15 ../../app/views/miq_ae_class/_method_form.html.haml:31 ../../app/views/miq_ae_class/_method_form.html.haml:143 ../../app/views/miq_ae_class/_class_form.html.haml:27 ../../app/views/miq_ae_class/_class_props.html.haml:29 ../../app/views/miq_ae_class/_class_fields.html.haml:14 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_timeprofile_form.html.haml:160 ../../app/views/report/_schedule_form.html.haml:17 ../../app/views/report/_report_list.html.haml:48 ../../app/views/report/_report_list.html.haml:87 ../../app/views/report/_report_list.html.haml:123 ../../app/views/report/_db_show.html.haml:14 ../../app/views/report/_db_form.html.haml:20 ../../app/views/report/_report_info.html.haml:124 ../../app/views/ontap_file_share/_create_datastore.html.haml:18 ../../app/views/shared/views/ems_common/angular/_form.html.haml:13 ../../app/views/shared/views/ems_common/_form.html.haml:18 ../../app/views/catalog/_form_resources_info.html.haml:53 ../../app/views/catalog/_ot_tree_show.html.haml:11 ../../app/views/catalog/_ot_add.html.haml:14 ../../app/views/catalog/_ot_copy.html.haml:21 ../../app/views/catalog/_svccat_tree_show.html.haml:28 ../../app/views/catalog/_sandt_tree_show.html.haml:233 ../../app/views/catalog/_stcat_tree_show.html.haml:11 ../../app/views/catalog/_stcat_form.html.haml:20 ../../app/views/catalog/_ot_edit.html.haml:14 ../../app/views/pxe/_pxe_image_type_form.html.haml:17 ../../app/views/pxe/_template_form.html.haml:15 ../../app/views/pxe/_iso_datastore_details.html.haml:24 ../../app/views/pxe/_pxe_server_details.html.haml:59 ../../app/views/pxe/_pxe_server_details.html.haml:106 ../../app/views/pxe/_pxe_form.html.haml:17 ../../app/views/miq_policy/_action_details.html.haml:76 ../../app/views/miq_capacity/_planning_summary.html.haml:49 ../yaml_strings.rb:2565
 msgid "Name"
 msgstr ""
 
@@ -15873,11 +22352,15 @@ msgstr ""
 msgid "Name / Description"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:596 ../../app/controllers/miq_ae_class_controller.rb:657 ../../app/controllers/miq_ae_class_controller.rb:2062 ../../app/controllers/miq_ae_class_controller.rb:2127 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:249 ../../app/controllers/ontap_file_share_controller.rb:117 ../../app/controllers/catalog_controller.rb:369 ../../app/controllers/catalog_controller.rb:867 ../../app/controllers/ops_controller/settings/tags.rb:54 ../../app/controllers/ops_controller/settings/ldap.rb:49 ../../app/controllers/ontap_storage_system_controller.rb:125
+#: ../../app/controllers/report_controller/dashboards.rb:334
+msgid "Name cannot contain \"|\""
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:625 ../../app/controllers/miq_ae_class_controller.rb:590 ../../app/controllers/miq_ae_class_controller.rb:651 ../../app/controllers/miq_ae_class_controller.rb:2064 ../../app/controllers/miq_ae_class_controller.rb:2129 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:249 ../../app/controllers/ontap_file_share_controller.rb:117 ../../app/controllers/catalog_controller.rb:330 ../../app/controllers/catalog_controller.rb:862 ../../app/controllers/ops_controller/settings/tags.rb:58 ../../app/controllers/ops_controller/settings/ldap.rb:49 ../../app/controllers/ops_controller/settings/ldap.rb:175 ../../app/controllers/ontap_storage_system_controller.rb:125 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:113 ../../app/controllers/pxe_controller/pxe_image_types.rb:166 ../../app/controllers/pxe_controller/pxe_servers.rb:296
 msgid "Name is required"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_topology/container_topology_controller.js:222
+#: ../../app/assets/javascripts/services/topology_service.js:5
 msgid "Name: "
 msgstr ""
 
@@ -15885,7 +22368,7 @@ msgstr ""
 msgid "Name: %s | %s Type: %s"
 msgstr ""
 
-#: ../../app/views/layouts/quadicon/_host.html.haml:76 ../../app/views/layouts/quadicon/_host.html.haml:85 ../../app/views/layouts/quadicon/_host.html.haml:94
+#: ../../app/views/layouts/quadicon/_host.html.haml:65 ../../app/views/layouts/quadicon/_host.html.haml:74 ../../app/views/layouts/quadicon/_host.html.haml:83
 msgid "Name: %s | Hostname: %s"
 msgstr ""
 
@@ -15917,6 +22400,11 @@ msgstr ""
 msgid "Need a valid UNC path"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#: ../yaml_strings.rb:3806
+msgid "NetApp Filers"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.NetappRemoteService
 #: ../dictionary_strings.rb:1601
 msgid "NetApp Remote Service"
@@ -15927,7 +22415,7 @@ msgstr ""
 msgid "NetApp Remote Services"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:49 ../model_attributes.rb:1351
+#: ../../app/helpers/host_helper/textual_summary.rb:205 ../../app/views/layouts/listnav/_host.html.haml:49 ../model_attributes.rb:1351
 msgid "Network"
 msgstr ""
 
@@ -15936,7 +22424,7 @@ msgid "Network Adapter Information"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.nics
-#: ../../app/views/vm_common/_config.html.haml:189 ../dictionary_strings.rb:2037
+#: ../../app/views/vm_common/_config.html.haml:186 ../dictionary_strings.rb:2037
 msgid "Network Adapters"
 msgstr ""
 
@@ -16027,7 +22515,7 @@ msgstr ""
 msgid "Network Type"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:45
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:41
 msgid "Network Utilization Trends"
 msgstr ""
 
@@ -16083,8 +22571,12 @@ msgstr ""
 msgid "Network|Subnet mask"
 msgstr ""
 
-#: ../../app/views/dashboard/_widget_footer.html.haml:13
+#: ../../app/helpers/service_helper/textual_summary.rb:78 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:49 ../../app/helpers/vm_helper/textual_summary.rb:217 ../../app/helpers/vm_helper/textual_summary.rb:224 ../../app/views/dashboard/_widget_footer.html.haml:13
 msgid "Never"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:373 ../../app/helpers/vm_helper/textual_summary.rb:731
+msgid "Never Verified"
 msgstr ""
 
 #: ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:6
@@ -16141,7 +22633,7 @@ msgid_plural "New setting will affect VMs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/controllers/catalog_controller.rb:992
+#: ../../app/controllers/catalog_controller.rb:987
 msgid "New template content cannot be empty"
 msgstr ""
 
@@ -16149,7 +22641,8 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_show.html.haml:108 ../../app/views/report/_widget_show.html.haml:305 ../../app/views/report/_show_schedule.html.haml:106 ../../app/views/report/_report_info.html.haml:149
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#: ../../app/views/ops/_schedule_show.html.haml:108 ../../app/views/report/_widget_show.html.haml:305 ../../app/views/report/_show_schedule.html.haml:106 ../../app/views/report/_report_info.html.haml:149 ../yaml_strings.rb:3221
 msgid "Next Run Time"
 msgstr ""
 
@@ -16197,44 +22690,16 @@ msgstr ""
 msgid "No %s found."
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports/editor.rb:914
-msgid "No %s were moved up"
-msgstr ""
-
-#: ../../app/controllers/ems_common.rb:852
-msgid "No %s were selected for deletion"
-msgstr ""
-
-#: ../../app/controllers/report_controller/schedules.rb:140
-msgid "No %s were selected to be disabled"
-msgstr ""
-
-#: ../../app/controllers/report_controller/schedules.rb:137
-msgid "No %s were selected to be enabled"
-msgstr ""
-
-#: ../../app/controllers/report_controller/dashboards.rb:464 ../../app/controllers/report_controller/menus.rb:504 ../../app/controllers/report_controller/menus.rb:548 ../../app/controllers/report_controller/reports/editor.rb:882 ../../app/controllers/report_controller/reports/editor.rb:1011
-msgid "No %s were selected to move down"
-msgstr ""
-
-#: ../../app/controllers/report_controller/menus.rb:439 ../../app/controllers/vm_common.rb:1862 ../../app/controllers/application_controller.rb:588 ../../app/controllers/miq_policy_controller.rb:798
+#: ../../app/controllers/application_controller.rb:588 ../../app/controllers/miq_policy_controller.rb:800
 msgid "No %s were selected to move left"
 msgstr ""
 
-#: ../../app/controllers/report_controller/menus.rb:454 ../../app/controllers/vm_common.rb:1850 ../../app/controllers/application_controller.rb:589
+#: ../../app/controllers/application_controller.rb:589
 msgid "No %s were selected to move right"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports/editor.rb:1057
-msgid "No %s were selected to move to the bottom"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports/editor.rb:1035
-msgid "No %s were selected to move to the top"
-msgstr ""
-
-#: ../../app/controllers/report_controller/dashboards.rb:440 ../../app/controllers/report_controller/menus.rb:483 ../../app/controllers/report_controller/menus.rb:527 ../../app/controllers/report_controller/reports/editor.rb:912 ../../app/controllers/report_controller/reports/editor.rb:989
-msgid "No %s were selected to move up"
+#: ../../app/helpers/container_summary_helper.rb:138 ../../app/helpers/textual_summary_helper.rb:48
+msgid "No %{label} have been assigned"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/miq_actions.rb:190 ../../app/controllers/miq_policy_controller/miq_actions.rb:212
@@ -16245,56 +22710,68 @@ msgstr ""
 msgid "No %{members} were selected to move right"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:905
+#: ../../app/controllers/miq_policy_controller.rb:907
 msgid "No %{member} selected to set to Asynchronous"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:887
+#: ../../app/controllers/miq_policy_controller.rb:889
 msgid "No %{member} selected to set to Synchronous"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:837
+#: ../../app/controllers/miq_policy_controller.rb:839
 msgid "No %{member} were selected to move left"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:819
+#: ../../app/controllers/miq_policy_controller.rb:821
 msgid "No %{member} were selected to move right"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:289 ../../app/controllers/repository_controller.rb:314 ../../app/controllers/miq_request_controller.rb:529 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:62 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1337 ../../app/controllers/service_controller.rb:218 ../../app/controllers/ops_controller/settings/ldap.rb:113 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:381 ../../app/controllers/ops_controller/settings/schedules.rb:172 ../../app/controllers/mixins/containers_common_mixin.rb:149 ../../app/controllers/miq_task_controller.rb:122 ../../app/controllers/miq_task_controller.rb:147 ../../app/controllers/miq_task_controller.rb:177 ../../app/controllers/provider_foreman_controller.rb:61 ../../app/controllers/application_controller/ci_processing.rb:1198 ../../app/controllers/application_controller/ci_processing.rb:1287 ../../app/controllers/application_controller/ci_processing.rb:1592 ../../app/controllers/application_controller/ci_processing.rb:1755 ../../app/controllers/application_controller/ci_processing.rb:1843 ../../app/controllers/application_controller/ci_processing.rb:1904
+#: ../../app/controllers/miq_request_controller.rb:529 ../../app/controllers/miq_ae_customization_controller/old_dialogs.rb:62 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:1337 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:381 ../../app/controllers/mixins/containers_common_mixin.rb:149 ../../app/controllers/miq_task_controller.rb:122 ../../app/controllers/miq_task_controller.rb:147 ../../app/controllers/miq_task_controller.rb:177 ../../app/controllers/provider_foreman_controller.rb:65 ../../app/controllers/application_controller/ci_processing.rb:1212 ../../app/controllers/application_controller/ci_processing.rb:1301 ../../app/controllers/application_controller/ci_processing.rb:1606 ../../app/controllers/application_controller/ci_processing.rb:1769 ../../app/controllers/application_controller/ci_processing.rb:1857 ../../app/controllers/application_controller/ci_processing.rb:1918
 msgid "No %{model} were selected for %{task}"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:341 ../../app/controllers/catalog_controller.rb:1213 ../../app/controllers/application_controller/ci_processing.rb:1939
+#: ../../app/controllers/repository_controller.rb:293 ../../app/controllers/service_controller.rb:213 ../../app/controllers/catalog_controller.rb:301 ../../app/controllers/catalog_controller.rb:1208 ../../app/controllers/ops_controller/settings/ldap.rb:113 ../../app/controllers/ops_controller/settings/schedules.rb:172 ../../app/controllers/application_controller/ci_processing.rb:1953
 msgid "No %{model} were selected for deletion"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:914
+#: ../../app/controllers/repository_controller.rb:319 ../../app/controllers/ems_common.rb:929
 msgid "No %{model} were selected for refresh"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:881
+#: ../../app/controllers/ems_common.rb:896
 msgid "No %{model} were selected for scanning"
 msgstr ""
 
-#: ../../app/controllers/storage_manager_controller.rb:413 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:215 ../../app/controllers/pxe_controller/iso_datastores.rb:107 ../../app/controllers/pxe_controller/pxe_image_types.rb:100 ../../app/controllers/pxe_controller/pxe_servers.rb:127
+#: ../../app/controllers/storage_manager_controller.rb:416 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:216 ../../app/controllers/pxe_controller/iso_datastores.rb:107 ../../app/controllers/pxe_controller/pxe_image_types.rb:100 ../../app/controllers/pxe_controller/pxe_servers.rb:127
 msgid "No %{model} were selected to %{button}"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2471
+#: ../../app/controllers/miq_ae_class_controller.rb:2473
 msgid "No %{model} were selected to be marked as %{action}"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2341
+#: ../../app/controllers/miq_ae_class_controller.rb:2343
 msgid "No %{name} were selected to move down"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2322
+#: ../../app/controllers/miq_ae_class_controller.rb:2324
 msgid "No %{name} were selected to move up"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:301 ../../app/controllers/configuration_controller.rb:370
+#: ../../app/controllers/chargeback_controller.rb:273 ../../app/controllers/configuration_controller.rb:372
 msgid "No %{records} were selected for deletion"
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:867
+msgid "No %{record} were selected for deletion"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:144
+msgid "No %{schedules} were selected to be disabled"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:141
+msgid "No %{schedules} were selected to be enabled"
 msgstr ""
 
 #: ../../app/views/miq_policy/_action_list.html.haml:4
@@ -16353,11 +22830,11 @@ msgstr ""
 msgid "No Datastores found in the current region."
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:229
+#: ../../app/controllers/repository_controller.rb:230
 msgid "No Default Repository SmartProxy is configured, contact your CFME Administrator"
 msgstr ""
 
-#: ../../app/views/catalog/_form_basic_info.html.haml:85
+#: ../../app/controllers/catalog_controller.rb:1677 ../../app/views/catalog/_form_basic_info.html.haml:85
 msgid "No Dialog"
 msgstr ""
 
@@ -16377,7 +22854,7 @@ msgstr ""
 msgid "No Items found."
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:601
+#: ../../app/controllers/catalog_controller.rb:567
 msgid "No Ordering Dialog is available"
 msgstr ""
 
@@ -16413,7 +22890,7 @@ msgstr ""
 msgid "No Records Found."
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:100
+#: ../../app/controllers/report_controller/schedules.rb:104
 msgid "No Report Schedules were selected to be Run now"
 msgstr ""
 
@@ -16437,7 +22914,7 @@ msgstr ""
 msgid "No Schedules available."
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:284
+#: ../../app/controllers/ops_controller/settings/rhn.rb:288
 msgid "No Server was selected"
 msgstr ""
 
@@ -16447,6 +22924,10 @@ msgstr ""
 
 #: ../../app/views/ops/_diagnostics_roles_servers_tab.html.haml:19 ../../app/views/ops/_diagnostics_servers_roles_tab.html.haml:19
 msgid "No Servers found."
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:102 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:95
+msgid "No Single Point Of Failure"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:121
@@ -16481,6 +22962,14 @@ msgstr ""
 msgid "No VMs match the selection criteria"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1943
+msgid "No VMs were selected to move left"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1931
+msgid "No VMs were selected to move right"
+msgstr ""
+
 #: ../../app/views/report/_widget_form_report.html.haml:56
 msgid "No Widget compatible Reports found"
 msgstr ""
@@ -16505,11 +22994,11 @@ msgstr ""
 msgid "No chart data found"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1874
+#: ../../app/controllers/vm_common.rb:1955
 msgid "No child VMs to move right, no action taken"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:101
+#: ../../app/controllers/provider_foreman_controller.rb:105
 msgid "No common configuration profiles available for the selected configured %s"
 msgstr ""
 
@@ -16541,19 +23030,39 @@ msgstr ""
 msgid "No expression defined, a condition must contain a valid expression."
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports/editor.rb:914
+msgid "No fields were moved up"
+msgstr ""
+
 #: ../../app/controllers/application_controller/buttons.rb:719
 msgid "No fields were selected to move bottom"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:653 ../../app/controllers/ops_controller/ops_rbac.rb:483 ../../app/controllers/application_controller/buttons.rb:1051
+#: ../../app/controllers/report_controller/dashboards.rb:464 ../../app/controllers/report_controller/menus.rb:505 ../../app/controllers/report_controller/menus.rb:549 ../../app/controllers/report_controller/reports/editor.rb:882 ../../app/controllers/report_controller/reports/editor.rb:1012 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:653 ../../app/controllers/ops_controller/ops_rbac.rb:483 ../../app/controllers/application_controller/buttons.rb:1051
 msgid "No fields were selected to move down"
+msgstr ""
+
+#: ../../app/controllers/report_controller/menus.rb:440
+msgid "No fields were selected to move left"
+msgstr ""
+
+#: ../../app/controllers/report_controller/menus.rb:455
+msgid "No fields were selected to move right"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports/editor.rb:1058
+msgid "No fields were selected to move to the bottom"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports/editor.rb:1036
+msgid "No fields were selected to move to the top"
 msgstr ""
 
 #: ../../app/controllers/application_controller/buttons.rb:698
 msgid "No fields were selected to move top"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_customization_controller/dialogs.rb:644 ../../app/controllers/ops_controller/ops_rbac.rb:461 ../../app/controllers/application_controller/buttons.rb:1030
+#: ../../app/controllers/report_controller/dashboards.rb:440 ../../app/controllers/report_controller/menus.rb:484 ../../app/controllers/report_controller/menus.rb:528 ../../app/controllers/report_controller/reports/editor.rb:912 ../../app/controllers/report_controller/reports/editor.rb:990 ../../app/controllers/miq_ae_customization_controller/dialogs.rb:644 ../../app/controllers/ops_controller/ops_rbac.rb:461 ../../app/controllers/application_controller/buttons.rb:1030
 msgid "No fields were selected to move up"
 msgstr ""
 
@@ -16593,11 +23102,11 @@ msgstr ""
 msgid "No policies have been chosen yet"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:428 ../../app/controllers/report_controller/saved_reports.rb:75 ../../app/controllers/application_controller.rb:799 ../../app/helpers/application_helper/button/chargeback_report_only.rb:7 ../../app/helpers/application_helper/button/chargeback_download_choice.rb:7
+#: ../../app/controllers/chargeback_controller.rb:427 ../../app/controllers/report_controller/saved_reports.rb:77 ../../app/controllers/application_controller.rb:799 ../../app/helpers/application_helper/button/chargeback_report_only.rb:7 ../../app/helpers/application_helper/button/chargeback_download_choice.rb:7
 msgid "No records found for this report"
 msgstr ""
 
-#: ../../app/controllers/miq_capacity_controller.rb:733 ../../app/controllers/dashboard_controller.rb:775 ../../app/controllers/application_controller/timelines.rb:225 ../../app/controllers/application_controller/timelines.rb:481
+#: ../../app/controllers/miq_capacity_controller.rb:734 ../../app/controllers/dashboard_controller.rb:616 ../../app/controllers/dashboard_controller.rb:762 ../../app/controllers/application_controller/timelines.rb:225 ../../app/controllers/application_controller/timelines.rb:483
 msgid "No records found for this timeline"
 msgstr ""
 
@@ -16639,7 +23148,7 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerNode
 #. TRANSLATORS: en.yml key: dictionary.table.container_node
-#: ../../app/helpers/application_helper.rb:1231 ../../app/helpers/application_helper.rb:1253 ../dictionary_strings.rb:1315 ../dictionary_strings.rb:1803
+#: ../../app/helpers/application_helper.rb:1238 ../../app/helpers/application_helper.rb:1260 ../dictionary_strings.rb:1315 ../dictionary_strings.rb:1803
 msgid "Node"
 msgstr ""
 
@@ -16651,14 +23160,19 @@ msgstr ""
 msgid "Node Selector"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerNode (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_node (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_nodes
-#: ../../app/presenters/menu/default_menu.rb:39 ../../app/helpers/application_helper.rb:1231 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:11 ../dictionary_strings.rb:1317 ../dictionary_strings.rb:1805 ../dictionary_strings.rb:1807
+#: ../../app/presenters/menu/default_menu.rb:39 ../../app/helpers/application_helper.rb:1238 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:11 ../yaml_strings.rb:1767 ../dictionary_strings.rb:1317 ../dictionary_strings.rb:1805 ../dictionary_strings.rb:1807
 msgid "Nodes"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:126
+#: ../../app/helpers/host_helper/textual_summary.rb:379 ../../app/helpers/vm_helper/textual_summary.rb:737
+msgid "Non-Compliant as of %{time} Ago"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:225 ../../app/helpers/storage_helper/textual_summary.rb:242 ../../app/views/layouts/listnav/_storage.html.haml:126
 msgid "Non-VM Files"
 msgstr ""
 
@@ -16667,7 +23181,11 @@ msgstr ""
 msgid "Non-VM Files Percent of Used"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_role_details.html.haml:61 ../../app/views/ops/_rbac_role_details.html.haml:64 ../../app/views/miq_request/_prov_vm_grid.html.haml:31 ../../app/views/miq_request/_prov_host_grid.html.haml:33 ../../app/views/miq_request/_prov_vc_grid.html.haml:27 ../../app/views/miq_request/_prov_pxe_img_grid.html.haml:26 ../../app/views/miq_request/_prov_ds_grid.html.haml:29 ../../app/views/miq_request/_prov_field.html.haml:258 ../../app/views/miq_request/_prov_field.html.haml:310 ../../app/views/miq_request/_prov_field.html.haml:433 ../../app/views/miq_request/_prov_field.html.haml:526 ../../app/views/miq_request/_prov_iso_img_grid.html.haml:26 ../../app/views/miq_request/_prov_template_grid.html.haml:26 ../../app/views/miq_request/_prov_windows_image_grid.html.haml:26 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:121 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:155 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:439 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/layouts/_edit_to_email.html.haml:22 ../../app/views/report/_form_columns_trend.html.haml:42 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:6 ../../app/views/shared/views/_retire.html.haml:49 ../../app/views/catalog/_form_resources_info.html.haml:119 ../../app/views/miq_policy/_alert_snmp.html.haml:129 ../../app/views/miq_policy/_action_options.html.haml:481 ../../app/views/miq_policy/_action_options.html.haml:493 ../../app/views/miq_capacity/_utilization_options.html.haml:45
+#: ../../app/controllers/ops_controller/settings/cap_and_u.rb:345 ../../app/controllers/ops_controller/settings/cap_and_u.rb:346
+msgid "Non-clustered Hosts"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:61 ../../app/helpers/storage_helper/textual_summary.rb:144 ../../app/helpers/storage_helper/textual_summary.rb:155 ../../app/helpers/ems_cloud_helper/textual_summary.rb:104 ../../app/helpers/ems_cloud_helper/textual_summary.rb:116 ../../app/helpers/service_helper/textual_summary.rb:88 ../../app/helpers/vm_cloud_helper/textual_summary.rb:159 ../../app/helpers/vm_cloud_helper/textual_summary.rb:170 ../../app/helpers/vm_cloud_helper/textual_summary.rb:183 ../../app/helpers/vm_cloud_helper/textual_summary.rb:194 ../../app/helpers/vm_cloud_helper/textual_summary.rb:205 ../../app/helpers/vm_cloud_helper/textual_summary.rb:218 ../../app/helpers/vm_cloud_helper/textual_summary.rb:232 ../../app/helpers/vm_cloud_helper/textual_summary.rb:244 ../../app/helpers/vm_cloud_helper/textual_summary.rb:258 ../../app/helpers/vm_cloud_helper/textual_summary.rb:272 ../../app/helpers/vm_cloud_helper/textual_summary.rb:554 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:189 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:211 ../../app/helpers/host_helper/textual_summary.rb:131 ../../app/helpers/host_helper/textual_summary.rb:216 ../../app/helpers/host_helper/textual_summary.rb:256 ../../app/helpers/host_helper/textual_summary.rb:295 ../../app/helpers/host_helper/textual_summary.rb:524 ../../app/helpers/host_helper/textual_summary.rb:538 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:61 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:74 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:86 ../../app/helpers/ems_cluster_helper/textual_summary.rb:126 ../../app/helpers/ems_cluster_helper/textual_summary.rb:192 ../../app/helpers/ems_infra_helper/textual_summary.rb:146 ../../app/helpers/ems_infra_helper/textual_summary.rb:158 ../../app/helpers/vm_helper.rb:23 ../../app/helpers/vm_helper.rb:28 ../../app/helpers/vm_infra_helper/textual_summary.rb:147 ../../app/helpers/vm_infra_helper/textual_summary.rb:182 ../../app/helpers/vm_infra_helper/textual_summary.rb:192 ../../app/helpers/vm_infra_helper/textual_summary.rb:203 ../../app/helpers/vm_infra_helper/textual_summary.rb:216 ../../app/helpers/vm_infra_helper/textual_summary.rb:239 ../../app/helpers/vm_infra_helper/textual_summary.rb:252 ../../app/helpers/vm_infra_helper/textual_summary.rb:280 ../../app/helpers/vm_infra_helper/textual_summary.rb:294 ../../app/helpers/vm_helper/textual_summary.rb:133 ../../app/helpers/vm_helper/textual_summary.rb:181 ../../app/helpers/vm_helper/textual_summary.rb:251 ../../app/helpers/vm_helper/textual_summary.rb:261 ../../app/helpers/vm_helper/textual_summary.rb:272 ../../app/helpers/vm_helper/textual_summary.rb:285 ../../app/helpers/vm_helper/textual_summary.rb:309 ../../app/helpers/vm_helper/textual_summary.rb:332 ../../app/helpers/vm_helper/textual_summary.rb:345 ../../app/helpers/vm_helper/textual_summary.rb:378 ../../app/helpers/vm_helper/textual_summary.rb:392 ../../app/helpers/resource_pool_helper/textual_summary.rb:60 ../../app/helpers/resource_pool_helper/textual_summary.rb:67 ../../app/helpers/resource_pool_helper/textual_summary.rb:79 ../../app/helpers/cloud_volume_helper/textual_summary.rb:40 ../../app/helpers/cloud_volume_helper/textual_summary.rb:67 ../../app/views/ops/_rbac_role_details.html.haml:61 ../../app/views/ops/_rbac_role_details.html.haml:64 ../../app/views/miq_request/_prov_vm_grid.html.haml:31 ../../app/views/miq_request/_prov_host_grid.html.haml:33 ../../app/views/miq_request/_prov_vc_grid.html.haml:27 ../../app/views/miq_request/_prov_pxe_img_grid.html.haml:26 ../../app/views/miq_request/_prov_ds_grid.html.haml:29 ../../app/views/miq_request/_prov_field.html.haml:258 ../../app/views/miq_request/_prov_field.html.haml:310 ../../app/views/miq_request/_prov_field.html.haml:433 ../../app/views/miq_request/_prov_field.html.haml:526 ../../app/views/miq_request/_prov_iso_img_grid.html.haml:26 ../../app/views/miq_request/_prov_template_grid.html.haml:26 ../../app/views/miq_request/_prov_windows_image_grid.html.haml:26 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:121 ../../app/views/miq_ae_customization/_dialog_sample.html.haml:155 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:295 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:439 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/layouts/_edit_to_email.html.haml:22 ../../app/views/report/_form_columns_trend.html.haml:42 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_columns_trend.html.haml:86 ../../app/views/report/_form_formatting.html.haml:88 ../../app/views/report/_form_sort.html.haml:119 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:6 ../../app/views/shared/views/_retire.html.haml:49 ../../app/views/catalog/_form_resources_info.html.haml:119 ../../app/views/miq_policy/_alert_snmp.html.haml:129 ../../app/views/miq_policy/_action_options.html.haml:481 ../../app/views/miq_policy/_action_options.html.haml:493 ../../app/views/miq_capacity/_utilization_options.html.haml:45
 msgid "None"
 msgstr ""
 
@@ -16691,7 +23209,7 @@ msgstr ""
 msgid "Normal Operating Ranges (up to 30 days' data)"
 msgstr ""
 
-#: ../../app/views/ops/_settings_server_tab.html.haml:64 ../../app/views/resource_pool/_config.html.haml:18 ../../app/views/ems_cluster/_config.html.haml:8 ../../app/views/layouts/_item.html.haml:145 ../../app/views/vm_common/_right_size.html.haml:1 ../../app/views/vm_common/_config.html.haml:55
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:428 ../../app/helpers/vm_cloud_helper/textual_summary.rb:442 ../../app/helpers/vm_cloud_helper/textual_summary.rb:496 ../../app/helpers/host_helper/textual_summary.rb:394 ../../app/helpers/host_helper/textual_summary.rb:502 ../../app/helpers/vm_infra_helper/textual_summary.rb:519 ../../app/helpers/vm_infra_helper/textual_summary.rb:532 ../../app/helpers/vm_infra_helper/textual_summary.rb:634 ../../app/helpers/vm_infra_helper/textual_summary.rb:667 ../../app/helpers/vm_infra_helper/textual_summary.rb:677 ../../app/helpers/vm_infra_helper/textual_summary.rb:687 ../../app/helpers/vm_infra_helper/textual_summary.rb:698 ../../app/helpers/vm_helper/textual_summary.rb:616 ../../app/helpers/vm_helper/textual_summary.rb:629 ../../app/helpers/vm_helper/textual_summary.rb:753 ../../app/helpers/vm_helper/textual_summary.rb:786 ../../app/helpers/vm_helper/textual_summary.rb:796 ../../app/helpers/vm_helper/textual_summary.rb:806 ../../app/helpers/vm_helper/textual_summary.rb:817 ../../app/views/ops/_settings_server_tab.html.haml:64 ../../app/views/resource_pool/_config.html.haml:18 ../../app/views/ems_cluster/_config.html.haml:8 ../../app/views/layouts/_item.html.haml:145 ../../app/views/vm_common/_right_size.html.haml:1 ../../app/views/vm_common/_config.html.haml:55
 msgid "Not Available"
 msgstr ""
 
@@ -16739,6 +23257,16 @@ msgstr ""
 msgid "Number"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2323
+msgid "Number (1,234)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2325
+msgid "Number (1,234.0)"
+msgstr ""
+
 #: ../../app/assets/javascripts/miq_application.js:98
 msgid "Number (Bytes)"
 msgstr ""
@@ -16759,8 +23287,12 @@ msgstr ""
 msgid "Number List"
 msgstr ""
 
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:77 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:70 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:49
+msgid "Number of Blocks"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_total_cores
-#: ../dictionary_strings.rb:441
+#: ../../app/helpers/host_helper/textual_summary.rb:229 ../../app/helpers/container_node_helper/textual_summary.rb:40 ../dictionary_strings.rb:441
 msgid "Number of CPU Cores"
 msgstr ""
 
@@ -16770,19 +23302,24 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.num_cpu
 #. TRANSLATORS: en.yml key: dictionary.column.cpu_sockets
-#: ../dictionary_strings.rb:655 ../dictionary_strings.rb:661
+#: ../../app/helpers/host_helper/textual_summary.rb:225 ../dictionary_strings.rb:655 ../dictionary_strings.rb:661
 msgid "Number of CPUs"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1671
+#: ../../app/controllers/vm_common.rb:1752
 msgid "Number of Disk"
 msgid_plural "Number of Disks"
 msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.num_disks
-#: ../dictionary_strings.rb:657
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:436 ../../app/helpers/vm_helper/textual_summary.rb:535 ../dictionary_strings.rb:657
 msgid "Number of Disks"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqUserRole.yaml
+#: ../yaml_strings.rb:3924
+msgid "Number of Groups"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.num_hard_disks
@@ -16802,8 +23339,18 @@ msgstr ""
 msgid "Number of Rows to Show"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#: ../yaml_strings.rb:3916
+msgid "Number of Users"
+msgstr ""
+
 #: ../../app/views/shared/views/_prov_dialog.html.haml:69
 msgid "Number of VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2327
+msgid "Number, 2 Decimals (1,234.00)"
 msgstr ""
 
 #: ../../app/views/layouts/_exp_editor.html.haml:67 ../../app/views/layouts/_exp_editor.html.haml:93
@@ -16819,7 +23366,7 @@ msgstr ""
 msgid "OS %s"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1691
+#: ../../app/controllers/vm_common.rb:1772
 msgid "OS Info"
 msgid_plural "OS Info"
 msgstr[0] ""
@@ -16862,7 +23409,14 @@ msgstr ""
 msgid "Object Info"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:47 ../../app/views/shared/buttons/_ab_list.html.haml:11
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../yaml_strings.rb:3154
+msgid "Object Name"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:91 ../../app/views/shared/buttons/_ab_list.html.haml:11
 msgid "Object Types"
 msgstr ""
 
@@ -16894,7 +23448,7 @@ msgstr ""
 msgid "One or more %{model} must be selected to %{task}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1065
+#: ../../app/controllers/application_controller/ci_processing.rb:1079
 msgid "One or more %{model} must be selected to Reconfigure"
 msgstr ""
 
@@ -16906,8 +23460,12 @@ msgstr ""
 msgid "One or more %{model} must be selected to Smart Tagging"
 msgstr ""
 
-#: ../../app/controllers/report_controller/menus.rb:466
+#: ../../app/controllers/report_controller/menus.rb:467
 msgid "One or more selected reports are not owned by your group, they cannot be moved"
+msgstr ""
+
+#: ../../app/controllers/report_controller/dashboards.rb:349
+msgid "One widget must be selected"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:88
@@ -17554,6 +24112,16 @@ msgstr ""
 msgid "OntapDiskMetricsRollup|User writes min"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#: ../yaml_strings.rb:3283
+msgid "OntapFileShares"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#: ../yaml_strings.rb:3867
+msgid "OntapLogicalDisks"
+msgstr ""
+
 #: ../model_attributes.rb:1520
 msgid "OntapLunDerivedMetric|Avg latency"
 msgstr ""
@@ -17708,6 +24276,16 @@ msgstr ""
 
 #: ../model_attributes.rb:1559
 msgid "OntapLunMetricsRollup|Write ops min"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#: ../yaml_strings.rb:3808
+msgid "OntapStorageSystems"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#: ../yaml_strings.rb:3525
+msgid "OntapStorageVolumes"
 msgstr ""
 
 #: ../model_attributes.rb:1561
@@ -18606,6 +25184,11 @@ msgstr ""
 msgid "Open Folder"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2197
+msgid "Open a web-based VMRC console for VMs"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:227
 msgid "Open a web-based VMRC console for this VM"
 msgstr ""
@@ -18614,8 +25197,18 @@ msgstr ""
 msgid "Open a web-based VMRC console for this VM.  This requires that VMRC is pre-configured to work in your browser."
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2193
+msgid "Open a web-based VNC console for VMs"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:220 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:215 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:205
 msgid "Open a web-based VNC or SPICE console for this VM"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2189
+msgid "Open a web-based console for VMs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:212 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:208
@@ -18654,8 +25247,38 @@ msgstr ""
 msgid "Openstack Infra provider"
 msgstr ""
 
-#: ../../app/views/provider_foreman/_main.html.haml:11 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:11
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:113
+msgid "Operate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1287
+msgid "Operate Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1330
+msgid "Operate Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1322
+msgid "Operate Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1265
+msgid "Operate User"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../../app/helpers/host_helper/textual_summary.rb:161 ../../app/helpers/vm_infra_helper/textual_summary.rb:127 ../../app/helpers/vm_helper/textual_summary.rb:161 ../../app/views/provider_foreman/_main.html.haml:11 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:11 ../yaml_strings.rb:3761
 msgid "Operating System"
+msgstr ""
+
+#: ../../app/helpers/container_image_helper/textual_summary.rb:42 ../../app/helpers/container_node_helper/textual_summary.rb:109
+msgid "Operating System Distribution"
 msgstr ""
 
 #: ../model_attributes.rb:1787
@@ -18766,8 +25389,15 @@ msgstr ""
 msgid "OperatingSystem|Version"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.operational_status_str
-#: ../dictionary_strings.rb:665
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:57 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:47 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:50 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:43 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:33 ../yaml_strings.rb:3176 ../dictionary_strings.rb:665
 msgid "Operational Status"
 msgstr ""
 
@@ -18800,23 +25430,36 @@ msgstr ""
 msgid "Options %s: %s"
 msgstr ""
 
-#: ../../app/views/ems_infra/scaling.html.haml:14
+#: ../../app/helpers/ui_constants.rb:104
+msgid "Orange"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#: ../../app/views/ems_infra/scaling.html.haml:14 ../yaml_strings.rb:3389
 msgid "Orchestration Stack"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1614
+msgid "Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate
 #. TRANSLATORS: en.yml key: dictionary.table.orchestration_template
-#: ../../app/views/catalog/_form_basic_info.html.haml:105 ../../app/views/catalog/_sandt_tree_show.html.haml:83 ../dictionary_strings.rb:1635 ../dictionary_strings.rb:2067
+#: ../../app/views/catalog/_form_basic_info.html.haml:105 ../../app/views/catalog/_sandt_tree_show.html.haml:83 ../yaml_strings.rb:3427 ../dictionary_strings.rb:1635 ../dictionary_strings.rb:2067
 msgid "Orchestration Template"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:770
+#: ../../app/controllers/catalog_controller.rb:740
 msgid "Orchestration Template \"%{name}\" was deleted."
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.OrchestrationTemplate (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.orchestration_template (plural form)
-#: ../../app/views/configuration/_ui_2.html.haml:49 ../dictionary_strings.rb:1637 ../dictionary_strings.rb:2069
+#: ../../app/controllers/catalog_controller.rb:840 ../../app/views/configuration/_ui_2.html.haml:49 ../yaml_strings.rb:209 ../dictionary_strings.rb:1637 ../dictionary_strings.rb:2069
 msgid "Orchestration Templates"
 msgstr ""
 
@@ -18852,12 +25495,17 @@ msgstr ""
 msgid "Orchestration template"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:761
+#: ../../app/controllers/catalog_controller.rb:731
 msgid "Orchestration template \"%{name}\" is read-only and cannot be deleted."
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:706
+#: ../../app/controllers/catalog_controller.rb:676
 msgid "Orchestration template \"%{name}\" is read-only and cannot be edited."
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#: ../yaml_strings.rb:3391
+msgid "OrchestrationStack"
 msgstr ""
 
 #: ../model_attributes.rb:1828
@@ -18992,12 +25640,21 @@ msgstr ""
 msgid "OrchestrationTemplate|Name"
 msgstr ""
 
-#: ../../app/views/catalog/_svccat_tree_show.html.haml:80
+#: ../../app/controllers/catalog_controller.rb:942 ../../app/views/catalog/_svccat_tree_show.html.haml:80
 msgid "Order"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:548
+msgid "Order %{model} \"%{name}\""
 msgstr ""
 
 #: ../../app/controllers/application_controller/dialog_runner.rb:43
 msgid "Order Request was Submitted"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:183
+msgid "Order Services"
 msgstr ""
 
 #: ../../app/views/miq_policy/_event_details.html.haml:78
@@ -19008,7 +25665,7 @@ msgstr ""
 msgid "Order of Actions if ANY Conditions are False"
 msgstr ""
 
-#: ../../app/views/catalog/_svccat_tree_show.html.haml:80
+#: ../../app/controllers/catalog_controller.rb:944 ../../app/views/catalog/_svccat_tree_show.html.haml:80
 msgid "Order this Service"
 msgstr ""
 
@@ -19020,16 +25677,32 @@ msgstr ""
 msgid "Original Value"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:1451
+msgid "Orphaned %{models}"
+msgstr ""
+
 #: ../../app/views/ops/_all_tabs.html.haml:239
 msgid "Orphaned Data"
+msgstr ""
+
+#: ../../app/presenters/tree_builder_images.rb:22
+msgid "Orphaned Images"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_instances.rb:22
 msgid "Orphaned Instances"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:428
+#: ../../app/controllers/ops_controller/diagnostics.rb:439
+msgid "Orphaned Records deleted for userid [%{number}]"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:444
 msgid "Orphaned Records for userid %{id} were successfully deleted"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1453
+msgid "Orphaned VMs & Templates"
 msgstr ""
 
 #: ../../app/presenters/tree_builder_vandt.rb:16
@@ -19084,7 +25757,16 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:118
+#: ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:55
+msgid "Other Identifying Info"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1181
+msgid "Other UI Tasks"
+msgstr ""
+
+#: ../../app/controllers/storage_controller.rb:217 ../../app/helpers/storage_helper/textual_summary.rb:226 ../../app/views/layouts/listnav/_storage.html.haml:118
 msgid "Other VM Files"
 msgstr ""
 
@@ -19097,7 +25779,8 @@ msgstr ""
 msgid "Outgoing SMTP E-mail Server"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:64
+#. TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:64 ../yaml_strings.rb:3466
 msgid "Outputs"
 msgstr ""
 
@@ -19114,9 +25797,16 @@ msgstr ""
 msgid "Owned by Me?"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.owner_name
-#: ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_form_filter_chargeback.html.haml:38 ../../app/views/report/_form_filter_chargeback.html.haml:104 ../dictionary_strings.rb:1193
+#: ../../app/views/report/_form_filter_chargeback.html.haml:21 ../../app/views/report/_form_filter_chargeback.html.haml:38 ../../app/views/report/_form_filter_chargeback.html.haml:104 ../yaml_strings.rb:3780 ../dictionary_strings.rb:1193
 msgid "Owner"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Job.yaml
+#: ../yaml_strings.rb:3881
+msgid "Owner Message"
 msgstr ""
 
 #: ../../app/controllers/application_controller/ci_processing.rb:155
@@ -19131,8 +25821,11 @@ msgstr ""
 msgid "PDF Output"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.pid
-#: ../dictionary_strings.rb:715
+#: ../yaml_strings.rb:3533 ../dictionary_strings.rb:715
 msgid "PID"
 msgstr ""
 
@@ -19140,11 +25833,12 @@ msgstr ""
 msgid "PM:"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:53 ../../app/views/miq_request/_prov_host_dialog.html.haml:44 ../../app/views/shared/views/_prov_dialog.html.haml:50
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:53 ../../app/views/miq_request/_prov_host_dialog.html.haml:44 ../../app/views/shared/views/_prov_dialog.html.haml:50 ../yaml_strings.rb:1522
 msgid "PXE"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_form.html.haml:99
+#: ../../app/helpers/pxe_helper/textual_summary.rb:20 ../../app/views/pxe/_pxe_form.html.haml:99
 msgid "PXE Directory"
 msgstr ""
 
@@ -19158,7 +25852,7 @@ msgid "PXE Image Menus"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.PxeImage (plural form)
-#: ../../app/views/pxe/_pxe_server_details.html.haml:51 ../dictionary_strings.rb:1661
+#: ../../app/presenters/tree_builder_pxe_servers.rb:34 ../../app/presenters/tree_builder_pxe_servers.rb:36 ../../app/views/pxe/_pxe_server_details.html.haml:51 ../dictionary_strings.rb:1661
 msgid "PXE Images"
 msgstr ""
 
@@ -19167,12 +25861,25 @@ msgstr ""
 msgid "PXE Server"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/PxeServer.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.PxeServer (plural form)
-#: ../dictionary_strings.rb:1669
+#: ../../app/controllers/pxe_controller.rb:80 ../yaml_strings.rb:1527 ../dictionary_strings.rb:1669
 msgid "PXE Servers"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:220
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:329 ../../app/helpers/vm_infra_helper/textual_summary.rb:343 ../../app/helpers/vm_helper/textual_summary.rb:441
+msgid "Package"
+msgid_plural "Packages"
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#: ../yaml_strings.rb:3442
+msgid "Package Name"
+msgstr ""
+
+#: ../../app/controllers/container_image_controller.rb:10 ../../app/controllers/host_controller.rb:250 ../../app/helpers/host_helper/textual_summary.rb:458 ../../app/helpers/container_summary_helper.rb:88 ../../app/views/layouts/listnav/_host.html.haml:220
 msgid "Packages"
 msgstr ""
 
@@ -19180,16 +25887,39 @@ msgstr ""
 msgid "Page Size"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:58 ../../app/views/miq_policy/_alert_details.html.haml:215 ../../app/views/miq_policy/_alert_details.html.haml:255
+#. TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:58 ../../app/views/miq_policy/_alert_details.html.haml:215 ../../app/views/miq_policy/_alert_details.html.haml:255 ../yaml_strings.rb:3349
 msgid "Parameters"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_tenant_details.html.haml:45
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../../app/helpers/flavor_helper/textual_summary.rb:61 ../yaml_strings.rb:3460
+msgid "Paravirtualization"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Tenant.yaml
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:45 ../yaml_strings.rb:3338
 msgid "Parent"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:77
+msgid "Parent %{title}"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:118 ../../app/helpers/vm_helper/textual_summary.rb:152
+msgid "Parent %{title} Platform"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_resource_pool.html.haml:23 ../../app/views/layouts/listnav/_resource_pool.html.haml:33
 msgid "Parent %{title}: %{name}"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:65
+msgid "Parent '%{title}'"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:88
+msgid "Parent Catalog Item"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_owning_cluster
@@ -19200,7 +25930,7 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_owning_datacenter
 #. TRANSLATORS: en.yml key: dictionary.column.v_parent_datacenter
-#: ../dictionary_strings.rb:1031 ../dictionary_strings.rb:1041
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:60 ../dictionary_strings.rb:1031 ../dictionary_strings.rb:1041
 msgid "Parent Datacenter"
 msgstr ""
 
@@ -19246,6 +25976,10 @@ msgstr ""
 msgid "Parent Resource Pool"
 msgstr ""
 
+#: ../../app/helpers/service_helper/textual_summary.rb:99
+msgid "Parent Service"
+msgstr ""
+
 #: ../../app/views/miq_policy/_action_options.html.haml:551 ../../app/views/miq_policy/_action_details.html.haml:492
 msgid "Parent Type"
 msgstr ""
@@ -19254,7 +25988,7 @@ msgstr ""
 msgid "Parent Type must be selected"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1693 ../../app/views/vm_common/_form.html.haml:73
+#: ../../app/controllers/vm_common.rb:1774 ../../app/helpers/vm_cloud_helper/textual_summary.rb:215 ../../app/helpers/vm_infra_helper/textual_summary.rb:249 ../../app/helpers/vm_helper/textual_summary.rb:342 ../../app/views/vm_common/_form.html.haml:73
 msgid "Parent VM"
 msgid_plural "Parent VM"
 msgstr[0] ""
@@ -19264,7 +25998,7 @@ msgstr[1] ""
 msgid "Parent VM Selection"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1047
+#: ../../app/controllers/vm_common.rb:1108
 msgid "Parent VM can not be one of the child VMs"
 msgstr ""
 
@@ -19341,15 +26075,23 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
+#: ../../app/controllers/storage_manager_controller.rb:281 ../../app/controllers/ops_controller/settings/zones.rb:128
+msgid "Password and Verify Password fields do not match"
+msgstr ""
+
 #: ../../app/views/ops/_settings_database_tab.html.haml:134 ../../app/views/ops/_settings_database_tab.html.haml:134
 msgid "Password fields must match to Validate Database Configuration"
+msgstr ""
+
+#: ../../app/controllers/pxe_controller/pxe_servers.rb:312
+msgid "Password is required"
 msgstr ""
 
 #: ../../app/views/dashboard/login.html.haml:55
 msgid "Password or Password+One-Time-Password"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/common.rb:459 ../../app/controllers/ops_controller/ops_rbac.rb:994 ../../app/controllers/pxe_controller/pxe_servers.rb:314 ../../app/controllers/ems_common.rb:525 ../../app/controllers/application_controller/ci_processing.rb:841
+#: ../../app/controllers/ops_controller/settings/common.rb:459 ../../app/controllers/ops_controller/ops_rbac.rb:995 ../../app/controllers/pxe_controller/pxe_servers.rb:314 ../../app/controllers/ems_common.rb:531 ../../app/controllers/application_controller/ci_processing.rb:841
 msgid "Password/Verify Password do not match"
 msgstr ""
 
@@ -19365,13 +26107,14 @@ msgstr ""
 msgid "Paste object details for use in a Button."
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1695 ../model_attributes.rb:1877
+#: ../../app/controllers/vm_common.rb:1776 ../model_attributes.rb:1877
 msgid "Patch"
 msgid_plural "Patches"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:202
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:308 ../../app/helpers/host_helper/textual_summary.rb:447 ../../app/helpers/vm_infra_helper/textual_summary.rb:330 ../../app/helpers/vm_helper/textual_summary.rb:428 ../../app/views/layouts/listnav/_host.html.haml:202 ../yaml_strings.rb:3843
 msgid "Patches"
 msgstr ""
 
@@ -19411,16 +26154,23 @@ msgstr ""
 msgid "Patch|Vendor"
 msgstr ""
 
-#: ../../app/views/repository/_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:110
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#: ../../app/helpers/pxe_helper/textual_summary.rb:84 ../../app/views/repository/_form.html.haml:34 ../../app/views/pxe/_pxe_server_details.html.haml:110 ../yaml_strings.rb:3446
 msgid "Path"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:81 ../../app/controllers/repository_controller.rb:140
+#: ../../app/controllers/repository_controller.rb:82 ../../app/controllers/repository_controller.rb:141
 msgid "Path must be a valid reference to a UNC location"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:147 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:178
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:147 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:178 ../yaml_strings.rb:2059
 msgid "Pause"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2061
+msgid "Pause Instance"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:177
@@ -19444,6 +26194,10 @@ msgstr ""
 msgid "Pct Free Disk"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:416
+msgid "Pending Approval"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_builtin_exp.html.haml:173 ../../app/views/miq_policy/_alert_builtin_exp.html.haml:183
 msgid "Per Minute"
 msgstr ""
@@ -19464,7 +26218,9 @@ msgstr ""
 msgid "Percent"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:91 ../../app/views/ops/_db_info.html.haml:184 ../../app/views/ops/_db_info.html.haml:221
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+#: ../../app/views/ops/_db_info.html.haml:91 ../../app/views/ops/_db_info.html.haml:184 ../../app/views/ops/_db_info.html.haml:221 ../yaml_strings.rb:2887
 msgid "Percent Bloat"
 msgstr ""
 
@@ -19477,8 +26233,323 @@ msgstr ""
 msgid "Percent Used of Provisioned Size"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2339
+msgid "Percent, 1 Decimal (99.0%)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2341
+msgid "Percent, 2 Decimals (99.00%)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2337
+msgid "Percentage (99%)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:328
+msgid "Perform Operations on Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1454
+msgid "Perform Operations on Base Storage Extents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:171
+msgid "Perform Operations on Catalog Items"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:284
+msgid "Perform Operations on Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:489
+msgid "Perform Operations on Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2015
+msgid "Perform Operations on Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1850
+msgid "Perform Operations on Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1826
+msgid "Perform Operations on Container Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1789
+msgid "Perform Operations on Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1929
+msgid "Perform Operations on Container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1814
+msgid "Perform Operations on Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1913
+msgid "Perform Operations on Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1899
+msgid "Perform Operations on Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1965
+msgid "Perform Operations on Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1652
+msgid "Perform Operations on Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:624
+msgid "Perform Operations on Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1470
+msgid "Perform Operations on File Shares"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:418
+msgid "Perform Operations on Flavors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:524
+msgid "Perform Operations on Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1592
+msgid "Perform Operations on ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2121
+msgid "Perform Operations on Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:435
+msgid "Perform Operations on Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2037
+msgid "Perform Operations on Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:374
+msgid "Perform Operations on Key Pairs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1490
+msgid "Perform Operations on Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1438
+msgid "Perform Operations on Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1734
+msgid "Perform Operations on Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1676
+msgid "Perform Operations on Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1712
+msgid "Perform Operations on Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1630
+msgid "Perform Operations on Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:225
+msgid "Perform Operations on Orchestration Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1533
+msgid "Perform Operations on PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1872
+msgid "Perform Operations on Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1763
+msgid "Perform Operations on Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1985
+msgid "Perform Operations on Providers and Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:707
+msgid "Perform Operations on Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:645
+msgid "Perform Operations on Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:115
+msgid "Perform Operations on Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:595
+msgid "Perform Operations on Resource Pools"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1504
+msgid "Perform Operations on SMI-S Agents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:728
+msgid "Perform Operations on Schedules"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:403
+msgid "Perform Operations on Security Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:259
+msgid "Perform Operations on Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:388
+msgid "Perform Operations on Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1398
+msgid "Perform Operations on Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1418
+msgid "Perform Operations on Storage Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2301
+msgid "Perform Operations on Template Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2273
+msgid "Perform Operations on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:346
+msgid "Perform Operations on Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2237
+msgid "Perform Operations on VM Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2159
+msgid "Perform Operations on VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:360
+msgid "Perform Operations on Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:772
+msgid "Perform Operations on Widgets"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:19 ../../app/helpers/application_helper/toolbar/host_center.rb:19 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:19 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:19 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:19 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:19 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:13 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:24 ../../app/helpers/application_helper/toolbar/storage_center.rb:13 ../../app/helpers/application_helper/toolbar/container_image_center.rb:13 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:24 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:15 ../../app/helpers/application_helper/toolbar/hosts_center.rb:22 ../../app/helpers/application_helper/toolbar/storages_center.rb:15 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:24 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:24 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:19 ../../app/helpers/application_helper/toolbar/container_images_center.rb:13
 msgid "Perform SmartState Analysis"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:626
+msgid "Perform SmartState Analysis for Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:526
+msgid "Perform SmartState Analysis for Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:493
+msgid "Perform SmartState Analysis on Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2123
+msgid "Perform SmartState Analysis on Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2039
+msgid "Perform SmartState Analysis on Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2275
+msgid "Perform SmartState Analysis on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1830
+msgid "Perform SmartState Analysis on VMs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/storages_center.rb:14
@@ -19621,8 +26692,37 @@ msgstr ""
 msgid "Performance Trends"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:42
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#: ../yaml_strings.rb:3816
+msgid "Permissions"
+msgstr ""
+
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:107 ../../app/helpers/container_group_helper/textual_summary.rb:42
 msgid "Persistent Volume Claim Name"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#: ../yaml_strings.rb:3883
+msgid "Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#: ../yaml_strings.rb:3885
+msgid "PersistentVolume"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#: ../yaml_strings.rb:3373
+msgid "Phase"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:674
+msgid "Physical NIC: %{name}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../yaml_strings.rb:3719
+msgid "Physical Resource"
 msgstr ""
 
 #: ../model_attributes.rb:1887
@@ -19645,12 +26745,23 @@ msgstr ""
 msgid "Plan for VM placement on %s or %s"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:155
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:155 ../yaml_strings.rb:1125
 msgid "Planning"
 msgstr ""
 
 #: ../../app/controllers/miq_capacity_controller.rb:560
 msgid "Planning options have been reset by the user"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#: ../yaml_strings.rb:3637
+msgid "Platform"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:103 ../../app/helpers/vm_infra_helper/textual_summary.rb:123 ../../app/helpers/vm_helper/textual_summary.rb:157
+msgid "Platform Tools"
 msgstr ""
 
 #: ../../app/views/ops/rhn/_server_table.html.haml:98
@@ -19661,8 +26772,8 @@ msgstr ""
 msgid "Please contact your administrator for assistance."
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:879
-msgid "Please correct invalid %s Entry Point prior to saving"
+#: ../../app/controllers/catalog_controller.rb:874
+msgid "Please correct invalid %{adjective} Entry Point prior to saving"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_dialog_cloud_quota.html.haml:30
@@ -19677,31 +26788,61 @@ msgstr ""
 msgid "Please select an Instance Type from above"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup
 #. TRANSLATORS: en.yml key: dictionary.table.container_group
-#: ../dictionary_strings.rb:1303 ../dictionary_strings.rb:1779
+#: ../yaml_strings.rb:2673 ../dictionary_strings.rb:1303 ../dictionary_strings.rb:1779
 msgid "Pod"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Container.yaml
+#: ../yaml_strings.rb:3869
+msgid "Pod Name"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerGroup (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_group (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_groups
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:43 ../dictionary_strings.rb:1305 ../dictionary_strings.rb:1781 ../dictionary_strings.rb:1783
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:43 ../yaml_strings.rb:1741 ../dictionary_strings.rb:1305 ../dictionary_strings.rb:1781 ../dictionary_strings.rb:1783
 msgid "Pods"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqPolicy.yaml
+#. TRANSLATORS: file: product/views/Policy.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1131 ../../app/views/miq_policy/_profile_details.html.haml:134 ../../app/views/miq_policy/_export.html.haml:105 ../dictionary_strings.rb:1543
+#: ../../app/controllers/miq_policy_controller.rb:1133 ../../app/views/miq_policy/_profile_details.html.haml:134 ../../app/views/miq_policy/_export.html.haml:105 ../yaml_strings.rb:850 ../dictionary_strings.rb:1543
 msgid "Policies"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Policy.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqPolicy
-#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:46 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:70 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:44 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:37 ../../app/helpers/application_helper/toolbar/host_center.rb:42 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:23 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:68 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:46 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:52 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:37 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:29 ../../app/helpers/application_helper/toolbar/services_center.rb:44 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:45 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:37 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:37 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:65 ../../app/helpers/application_helper/toolbar/users_center.rb:46 ../../app/helpers/application_helper/toolbar/container_service_center.rb:46 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:23 ../../app/helpers/application_helper/toolbar/container_center.rb:29 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:38 ../../app/helpers/application_helper/toolbar/container_route_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/security_group_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:49 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:57 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:29 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:61 ../../app/helpers/application_helper/toolbar/repository_center.rb:36 ../../app/helpers/application_helper/toolbar/container_project_center.rb:53 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:40 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:70 ../../app/helpers/application_helper/toolbar/vms_center.rb:62 ../../app/helpers/application_helper/toolbar/container_node_center.rb:53 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:37 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:28 ../../app/helpers/application_helper/toolbar/storage_center.rb:30 ../../app/helpers/application_helper/toolbar/flavors_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:22 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:56 ../../app/helpers/application_helper/toolbar/service_center.rb:41 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:37 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:41 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:25 ../../app/helpers/application_helper/toolbar/container_group_center.rb:53 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:39 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:6 ../../app/helpers/application_helper/toolbar/flavor_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:37 ../../app/helpers/application_helper/toolbar/hosts_center.rb:73 ../../app/helpers/application_helper/toolbar/storages_center.rb:36 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:27 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:87 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:71 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:56 ../../app/helpers/application_helper/toolbar/repositories_center.rb:49 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:21 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:37 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:43 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:29 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:47 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:53 ../../app/helpers/application_helper/toolbar/tenants_center.rb:41 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:33 ../../app/helpers/application_helper/toolbar/containers_center.rb:37 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:32 ../../app/helpers/application_helper/toolbar/container_images_center.rb:25 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:41 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:6 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:47 ../dictionary_strings.rb:1541
+#: ../../app/helpers/application_helper/toolbar/orchestration_templates_center.rb:46 ../../app/helpers/application_helper/toolbar/ontap_logical_disks_center.rb:6 ../../app/helpers/application_helper/toolbar/vm_center.rb:70 ../../app/helpers/application_helper/toolbar/miq_groups_center.rb:44 ../../app/helpers/application_helper/toolbar/container_image_registries_center.rb:37 ../../app/helpers/application_helper/toolbar/host_center.rb:42 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:23 ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:68 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:46 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:52 ../../app/helpers/application_helper/toolbar/availability_zones_center.rb:6 ../../app/helpers/application_helper/toolbar/middleware_servers_center.rb:37 ../../app/helpers/application_helper/toolbar/container_image_registry_center.rb:29 ../../app/helpers/application_helper/toolbar/configured_system_ansibletower_center.rb:6 ../../app/helpers/application_helper/toolbar/services_center.rb:44 ../../app/helpers/application_helper/toolbar/security_groups_center.rb:6 ../../app/helpers/application_helper/toolbar/tenant_center.rb:45 ../../app/helpers/application_helper/toolbar/container_routes_center.rb:37 ../../app/helpers/application_helper/toolbar/container_projects_center.rb:37 ../../app/helpers/application_helper/toolbar/cloud_volume_snapshots_center.rb:6 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:23 ../../app/helpers/application_helper/toolbar/cloud_volume_snapshot_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:65 ../../app/helpers/application_helper/toolbar/users_center.rb:46 ../../app/helpers/application_helper/toolbar/container_service_center.rb:46 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:23 ../../app/helpers/application_helper/toolbar/configured_systems_center.rb:26 ../../app/helpers/application_helper/toolbar/container_center.rb:29 ../../app/helpers/application_helper/toolbar/orchestration_template_center.rb:38 ../../app/helpers/application_helper/toolbar/container_route_center.rb:29 ../../app/helpers/application_helper/toolbar/ontap_file_shares_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/security_group_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_containers_center.rb:49 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:57 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:29 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:61 ../../app/helpers/application_helper/toolbar/repository_center.rb:36 ../../app/helpers/application_helper/toolbar/container_project_center.rb:53 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:40 ../../app/helpers/application_helper/toolbar/cloud_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/auth_key_pair_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:70 ../../app/helpers/application_helper/toolbar/vms_center.rb:62 ../../app/helpers/application_helper/toolbar/container_node_center.rb:53 ../../app/helpers/application_helper/toolbar/container_groups_center.rb:37 ../../app/helpers/application_helper/toolbar/miq_group_center.rb:28 ../../app/helpers/application_helper/toolbar/storage_center.rb:30 ../../app/helpers/application_helper/toolbar/flavors_center.rb:6 ../../app/helpers/application_helper/toolbar/container_image_center.rb:22 ../../app/helpers/application_helper/toolbar/configured_system_center.rb:26 ../../app/helpers/application_helper/toolbar/ems_infras_center.rb:56 ../../app/helpers/application_helper/toolbar/service_center.rb:41 ../../app/helpers/application_helper/toolbar/container_nodes_center.rb:37 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:96 ../../app/helpers/application_helper/toolbar/ems_clusters_center.rb:45 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:41 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:25 ../../app/helpers/application_helper/toolbar/container_group_center.rb:53 ../../app/helpers/application_helper/toolbar/ems_middlewares_center.rb:39 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:6 ../../app/helpers/application_helper/toolbar/flavor_center.rb:6 ../../app/helpers/application_helper/toolbar/ontap_storage_volumes_center.rb:6 ../../app/helpers/application_helper/toolbar/container_services_center.rb:37 ../../app/helpers/application_helper/toolbar/hosts_center.rb:73 ../../app/helpers/application_helper/toolbar/auth_key_pair_clouds_center.rb:6 ../../app/helpers/application_helper/toolbar/storages_center.rb:36 ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:27 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:87 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:71 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:53 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:21 ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:56 ../../app/helpers/application_helper/toolbar/repositories_center.rb:49 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:21 ../../app/helpers/application_helper/toolbar/container_replicators_center.rb:37 ../../app/helpers/application_helper/toolbar/servicetemplates_center.rb:43 ../../app/helpers/application_helper/toolbar/middleware_server_center.rb:29 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/cloud_tenant_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:47 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:53 ../../app/helpers/application_helper/toolbar/tenants_center.rb:41 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:6 ../../app/helpers/application_helper/toolbar/cloud_tenants_center.rb:6 ../../app/helpers/application_helper/toolbar/user_center.rb:33 ../../app/helpers/application_helper/toolbar/containers_center.rb:37 ../../app/helpers/application_helper/toolbar/persistent_volume_center.rb:32 ../../app/helpers/application_helper/toolbar/container_images_center.rb:25 ../../app/helpers/application_helper/toolbar/persistent_volumes_center.rb:41 ../../app/helpers/application_helper/toolbar/ontap_storage_systems_center.rb:6 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:26 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:47 ../yaml_strings.rb:3804 ../dictionary_strings.rb:1541
 msgid "Policy"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:763
+msgid "Policy %{caption}:"
 msgstr ""
 
 #: ../../app/views/miq_policy/_policy_details.html.haml:155
 msgid "Policy Conditions:"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:950
+msgid "Policy Import/Export"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:954
+msgid "Policy Log"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet
@@ -19709,8 +26850,15 @@ msgstr ""
 msgid "Policy Profile"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:722
+msgid "Policy Profile:"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqPolicySet.yaml
+#. TRANSLATORS: file: product/views/PolicySet.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqPolicySet (plural form)
-#: ../../app/controllers/miq_policy_controller.rb:1130 ../../app/views/miq_policy/_export.html.haml:105 ../dictionary_strings.rb:1547
+#: ../../app/controllers/miq_policy_controller.rb:1132 ../../app/views/miq_policy/_export.html.haml:105 ../yaml_strings.rb:836 ../dictionary_strings.rb:1547
 msgid "Policy Profiles"
 msgstr ""
 
@@ -19722,12 +26870,17 @@ msgstr ""
 msgid "Policy Selection"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:82 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:80 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:58 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:64 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:78 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:87 ../../app/helpers/application_helper/toolbar/vms_center.rb:79 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:113 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:104 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:88 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:59
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:82 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:80 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:58 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:64 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:69 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:78 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:87 ../../app/helpers/application_helper/toolbar/vms_center.rb:79 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:113 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:104 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:88 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:59 ../yaml_strings.rb:946
 msgid "Policy Simulation"
 msgstr ""
 
 #: ../../app/views/vm_common/_policies.html.haml:11
 msgid "Policy Simulation Details"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:671
+msgid "Policy Simulation Details for %{name}"
 msgstr ""
 
 #: ../../app/views/miq_policy/_rsop_results.html.haml:65
@@ -19798,12 +26951,31 @@ msgstr ""
 msgid "PolicyEvent|Username"
 msgstr ""
 
-#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/views/ops/_ldap_domain_show.html.haml:259 ../../app/views/ops/_settings_server_tab.html.haml:400 ../../app/views/ops/_settings_workers_tab.html.haml:537 ../../app/views/ops/_ldap_server_entries.html.haml:22 ../../app/views/ems_middleware/_form_fields.html.haml:24 ../../app/views/storage_manager/_form.html.haml:99 ../../app/views/security_group/_main.html.haml:20 ../../app/views/ems_container/_form_fields.html.haml:24
+#. TRANSLATORS: file: product/views/PolicySet.yaml
+#: ../yaml_strings.rb:2818
+msgid "PolicySet"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../../app/helpers/storage_manager_helper/textual_summary.rb:27 ../../app/views/ops/_ldap_domain_show.html.haml:259 ../../app/views/ops/_settings_server_tab.html.haml:400 ../../app/views/ops/_settings_workers_tab.html.haml:537 ../../app/views/ops/_ldap_server_entries.html.haml:22 ../../app/views/ems_middleware/_form_fields.html.haml:24 ../../app/views/storage_manager/_form.html.haml:99 ../../app/views/security_group/_main.html.haml:20 ../../app/views/ems_container/_form_fields.html.haml:24 ../yaml_strings.rb:3068
 msgid "Port"
 msgstr ""
 
 #: ../../app/views/container_service/_main.html.haml:9
 msgid "Port Configurations"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:685
+msgid "Port Group: %{name}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#: ../../app/helpers/container_service_helper/textual_summary.rb:54 ../yaml_strings.rb:3581
+msgid "Portal IP"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:162 ../../app/helpers/application_helper/toolbar/host_center.rb:114 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:158 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:127 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:199 ../../app/helpers/application_helper/toolbar/hosts_center.rb:138 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:150
@@ -19818,8 +26990,24 @@ msgstr ""
 msgid "Power Management"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:190 ../../app/helpers/application_helper/toolbar/host_center.rb:163 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:186 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:238 ../../app/helpers/application_helper/toolbar/hosts_center.rb:185 ../../app/views/catalog/_form_resources_info.html.haml:118
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:190 ../../app/helpers/application_helper/toolbar/host_center.rb:163 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:186 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:238 ../../app/helpers/application_helper/toolbar/hosts_center.rb:185 ../../app/views/catalog/_form_resources_info.html.haml:118 ../yaml_strings.rb:546
 msgid "Power Off"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2057
+msgid "Power Off Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2177
+msgid "Power Off VM"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:548
+msgid "Power Off a Host / Node"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:237 ../../app/helpers/application_helper/toolbar/hosts_center.rb:184
@@ -19846,8 +27034,24 @@ msgstr ""
 msgid "Power Off this item?"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:183 ../../app/helpers/application_helper/toolbar/host_center.rb:156 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:179 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:228 ../../app/helpers/application_helper/toolbar/hosts_center.rb:177 ../../app/views/catalog/_form_resources_info.html.haml:117
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:183 ../../app/helpers/application_helper/toolbar/host_center.rb:156 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:179 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:228 ../../app/helpers/application_helper/toolbar/hosts_center.rb:177 ../../app/views/catalog/_form_resources_info.html.haml:117 ../yaml_strings.rb:542
 msgid "Power On"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2055
+msgid "Power On Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2175
+msgid "Power On VM"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:544
+msgid "Power On a Host / Node"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:227 ../../app/helpers/application_helper/toolbar/hosts_center.rb:176
@@ -19878,6 +27082,10 @@ msgstr ""
 msgid "Power Operations"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:510 ../../app/helpers/host_helper/textual_summary.rb:184 ../../app/helpers/vm_infra_helper/textual_summary.rb:648 ../../app/helpers/vm_helper/textual_summary.rb:767
+msgid "Power State"
+msgstr ""
+
 #: ../../app/views/vm_common/console_mks.html.haml:43
 msgid "Press Ctl+Alt to release cursor."
 msgstr ""
@@ -19898,12 +27106,28 @@ msgstr ""
 msgid "Press the Apply button to import the good records into the CFME database"
 msgstr ""
 
-#: ../../app/controllers/dashboard_controller.rb:622
+#: ../../app/controllers/dashboard_controller.rb:606
 msgid "Press your browser's Back button or click a tab to continue"
 msgstr ""
 
 #: ../../app/views/layouts/_exception_contents.html.haml:31
 msgid "Pressing the back button during a session."
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:377
+msgid "Preview tab is not available until Chargeback Filters has been configured"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:365
+msgid "Preview tab is not available until Trend Target Limit has been configured"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:362
+msgid "Preview tab is not available until Trending for field has been selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:372
+msgid "Preview tab is not available until at least 1 field has been selected"
 msgstr ""
 
 #: ../../app/views/report/_report_list.html.haml:128 ../../app/views/report/_report_info.html.haml:20
@@ -19914,11 +27138,20 @@ msgstr ""
 msgid "Primary (Record) Filter - Filters the %s table records"
 msgstr ""
 
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:110 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:103 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:70
+msgid "Primordial"
+msgstr ""
+
 #: ../../app/views/ops/_selected_by_servers.html.haml:194 ../../app/views/ops/_selected_by_roles.html.haml:78
 msgid "Priority"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1546
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:968
+msgid "Priority Order"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_class_controller.rb:1540
 msgid "Priority Order was saved"
 msgstr ""
 
@@ -19934,8 +27167,22 @@ msgstr ""
 msgid "Private Keys do not match"
 msgstr ""
 
+#: ../../app/helpers/container_helper/textual_summary.rb:84
+msgid "Privileged"
+msgstr ""
+
 #: ../../app/views/ops/_selected_by_roles.html.haml:96
 msgid "Process ID"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OsProcess-processes.yaml
+#: ../yaml_strings.rb:3907
+msgid "Processes"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#: ../yaml_strings.rb:3400
+msgid "Processor Cores Per Socket"
 msgstr ""
 
 #: ../../app/views/miq_request/_reconfigure_show.html.haml:49
@@ -19946,11 +27193,13 @@ msgstr ""
 msgid "Processor Options"
 msgstr ""
 
-#: ../../app/views/miq_request/_reconfigure_show.html.haml:35
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#: ../../app/views/miq_request/_reconfigure_show.html.haml:35 ../yaml_strings.rb:3398
 msgid "Processor Sockets"
 msgstr ""
 
-#: ../../app/views/vm_common/_reconfigure.html.haml:64 ../../app/views/vm_common/_right_size.html.haml:180 ../../app/views/vm_common/_right_size.html.haml:264 ../../app/views/vm_common/_right_size.html.haml:347
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
+#: ../../app/views/vm_common/_reconfigure.html.haml:64 ../../app/views/vm_common/_right_size.html.haml:180 ../../app/views/vm_common/_right_size.html.haml:264 ../../app/views/vm_common/_right_size.html.haml:347 ../yaml_strings.rb:3782
 msgid "Processors"
 msgstr ""
 
@@ -19962,14 +27211,32 @@ msgstr ""
 msgid "Product Features (%s)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#: ../yaml_strings.rb:3444
+msgid "Product Key"
+msgstr ""
+
+#: ../../app/helpers/container_image_helper/textual_summary.rb:52
+msgid "Product Name"
+msgstr ""
+
+#: ../../app/helpers/container_image_helper/textual_summary.rb:47
+msgid "Product Type"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate
 #: ../dictionary_strings.rb:1651
 msgid "Product Update"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.ProductUpdate (plural form)
-#: ../dictionary_strings.rb:1653
+#: ../yaml_strings.rb:1224 ../dictionary_strings.rb:1653
 msgid "Product Updates"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:120
+msgid "Production"
 msgstr ""
 
 #: ../../app/views/miq_policy/_alert_profile_details.html.haml:74
@@ -19982,22 +27249,32 @@ msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerProject
 #. TRANSLATORS: en.yml key: dictionary.table.container_project
-#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:122 ../dictionary_strings.rb:1319 ../dictionary_strings.rb:1821
+#: ../../app/controllers/ops_controller/ops_rbac.rb:574 ../../app/views/shared/views/ems_common/angular/_form.html.haml:122 ../dictionary_strings.rb:1319 ../dictionary_strings.rb:1821
 msgid "Project"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#. TRANSLATORS: file: product/views/ContainerRoute.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#: ../yaml_strings.rb:3364
+msgid "Project Name"
 msgstr ""
 
 #: ../../app/views/ops/_rbac_group_details.html.haml:88
 msgid "Project/Tenant"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerProject (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_project (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_projects
-#: ../../app/views/ops/_rbac_tenant_details.html.haml:117 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:35 ../dictionary_strings.rb:1321 ../dictionary_strings.rb:1823 ../dictionary_strings.rb:1825
+#: ../../app/views/ops/_rbac_tenant_details.html.haml:117 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:35 ../yaml_strings.rb:1917 ../dictionary_strings.rb:1321 ../dictionary_strings.rb:1823 ../dictionary_strings.rb:1825
 msgid "Projects"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:44 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:44
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:44 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:44 ../yaml_strings.rb:1370
 msgid "Promote Server"
 msgstr ""
 
@@ -20005,7 +27282,7 @@ msgstr ""
 msgid "Promote Server #{@record.miq_server.name} [#{@record.miq_server.id}] to primary for the #{@record.server_role.description} Role"
 msgstr ""
 
-#: ../../app/views/ops/_db_summary.html.haml:5 ../../app/views/provider_foreman/_main.html.haml:7 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:7 ../../app/views/service/_svcs_show.html.haml:7 ../../app/views/middleware_server/_main.html.haml:7 ../../app/views/container_service/_main.html.haml:7 ../../app/views/resource_pool/_main.html.haml:7 ../../app/views/vm_cloud/_main.html.haml:7 ../../app/views/ems_middleware/_main.html.haml:7 ../../app/views/cloud_volume/_main.html.haml:7 ../../app/views/flavor/_main.html.haml:7 ../../app/views/storage_manager/_main.html.haml:7 ../../app/views/ontap_storage_system/_main.html.haml:7 ../../app/views/orchestration_stack/_main.html.haml:7 ../../app/views/repository/_main.html.haml:7 ../../app/views/host/_main.html.haml:7 ../../app/views/ontap_logical_disk/_main.html.haml:7 ../../app/views/persistent_volume/_main.html.haml:7 ../../app/views/auth_key_pair_cloud/_main.html.haml:9 ../../app/views/container_group/_main.html.haml:7 ../../app/views/container/_container_show.html.haml:7 ../../app/views/security_group/_main.html.haml:7 ../../app/views/ontap_storage_volume/_main.html.haml:7 ../../app/views/container_replicator/_main.html.haml:7 ../../app/views/layouts/listnav/_cloud_volume.html.haml:11 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:7 ../../app/views/layouts/listnav/_resource_pool.html.haml:8 ../../app/views/layouts/listnav/_host.html.haml:33 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:11 ../../app/views/layouts/listnav/_container_group.html.haml:11 ../../app/views/layouts/listnav/_repository.html.haml:7 ../../app/views/layouts/listnav/_storage.html.haml:8 ../../app/views/layouts/listnav/_flavor.html.haml:7 ../../app/views/layouts/listnav/_container_image_registry.html.haml:11 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:7 ../../app/views/layouts/listnav/_middleware_server.html.haml:11 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:11 ../../app/views/layouts/listnav/_service.html.haml:7 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:7 ../../app/views/layouts/listnav/_ems_container.html.haml:11 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:7 ../../app/views/layouts/listnav/_container_image.html.haml:11 ../../app/views/layouts/listnav/_ems_cluster.html.haml:8 ../../app/views/layouts/listnav/_persistent_volume.html.haml:11 ../../app/views/layouts/listnav/_storage_manager.html.haml:7 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:7 ../../app/views/layouts/listnav/_ems_infra.html.haml:9 ../../app/views/layouts/listnav/_container_replicator.html.haml:11 ../../app/views/layouts/listnav/_container_node.html.haml:11 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:7 ../../app/views/layouts/listnav/_ems_middleware.html.haml:11 ../../app/views/layouts/listnav/_ems_cloud.html.haml:11 ../../app/views/layouts/listnav/_availability_zone.html.haml:11 ../../app/views/layouts/listnav/_security_group.html.haml:11 ../../app/views/layouts/listnav/_container_route.html.haml:11 ../../app/views/layouts/listnav/_container_service.html.haml:11 ../../app/views/layouts/listnav/_container_project.html.haml:11 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:7 ../../app/views/layouts/listnav/_pxe_server.html.haml:7 ../../app/views/container_image_registry/_main.html.haml:7 ../../app/views/container_route/_main.html.haml:7 ../../app/views/middleware_deployment/_main.html.haml:7 ../../app/views/vm_common/_main.html.haml:7 ../../app/views/storage/_main.html.haml:7 ../../app/views/miq_ae_class/_all_tabs.html.haml:14 ../../app/views/miq_ae_class/_all_tabs.html.haml:55 ../../app/views/miq_ae_class/_class_form.html.haml:5 ../../app/views/miq_ae_class/_class_props.html.haml:6 ../../app/views/ems_container/_main.html.haml:7 ../../app/views/container_node/_main.html.haml:7 ../../app/views/ontap_file_share/_main.html.haml:7 ../../app/views/shared/views/ems_common/_main.html.haml:7 ../../app/views/container_project/_main.html.haml:7 ../../app/views/container_image/_main.html.haml:7
+#: ../../app/views/ops/_db_summary.html.haml:5 ../../app/views/provider_foreman/_main.html.haml:7 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:7 ../../app/views/service/_svcs_show.html.haml:7 ../../app/views/middleware_server/_main.html.haml:7 ../../app/views/container_service/_main.html.haml:7 ../../app/views/resource_pool/_main.html.haml:7 ../../app/views/vm_cloud/_main.html.haml:7 ../../app/views/ems_middleware/_main.html.haml:7 ../../app/views/cloud_volume/_main.html.haml:7 ../../app/views/flavor/_main.html.haml:7 ../../app/views/storage_manager/_main.html.haml:7 ../../app/views/ontap_storage_system/_main.html.haml:7 ../../app/views/orchestration_stack/_main.html.haml:7 ../../app/views/repository/_main.html.haml:7 ../../app/views/host/_main.html.haml:7 ../../app/views/ontap_logical_disk/_main.html.haml:7 ../../app/views/persistent_volume/_main.html.haml:7 ../../app/views/auth_key_pair_cloud/_main.html.haml:9 ../../app/views/container_group/_main.html.haml:7 ../../app/views/container/_container_show.html.haml:7 ../../app/views/security_group/_main.html.haml:7 ../../app/views/ontap_storage_volume/_main.html.haml:7 ../../app/views/container_replicator/_main.html.haml:7 ../../app/views/layouts/listnav/_cloud_volume.html.haml:7 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:7 ../../app/views/layouts/listnav/_resource_pool.html.haml:8 ../../app/views/layouts/listnav/_host.html.haml:33 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:7 ../../app/views/layouts/listnav/_container_group.html.haml:7 ../../app/views/layouts/listnav/_repository.html.haml:7 ../../app/views/layouts/listnav/_storage.html.haml:8 ../../app/views/layouts/listnav/_flavor.html.haml:7 ../../app/views/layouts/listnav/_container_image_registry.html.haml:7 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:7 ../../app/views/layouts/listnav/_middleware_server.html.haml:7 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:7 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:11 ../../app/views/layouts/listnav/_service.html.haml:7 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:7 ../../app/views/layouts/listnav/_ems_container.html.haml:7 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:7 ../../app/views/layouts/listnav/_container_image.html.haml:7 ../../app/views/layouts/listnav/_ems_cluster.html.haml:8 ../../app/views/layouts/listnav/_persistent_volume.html.haml:7 ../../app/views/layouts/listnav/_storage_manager.html.haml:7 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:7 ../../app/views/layouts/listnav/_ems_infra.html.haml:9 ../../app/views/layouts/listnav/_container_replicator.html.haml:7 ../../app/views/layouts/listnav/_container_node.html.haml:7 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:7 ../../app/views/layouts/listnav/_ems_middleware.html.haml:7 ../../app/views/layouts/listnav/_ems_cloud.html.haml:7 ../../app/views/layouts/listnav/_availability_zone.html.haml:7 ../../app/views/layouts/listnav/_security_group.html.haml:7 ../../app/views/layouts/listnav/_container_route.html.haml:7 ../../app/views/layouts/listnav/_container_service.html.haml:7 ../../app/views/layouts/listnav/_container_project.html.haml:7 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:7 ../../app/views/layouts/listnav/_pxe_server.html.haml:7 ../../app/views/container_image_registry/_main.html.haml:7 ../../app/views/container_route/_main.html.haml:7 ../../app/views/cloud_volume_snapshot/_main.html.haml:7 ../../app/views/middleware_deployment/_main.html.haml:7 ../../app/views/vm_common/_main.html.haml:7 ../../app/views/storage/_main.html.haml:7 ../../app/views/miq_ae_class/_all_tabs.html.haml:14 ../../app/views/miq_ae_class/_all_tabs.html.haml:55 ../../app/views/miq_ae_class/_class_form.html.haml:5 ../../app/views/miq_ae_class/_class_props.html.haml:6 ../../app/views/ems_container/_main.html.haml:7 ../../app/views/container_node/_main.html.haml:7 ../../app/views/ontap_file_share/_main.html.haml:7 ../../app/views/shared/views/ems_common/_main.html.haml:7 ../../app/views/container_project/_main.html.haml:7 ../../app/views/container_image/_main.html.haml:7
 msgid "Properties"
 msgstr ""
 
@@ -20017,27 +27294,66 @@ msgstr ""
 msgid "Protected"
 msgstr ""
 
-#: ../../app/helpers/container_service_helper/textual_summary.rb:18
+#. TRANSLATORS: file: product/views/FirewallRule.yaml
+#: ../../app/helpers/container_service_helper/textual_summary.rb:18 ../yaml_strings.rb:3826
 msgid "Protocol"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#. TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#. TRANSLATORS: file: product/views/ContainerProject.yaml
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#. TRANSLATORS: file: product/views/ContainerRoute.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiddlewareServer.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager
-#: ../../app/helpers/provider_configuration_manager_helper.rb:31 ../../app/helpers/provider_foreman_helper.rb:42 ../../app/views/catalog/_form_basic_info.html.haml:127 ../../app/views/catalog/_sandt_tree_show.html.haml:97 ../dictionary_strings.rb:1351 ../dictionary_strings.rb:1409 ../model_attributes.rb:1901
+#: ../../app/helpers/provider_configuration_manager_helper.rb:31 ../../app/helpers/provider_foreman_helper.rb:42 ../../app/views/catalog/_form_basic_info.html.haml:127 ../../app/views/catalog/_sandt_tree_show.html.haml:97 ../yaml_strings.rb:2623 ../dictionary_strings.rb:1351 ../dictionary_strings.rb:1409 ../model_attributes.rb:1901
 msgid "Provider"
 msgstr ""
 
-#: ../../app/controllers/ems_infra_controller.rb:68
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2944
+msgid "Provider Name"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2666
+msgid "Provider User Name"
+msgstr ""
+
+#: ../../app/controllers/ems_infra_controller.rb:69
 msgid "Provider is not ready to be scaled, another operation is in progress."
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_topology/container_topology_controller.js:228
+#: ../../app/controllers/pxe_controller/iso_datastores.rb:49
+msgid "Provider is required"
+msgstr ""
+
+#: ../../app/assets/javascripts/services/topology_service.js:11
 msgid "Provider: "
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ExtManagementSystem (plural form)
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::BaseManager (plural form)
-#: ../../app/presenters/menu/default_menu.rb:26 ../../app/presenters/menu/default_menu.rb:43 ../../app/presenters/menu/default_menu.rb:79 ../../app/presenters/menu/default_menu.rb:114 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:4 ../dictionary_strings.rb:1353 ../dictionary_strings.rb:1411
+#: ../../app/presenters/menu/default_menu.rb:26 ../../app/presenters/menu/default_menu.rb:43 ../../app/presenters/menu/default_menu.rb:79 ../../app/presenters/menu/default_menu.rb:114 ../../app/controllers/provider_foreman_controller.rb:448 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:4 ../yaml_strings.rb:1638 ../dictionary_strings.rb:1353 ../dictionary_strings.rb:1411
 msgid "Providers"
 msgstr ""
 
@@ -20063,10 +27379,6 @@ msgstr ""
 msgid "Provision"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1757 ../../app/controllers/vm_common.rb:1761
-msgid "Provision %s"
-msgstr ""
-
 #: ../../app/views/miq_request/_pre_prov.html.haml:8
 msgid "Provision %s based on the selected %s"
 msgstr ""
@@ -20075,19 +27387,30 @@ msgstr ""
 msgid "Provision %s was cancelled by the user"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1753
+#: ../../app/controllers/vm_common.rb:1834
 msgid "Provision %{model} - Select %{typ}"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1838 ../../app/controllers/vm_common.rb:1842
+msgid "Provision %{tables}"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_provider_foreman_configured_system_center.rb:13 ../../app/helpers/application_helper/toolbar/x_configured_system_center.rb:13
 msgid "Provision Configured System"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:13 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:13
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/configured_systems_center.rb:13 ../../app/helpers/application_helper/toolbar/configured_system_center.rb:13 ../../app/helpers/application_helper/toolbar/configured_system_foreman_center.rb:13 ../../app/helpers/application_helper/toolbar/configured_systems_foreman_center.rb:13 ../yaml_strings.rb:1989
 msgid "Provision Configured Systems"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:123
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:582
+msgid "Provision Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:123 ../yaml_strings.rb:2093
 msgid "Provision Instances"
 msgstr ""
 
@@ -20095,7 +27418,13 @@ msgstr ""
 msgid "Provision Order"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:148
+#. TRANSLATORS: file: product/views/PxeImageType.yaml
+#: ../../app/helpers/pxe_helper/textual_summary.rb:120 ../yaml_strings.rb:3213
+msgid "Provision Type"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:148 ../yaml_strings.rb:2203
 msgid "Provision VMs"
 msgstr ""
 
@@ -20121,6 +27450,10 @@ msgstr ""
 msgid "Provisioned Hosts"
 msgstr ""
 
+#: ../../app/helpers/vm_helper/textual_summary.rb:234
+msgid "Provisioned On"
+msgstr ""
+
 #: ../../app/views/vm_common/_disks.html.haml:15
 msgid "Provisioned Size"
 msgstr ""
@@ -20135,8 +27468,18 @@ msgstr ""
 msgid "Provisioned VMs"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:882 ../../app/views/catalog/_sandt_tree_show.html.haml:106
+#: ../../app/controllers/catalog_controller.rb:877 ../../app/views/catalog/_sandt_tree_show.html.haml:106
 msgid "Provisioning"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/miq_ae_customization_controller.rb:195 ../yaml_strings.rb:1081
+msgid "Provisioning Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1083
+msgid "Provisioning Dialogs Accordion"
 msgstr ""
 
 #: ../../app/views/catalog/_form_basic_info.html.haml:147
@@ -20147,15 +27490,21 @@ msgstr ""
 msgid "Provisioning Entry Point (NameSpace/Class/Instance)"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:375 ../../app/controllers/catalog_controller.rb:869
+#: ../../app/controllers/catalog_controller.rb:336 ../../app/controllers/catalog_controller.rb:864
 msgid "Provisioning Entry Point is required"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqProvision.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqProvision (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_provision (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_provisions
-#: ../dictionary_strings.rb:1551 ../dictionary_strings.rb:1989 ../dictionary_strings.rb:1997
+#: ../yaml_strings.rb:3329 ../dictionary_strings.rb:1551 ../dictionary_strings.rb:1989 ../dictionary_strings.rb:1997
 msgid "Provisions"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2209
+msgid "Publish VMs to a Template"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:161
@@ -20164,6 +27513,23 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:112 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:110
 msgid "Publish this VM to a Template"
+msgstr ""
+
+#: ../../app/helpers/provider_foreman_helper.rb:153
+msgid "Puppet Realm"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:14
+msgid "Purple Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:13
+msgid "Purple Text"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:556
+msgid "Put a Host / Node into Maintenance Mode"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/host_center.rb:119
@@ -20283,6 +27649,11 @@ msgstr ""
 msgid "Queue this Report to be generated"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:732
+msgid "Queue up Schedules to run now"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_report_schedules_center.rb:51 ../../app/helpers/application_helper/toolbar/miq_schedules_center.rb:51
 msgid "Queue up selected Schedules to run now"
 msgstr ""
@@ -20291,8 +27662,17 @@ msgstr ""
 msgid "Queue up this Schedule to run now"
 msgstr ""
 
-#: ../../app/views/miq_task/_tasks_options.html.haml:88 ../../app/views/miq_task/_tasks_options.html.haml:88
+#. TRANSLATORS: file: product/views/Job.yaml
+#: ../../app/helpers/ui_constants.rb:412 ../../app/views/miq_task/_tasks_options.html.haml:88 ../../app/views/miq_task/_tasks_options.html.haml:88 ../yaml_strings.rb:3879
 msgid "Queued"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#: ../yaml_strings.rb:2826
+msgid "Queued At"
 msgstr ""
 
 #: ../../app/views/cloud_tenant/_main.html.haml:9
@@ -20313,11 +27693,20 @@ msgstr ""
 msgid "RAM Size (MB)"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/rhn.rb:207
+msgid "RHN Login"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:208
+msgid "RHN Password"
+msgstr ""
+
 #: ../../app/views/layouts/_multi_auth_credentials.html.haml:29 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:24
 msgid "RSA key pair"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:11
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:11 ../../app/controllers/alert_controller.rb:65 ../yaml_strings.rb:822
 msgid "RSS"
 msgstr ""
 
@@ -20329,23 +27718,27 @@ msgstr ""
 msgid "RSS Feed no longer exists"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:43
+#: ../../app/helpers/ui_constants.rb:552
+msgid "RSS Feeds"
+msgstr ""
+
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:113 ../../app/helpers/container_group_helper/textual_summary.rb:43
 msgid "Rados Ceph Monitors"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:44
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:119 ../../app/helpers/container_group_helper/textual_summary.rb:44
 msgid "Rados Image Name"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:47
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:137 ../../app/helpers/container_group_helper/textual_summary.rb:47
 msgid "Rados Keyring"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:45
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:125 ../../app/helpers/container_group_helper/textual_summary.rb:45
 msgid "Rados Pool Name"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:46
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:131 ../../app/helpers/container_group_helper/textual_summary.rb:46
 msgid "Rados User Name"
 msgstr ""
 
@@ -20361,7 +27754,7 @@ msgstr ""
 msgid "Rate"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:361
+#: ../../app/controllers/chargeback_controller.rb:343
 msgid "Rate Assignments saved"
 msgstr ""
 
@@ -20369,8 +27762,19 @@ msgstr ""
 msgid "Rate Details"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:60
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/tree_builder.rb:105 ../../app/controllers/chargeback_controller.rb:359 ../yaml_strings.rb:804
 msgid "Rates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:806
+msgid "Rates Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../yaml_strings.rb:3265
+msgid "Raw Disk Mappings"
 msgstr ""
 
 #: ../../app/views/layouts/_exp_editor.html.haml:40
@@ -20397,7 +27801,9 @@ msgstr ""
 msgid "Read Hit (IOPS)"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_role_details.html.haml:102 ../../app/views/catalog/_ot_tree_show.html.haml:50
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#. TRANSLATORS: file: product/views/MiqUserRole.yaml
+#: ../../app/views/ops/_rbac_role_details.html.haml:102 ../../app/views/catalog/_ot_tree_show.html.haml:50 ../yaml_strings.rb:3914
 msgid "Read Only"
 msgstr ""
 
@@ -20405,11 +27811,11 @@ msgstr ""
 msgid "Read Only %{model} \"%{name}\" can not be edited"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1916
+#: ../../app/controllers/miq_ae_class_controller.rb:1918
 msgid "Read Only %{model} \"%{name}\" cannot be deleted"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2386
+#: ../../app/controllers/miq_ae_class_controller.rb:2388
 msgid "Read Only %{model} \"%{name}\" cannot be edited"
 msgstr ""
 
@@ -20417,24 +27823,37 @@ msgstr ""
 msgid "Read only"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:50
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:153 ../../app/helpers/container_group_helper/textual_summary.rb:50
 msgid "Read-Only"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../yaml_strings.rb:3367
+msgid "Ready"
 msgstr ""
 
 #: ../../app/helpers/provider_foreman_helper.rb:72 ../../app/views/ems_infra/_form_fields.html.haml:47
 msgid "Realm"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:142 ../../app/controllers/ems_common.rb:519
+#: ../../app/controllers/ems_common.rb:146 ../../app/controllers/ems_common.rb:525
 msgid "Realm is required"
 msgstr ""
 
-#: ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/miq_request/_request.html.haml:199 ../../app/views/miq_request/_request_details.html.haml:84
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/helpers/container_helper/textual_summary.rb:30 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/miq_request/_request.html.haml:199 ../../app/views/miq_request/_request_details.html.haml:84 ../yaml_strings.rb:3677
 msgid "Reason"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_options.html.haml:106
 msgid "Reason:"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#: ../yaml_strings.rb:3889
+msgid "Reclaim Policy"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:166 ../../app/views/vm_common/_right_size.html.haml:250 ../../app/views/vm_common/_right_size.html.haml:333
@@ -20445,12 +27864,16 @@ msgstr ""
 msgid "Reconfigurable"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:884 ../../app/views/catalog/_sandt_tree_show.html.haml:108
+#: ../../app/controllers/catalog_controller.rb:879 ../../app/views/catalog/_sandt_tree_show.html.haml:108
 msgid "Reconfigure"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1788
-msgid "Reconfigure %s"
+#: ../../app/controllers/service_controller.rb:166
+msgid "Reconfigure %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1869
+msgid "Reconfigure %{table}"
 msgstr ""
 
 #: ../../app/views/miq_policy/_action_options.html.haml:240 ../../app/views/miq_policy/_action_details.html.haml:261
@@ -20473,11 +27896,31 @@ msgstr ""
 msgid "Reconfigure Selected items"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1071
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:255
+msgid "Reconfigure Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:257
+msgid "Reconfigure Services Options"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2227
+msgid "Reconfigure VM Memory/CPUs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2225
+msgid "Reconfigure VMs"
+msgstr ""
+
+#: ../../app/controllers/application_controller/ci_processing.rb:1085
 msgid "Reconfigure does not apply because you selected at least one %{model}"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1077
+#: ../../app/controllers/application_controller/ci_processing.rb:1091
 msgid "Reconfigure does not apply because you selected at least one un-reconfigurable VM"
 msgstr ""
 
@@ -20509,8 +27952,24 @@ msgstr ""
 msgid "Reconfigure this VM"
 msgstr ""
 
+#: ../../app/helpers/application_helper.rb:852
+msgid "Record is not ExtManagementSystem class"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:863
+msgid "Record is not VmOrTemplate class"
+msgstr ""
+
 #: ../../app/controllers/ops_controller/settings.rb:24
 msgid "Records were successfully imported"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:103
+msgid "Red"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:4
+msgid "Red Background"
 msgstr ""
 
 #: ../../app/views/support/show.html.haml:81
@@ -20525,6 +27984,10 @@ msgstr ""
 msgid "Red Hat Updates"
 msgstr ""
 
+#: ../../app/helpers/report_helper.rb:3
+msgid "Red Text"
+msgstr ""
+
 #: ../../app/views/miq_capacity/_planning_vm_profile.html.haml:3
 msgid "Reference VM Profile"
 msgstr ""
@@ -20537,12 +28000,44 @@ msgstr ""
 msgid "Referenced by Actions"
 msgstr ""
 
-#: ../../app/views/ops/_settings_workers_tab.html.haml:432 ../../app/views/container_topology/show.html.haml:25 ../../app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml:27 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:41
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_settings_workers_tab.html.haml:432 ../../app/views/shared/_topology_header.html.haml:19 ../../app/views/shared/dialogs/_dialog_field_drop_down_list.html.haml:27 ../../app/views/shared/dialogs/_dialog_field_radio_button.html.haml:41 ../yaml_strings.rb:296
 msgid "Refresh"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:13 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:13
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1344
+msgid "Refresh Audit Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:298
+msgid "Refresh Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1654
+msgid "Refresh Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1346
+msgid "Refresh EVM Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:443
+msgid "Refresh Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/storage_manager_controller.rb:399 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:13 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:13 ../yaml_strings.rb:1506
 msgid "Refresh Inventory"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1508
+msgid "Refresh Inventory and power states for all items related of Storage Managers"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:12
@@ -20577,6 +28072,21 @@ msgstr ""
 msgid "Refresh List"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1678
+msgid "Refresh Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1348
+msgid "Refresh Production Log"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1991
+msgid "Refresh Providers"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:36 ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:28 ../../app/helpers/application_helper/toolbar/pxe_server_center.rb:26 ../../app/helpers/application_helper/toolbar/iso_datastore_center.rb:21
 msgid "Refresh Relationships"
 msgstr ""
@@ -20587,6 +28097,11 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/repositories_center.rb:12
 msgid "Refresh Relationships and Power States for all items related to the selected Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:651
+msgid "Refresh Relationships and Power States of Repository"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:14 ../../app/helpers/application_helper/toolbar/configuration_profile_foreman_center.rb:14
@@ -20625,7 +28140,8 @@ msgstr ""
 msgid "Refresh Relationships for this PXE Server?"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:22 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:19
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/storage_manager_controller.rb:405 ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:22 ../../app/helpers/application_helper/toolbar/storage_manager_center.rb:19 ../yaml_strings.rb:1510
 msgid "Refresh Status"
 msgstr ""
 
@@ -20645,7 +28161,17 @@ msgstr ""
 msgid "Refresh Status for all Storage CIs known to this Storage Manager?"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:917 ../../app/controllers/ems_common.rb:928
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1512
+msgid "Refresh Status for all items related of Storage Managers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:788
+msgid "Refresh Widgets"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:322 ../../app/controllers/repository_controller.rb:333 ../../app/controllers/ems_common.rb:932 ../../app/controllers/ems_common.rb:943
 msgid "Refresh initiated for %{count_model} from the CFME Database"
 msgstr ""
 
@@ -20671,6 +28197,41 @@ msgstr ""
 
 #: ../../app/controllers/application_controller/performance.rb:175
 msgid "Refresh of recent C&U data has been initiated"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1594
+msgid "Refresh relationships and power states for all items related of ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2131
+msgid "Refresh relationships and power states for all items related of Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2053
+msgid "Refresh relationships and power states for all items related of Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1535
+msgid "Refresh relationships and power states for all items related of PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2283
+msgid "Refresh relationships and power states for all items related of Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2173
+msgid "Refresh relationships and power states for all items related of VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:538
+msgid "Refresh relationships and power states for all items related to Hosts / Nodes"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_clouds_center.rb:12
@@ -20773,6 +28334,11 @@ msgstr ""
 msgid "Refresh relationships and power states for all items related to this item?"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1993
+msgid "Refresh relationships for all items related of Provider"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/provider_foreman_center.rb:13
 msgid "Refresh relationships for all items related to the selected items"
 msgstr ""
@@ -20789,10 +28355,42 @@ msgstr ""
 msgid "Refresh relationships for all items related to this Provider?"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#. TRANSLATORS: file: product/views/EmsCluster.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/Repository.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#. TRANSLATORS: file: product/views/Storage.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqRegion
 #. TRANSLATORS: en.yml key: dictionary.table.miq_region
-#: ../../app/views/shared/views/ems_common/angular/_form.html.haml:75 ../../app/views/shared/views/ems_common/angular/_form.html.haml:103 ../dictionary_strings.rb:1557 ../dictionary_strings.rb:2001
+#: ../../app/helpers/ems_cloud_helper/textual_summary.rb:28 ../../app/helpers/vm_cloud_helper/textual_summary.rb:63 ../../app/helpers/vm_infra_helper/textual_summary.rb:74 ../../app/helpers/provider_foreman_helper.rb:131 ../../app/helpers/vm_helper/textual_summary.rb:86 ../../app/views/shared/views/ems_common/angular/_form.html.haml:75 ../../app/views/shared/views/ems_common/angular/_form.html.haml:103 ../yaml_strings.rb:3101 ../dictionary_strings.rb:1557 ../dictionary_strings.rb:2001
 msgid "Region"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2966
+msgid "Region Description"
 msgstr ""
 
 #: ../../app/views/ops/_settings_details_tab.html.haml:10
@@ -20826,18 +28424,24 @@ msgstr ""
 msgid "Register to"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:289
+#: ../../app/controllers/ops_controller/settings/rhn.rb:293
 msgid "Registration"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.registry_items (plural form)
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:27 ../dictionary_strings.rb:2075
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:27 ../yaml_strings.rb:1832 ../dictionary_strings.rb:2075
 msgid "Registries"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/RegistryItem.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.registry_items
-#: ../../app/views/ops/_ap_form.html.haml:88 ../dictionary_strings.rb:2073
+#: ../../app/helpers/ui_constants.rb:488 ../../app/views/ops/_ap_form.html.haml:88 ../yaml_strings.rb:3290 ../dictionary_strings.rb:2073
 msgid "Registry"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:414 ../../app/helpers/vm_infra_helper/textual_summary.rb:425 ../../app/helpers/vm_helper/textual_summary.rb:524
+msgid "Registry Entries"
 msgstr ""
 
 #: ../../app/views/ops/_ap_form_registry.html.haml:3
@@ -20852,7 +28456,7 @@ msgstr ""
 msgid "Registry Hive"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1699
+#: ../../app/controllers/vm_common.rb:1780
 msgid "Registry Item"
 msgid_plural "Registry Items"
 msgstr[0] ""
@@ -20874,7 +28478,7 @@ msgstr ""
 msgid "Registry Value"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1426
+#: ../../app/controllers/application_controller/filter.rb:1317
 msgid "Registry Value Error: %{msg}"
 msgstr ""
 
@@ -20914,7 +28518,8 @@ msgstr ""
 msgid "Relationship"
 msgstr ""
 
-#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:92 ../../app/views/service/_svcs_show.html.haml:11 ../../app/views/middleware_server/_main.html.haml:12 ../../app/views/container_service/_main.html.haml:18 ../../app/views/resource_pool/_main.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:12 ../../app/views/vm_cloud/_main.html.haml:15 ../../app/views/ems_middleware/_main.html.haml:15 ../../app/views/cloud_volume/_main.html.haml:9 ../../app/views/flavor/_main.html.haml:9 ../../app/views/ontap_storage_system/_main.html.haml:14 ../../app/views/orchestration_stack/_main.html.haml:11 ../../app/views/host/_main.html.haml:9 ../../app/views/ontap_logical_disk/_main.html.haml:9 ../../app/views/persistent_volume/_main.html.haml:13 ../../app/views/availability_zone/_main.html.haml:7 ../../app/views/ems_cluster/_main.html.haml:7 ../../app/views/auth_key_pair_cloud/_main.html.haml:7 ../../app/views/container_group/_main.html.haml:21 ../../app/views/container/_container_show.html.haml:12 ../../app/views/security_group/_main.html.haml:12 ../../app/views/ontap_storage_volume/_main.html.haml:14 ../../app/views/container_replicator/_main.html.haml:16 ../../app/views/layouts/listnav/_cloud_volume.html.haml:21 ../../app/views/layouts/listnav/_resource_pool.html.haml:20 ../../app/views/layouts/listnav/_host.html.haml:92 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:21 ../../app/views/layouts/listnav/_container_group.html.haml:51 ../../app/views/layouts/listnav/_repository.html.haml:19 ../../app/views/layouts/listnav/_storage.html.haml:26 ../../app/views/layouts/listnav/_storage.html.haml:45 ../../app/views/layouts/listnav/_flavor.html.haml:19 ../../app/views/layouts/listnav/_container_image_registry.html.haml:21 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:19 ../../app/views/layouts/listnav/_middleware_server.html.haml:21 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:21 ../../app/views/layouts/listnav/_service.html.haml:19 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:20 ../../app/views/layouts/listnav/_ems_container.html.haml:50 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:17 ../../app/views/layouts/listnav/_container_image.html.haml:21 ../../app/views/layouts/listnav/_ems_cluster.html.haml:41 ../../app/views/layouts/listnav/_persistent_volume.html.haml:21 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:19 ../../app/views/layouts/listnav/_ems_infra.html.haml:27 ../../app/views/layouts/listnav/_container_replicator.html.haml:50 ../../app/views/layouts/listnav/_container_node.html.haml:51 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:19 ../../app/views/layouts/listnav/_ems_middleware.html.haml:20 ../../app/views/layouts/listnav/_ems_cloud.html.haml:27 ../../app/views/layouts/listnav/_availability_zone.html.haml:21 ../../app/views/layouts/listnav/_security_group.html.haml:23 ../../app/views/layouts/listnav/_container_route.html.haml:21 ../../app/views/layouts/listnav/_container_service.html.haml:35 ../../app/views/layouts/listnav/_container_project.html.haml:50 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:19 ../../app/views/container_image_registry/_main.html.haml:13 ../../app/views/container_route/_main.html.haml:14 ../../app/views/middleware_deployment/_main.html.haml:12 ../../app/views/vm_common/_main.html.haml:11 ../../app/views/storage/_main.html.haml:11 ../../app/views/ems_container/_main.html.haml:18 ../../app/views/container_node/_main.html.haml:15 ../../app/views/ontap_file_share/_main.html.haml:14 ../../app/views/shared/views/ems_common/_main.html.haml:14 ../../app/views/container_project/_main.html.haml:18 ../../app/views/container_image/_main.html.haml:13 ../../app/views/cloud_tenant/_main.html.haml:7
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/container_controller.rb:185 ../../app/views/ops/_settings_evm_servers_tab.html.haml:92 ../../app/views/service/_svcs_show.html.haml:11 ../../app/views/middleware_server/_main.html.haml:12 ../../app/views/container_service/_main.html.haml:18 ../../app/views/resource_pool/_main.html.haml:9 ../../app/views/vm_cloud/_main.html.haml:12 ../../app/views/vm_cloud/_main.html.haml:15 ../../app/views/ems_middleware/_main.html.haml:15 ../../app/views/cloud_volume/_main.html.haml:9 ../../app/views/flavor/_main.html.haml:9 ../../app/views/ontap_storage_system/_main.html.haml:14 ../../app/views/orchestration_stack/_main.html.haml:11 ../../app/views/host/_main.html.haml:9 ../../app/views/ontap_logical_disk/_main.html.haml:9 ../../app/views/persistent_volume/_main.html.haml:13 ../../app/views/availability_zone/_main.html.haml:7 ../../app/views/ems_cluster/_main.html.haml:7 ../../app/views/auth_key_pair_cloud/_main.html.haml:7 ../../app/views/container_group/_main.html.haml:21 ../../app/views/container/_container_show.html.haml:12 ../../app/views/security_group/_main.html.haml:12 ../../app/views/ontap_storage_volume/_main.html.haml:14 ../../app/views/container_replicator/_main.html.haml:16 ../../app/views/layouts/listnav/_cloud_volume.html.haml:17 ../../app/views/layouts/listnav/_resource_pool.html.haml:20 ../../app/views/layouts/listnav/_host.html.haml:92 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:17 ../../app/views/layouts/listnav/_container_group.html.haml:47 ../../app/views/layouts/listnav/_repository.html.haml:19 ../../app/views/layouts/listnav/_storage.html.haml:26 ../../app/views/layouts/listnav/_storage.html.haml:45 ../../app/views/layouts/listnav/_flavor.html.haml:19 ../../app/views/layouts/listnav/_container_image_registry.html.haml:17 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:19 ../../app/views/layouts/listnav/_middleware_server.html.haml:17 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:17 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:21 ../../app/views/layouts/listnav/_service.html.haml:19 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:20 ../../app/views/layouts/listnav/_ems_container.html.haml:46 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:17 ../../app/views/layouts/listnav/_container_image.html.haml:17 ../../app/views/layouts/listnav/_ems_cluster.html.haml:41 ../../app/views/layouts/listnav/_persistent_volume.html.haml:17 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:19 ../../app/views/layouts/listnav/_ems_infra.html.haml:27 ../../app/views/layouts/listnav/_container_replicator.html.haml:46 ../../app/views/layouts/listnav/_container_node.html.haml:47 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:19 ../../app/views/layouts/listnav/_ems_middleware.html.haml:16 ../../app/views/layouts/listnav/_ems_cloud.html.haml:23 ../../app/views/layouts/listnav/_availability_zone.html.haml:17 ../../app/views/layouts/listnav/_security_group.html.haml:19 ../../app/views/layouts/listnav/_container_route.html.haml:17 ../../app/views/layouts/listnav/_container_service.html.haml:31 ../../app/views/layouts/listnav/_container_project.html.haml:46 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:19 ../../app/views/container_image_registry/_main.html.haml:13 ../../app/views/container_route/_main.html.haml:14 ../../app/views/cloud_volume_snapshot/_main.html.haml:9 ../../app/views/middleware_deployment/_main.html.haml:12 ../../app/views/vm_common/_main.html.haml:11 ../../app/views/storage/_main.html.haml:11 ../../app/views/ems_container/_main.html.haml:18 ../../app/views/container_node/_main.html.haml:15 ../../app/views/ontap_file_share/_main.html.haml:14 ../../app/views/shared/views/ems_common/_main.html.haml:14 ../../app/views/container_project/_main.html.haml:18 ../../app/views/container_image/_main.html.haml:13 ../../app/views/cloud_tenant/_main.html.haml:7 ../yaml_strings.rb:1937
 msgid "Relationships"
 msgstr ""
 
@@ -20930,19 +28535,52 @@ msgstr ""
 msgid "Relationship|Resource type"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/miq_requests_center.rb:7 ../../app/helpers/application_helper/toolbar/miq_request_center.rb:24 ../../app/helpers/application_helper/toolbar/tasks_center.rb:7
+#. TRANSLATORS: file: product/views/Repository.yaml
+#: ../yaml_strings.rb:3425
+msgid "Relative Path"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#: ../yaml_strings.rb:3440
+msgid "Release"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/miq_requests_center.rb:7 ../../app/helpers/application_helper/toolbar/miq_request_center.rb:24 ../../app/helpers/application_helper/toolbar/tasks_center.rb:7 ../yaml_strings.rb:109
 msgid "Reload"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/ems_container_center.rb:6 ../../app/helpers/application_helper/toolbar/vmdb_tables_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:6 ../../app/helpers/application_helper/toolbar/vmdb_table_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:6
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/ems_container_center.rb:6 ../../app/helpers/application_helper/toolbar/vmdb_tables_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:6 ../../app/helpers/application_helper/toolbar/vmdb_table_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:6 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:6 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:6 ../yaml_strings.rb:1358
 msgid "Reload Current Display"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1382
+msgid "Reload Display"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:111
+msgid "Reload Requests"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_widgets_center.rb:6
 msgid "Reload Widgets"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_history.rb:74
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1350
+msgid "Reload Workers Display"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1612
+msgid "Reload charts"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_history.rb:74 ../yaml_strings.rb:1374
 msgid "Reload current display"
 msgstr ""
 
@@ -20974,7 +28612,8 @@ msgstr ""
 msgid "Reload the charts from the most recent C&U data"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/miq_requests_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_request_center.rb:23 ../../app/helpers/application_helper/toolbar/tasks_center.rb:6
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/miq_requests_center.rb:6 ../../app/helpers/application_helper/toolbar/miq_request_center.rb:23 ../../app/helpers/application_helper/toolbar/tasks_center.rb:6 ../yaml_strings.rb:1187
 msgid "Reload the current display"
 msgstr ""
 
@@ -20982,11 +28621,16 @@ msgstr ""
 msgid "Remote Console plugin is not properly installed."
 msgstr ""
 
-#: ../../app/views/layouts/_multi_auth_credentials.html.haml:33 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:31
+#: ../../app/helpers/host_helper/textual_summary.rb:531 ../../app/views/layouts/_multi_auth_credentials.html.haml:33 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:31
 msgid "Remote Login"
 msgstr ""
 
-#: ../../app/views/report/_form_styling.html.haml:57
+#: ../../app/controllers/host_controller.rb:792
+msgid "Remote Login Password and Verify Password fields do not match"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/report/_form_styling.html.haml:57 ../yaml_strings.rb:302
 msgid "Remove"
 msgstr ""
 
@@ -21054,20 +28698,117 @@ msgstr ""
 msgid "Remove %s"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:34
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:196
+msgid "Remove Catalog"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:151
+msgid "Remove Catalog Item"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:153
+msgid "Remove Catalog Items from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:198
+msgid "Remove Catalog from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:304
+msgid "Remove Cloud Providers from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:504
+msgid "Remove Clusters / Deployment Roles from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:893
+msgid "Remove Condition from specified Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1951
+msgid "Remove Container"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1844
+msgid "Remove Container Image Registries from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1783
+msgid "Remove Container Nodes from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1808
+msgid "Remove Container Replicators from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1893
+msgid "Remove Container Services from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1660
+msgid "Remove Containers Providers from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1953
+msgid "Remove Containers from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/customization_templates_center.rb:34 ../yaml_strings.rb:1564
 msgid "Remove Customization Templates from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:632
+msgid "Remove Datastores from the VMDB"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domains_center.rb:26
 msgid "Remove Domains"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:18
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:578
+msgid "Remove Hosts / Nodes from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/iso_datastores_center.rb:18 ../yaml_strings.rb:1600
 msgid "Remove ISO Datastores from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2137
+msgid "Remove Images from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:447
+msgid "Remove Infrastructure Providers from the VMDB"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_ae_instances_center.rb:52
 msgid "Remove Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2097
+msgid "Remove Instances from the VMDB"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/servicetemplatecatalog_center.rb:20 ../../app/helpers/application_helper/toolbar/servicetemplate_center.rb:30
@@ -21082,19 +28823,67 @@ msgstr ""
 msgid "Remove Methods"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1728
+msgid "Remove Middleware Deployments from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1684
+msgid "Remove Middleware Providers from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1706
+msgid "Remove Middleware Servers from the VMDB"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:48
 msgid "Remove Namespaces"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:26
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1626
+msgid "Remove Orchestration Stacks from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:223
+msgid "Remove Orchestration Template"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/pxe_servers_center.rb:26 ../yaml_strings.rb:1541
 msgid "Remove PXE Servers from the VMDB"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/repositories_center.rb:37
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1866
+msgid "Remove Persistent Volumes from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1757
+msgid "Remove Pods from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1997
+msgid "Remove Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1999
+msgid "Remove Proviers from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/repositories_center.rb:37 ../yaml_strings.rb:657
 msgid "Remove Repositories from the VMDB"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:15
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/resource_pools_center.rb:15 ../yaml_strings.rb:603
 msgid "Remove Resource Pools from the VMDB"
 msgstr ""
 
@@ -21110,15 +28899,23 @@ msgstr ""
 msgid "Remove Service from the VMDB"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/services_center.rb:23
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:247
+msgid "Remove Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/services_center.rb:23 ../yaml_strings.rb:249
 msgid "Remove Services from the VMDB"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:46
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/storage_managers_center.rb:46 ../yaml_strings.rb:1518
 msgid "Remove Storage Managers from the VMDB"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:26
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/pxe_image_types_center.rb:26 ../yaml_strings.rb:1581
 msgid "Remove System Image Types from the VMDB"
 msgstr ""
 
@@ -21130,8 +28927,18 @@ msgstr ""
 msgid "Remove Tags Settings"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2291
+msgid "Remove Templates from the TemplateDB"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:49 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:58
 msgid "Remove Templates from the VMDB"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2217
+msgid "Remove VMs from the VMDB"
 msgstr ""
 
 #: ../../app/views/miq_policy/_event_details.html.haml:129
@@ -21152,6 +28959,11 @@ msgstr ""
 
 #: ../../app/presenters/widget_presenter.rb:55
 msgid "Remove from Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:891
+msgid "Remove from Policy"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:43 ../../app/helpers/application_helper/toolbar/host_center.rb:32 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:42 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:36 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:36 ../../app/helpers/application_helper/toolbar/resource_pool_center.rb:13 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:36 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:19 ../../app/helpers/application_helper/toolbar/repository_center.rb:26 ../../app/helpers/application_helper/toolbar/storage_center.rb:20 ../../app/helpers/application_helper/toolbar/miq_dialog_center.rb:24 ../../app/helpers/application_helper/toolbar/chargeback_center.rb:61 ../../app/helpers/application_helper/toolbar/dialog_center.rb:25 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:37
@@ -21526,7 +29338,8 @@ msgstr ""
 msgid "Remove this widget"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:23
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/custom_button_set_center.rb:23 ../yaml_strings.rb:1107
 msgid "Reorder"
 msgstr ""
 
@@ -21540,6 +29353,11 @@ msgstr ""
 
 #: ../../app/views/layouts/_lightbox_panel.html.haml:5
 msgid "Replace me."
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
+#: ../yaml_strings.rb:3643
+msgid "Replicas"
 msgstr ""
 
 #: ../../app/views/ops/_diagnostics_replication_tab.html.haml:16
@@ -21568,10 +29386,12 @@ msgstr ""
 msgid "Replicator"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ContainerReplicator.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerReplicator (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_replicator (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_replicators
-#: ../dictionary_strings.rb:1329 ../dictionary_strings.rb:1787 ../dictionary_strings.rb:1789
+#: ../yaml_strings.rb:1794 ../dictionary_strings.rb:1329 ../dictionary_strings.rb:1787 ../dictionary_strings.rb:1789
 msgid "Replicators"
 msgstr ""
 
@@ -21590,6 +29410,14 @@ msgstr ""
 
 #: ../../app/views/report/_report_list.html.haml:215
 msgid "Report Info"
+msgstr ""
+
+#: ../../app/controllers/report_controller/menus.rb:234
+msgid "Report Menu for role \"%{role}\" was saved"
+msgstr ""
+
+#: ../../app/controllers/report_controller/menus.rb:214
+msgid "Report Menu set to default"
 msgstr ""
 
 #: ../../app/views/report/_role_list.html.haml:93
@@ -21636,7 +29464,7 @@ msgstr ""
 msgid "Report is not Scheduled."
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:389 ../../app/controllers/report_controller/saved_reports.rb:82
+#: ../../app/controllers/chargeback_controller.rb:388 ../../app/controllers/report_controller/saved_reports.rb:84
 msgid "Report is not authorized for the logged in user"
 msgstr ""
 
@@ -21656,21 +29484,34 @@ msgstr ""
 msgid "Reporting Workers"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqReport (plural form)
-#: ../../app/presenters/menu/default_menu.rb:7 ../../app/controllers/report_controller.rb:286 ../../app/views/configuration/_ui_1.html.haml:113 ../../app/views/report/_role_list.html.haml:16 ../dictionary_strings.rb:1563
+#: ../../app/presenters/menu/default_menu.rb:7 ../../app/controllers/chargeback_controller.rb:355 ../../app/controllers/report_controller.rb:282 ../../app/helpers/ui_constants.rb:550 ../../app/views/configuration/_ui_1.html.haml:113 ../../app/views/report/_role_list.html.haml:16 ../yaml_strings.rb:677 ../dictionary_strings.rb:1563
 msgid "Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:802
+msgid "Reports Accordion"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_form.html.haml:144
 msgid "Reports Currently Using This Time Profile"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:52 ../../app/views/configuration/_ui_2.html.haml:349
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Repository.yaml
+#: ../../app/presenters/menu/default_menu.rb:52 ../../app/views/configuration/_ui_2.html.haml:360 ../yaml_strings.rb:635
 msgid "Repositories"
 msgstr ""
 
-#: ../model_attributes.rb:1941
+#. TRANSLATORS: file: product/views/Repository.yaml
+#: ../yaml_strings.rb:3423 ../model_attributes.rb:1941
 msgid "Repository"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:210
+msgid "Repository Name"
 msgstr ""
 
 #: ../../app/views/ops/rhn/_info_subscribed.html.haml:75
@@ -21679,6 +29520,10 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_rhn_edit_tab.html.haml:67
 msgid "Repository Name(s):"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:300 ../../app/controllers/repository_controller.rb:328
+msgid "Repository no longer exists"
 msgstr ""
 
 #: ../model_attributes.rb:1942
@@ -21715,7 +29560,9 @@ msgstr ""
 msgid "Request Details"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:18
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:18 ../yaml_strings.rb:3659
 msgid "Request ID"
 msgstr ""
 
@@ -21727,11 +29574,14 @@ msgstr ""
 msgid "Request Information"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:44
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:44 ../yaml_strings.rb:3711
 msgid "Request State"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:71
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:71 ../yaml_strings.rb:3665
 msgid "Request Type"
 msgstr ""
 
@@ -21747,15 +29597,27 @@ msgstr ""
 msgid "Request is required"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:185
+msgid "Request to Order Services"
+msgstr ""
+
 #: ../../app/helpers/application_helper/toolbar/vms_center.rb:113
 msgid "Request to Provision"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:122
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:584
+msgid "Request to Provision Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:122 ../yaml_strings.rb:2095
 msgid "Request to Provision Instances"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:147
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:147 ../yaml_strings.rb:2205
 msgid "Request to Provision VMs"
 msgstr ""
 
@@ -21763,11 +29625,26 @@ msgstr ""
 msgid "Request to Provision items"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2211
+msgid "Request to Publish VMs to a Template"
+msgstr ""
+
 #: ../../app/views/miq_request/_request_details.html.haml:18
 msgid "Requested by"
 msgstr ""
 
-#: ../../app/views/miq_request/_request.html.haml:58
+#: ../../app/controllers/alert_controller.rb:41
+msgid "Requested feed is invalid"
+msgstr ""
+
+#: ../../app/helpers/container_replicator_helper/textual_summary.rb:25
+msgid "Requested pods"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#: ../../app/views/miq_request/_request.html.haml:58 ../yaml_strings.rb:3662
 msgid "Requester"
 msgstr ""
 
@@ -21775,10 +29652,13 @@ msgstr ""
 msgid "Requester:"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqRequest (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_request (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_requests
-#: ../../app/presenters/menu/default_menu.rb:20 ../../app/presenters/menu/default_menu.rb:54 ../../app/presenters/menu/default_menu.rb:148 ../dictionary_strings.rb:1567 ../dictionary_strings.rb:2009 ../dictionary_strings.rb:2011
+#: ../../app/presenters/menu/default_menu.rb:20 ../../app/presenters/menu/default_menu.rb:54 ../../app/presenters/menu/default_menu.rb:148 ../yaml_strings.rb:93 ../dictionary_strings.rb:1567 ../dictionary_strings.rb:2009 ../dictionary_strings.rb:2011
 msgid "Requests"
 msgstr ""
 
@@ -21794,6 +29674,10 @@ msgstr ""
 msgid "Required. Should have privileged access, such as root or administrator."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:392
+msgid "Reservation"
+msgstr ""
+
 #: ../model_attributes.rb:1946
 msgid "Reserve"
 msgstr ""
@@ -21806,7 +29690,8 @@ msgstr ""
 msgid "Reserve|Resource type"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:204 ../../app/helpers/application_helper/toolbar/host_center.rb:170 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:200 ../../app/helpers/application_helper/toolbar/x_edit_view.rb:20 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:258 ../../app/helpers/application_helper/toolbar/hosts_center.rb:193 ../../app/views/miq_request/_prov_options.html.haml:127 ../../app/views/miq_request/_prov_options.html.haml:153 ../../app/views/miq_task/_tasks_options.html.haml:150 ../../app/views/miq_task/_tasks_options.html.haml:175 ../../app/views/layouts/_x_edit_buttons.html.haml:161 ../../app/views/layouts/_form_buttons.html.haml:66 ../../app/views/layouts/_form_buttons.html.haml:73 ../../app/views/layouts/_form_buttons.html.haml:101 ../../app/views/layouts/_edit_buttons.html.haml:32 ../../app/views/layouts/_adv_search_footer.html.haml:73 ../../app/views/layouts/_edit_form_buttons.html.haml:97 ../../app/views/layouts/_edit_form_buttons.html.haml:113 ../../app/views/layouts/_edit_form_buttons.html.haml:122 ../../app/views/layouts/_edit_form_buttons.html.haml:164 ../../app/views/layouts/_x_dialog_buttons.html.haml:39 ../../app/views/layouts/_x_dialog_buttons.html.haml:68 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:25 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:51 ../../app/views/miq_capacity/planning.html.haml:19 ../../app/views/miq_capacity/planning.html.haml:36
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:204 ../../app/helpers/application_helper/toolbar/host_center.rb:170 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:200 ../../app/helpers/application_helper/toolbar/x_edit_view.rb:20 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:258 ../../app/helpers/application_helper/toolbar/hosts_center.rb:193 ../../app/views/miq_request/_prov_options.html.haml:127 ../../app/views/miq_request/_prov_options.html.haml:153 ../../app/views/miq_task/_tasks_options.html.haml:150 ../../app/views/miq_task/_tasks_options.html.haml:175 ../../app/views/layouts/_x_edit_buttons.html.haml:161 ../../app/views/layouts/_form_buttons.html.haml:66 ../../app/views/layouts/_form_buttons.html.haml:73 ../../app/views/layouts/_form_buttons.html.haml:101 ../../app/views/layouts/_edit_buttons.html.haml:32 ../../app/views/layouts/_adv_search_footer.html.haml:73 ../../app/views/layouts/_edit_form_buttons.html.haml:97 ../../app/views/layouts/_edit_form_buttons.html.haml:113 ../../app/views/layouts/_edit_form_buttons.html.haml:122 ../../app/views/layouts/_edit_form_buttons.html.haml:164 ../../app/views/layouts/_x_dialog_buttons.html.haml:39 ../../app/views/layouts/_x_dialog_buttons.html.haml:68 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:25 ../../app/views/miq_ae_tools/_resolve_form_buttons.html.haml:51 ../../app/views/miq_capacity/planning.html.haml:19 ../../app/views/miq_capacity/planning.html.haml:36 ../yaml_strings.rb:550
 msgid "Reset"
 msgstr ""
 
@@ -21822,8 +29707,29 @@ msgstr ""
 msgid "Reset Changes"
 msgstr ""
 
-#: ../../app/views/dashboard/_widgets_menu.html.haml:44
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:673
+msgid "Reset Dashboard Widgets"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/dashboard/_widgets_menu.html.haml:44 ../yaml_strings.rb:675
 msgid "Reset Dashboard Widgets to the defaults"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2075
+msgid "Reset Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2181
+msgid "Reset VM"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:552
+msgid "Reset a Host / Node"
 msgstr ""
 
 #: ../../app/views/miq_ae_tools/_import_export.html.haml:76
@@ -21878,7 +29784,7 @@ msgstr ""
 msgid "Reset to Default"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:280
+#: ../../app/controllers/ops_controller/diagnostics.rb:292
 msgid "Reset/synchronization process successfully initiated"
 msgstr ""
 
@@ -21890,20 +29796,27 @@ msgstr ""
 msgid "Resolve conflicts to import the file"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1701 ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42
+#: ../../app/controllers/vm_common.rb:1782 ../../app/helpers/container_project_helper/textual_summary.rb:21 ../../app/helpers/container_project_helper/textual_summary.rb:42
 msgid "Resource"
 msgid_plural "Resources"
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../yaml_strings.rb:3721
+msgid "Resource Category"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.ResourcePool
-#: ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:43 ../../app/views/shared/views/_prov_dialog.html.haml:114 ../dictionary_strings.rb:1671
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:203 ../../app/helpers/vm_helper/textual_summary.rb:272 ../../app/views/miq_request/_prov_vm_migrate_dialog.html.haml:43 ../../app/views/shared/views/_prov_dialog.html.haml:114 ../dictionary_strings.rb:1671
 msgid "Resource Pool"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ResourcePool (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.resource_pools
-#: ../../app/presenters/menu/default_menu.rb:49 ../../app/views/layouts/listnav/_host.html.haml:122 ../../app/views/layouts/listnav/_ems_cluster.html.haml:79 ../../app/views/configuration/_ui_2.html.haml:321 ../dictionary_strings.rb:1673 ../dictionary_strings.rb:2077
+#: ../../app/presenters/menu/default_menu.rb:49 ../../app/views/layouts/listnav/_host.html.haml:122 ../../app/views/layouts/listnav/_ems_cluster.html.haml:79 ../../app/views/configuration/_ui_2.html.haml:332 ../yaml_strings.rb:587 ../dictionary_strings.rb:1673 ../dictionary_strings.rb:2077
 msgid "Resource Pools"
 msgstr ""
 
@@ -21911,11 +29824,21 @@ msgstr ""
 msgid "Resource Quota"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../yaml_strings.rb:3723
+msgid "Resource Status"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../yaml_strings.rb:3725
+msgid "Resource Status Reason"
+msgstr ""
+
 #: ../model_attributes.rb:1949
 msgid "Resource action"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:373
+#: ../../app/controllers/catalog_controller.rb:334
 msgid "Resource must be selected"
 msgstr ""
 
@@ -22023,7 +29946,8 @@ msgstr ""
 msgid "ResourcePool|Vapp"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:70 ../../app/views/catalog/_form_resources_info.html.haml:8 ../../app/views/catalog/_form.html.haml:12 ../../app/views/catalog/_sandt_tree_show.html.haml:221
+#. TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:140 ../../app/helpers/vm_infra_helper/textual_summary.rb:168 ../../app/helpers/vm_helper/textual_summary.rb:202 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:70 ../../app/views/catalog/_form_resources_info.html.haml:8 ../../app/views/catalog/_form.html.haml:12 ../../app/views/catalog/_sandt_tree_show.html.haml:221 ../yaml_strings.rb:3715
 msgid "Resources"
 msgstr ""
 
@@ -22036,8 +29960,34 @@ msgstr ""
 msgid "Restart"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:175 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:171 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:217 ../../app/helpers/application_helper/tasks.rb:10
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:175 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:171 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:217 ../../app/helpers/application_helper/tasks.rb:10 ../yaml_strings.rb:2081
 msgid "Restart Guest"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:570
+msgid "Restart Host"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerGroup.yaml
+#: ../yaml_strings.rb:3375
+msgid "Restart Policy"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1352
+msgid "Restart Server"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1354
+msgid "Restart Worker"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:572
+msgid "Restart a Host / Node"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:87
@@ -22046,6 +29996,16 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/diagnostics_server_center.rb:80
 msgid "Restart server"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2083
+msgid "Restart the Guest OS on Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2185
+msgid "Restart the Guest OS on VMs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:216
@@ -22080,7 +30040,9 @@ msgstr ""
 msgid "Restart this item?"
 msgstr ""
 
-#: ../../app/views/layouts/_tl_options.html.haml:114
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+#: ../../app/views/layouts/_tl_options.html.haml:114 ../yaml_strings.rb:2595
 msgid "Result"
 msgstr ""
 
@@ -22104,7 +30066,27 @@ msgstr ""
 msgid "Resume this Instance?"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:1186
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2049
+msgid "Retire Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1634
+msgid "Retire Orchestration Stack"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:267
+msgid "Retire Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2171
+msgid "Retire VMs"
+msgstr ""
+
+#: ../../app/controllers/application_controller/ci_processing.rb:1200
 msgid "Retire does not apply to selected %{model}"
 msgstr ""
 
@@ -22156,11 +30138,16 @@ msgstr ""
 msgid "Retire this VM?"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:886 ../../app/helpers/application_helper/tasks.rb:12 ../../app/views/catalog/_sandt_tree_show.html.haml:108
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../yaml_strings.rb:3683
+msgid "Retired"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:881 ../../app/helpers/application_helper/tasks.rb:12 ../../app/views/catalog/_sandt_tree_show.html.haml:108
 msgid "Retirement"
 msgstr ""
 
-#: ../../app/views/shared/views/_retire.html.haml:18
+#: ../../app/helpers/service_helper/textual_summary.rb:76 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:47 ../../app/helpers/vm_helper/textual_summary.rb:222 ../../app/views/shared/views/_retire.html.haml:18
 msgid "Retirement Date"
 msgstr ""
 
@@ -22170,6 +30157,10 @@ msgstr ""
 
 #: ../../app/views/catalog/_form_basic_info.html.haml:231
 msgid "Retirement Entry Point (NameSpace/Class/Instance)"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:82
+msgid "Retirement State"
 msgstr ""
 
 #: ../../app/views/shared/views/_retire.html.haml:44
@@ -22200,12 +30191,27 @@ msgstr ""
 msgid "Retry state machine simulation, with preserved attributes"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:266 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:259 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:142 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:146
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:266 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:259 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:142 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:146 ../yaml_strings.rb:2251
 msgid "Revert to selected snapshot"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1796
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2309
+msgid "Revert to selected snapshot on Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2253
+msgid "Revert to selected snapshot on VMs"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1877
 msgid "Right Size Recommendation for %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:885
+msgid "Right Size VM '%{name}''"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_center.rb:57 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:55 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:44 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:77 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:68
@@ -22214,6 +30220,11 @@ msgstr ""
 
 #: ../../app/controllers/application_controller/ci_processing.rb:331
 msgid "Right-Size Recommendations does not apply to selected %{model}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2221
+msgid "Right-Size VMs"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:321
@@ -22228,8 +30239,11 @@ msgstr ""
 msgid "Right-Sizing (Moderate - derived from High NORM)"
 msgstr ""
 
+#. TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#. TRANSLATORS: file: product/views/User.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole
-#: ../../app/views/ops/_selected_by_servers.html.haml:168 ../../app/views/ops/_selected_by_roles.html.haml:7 ../../app/views/ops/_rbac_user_details.html.haml:200 ../../app/views/ops/_rbac_group_details.html.haml:54 ../dictionary_strings.rb:1589
+#: ../../app/views/ops/_selected_by_servers.html.haml:168 ../../app/views/ops/_selected_by_roles.html.haml:7 ../../app/views/ops/_rbac_user_details.html.haml:200 ../../app/views/ops/_rbac_group_details.html.haml:54 ../yaml_strings.rb:2417 ../dictionary_strings.rb:1589
 msgid "Role"
 msgstr ""
 
@@ -22245,8 +30259,13 @@ msgstr ""
 msgid "Role no longer exists"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/diagnostics.rb:1045
+msgid "Role: %{description} (%{status})"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqUserRole (plural form)
-#: ../dictionary_strings.rb:1591
+#: ../../app/presenters/tree_builder_ops_rbac.rb:30 ../../app/controllers/ops_controller.rb:702 ../../app/controllers/ops_controller.rb:717 ../yaml_strings.rb:1289 ../dictionary_strings.rb:1591
 msgid "Roles"
 msgstr ""
 
@@ -22266,16 +30285,22 @@ msgstr ""
 msgid "Roll Up Performance"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:548 ../yaml_strings.rb:3624
+msgid "Root Device Type"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute
 #. TRANSLATORS: en.yml key: dictionary.table.container_route
 #: ../dictionary_strings.rb:1323 ../dictionary_strings.rb:1815
 msgid "Route"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerRoute (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_route (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_routes
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:67 ../dictionary_strings.rb:1325 ../dictionary_strings.rb:1817 ../dictionary_strings.rb:1819
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:67 ../yaml_strings.rb:1903 ../dictionary_strings.rb:1325 ../dictionary_strings.rb:1817 ../dictionary_strings.rb:1819
 msgid "Routes"
 msgstr ""
 
@@ -22283,7 +30308,9 @@ msgstr ""
 msgid "Row Count"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:43 ../../app/views/ops/_db_info.html.haml:136 ../../app/views/ops/_db_info.html.haml:215
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+#: ../../app/helpers/ops_helper/textual_summary.rb:101 ../../app/views/ops/_db_info.html.haml:43 ../../app/views/ops/_db_info.html.haml:136 ../../app/views/ops/_db_info.html.haml:215 ../yaml_strings.rb:2872
 msgid "Rows"
 msgstr ""
 
@@ -22331,12 +30358,29 @@ msgstr ""
 msgid "Run"
 msgstr ""
 
-#: ../../app/views/ops/_schedule_show.html.haml:84 ../../app/views/report/_widget_show.html.haml:295 ../../app/views/report/_show_schedule.html.haml:82
+#: ../../app/helpers/container_helper/textual_summary.rb:114
+msgid "Run As Non Root"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:89
+msgid "Run As User"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#: ../../app/views/ops/_schedule_show.html.haml:84 ../../app/views/report/_widget_show.html.haml:295 ../../app/views/report/_show_schedule.html.haml:82 ../yaml_strings.rb:2831
 msgid "Run At"
 msgstr ""
 
 #: ../../app/views/ops/_diagnostics_database_tab.html.haml:197 ../../app/views/ops/_diagnostics_database_tab.html.haml:216
 msgid "Run Database Garbage Collection Now"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:730
+msgid "Run Now"
 msgstr ""
 
 #: ../../app/views/chargeback/_reports_list.html.haml:56
@@ -22351,27 +30395,66 @@ msgstr ""
 msgid "Run a Database backup now"
 msgstr ""
 
-#: ../../app/views/miq_task/_tasks_options.html.haml:96
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:709
+msgid "Run a selected Report"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#: ../../app/views/miq_task/_tasks_options.html.haml:96 ../yaml_strings.rb:3767
 msgid "Running"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:72 ../../app/helpers/ems_cluster_helper/textual_summary.rb:49
-msgid "Running (%s)"
+#: ../../app/helpers/host_helper/textual_summary.rb:73 ../../app/helpers/ems_cluster_helper/textual_summary.rb:50
+msgid "Running (%{number})"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1697
+#: ../../app/controllers/vm_common.rb:1778
 msgid "Running Process"
 msgid_plural "Running Processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../app/controllers/host_controller.rb:182
-msgid "Running system services of %s"
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:425 ../../app/helpers/vm_infra_helper/textual_summary.rb:516 ../../app/helpers/vm_helper/textual_summary.rb:613
+msgid "Running Processes"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:212
+msgid "Running system services of %{name}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ContainerNode.yaml
+#: ../yaml_strings.rb:3765
+msgid "Runtime Version"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.miq_scsi_luns
 #: ../dictionary_strings.rb:2015
 msgid "SCSI LUNs"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:748
+msgid "SCSI Target %{target}"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:750
+msgid "SCSI Target %{target} (%{name})"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:110
+msgid "SELinux Level"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:100
+msgid "SELinux Role"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:105
+msgid "SELinux Type"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:95
+msgid "SELinux User"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.MiqSmisAgent
@@ -22388,8 +30471,19 @@ msgstr ""
 msgid "SMTP E-mail Server settings and Test E-mail Address are needed to send test email"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1460
+msgid "SNIA File Shares"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1480
+msgid "SNIA Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.notify_snmp
-#: ../dictionary_strings.rb:653
+#: ../yaml_strings.rb:3705 ../dictionary_strings.rb:653
 msgid "SNMP"
 msgstr ""
 
@@ -22405,9 +30499,23 @@ msgstr ""
 msgid "SPICE Console"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3536
+msgid "SPID"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:441
+msgid "SSH Root"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.ssh_permit_root_login
 #: ../dictionary_strings.rb:947
 msgid "SSH Root Access"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:533
+msgid "SSH keypair"
 msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:454
@@ -22472,32 +30580,56 @@ msgstr ""
 msgid "Save..."
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:61
+#: ../../app/controllers/chargeback_controller.rb:386
+msgid "Saved Chargeback Report [%{name}]"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:106
 msgid "Saved Chargeback Reports"
 msgstr ""
 
-#: ../../app/controllers/report_controller/saved_reports.rb:32
-msgid "Saved Report \"%s\" not found, Schedule may have failed"
+#: ../../app/controllers/report_controller/saved_reports.rb:23
+msgid "Saved Report \"%{name}\""
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:398
+#: ../../app/controllers/chargeback_controller.rb:397
 msgid "Saved Report \"%{name}\" not found, Schedule may have failed"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:281 ../../app/views/report/_report_list.html.haml:219
+#: ../../app/controllers/report_controller/saved_reports.rb:33
+msgid "Saved Report \"%{time}\" not found, Schedule may have failed"
+msgstr ""
+
+#: ../../app/controllers/report_controller/saved_reports.rb:96
+msgid "Saved Report no longer exists"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/report_controller.rb:277 ../../app/views/report/_report_list.html.haml:219 ../yaml_strings.rb:681
 msgid "Saved Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:683
+msgid "Saved Reports Accordion"
 msgstr ""
 
 #: ../../app/views/vm_common/_right_size.html.haml:170 ../../app/views/vm_common/_right_size.html.haml:254 ../../app/views/vm_common/_right_size.html.haml:337
 msgid "Savings"
 msgstr ""
 
-#: ../../app/views/ems_infra/scaling.html.haml:59
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ems_infra/scaling.html.haml:59 ../yaml_strings.rb:453
 msgid "Scale"
 msgstr ""
 
 #: ../../app/controllers/ems_infra_controller.rb:29 ../../app/views/ems_infra/scaling.html.haml:59
 msgid "Scale Infrastructure Provider"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:455
+msgid "Scale an Infrastructure Provider"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:30
@@ -22508,7 +30640,7 @@ msgstr ""
 msgid "Scaling"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1703
+#: ../../app/controllers/vm_common.rb:1784
 msgid "Scan History"
 msgid_plural "Scan History"
 msgstr[0] ""
@@ -22562,6 +30694,11 @@ msgstr ""
 
 #: ../model_attributes.rb:1991
 msgid "ScanHistory|Updated on"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ScanItemSet.yaml
+#: ../yaml_strings.rb:3620
+msgid "ScanItemSet"
 msgstr ""
 
 #: ../model_attributes.rb:2005
@@ -22652,8 +30789,13 @@ msgstr ""
 msgid "ScanItem|Updated on"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:409
+msgid "Scanning"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule
-#: ../dictionary_strings.rb:1569
+#: ../yaml_strings.rb:3215 ../dictionary_strings.rb:1569
 msgid "Schedule"
 msgstr ""
 
@@ -22661,17 +30803,24 @@ msgstr ""
 msgid "Schedule Info"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqSchedule (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.miq_schedules
-#: ../../app/controllers/report_controller.rb:291 ../../app/views/ops/_settings_evm_servers_tab.html.haml:148 ../../app/views/ops/_settings_details_tab.html.haml:95 ../../app/views/report/_report_info.html.haml:109 ../dictionary_strings.rb:1571 ../dictionary_strings.rb:2013
+#: ../../app/presenters/tree_builder_ops_settings.rb:28 ../../app/controllers/report_controller.rb:287 ../../app/views/ops/_settings_evm_servers_tab.html.haml:148 ../../app/views/ops/_settings_details_tab.html.haml:95 ../../app/views/report/_report_info.html.haml:109 ../yaml_strings.rb:722 ../dictionary_strings.rb:1571 ../dictionary_strings.rb:2013
 msgid "Schedules"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:724
+msgid "Schedules Accordion"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_all_tabs.html.haml:17 ../../app/views/miq_ae_class/_class_fields.html.haml:8 ../../app/views/miq_ae_class/_class_fields.html.haml:87
 msgid "Schema"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1064
+#: ../../app/controllers/miq_ae_class_controller.rb:1058
 msgid "Schema for %{model} \"%{name}\" was saved"
 msgstr ""
 
@@ -22712,7 +30861,7 @@ msgstr ""
 msgid "Search Expression Preview"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:598
+#: ../../app/controllers/application_controller/filter.rb:600
 msgid "Search Name is required"
 msgstr ""
 
@@ -22761,7 +30910,14 @@ msgstr ""
 msgid "Security"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:28 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:46
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
+#: ../yaml_strings.rb:3267
+msgid "Security Group"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#: ../../app/presenters/menu/default_menu.rb:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:28 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:46 ../yaml_strings.rb:393
 msgid "Security Groups"
 msgstr ""
 
@@ -22771,6 +30927,11 @@ msgstr ""
 
 #: ../model_attributes.rb:2016
 msgid "Security group"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SecurityGroup.yaml
+#: ../yaml_strings.rb:3269
+msgid "SecurityGroup"
 msgstr ""
 
 #: ../model_attributes.rb:2017
@@ -22823,6 +30984,10 @@ msgstr ""
 
 #: ../../app/views/vm_common/_evm_relationship.html.haml:17
 msgid "Select Server:"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:355
+msgid "Select Start date and End date to Collect C & U Data"
 msgstr ""
 
 #: ../../app/views/miq_request/_prov_host_dialog.html.haml:26 ../../app/views/miq_request/_prov_configured_system_foreman_dialog.html.haml:26 ../../app/views/shared/views/_prov_dialog.html.haml:28
@@ -23025,7 +31190,7 @@ msgstr ""
 msgid "Select an Owner:"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1498
+#: ../../app/controllers/application_controller/filter.rb:1389
 msgid "Select an expression element type"
 msgstr ""
 
@@ -23061,51 +31226,35 @@ msgstr ""
 msgid "Select one or more items to delete"
 msgstr ""
 
-#: ../../app/controllers/report_controller/dashboards.rb:471 ../../app/controllers/report_controller/menus.rb:509 ../../app/controllers/report_controller/menus.rb:553 ../../app/controllers/report_controller/reports/editor.rb:1016
-msgid "Select only one or consecutive %s to move down"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports/editor.rb:1062
-msgid "Select only one or consecutive %s to move to the bottom"
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports/editor.rb:1040
-msgid "Select only one or consecutive %s to move to the top"
-msgstr ""
-
-#: ../../app/controllers/report_controller/dashboards.rb:447 ../../app/controllers/report_controller/menus.rb:488 ../../app/controllers/report_controller/menus.rb:532 ../../app/controllers/report_controller/reports/editor.rb:994
-msgid "Select only one or consecutive %s to move up"
-msgstr ""
-
-#: ../../app/controllers/miq_policy_controller.rb:870
+#: ../../app/controllers/miq_policy_controller.rb:872
 msgid "Select only one or consecutive %{member} to move down"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:853
+#: ../../app/controllers/miq_policy_controller.rb:855
 msgid "Select only one or consecutive %{member} to move up"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2355
+#: ../../app/controllers/miq_ae_class_controller.rb:2357
 msgid "Select only one or consecutive %{name} to move down"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2334
+#: ../../app/controllers/miq_ae_class_controller.rb:2336
 msgid "Select only one or consecutive %{name} to move up"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:488 ../../app/controllers/application_controller/buttons.rb:1056
+#: ../../app/controllers/report_controller/dashboards.rb:471 ../../app/controllers/report_controller/menus.rb:510 ../../app/controllers/report_controller/menus.rb:554 ../../app/controllers/report_controller/reports/editor.rb:1017 ../../app/controllers/ops_controller/ops_rbac.rb:488 ../../app/controllers/application_controller/buttons.rb:1056
 msgid "Select only one or consecutive fields to move down"
 msgstr ""
 
-#: ../../app/controllers/application_controller/buttons.rb:724
+#: ../../app/controllers/report_controller/reports/editor.rb:1063 ../../app/controllers/application_controller/buttons.rb:724
 msgid "Select only one or consecutive fields to move to the bottom"
 msgstr ""
 
-#: ../../app/controllers/application_controller/buttons.rb:703
+#: ../../app/controllers/report_controller/reports/editor.rb:1041 ../../app/controllers/application_controller/buttons.rb:703
 msgid "Select only one or consecutive fields to move to the top"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/ops_rbac.rb:466 ../../app/controllers/application_controller/buttons.rb:1035
+#: ../../app/controllers/report_controller/dashboards.rb:447 ../../app/controllers/report_controller/menus.rb:489 ../../app/controllers/report_controller/menus.rb:533 ../../app/controllers/report_controller/reports/editor.rb:995 ../../app/controllers/ops_controller/ops_rbac.rb:466 ../../app/controllers/application_controller/buttons.rb:1035
 msgid "Select only one or consecutive fields to move up"
 msgstr ""
 
@@ -23125,11 +31274,15 @@ msgstr ""
 msgid "Selected"
 msgstr ""
 
-#: ../../app/controllers/application_controller.rb:2474
+#: ../../app/controllers/application_controller.rb:2473
 msgid "Selected %{model_name} no longer exists"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:490
+#: ../../app/helpers/ui_constants.rb:444 ../../app/helpers/ui_constants.rb:448 ../../app/helpers/ui_constants.rb:452 ../../app/helpers/ui_constants.rb:456 ../../app/helpers/ui_constants.rb:457 ../../app/helpers/ui_constants.rb:463 ../../app/helpers/ui_constants.rb:467 ../../app/helpers/ui_constants.rb:474 ../../app/helpers/ui_constants.rb:475
+msgid "Selected %{tables}"
+msgstr ""
+
+#: ../../app/controllers/chargeback_controller.rb:489
 msgid "Selected Chargeback Report no longer exists"
 msgstr ""
 
@@ -23137,7 +31290,7 @@ msgstr ""
 msgid "Selected Day"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:72
+#: ../../app/views/report/_column_lists.html.haml:69
 msgid "Selected Fields:"
 msgstr ""
 
@@ -23153,7 +31306,7 @@ msgstr ""
 msgid "Selected Resources"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:475
+#: ../../app/controllers/chargeback_controller.rb:474
 msgid "Selected Saved Chargeback Report no longer exists"
 msgstr ""
 
@@ -23217,13 +31370,24 @@ msgstr ""
 msgid "Send&#160;Ctrl-Alt-Delete"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqGroup.yaml
+#: ../yaml_strings.rb:3918
+msgid "Sequence"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.MiqServer
 #. TRANSLATORS: en.yml key: dictionary.table.miq_server
-#: ../../app/views/ops/_all_tabs.html.haml:24 ../dictionary_strings.rb:1577 ../dictionary_strings.rb:2017
+#: ../../app/views/ops/_all_tabs.html.haml:24 ../yaml_strings.rb:3574 ../dictionary_strings.rb:1577 ../dictionary_strings.rb:2017
 msgid "Server"
 msgstr ""
 
-#: ../../app/views/ops/rhn/_info_subscribed.html.haml:29
+#: ../../app/controllers/ops_controller/diagnostics.rb:32
+msgid "Server '%{name}' restarted"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:209 ../../app/views/ops/rhn/_info_subscribed.html.haml:29
 msgid "Server Address"
 msgstr ""
 
@@ -23235,7 +31399,8 @@ msgstr ""
 msgid "Server License"
 msgstr ""
 
-#: ../../app/views/support/show.html.haml:17
+#. TRANSLATORS: file: product/views/MiddlewareServer.yaml
+#: ../../app/views/support/show.html.haml:17 ../yaml_strings.rb:3632
 msgid "Server Name"
 msgstr ""
 
@@ -23298,11 +31463,17 @@ msgstr ""
 msgid "Servers by Roles"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Service.yaml
+#. TRANSLATORS: file: product/views/Vsc.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerService
 #. TRANSLATORS: en.yml key: dictionary.model.Service
 #. TRANSLATORS: en.yml key: dictionary.table.container_service
-#: ../../app/views/ops/rhn/_info_subscribed.html.haml:13 ../../app/views/vm_common/_add_to_service.html.haml:29 ../dictionary_strings.rb:1331 ../dictionary_strings.rb:1683 ../dictionary_strings.rb:1809 ../model_attributes.rb:2029
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:241 ../../app/helpers/vm_infra_helper/textual_summary.rb:236 ../../app/helpers/vm_helper/textual_summary.rb:329 ../../app/views/ops/rhn/_info_subscribed.html.haml:13 ../../app/views/vm_common/_add_to_service.html.haml:29 ../yaml_strings.rb:2865 ../dictionary_strings.rb:1331 ../dictionary_strings.rb:1683 ../dictionary_strings.rb:1809 ../model_attributes.rb:2029
 msgid "Service"
+msgstr ""
+
+#: ../../app/controllers/service_controller.rb:148
+msgid "Service \"%{name}\" was saved"
 msgstr ""
 
 #: ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:27
@@ -23323,20 +31494,30 @@ msgstr ""
 msgid "Service Catalog Items"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:49
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/catalog_controller.rb:830 ../../app/views/configuration/_ui_2.html.haml:49 ../yaml_strings.rb:177
 msgid "Service Catalogs"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1153
+#: ../../app/controllers/catalog_controller.rb:1148
 msgid "Service Dialog \"%{name}\" was successfully created"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:73
+#: ../../app/presenters/tree_builder.rb:122
 msgid "Service Dialog Import/Export"
 msgstr ""
 
 #: ../../app/views/catalog/_service_dialog_from_ot.html.haml:14 ../../app/assets/javascripts/dialog_import_export.js:20
 msgid "Service Dialog Name"
+msgstr ""
+
+#: ../../app/controllers/miq_ae_customization_controller.rb:200
+msgid "Service Dialogs"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../yaml_strings.rb:3845
+msgid "Service Pack"
 msgstr ""
 
 #: ../../app/views/vm_common/_add_to_service.html.haml:22
@@ -23348,8 +31529,11 @@ msgstr ""
 msgid "Service Time (Seconds)"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.svc_type
-#: ../dictionary_strings.rb:951
+#: ../yaml_strings.rb:3133 ../dictionary_strings.rb:951
 msgid "Service Type"
 msgstr ""
 
@@ -23461,12 +31645,16 @@ msgstr ""
 msgid "ServiceTemplate|Service type"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Service.yaml
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#. TRANSLATORS: file: product/views/Vsc.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ContainerService (plural form)
 #. TRANSLATORS: en.yml key: dictionary.model.Service (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_service (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.container_services
 #. TRANSLATORS: en.yml key: dictionary.table.host_services
-#: ../../app/presenters/menu/default_menu.rb:16 ../../app/controllers/host_controller.rb:175 ../../app/views/layouts/listnav/_host.html.haml:226 ../../app/views/configuration/_ui_2.html.haml:46 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:51 ../dictionary_strings.rb:1333 ../dictionary_strings.rb:1685 ../dictionary_strings.rb:1811 ../dictionary_strings.rb:1813 ../dictionary_strings.rb:1931
+#: ../../app/presenters/menu/default_menu.rb:16 ../../app/controllers/service_controller.rb:195 ../../app/controllers/host_controller.rb:205 ../../app/helpers/ui_constants.rb:431 ../../app/helpers/host_helper/textual_summary.rb:469 ../../app/views/layouts/listnav/_host.html.haml:226 ../../app/views/configuration/_ui_2.html.haml:46 ../../app/assets/javascripts/controllers/container_dashboard/util/dashboard-utils-factory.js:51 ../yaml_strings.rb:1879 ../dictionary_strings.rb:1333 ../dictionary_strings.rb:1685 ../dictionary_strings.rb:1811 ../dictionary_strings.rb:1813 ../dictionary_strings.rb:1931
 msgid "Services"
 msgstr ""
 
@@ -23514,6 +31702,11 @@ msgstr ""
 msgid "Service|Retires on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#: ../yaml_strings.rb:3583
+msgid "Session Affinity"
+msgstr ""
+
 #: ../../app/views/support/show.html.haml:13
 msgid "Session Information"
 msgstr ""
@@ -23522,7 +31715,7 @@ msgstr ""
 msgid "Session Timeout"
 msgstr ""
 
-#: ../../app/controllers/dashboard_controller.rb:427
+#: ../../app/controllers/dashboard_controller.rb:411
 msgid "Session was timed out due to inactivity. Please log in again."
 msgstr ""
 
@@ -23530,12 +31723,17 @@ msgstr ""
 msgid "Set Custom Attribute Settings"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:38 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:37 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:31 ../../app/helpers/application_helper/toolbar/services_center.rb:33 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:31 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:41 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:50 ../../app/helpers/application_helper/toolbar/vms_center.rb:41 ../../app/helpers/application_helper/toolbar/service_center.rb:27 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:59 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:50 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:50 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:32
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:38 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:37 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:31 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:31 ../../app/helpers/application_helper/toolbar/services_center.rb:33 ../../app/helpers/application_helper/toolbar/x_template_cloud_center.rb:31 ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:41 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:50 ../../app/helpers/application_helper/toolbar/vms_center.rb:41 ../../app/helpers/application_helper/toolbar/service_center.rb:27 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:59 ../../app/helpers/application_helper/toolbar/template_clouds_center.rb:50 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:50 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:32 ../yaml_strings.rb:251
 msgid "Set Ownership"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1765 ../../app/controllers/service_controller.rb:267
-msgid "Set Ownership for %s"
+#: ../../app/controllers/service_controller.rb:262
+msgid "Set Ownership for %{model}"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1846
+msgid "Set Ownership for %{table}"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/services_center.rb:32
@@ -23570,16 +31768,52 @@ msgstr ""
 msgid "Set Ownership for this VM"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2129
+msgid "Set Ownership of Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2051
+msgid "Set Ownership of Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2281
+msgid "Set Ownership of Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:253
+msgid "Set Ownership of VMs"
+msgstr ""
+
 #: ../../app/controllers/application_controller/ci_processing.rb:117
 msgid "Set Ownership was cancelled by the user"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:123 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:45 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:121 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:90 ../../app/helpers/application_helper/toolbar/service_center.rb:64
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:123 ../../app/helpers/application_helper/toolbar/orchestration_stack_center.rb:45 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:121 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:90 ../../app/helpers/application_helper/toolbar/service_center.rb:64 ../yaml_strings.rb:263
 msgid "Set Retirement Date"
 msgstr ""
 
 #: ../../app/controllers/application_controller/ci_processing.rb:189
 msgid "Set Retirement Date does not apply to selected %{model}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2047
+msgid "Set Retirement Date for Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:265
+msgid "Set Retirement Date for Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2169
+msgid "Set Retirement Date for VMs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/services_center.rb:73 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:178 ../../app/helpers/application_helper/toolbar/orchestration_stacks_center.rb:54 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:129
@@ -23634,11 +31868,15 @@ msgstr ""
 msgid "Set/Remove Retirement Date"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1792 ../../app/controllers/service_controller.rb:271
-msgid "Set/Remove retirement date for %s"
+#: ../../app/controllers/service_controller.rb:266
+msgid "Set/Remove retirement date for %{model}"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:724 ../../app/controllers/ops_controller/diagnostics.rb:742
+#: ../../app/controllers/vm_common.rb:1873
+msgid "Set/Remove retirement date for %{table}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:744 ../../app/controllers/ops_controller/diagnostics.rb:762
 msgid "Setting priority is not allowed for the selected item"
 msgstr ""
 
@@ -23646,7 +31884,8 @@ msgstr ""
 msgid "Setting tracing to true may cause excessive log lines to be written"
 msgstr ""
 
-#: ../../app/views/ops/_zone_form.html.haml:185 ../../app/views/ops/_all_tabs.html.haml:292
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/ops_controller.rb:210 ../../app/views/ops/_zone_form.html.haml:185 ../../app/views/ops/_all_tabs.html.haml:292 ../yaml_strings.rb:1207
 msgid "Settings"
 msgstr ""
 
@@ -23662,12 +31901,42 @@ msgstr ""
 msgid "Settings %{model} \"%{name}\" (current)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:161 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:198
+#: ../../app/controllers/ops_controller.rb:466
+msgid "Settings %{text}"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1209
+msgid "Settings Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#: ../yaml_strings.rb:2573
+msgid "Severity"
+msgstr ""
+
+#: ../../app/helpers/ontap_file_share_helper/textual_summary.rb:51
+msgid "Sharing Directory"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:161 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:198 ../yaml_strings.rb:2067
 msgid "Shelve"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:168 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:208
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2069
+msgid "Shelve Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:168 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:208 ../yaml_strings.rb:2071
 msgid "Shelve Offload"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2073
+msgid "Shelve Offload Instance"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:207
@@ -23702,11 +31971,16 @@ msgstr ""
 msgid "Shelve this Instance?"
 msgstr ""
 
+#: ../../app/controllers/report_controller/widgets.rb:741
+msgid "Shortcut description is required"
+msgstr ""
+
 #: ../../app/views/report/_widget_show.html.haml:227
 msgid "Shortcuts"
 msgstr ""
 
-#: ../../app/views/layouts/_tl_options.html.haml:18 ../../app/views/layouts/_tl_options.html.haml:87 ../../app/views/layouts/_perf_options.html.haml:38 ../../app/views/layouts/_perf_options.html.haml:79 ../../app/views/layouts/_role_visibility.html.haml:17 ../../app/views/report/_widget_show.html.haml:337 ../../app/views/shared/buttons/_ab_show.html.haml:206 ../../app/views/miq_capacity/_planning_options.html.haml:261 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:58
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/layouts/_tl_options.html.haml:18 ../../app/views/layouts/_tl_options.html.haml:87 ../../app/views/layouts/_perf_options.html.haml:38 ../../app/views/layouts/_perf_options.html.haml:79 ../../app/views/layouts/_role_visibility.html.haml:17 ../../app/views/report/_widget_show.html.haml:337 ../../app/views/shared/buttons/_ab_show.html.haml:206 ../../app/views/miq_capacity/_planning_options.html.haml:261 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:58 ../yaml_strings.rb:105
 msgid "Show"
 msgstr ""
 
@@ -23758,11 +32032,43 @@ msgstr ""
 msgid "Show %{host} drift history"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:69
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:71
+msgid "Show %{label}"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:191 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:213 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:63 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:76 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:88
+msgid "Show %{label} '%{name}'"
+msgstr ""
+
+#: ../../app/helpers/textual_summary_helper.rb:88
+msgid "Show %{label} '%{value}'"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:975
+msgid "Show %{name}"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:71
 msgid "Show %{plural_linked_name}"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:73 ../../app/views/layouts/listnav/_container_group.html.haml:23 ../../app/views/layouts/listnav/_storage.html.haml:18 ../../app/views/layouts/listnav/_ems_container.html.haml:23 ../../app/views/layouts/listnav/_ems_cluster.html.haml:26 ../../app/views/layouts/listnav/_container_replicator.html.haml:23 ../../app/views/layouts/listnav/_container_node.html.haml:23 ../../app/views/layouts/listnav/_container_service.html.haml:23 ../../app/views/layouts/listnav/_container_project.html.haml:23
+#: ../../app/helpers/host_helper/textual_summary.rb:207 ../../app/helpers/host_helper/textual_summary.rb:504
+msgid "Show %{title} Network"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:196
+msgid "Show %{title} Storage Adapters"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:218
+msgid "Show %{title} devices"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:194
+msgid "Show %{title} drift history"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_host.html.haml:73 ../../app/views/layouts/listnav/_container_group.html.haml:19 ../../app/views/layouts/listnav/_storage.html.haml:18 ../../app/views/layouts/listnav/_ems_container.html.haml:19 ../../app/views/layouts/listnav/_ems_cluster.html.haml:26 ../../app/views/layouts/listnav/_container_replicator.html.haml:19 ../../app/views/layouts/listnav/_container_node.html.haml:19 ../../app/views/layouts/listnav/_container_service.html.haml:19 ../../app/views/layouts/listnav/_container_project.html.haml:19
 msgid "Show Capacity & Utilization"
 msgstr ""
 
@@ -23822,8 +32128,124 @@ msgstr ""
 msgid "Show Capacity & Utilization data for this item"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:324
+msgid "Show Capacity & Utilization data of Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:483
+msgid "Show Capacity & Utilization data of Clusters / Deployment Roles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1963
+msgid "Show Capacity & Utilization data of Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:622
+msgid "Show Capacity & Utilization data of Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:520
+msgid "Show Capacity & Utilization data of Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2117
+msgid "Show Capacity & Utilization data of Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2033
+msgid "Show Capacity & Utilization data of Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1432
+msgid "Show Capacity & Utilization data of Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1702
+msgid "Show Capacity & Utilization data of Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1777
+msgid "Show Capacity & Utilization data of Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1753
+msgid "Show Capacity & Utilization data of Pods"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1925
+msgid "Show Capacity & Utilization data of Project"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1648
+msgid "Show Capacity & Utilization data of Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1804
+msgid "Show Capacity & Utilization data of Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1889
+msgid "Show Capacity & Utilization data of Service"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2269
+msgid "Show Capacity & Utilization data of Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:342
+msgid "Show Capacity & Utilization data of Tenants"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2155
+msgid "Show Capacity & Utilization data of VMs"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:398
+msgid "Show Compliance History of this %{title} (Last 10 Checks)"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:500 ../../app/helpers/vm_infra_helper/textual_summary.rb:638 ../../app/helpers/vm_helper/textual_summary.rb:757
+msgid "Show Compliance History of this VM (Last 10 Checks)"
+msgstr ""
+
 #: ../../app/views/report/_form_filter_chargeback.html.haml:16 ../../app/views/report/_form_filter_chargeback.html.haml:149
 msgid "Show Costs by"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:243
+msgid "Show Costs by must be selected"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:385
+msgid "Show Details of Compliance Check on %{date}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:444
+msgid "Show Event Log on this VM"
+msgid_plural "Show Event Logs on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:534 ../../app/helpers/vm_helper/textual_summary.rb:631
+msgid "Show Event Logs on this VM"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_bottlenecks_options.html.haml:38
@@ -23834,12 +32256,32 @@ msgstr ""
 msgid "Show Input Parameters"
 msgstr ""
 
+#: ../../app/helpers/storage_helper/textual_summary.rb:251
+msgid "Show Non-VM Files installed on this %{storage}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:114 ../../app/helpers/host_helper/textual_summary.rb:175 ../../app/helpers/vm_infra_helper/textual_summary.rb:134 ../../app/helpers/vm_helper/textual_summary.rb:168
+msgid "Show OS container information"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:235
+msgid "Show Other VM Files installed on this %{storage}"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_storage.html.haml:118
 msgid "Show Other VM files on this %s"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_resource_pool.html.haml:33
 msgid "Show Parent %{host}"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:69
+msgid "Show Parent %{title} %{name}"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:81
+msgid "Show Parent %{title} '%{name}'"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:366
@@ -23854,15 +32296,25 @@ msgstr ""
 msgid "Show Resource Pools"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:432
+msgid "Show Running Process on this VM"
+msgid_plural "Show Running Processes on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:523 ../../app/helpers/vm_helper/textual_summary.rb:620
+msgid "Show Running Processes on this VM"
+msgstr ""
+
 #: ../../app/views/report/_form_sort.html.haml:73
 msgid "Show Sort Breaks"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:16 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:16 ../../app/views/layouts/listnav/_container_group.html.haml:16 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_middleware_server.html.haml:16 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:16 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:16 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:16 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_persistent_volume.html.haml:16 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:16 ../../app/views/layouts/listnav/_container_node.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_ems_middleware.html.haml:16 ../../app/views/layouts/listnav/_ems_cloud.html.haml:16 ../../app/views/layouts/listnav/_availability_zone.html.haml:16 ../../app/views/layouts/listnav/_security_group.html.haml:16 ../../app/views/layouts/listnav/_container_route.html.haml:16 ../../app/views/layouts/listnav/_container_service.html.haml:16 ../../app/views/layouts/listnav/_container_project.html.haml:16 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:12 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:12 ../../app/views/layouts/listnav/_container_group.html.haml:12 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:12 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_middleware_server.html.haml:12 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:12 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:16 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:12 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:12 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_persistent_volume.html.haml:12 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:12 ../../app/views/layouts/listnav/_container_node.html.haml:12 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_ems_middleware.html.haml:12 ../../app/views/layouts/listnav/_ems_cloud.html.haml:12 ../../app/views/layouts/listnav/_availability_zone.html.haml:12 ../../app/views/layouts/listnav/_security_group.html.haml:12 ../../app/views/layouts/listnav/_container_route.html.haml:12 ../../app/views/layouts/listnav/_container_service.html.haml:12 ../../app/views/layouts/listnav/_container_project.html.haml:12 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12
 msgid "Show Summary"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:38 ../../app/views/layouts/listnav/_ems_container.html.haml:38 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:38 ../../app/views/layouts/listnav/_container_node.html.haml:38 ../../app/views/layouts/listnav/_ems_cloud.html.haml:18 ../../app/views/layouts/listnav/_container_project.html.haml:38
+#: ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:34 ../../app/views/layouts/listnav/_ems_container.html.haml:34 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:34 ../../app/views/layouts/listnav/_container_node.html.haml:34 ../../app/views/layouts/listnav/_ems_cloud.html.haml:14 ../../app/views/layouts/listnav/_container_project.html.haml:34
 msgid "Show Timelines"
 msgstr ""
 
@@ -23942,8 +32394,20 @@ msgstr ""
 msgid "Show VM"
 msgstr ""
 
+#: ../../app/helpers/storage_helper/textual_summary.rb:219
+msgid "Show VM Memory Files installed on this %{storage}"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:185
+msgid "Show VM Provisioned Disk Files installed on this %{table}"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_storage.html.haml:94
 msgid "Show VM Provisioned Disk Files on this %s"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:202
+msgid "Show VM Snapshot Files installed on this %{storage}"
 msgstr ""
 
 #: ../../app/views/layouts/_perf_options.html.haml:114
@@ -23958,6 +32422,10 @@ msgstr ""
 msgid "Show VM snapshot files on this %s"
 msgstr ""
 
+#: ../../app/helpers/host_helper/textual_summary.rb:136 ../../app/helpers/vm_helper/textual_summary.rb:136
+msgid "Show VMM container information"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:67
 msgid "Show VMM information"
 msgstr ""
@@ -23970,8 +32438,16 @@ msgstr ""
 msgid "Show VMs & Templates"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:42
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:143
+msgid "Show VMs in this %{title}, but not in Resource Pools below"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:91 ../../app/views/layouts/listnav/_resource_pool.html.haml:42
 msgid "Show VMs in this Resource Pool, but not in Resource Pools below"
+msgstr ""
+
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:83
+msgid "Show Virtual Machines & Templates"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_storage.html.haml:48 ../../app/views/layouts/listnav/_storage.html.haml:67 ../../app/views/layouts/listnav/_storage.html.haml:75 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:30 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:40 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:48 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:56 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:32 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:50 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:61 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:70 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:79
@@ -23982,6 +32458,26 @@ msgstr ""
 msgid "Show all %{base_storage_extent}"
 msgstr ""
 
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:61
+msgid "Show all %{children}"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:80 ../../app/helpers/storage_helper/textual_summary.rb:91 ../../app/helpers/storage_helper/textual_summary.rb:102 ../../app/helpers/storage_helper/textual_summary.rb:124 ../../app/helpers/storage_helper/textual_summary.rb:135 ../../app/helpers/ems_cloud_helper/textual_summary.rb:58 ../../app/helpers/ems_cloud_helper/textual_summary.rb:69 ../../app/helpers/vm_cloud_helper/textual_summary.rb:532 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:202 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:224 ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:235 ../../app/helpers/host_helper/textual_summary.rb:283 ../../app/helpers/host_helper/textual_summary.rb:315 ../../app/helpers/host_helper/textual_summary.rb:331 ../../app/helpers/host_helper/textual_summary.rb:342 ../../app/helpers/host_helper/textual_summary.rb:353 ../../app/helpers/host_helper/textual_summary.rb:364 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:74 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:100 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:111 ../../app/helpers/orchestration_stack_helper/textual_summary.rb:122 ../../app/helpers/security_group_helper/textual_summary.rb:54 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:67 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:78 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:89 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:100 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:111 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:122 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:126 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:137 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:99 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:110 ../../app/helpers/flavor_helper/textual_summary.rb:83 ../../app/helpers/auth_key_pair_cloud_helper/textual_summary.rb:39 ../../app/helpers/ems_cluster_helper/textual_summary.rb:205 ../../app/helpers/ems_cluster_helper/textual_summary.rb:216 ../../app/helpers/ems_infra_helper/textual_summary.rb:94 ../../app/helpers/ems_infra_helper/textual_summary.rb:105 ../../app/helpers/repository_helper/textual_summary.rb:25 ../../app/helpers/vm_infra_helper/textual_summary.rb:546 ../../app/helpers/vm_infra_helper/textual_summary.rb:558 ../../app/helpers/vm_infra_helper/textual_summary.rb:570 ../../app/helpers/vm_infra_helper/textual_summary.rb:582 ../../app/helpers/vm_helper/textual_summary.rb:643 ../../app/helpers/vm_helper/textual_summary.rb:655 ../../app/helpers/vm_helper/textual_summary.rb:667 ../../app/helpers/vm_helper/textual_summary.rb:679 ../../app/helpers/cloud_tenant_helper/textual_summary.rb:35 ../../app/helpers/cloud_tenant_helper/textual_summary.rb:46 ../../app/helpers/availability_zone_helper/textual_summary.rb:28 ../../app/helpers/availability_zone_helper/textual_summary.rb:43 ../../app/helpers/textual_summary_helper.rb:132 ../../app/helpers/ems_container_helper/textual_summary.rb:107
+msgid "Show all %{label}"
+msgstr ""
+
+#: ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:115
+msgid "Show all %{label} %{name}"
+msgstr ""
+
+#: ../../app/helpers/cloud_volume_helper/textual_summary.rb:81
+msgid "Show all %{models}"
+msgstr ""
+
+#: ../../app/helpers/application_helper.rb:967
+msgid "Show all %{names}"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_ems_cluster.html.haml:113
 msgid "Show all %{ontap_file_share}"
 msgstr ""
@@ -23990,15 +32486,27 @@ msgstr ""
 msgid "Show all %{ontap_storage_system}"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:133
+msgid "Show all %{title}"
+msgstr ""
+
+#: ../../app/helpers/cloud_volume_snapshot_helper/textual_summary.rb:32
+msgid "Show all %{volumes} based on this Snapshot."
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_orchestration_stack.html.haml:52
 msgid "Show all Cloud Networks"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:49
+msgid "Show all Cloud Volumes based on this Snapshot"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_cloud_tenant.html.haml:42
 msgid "Show all Images"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:33 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:32 ../../app/views/layouts/listnav/_security_group.html.haml:34 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38
+#: ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:29 ../../app/views/layouts/listnav/_flavor.html.haml:31 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:35 ../../app/views/layouts/listnav/_availability_zone.html.haml:28 ../../app/views/layouts/listnav/_security_group.html.haml:30 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:38
 msgid "Show all Instances"
 msgstr ""
 
@@ -24026,6 +32534,10 @@ msgstr ""
 msgid "Show all Templates in this %{cluster_title}"
 msgstr ""
 
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:165
+msgid "Show all Templates in this %{title}"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:130 ../../app/views/layouts/listnav/_ems_infra.html.haml:65
 msgid "Show all VMs"
 msgstr ""
@@ -24034,8 +32546,16 @@ msgstr ""
 msgid "Show all VMs in this %{cluster_title}"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:50
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:153
+msgid "Show all VMs in this %{title}"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:101 ../../app/views/layouts/listnav/_resource_pool.html.haml:50
 msgid "Show all VMs in this Resource Pool"
+msgstr ""
+
+#: ../../app/helpers/cloud_volume_helper/textual_summary.rb:93
+msgid "Show all attached %{models}"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_repository.html.haml:29
@@ -24044,6 +32564,10 @@ msgstr ""
 
 #: ../../app/views/layouts/listnav/_repository.html.haml:22
 msgid "Show all discovered VMs"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:168
+msgid "Show all files installed on this %{table}"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_storage.html.haml:86
@@ -24078,6 +32602,16 @@ msgstr ""
 msgid "Show daily data from"
 msgstr ""
 
+#: ../../app/helpers/vm_helper/textual_summary.rb:537
+msgid "Show disk on this VM"
+msgid_plural "Show disks on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:438
+msgid "Show disks on this VM"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:86
 msgid "Show esx logs on this VM"
 msgstr ""
@@ -24102,32 +32636,32 @@ msgstr ""
 msgid "Show in Console"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:86
-msgid "Show list of all %s"
+#: ../../app/helpers/host_helper/textual_summary.rb:88
+msgid "Show list of all %{name}"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:92
-msgid "Show list of configuration files of %s"
+#: ../../app/helpers/host_helper/textual_summary.rb:95
+msgid "Show list of configuration files of %{name}"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:79
-msgid "Show list of failed %s"
+#: ../../app/helpers/host_helper/textual_summary.rb:80
+msgid "Show list of failed %{name}"
 msgstr ""
 
-#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:63
-msgid "Show list of hosts with %s"
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:73
+msgid "Show list of hosts with %{name}"
 msgstr ""
 
-#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:56
-msgid "Show list of hosts with failed %s"
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:61
+msgid "Show list of hosts with failed %{name}"
 msgstr ""
 
 #: ../../app/helpers/ems_cluster_helper/textual_summary.rb:49
-msgid "Show list of hosts with running %s"
+msgid "Show list of hosts with running %{name}"
 msgstr ""
 
 #: ../../app/helpers/host_helper/textual_summary.rb:72
-msgid "Show list of running %s"
+msgid "Show list of running %{name}"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_service.html.haml:30
@@ -24146,15 +32680,19 @@ msgstr ""
 msgid "Show out of scope items:"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_security_group.html.haml:43 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:24
+#: ../../app/views/layouts/listnav/_security_group.html.haml:39 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:24
 msgid "Show parent %s for this %s"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:266 ../../app/helpers/vm_helper/textual_summary.rb:360
+msgid "Show parent and child VMs"
 msgstr ""
 
 #: ../../app/views/vm_common/_policy_options.html.haml:32 ../../app/views/miq_policy/_rsop_results.html.haml:34
 msgid "Show policies:"
 msgstr ""
 
-#: ../../app/views/layouts/quadicon/_quadicon_text.html.haml:44 ../../app/views/layouts/quadicon/_vm_or_template.html.haml:147
+#: ../../app/views/layouts/quadicon/_quadicon_text.html.haml:44 ../../app/views/layouts/quadicon/_vm_or_template.html.haml:119
 msgid "Show policy details for %s"
 msgstr ""
 
@@ -24162,8 +32700,114 @@ msgstr ""
 msgid "Show registered VMs"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:140 ../../app/helpers/vm_infra_helper/textual_summary.rb:168 ../../app/helpers/vm_helper/textual_summary.rb:202
+msgid "Show resources of this VM"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:346 ../../app/helpers/vm_helper/textual_summary.rb:445
+msgid "Show the %{label} installed on this VM"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:493
+msgid "Show the Advanced Setting installed on this %{title}"
+msgid_plural "Show the Advanced Settings installed on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:390 ../../app/helpers/vm_infra_helper/textual_summary.rb:401 ../../app/helpers/vm_helper/textual_summary.rb:500
+msgid "Show the File System Driver installed on this VM"
+msgid_plural "Show the File System Drivers installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:482
+msgid "Show the File installed on this %{title}"
+msgid_plural "Show the Files installed on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:402 ../../app/helpers/vm_infra_helper/textual_summary.rb:413 ../../app/helpers/vm_helper/textual_summary.rb:512
+msgid "Show the File installed on this VM"
+msgid_plural "Show the Files installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:432
+msgid "Show the Firewall Rule defined on this %{title}"
+msgid_plural "Show the Firewall Rules defined on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:420
+msgid "Show the Group defined on this %{title}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:297 ../../app/helpers/vm_infra_helper/textual_summary.rb:319 ../../app/helpers/vm_helper/textual_summary.rb:417
+msgid "Show the Group defined on this VM"
+msgid_plural "Show the Groups defined on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:346 ../../app/helpers/vm_infra_helper/textual_summary.rb:360 ../../app/helpers/vm_helper/textual_summary.rb:459
+msgid "Show the Init Process installed on this VM"
+msgid_plural "Show the Init Processes installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:375 ../../app/helpers/vm_infra_helper/textual_summary.rb:387 ../../app/helpers/vm_helper/textual_summary.rb:486
+msgid "Show the Kernel Driver installed on this VM"
+msgid_plural "Show the Kernel Drivers installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:460
+msgid "Show the Package installed on this %{title}"
+msgid_plural "Show the Packages installed on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:449
+msgid "Show the Patch defined on this %{title}"
+msgid_plural "Show the Patches defined on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:310 ../../app/helpers/vm_infra_helper/textual_summary.rb:332 ../../app/helpers/vm_helper/textual_summary.rb:430
+msgid "Show the Patch defined on this VM"
+msgid_plural "Show the Patches defined on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:416 ../../app/helpers/vm_infra_helper/textual_summary.rb:427 ../../app/helpers/vm_helper/textual_summary.rb:526
+msgid "Show the Registry Item installed on this VM"
+msgid_plural "Show the Registry Items installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:471
+msgid "Show the Service installed on this %{title}"
+msgid_plural "Show the Services installed on this %{title}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:286 ../../app/helpers/host_helper/textual_summary.rb:409 ../../app/helpers/vm_infra_helper/textual_summary.rb:308 ../../app/helpers/vm_helper/textual_summary.rb:406
+msgid "Show the User defined on this VM"
+msgid_plural "Show the Users defined on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:360 ../../app/helpers/vm_infra_helper/textual_summary.rb:373 ../../app/helpers/vm_helper/textual_summary.rb:472
+msgid "Show the Win32 Service installed on this VM"
+msgid_plural "Show the Win32 Services installed on this VM"
+msgstr[0] ""
+msgstr[1] ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:238
 msgid "Show the advanced settings on this %{host}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:131 ../../app/helpers/vm_infra_helper/textual_summary.rb:160 ../../app/helpers/vm_helper/textual_summary.rb:194
+msgid "Show the advanced settings on this VM"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_host.html.haml:232
@@ -24190,6 +32834,10 @@ msgstr ""
 msgid "Show the services installed on this %{host}"
 msgstr ""
 
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:149 ../../app/helpers/vm_helper/textual_summary.rb:183
+msgid "Show the snapshot info for this VM"
+msgstr ""
+
 #: ../../app/views/layouts/listnav/_host.html.haml:187
 msgid "Show the users defined on this %{host}"
 msgstr ""
@@ -24198,15 +32846,23 @@ msgstr ""
 msgid "Show this %s parent %s"
 msgstr ""
 
-#: ../../app/helpers/host_helper/textual_summary.rb:283
-msgid "Show this %s's %s"
-msgstr ""
-
-#: ../../app/helpers/application_helper.rb:47
+#: ../../app/helpers/application_helper.rb:49
 msgid "Show this %{entity_name}'s parent %{linked_entity_name}"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_availability_zone.html.haml:26
+#: ../../app/helpers/host_helper/textual_summary.rb:258
+msgid "Show this %{host_title}'s %{cluster_title}"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:220 ../../app/helpers/vm_infra_helper/textual_summary.rb:228 ../../app/helpers/vm_helper/textual_summary.rb:289 ../../app/helpers/vm_helper/textual_summary.rb:297
+msgid "Show this %{label}"
+msgstr ""
+
+#: ../../app/helpers/host_helper/textual_summary.rb:297
+msgid "Show this %{title}'s %{label}"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_availability_zone.html.haml:22
 msgid "Show this Availability Zone's parent %s"
 msgstr ""
 
@@ -24214,19 +32870,79 @@ msgstr ""
 msgid "Show this Cloud Tenant's parent %s"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:26 ../../app/views/layouts/listnav/_cloud_volume.html.haml:34 ../../app/views/layouts/listnav/_cloud_volume.html.haml:42
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:46
+msgid "Show this Cloud Volume's parent %s"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_cloud_volume.html.haml:22 ../../app/views/layouts/listnav/_cloud_volume.html.haml:30 ../../app/views/layouts/listnav/_cloud_volume.html.haml:38
 msgid "Show this Cloud Volumes's parent %s"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:146 ../../app/helpers/storage_helper/textual_summary.rb:157
+msgid "Show this Datastore's %{label}"
 msgstr ""
 
 #: ../../app/views/layouts/listnav/_flavor.html.haml:24
 msgid "Show this Flavor's parent %s"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_security_group.html.haml:28
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:221
+msgid "Show this Image's parent"
+msgstr ""
+
+#: ../../app/helpers/orchestration_stack_helper/textual_summary.rb:62
+msgid "Show this Orchestration Template"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_security_group.html.haml:24
 msgid "Show this Security Group's parent %s"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_persistent_volume.html.haml:26
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:247 ../../app/helpers/vm_infra_helper/textual_summary.rb:242 ../../app/helpers/vm_helper/textual_summary.rb:335
+msgid "Show this Service"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:102
+msgid "Show this Service's Parent Service"
+msgstr ""
+
+#: ../../app/helpers/service_helper/textual_summary.rb:90
+msgid "Show this Service's Parent Service Catalog"
+msgstr ""
+
+#: ../../app/helpers/cloud_volume_snapshot_helper/textual_summary.rb:51
+msgid "Show this Snapshot's %{parent}"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:26 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:34 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:57
+msgid "Show this Snapshot's parent %{parent}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:185 ../../app/helpers/vm_cloud_helper/textual_summary.rb:196 ../../app/helpers/vm_cloud_helper/textual_summary.rb:207 ../../app/helpers/vm_cloud_helper/textual_summary.rb:556 ../../app/helpers/vm_helper/textual_summary.rb:311 ../../app/helpers/vm_helper/textual_summary.rb:322
+msgid "Show this VM's %{label}"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:234
+msgid "Show this VM's %{label} '%{name}'"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:161 ../../app/helpers/vm_cloud_helper/textual_summary.rb:172 ../../app/helpers/vm_infra_helper/textual_summary.rb:184 ../../app/helpers/vm_infra_helper/textual_summary.rb:194 ../../app/helpers/vm_helper/textual_summary.rb:253 ../../app/helpers/vm_helper/textual_summary.rb:263
+msgid "Show this VM's %{title}"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:205 ../../app/helpers/vm_helper/textual_summary.rb:274
+msgid "Show this VM's Resource Pool"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:255 ../../app/helpers/vm_helper/textual_summary.rb:348
+msgid "Show this VM's parent"
+msgstr ""
+
+#: ../../app/helpers/cloud_volume_helper/textual_summary.rb:43 ../../app/helpers/cloud_volume_helper/textual_summary.rb:58 ../../app/helpers/cloud_volume_helper/textual_summary.rb:69
+msgid "Show this Volume's %{parent}"
+msgstr ""
+
+#: ../../app/views/layouts/listnav/_persistent_volume.html.haml:22
 msgid "Show this container volume's parent %s"
 msgstr ""
 
@@ -24238,16 +32954,63 @@ msgstr ""
 msgid "Show tree of all VMs by Resource Pool in this %{cluster_title}"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_resource_pool.html.haml:58
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:175
+msgid "Show tree of all VMs by Resource Pool in this %{title}"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:112 ../../app/views/layouts/listnav/_resource_pool.html.haml:58
 msgid "Show tree of all VMs in this Resource Pool"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:275 ../../app/helpers/vm_infra_helper/textual_summary.rb:297 ../../app/helpers/vm_helper/textual_summary.rb:395
+msgid "Show virtual machine analysis history"
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:261 ../../app/helpers/vm_infra_helper/textual_summary.rb:283 ../../app/helpers/vm_helper/textual_summary.rb:381
+msgid "Show virtual machine drift history"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:267 ../../app/helpers/vm_helper/textual_summary.rb:361
+msgid "Show virtual machine genealogy"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/host_center.rb:141 ../../app/helpers/application_helper/toolbar/hosts_center.rb:156 ../../app/views/catalog/_form_resources_info.html.haml:118
 msgid "Shutdown"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:168 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:164 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:207
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:168 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:164 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:207 ../yaml_strings.rb:2077
 msgid "Shutdown Guest"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:566
+msgid "Shutdown Host"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:562
+msgid "Shutdown Host to Standby"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:568
+msgid "Shutdown a Host / Node"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:564
+msgid "Shutdown a Host / Node to Standby Mode"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2079
+msgid "Shutdown the Guest OS on Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2183
+msgid "Shutdown the Guest OS on VMs"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:206
@@ -24298,15 +33061,22 @@ msgstr ""
 msgid "Shutdown this item?"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/custom_button_center.rb:27
+#: ../../app/helpers/container_helper/textual_summary.rb:46
+msgid "Signal"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/custom_button_center.rb:27 ../yaml_strings.rb:1115
 msgid "Simulate"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/custom_button_center.rb:26
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/custom_button_center.rb:26 ../yaml_strings.rb:1117
 msgid "Simulate using Button details"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:135 ../../app/presenters/menu/default_menu.rb:144
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:135 ../../app/presenters/menu/default_menu.rb:144 ../yaml_strings.rb:944
 msgid "Simulation"
 msgstr ""
 
@@ -24330,13 +33100,43 @@ msgstr ""
 msgid "Single Value"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#. TRANSLATORS: file: product/views/Filesystem.yaml
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_size_numeric
-#: ../../app/views/ops/_db_info.html.haml:59 ../../app/views/ops/_db_info.html.haml:152 ../../app/views/ops/_db_info.html.haml:217 ../../app/views/vm_common/_snapshots_desc.html.haml:31 ../dictionary_strings.rb:1063
+#: ../../app/helpers/ops_helper/textual_summary.rb:109 ../../app/views/ops/_db_info.html.haml:59 ../../app/views/ops/_db_info.html.haml:152 ../../app/views/ops/_db_info.html.haml:217 ../../app/views/vm_common/_snapshots_desc.html.haml:31 ../yaml_strings.rb:2881 ../dictionary_strings.rb:1063
 msgid "Size"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+#. TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+#: ../yaml_strings.rb:2929
+msgid "Size (Bytes)"
 msgstr ""
 
 #: ../../app/views/ontap_storage_system/_create_logical_disk.html.haml:41
 msgid "Size (GB)"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:122
+msgid "Size Available"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:130
+msgid "Size Total"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:126
+msgid "Size Used"
 msgstr ""
 
 #: ../../app/controllers/ontap_storage_system_controller.rb:127
@@ -24382,7 +33182,7 @@ msgstr ""
 msgid "Small Trees"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_tag_box.html.haml:1 ../../app/views/provider_foreman/_main.html.haml:18 ../../app/views/service/_svcs_show.html.haml:20 ../../app/views/middleware_server/_main.html.haml:14 ../../app/views/container_service/_main.html.haml:20 ../../app/views/resource_pool/_main.html.haml:16 ../../app/views/vm_cloud/_main.html.haml:36 ../../app/views/ems_middleware/_main.html.haml:21 ../../app/views/cloud_volume/_main.html.haml:14 ../../app/views/flavor/_main.html.haml:14 ../../app/views/ontap_storage_system/_main.html.haml:9 ../../app/views/orchestration_stack/_main.html.haml:16 ../../app/views/repository/_main.html.haml:9 ../../app/views/host/_main.html.haml:25 ../../app/views/ontap_logical_disk/_main.html.haml:18 ../../app/views/persistent_volume/_main.html.haml:16 ../../app/views/availability_zone/_main.html.haml:14 ../../app/views/ems_cluster/_main.html.haml:21 ../../app/views/auth_key_pair_cloud/_main.html.haml:14 ../../app/views/container_group/_main.html.haml:27 ../../app/views/container/_container_show.html.haml:15 ../../app/views/security_group/_main.html.haml:22 ../../app/views/ontap_storage_volume/_main.html.haml:9 ../../app/views/container_replicator/_main.html.haml:18 ../../app/views/container_image_registry/_main.html.haml:16 ../../app/views/container_route/_main.html.haml:18 ../../app/views/middleware_deployment/_main.html.haml:14 ../../app/views/vm_common/_main.html.haml:41 ../../app/views/storage/_main.html.haml:21 ../../app/views/ems_container/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:19 ../../app/views/ontap_file_share/_main.html.haml:9 ../../app/views/shared/views/ems_common/_main.html.haml:16 ../../app/views/container_project/_main.html.haml:20 ../../app/views/container_image/_main.html.haml:16 ../../app/views/cloud_tenant/_main.html.haml:14
+#: ../../app/views/ops/_rbac_tag_box.html.haml:1 ../../app/views/provider_foreman/_main.html.haml:18 ../../app/views/service/_svcs_show.html.haml:20 ../../app/views/middleware_server/_main.html.haml:14 ../../app/views/container_service/_main.html.haml:20 ../../app/views/resource_pool/_main.html.haml:16 ../../app/views/vm_cloud/_main.html.haml:36 ../../app/views/ems_middleware/_main.html.haml:21 ../../app/views/cloud_volume/_main.html.haml:14 ../../app/views/flavor/_main.html.haml:14 ../../app/views/ontap_storage_system/_main.html.haml:9 ../../app/views/orchestration_stack/_main.html.haml:16 ../../app/views/repository/_main.html.haml:9 ../../app/views/host/_main.html.haml:25 ../../app/views/ontap_logical_disk/_main.html.haml:18 ../../app/views/persistent_volume/_main.html.haml:16 ../../app/views/availability_zone/_main.html.haml:14 ../../app/views/ems_cluster/_main.html.haml:21 ../../app/views/auth_key_pair_cloud/_main.html.haml:14 ../../app/views/container_group/_main.html.haml:27 ../../app/views/container/_container_show.html.haml:15 ../../app/views/security_group/_main.html.haml:22 ../../app/views/ontap_storage_volume/_main.html.haml:9 ../../app/views/container_replicator/_main.html.haml:18 ../../app/views/container_image_registry/_main.html.haml:16 ../../app/views/container_route/_main.html.haml:18 ../../app/views/cloud_volume_snapshot/_main.html.haml:14 ../../app/views/middleware_deployment/_main.html.haml:14 ../../app/views/vm_common/_main.html.haml:41 ../../app/views/storage/_main.html.haml:21 ../../app/views/ems_container/_main.html.haml:24 ../../app/views/container_node/_main.html.haml:19 ../../app/views/ontap_file_share/_main.html.haml:9 ../../app/views/shared/views/ems_common/_main.html.haml:16 ../../app/views/container_project/_main.html.haml:20 ../../app/views/container_image/_main.html.haml:16 ../../app/views/cloud_tenant/_main.html.haml:14
 msgid "Smart Management"
 msgstr ""
 
@@ -24409,7 +33209,7 @@ msgstr ""
 msgid "SmartProxy Server IP"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1705 ../model_attributes.rb:2066
+#: ../../app/controllers/vm_common.rb:1786 ../model_attributes.rb:2066
 msgid "Snapshot"
 msgid_plural "Snapshots"
 msgstr[0] ""
@@ -24421,6 +33221,18 @@ msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/miq_actions.rb:405
 msgid "Snapshot Age must be selected"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:134
+msgid "Snapshot Blocks Reserved"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:409
+msgid "Snapshot Create"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:410
+msgid "Snapshot Delete"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_snapshot_percent_of_used
@@ -24440,8 +33252,25 @@ msgstr ""
 msgid "Snapshot Settings"
 msgstr ""
 
+#: ../../app/controllers/vm_common.rb:627
+msgid "Snapshot VM '%{name}'"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:598
+msgid "Snapshot VM '%{name}''"
+msgstr ""
+
 #: ../../app/views/vm_common/_snap.html.haml:43
 msgid "Snapshot VM memory"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:613
+msgid "Snapshot of VM %{name} was cancelled by the user"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:147 ../../app/helpers/vm_infra_helper/textual_summary.rb:484 ../../app/helpers/vm_helper/textual_summary.rb:181 ../../app/helpers/vm_helper/textual_summary.rb:583 ../../app/views/configuration/_ui_2.html.haml:240 ../yaml_strings.rb:2229
+msgid "Snapshots"
 msgstr ""
 
 #: ../model_attributes.rb:2067
@@ -24500,6 +33329,21 @@ msgstr ""
 msgid "Snapshot|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#: ../yaml_strings.rb:3281
+msgid "Snia File Share"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#: ../yaml_strings.rb:3156
+msgid "Snia Local File System"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#: ../yaml_strings.rb:3158
+msgid "SniaLocalFileSystems"
+msgstr ""
+
 #: ../../app/views/vm_common/_reconfigure.html.haml:92
 msgid "Sockets"
 msgstr ""
@@ -24522,6 +33366,10 @@ msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:185
 msgid "Soft Reboot this Instance?"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:432
+msgid "Software"
 msgstr ""
 
 #: ../../app/views/ops/rhn/_info_unsubscribed.html.haml:5
@@ -24552,8 +33400,17 @@ msgstr ""
 msgid "Sorted by: "
 msgstr ""
 
-#: ../../app/views/ops/_ap_form_nteventlog.html.haml:19 ../../app/views/security_group/_main.html.haml:20 ../../app/views/chargeback/_reports_list.html.haml:60 ../../app/views/miq_capacity/_planning_options.html.haml:116 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:7
+#. TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#: ../../app/views/ops/_ap_form_nteventlog.html.haml:19 ../../app/views/security_group/_main.html.haml:20 ../../app/views/chargeback/_reports_list.html.haml:60 ../../app/views/miq_capacity/_planning_options.html.haml:116 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:7 ../yaml_strings.rb:2835
 msgid "Source"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2639
+msgid "Source Host"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.src_host_name
@@ -24561,8 +33418,16 @@ msgstr ""
 msgid "Source Host Name"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2642
+msgid "Source VM"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.src_vm_location
-#: ../dictionary_strings.rb:943
+#: ../yaml_strings.rb:2645 ../dictionary_strings.rb:943
 msgid "Source VM Location"
 msgstr ""
 
@@ -24597,7 +33462,7 @@ msgid "Stack"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.table.orchestration_stack (plural form)
-#: ../../app/presenters/menu/default_menu.rb:33 ../../app/views/configuration/_ui_2.html.haml:201 ../dictionary_strings.rb:2065
+#: ../../app/presenters/menu/default_menu.rb:33 ../../app/controllers/ems_common.rb:75 ../../app/views/configuration/_ui_2.html.haml:201 ../dictionary_strings.rb:2065
 msgid "Stacks"
 msgstr ""
 
@@ -24606,8 +33471,11 @@ msgstr ""
 msgid "Stamped Approvals"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.start_trend_value
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:140 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:168 ../../app/views/ems_cloud/discover.html.haml:54 ../../app/views/layouts/_discover.html.haml:103 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../dictionary_strings.rb:949
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:140 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:168 ../../app/views/ems_cloud/discover.html.haml:54 ../../app/views/layouts/_discover.html.haml:103 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_form_resources_info.html.haml:61 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../../app/views/catalog/_sandt_tree_show.html.haml:238 ../yaml_strings.rb:3137 ../dictionary_strings.rb:949
 msgid "Start"
 msgstr ""
 
@@ -24619,7 +33487,8 @@ msgstr ""
 msgid "Start Page"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:26 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:26
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:26 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:26 ../yaml_strings.rb:1364
 msgid "Start Role"
 msgstr ""
 
@@ -24627,11 +33496,11 @@ msgstr ""
 msgid "Start TLS Automatically"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:660
+#: ../../app/controllers/ops_controller/diagnostics.rb:680
 msgid "Start is not allowed for the selected item"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:668
+#: ../../app/controllers/ops_controller/diagnostics.rb:688
 msgid "Start successfully initiated"
 msgstr ""
 
@@ -24663,6 +33532,18 @@ msgstr ""
 msgid "Start this Instance?"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/ScanHistory.yaml
+#: ../yaml_strings.rb:3325
+msgid "Started"
+msgstr ""
+
+#: ../../app/helpers/container_helper/textual_summary.rb:34
+msgid "Started At"
+msgstr ""
+
 #: ../../app/views/ops/_selected_by_servers.html.haml:61 ../../app/views/ops/_selected_by_roles.html.haml:109 ../../app/views/ops/_server_desc.html.haml:39
 msgid "Started On"
 msgstr ""
@@ -24687,7 +33568,10 @@ msgstr ""
 msgid "Starting process must be specified"
 msgstr ""
 
-#: ../../app/views/miq_request/_ae_prov_show.html.haml:18
+#. TRANSLATORS: file: product/views/Container.yaml
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:118 ../../app/views/miq_request/_ae_prov_show.html.haml:18 ../yaml_strings.rb:3559
 msgid "State"
 msgstr ""
 
@@ -24761,20 +33645,59 @@ msgstr ""
 msgid "State - Peak Number of VMs Powered On  - Hourly Count / Daily Avg"
 msgstr ""
 
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:524 ../../app/helpers/vm_infra_helper/textual_summary.rb:660 ../../app/helpers/vm_helper/textual_summary.rb:779
+msgid "State Changed On"
+msgstr ""
+
 #: ../../app/views/catalog/_form_basic_info.html.haml:151 ../../app/views/catalog/_form_basic_info.html.haml:193 ../../app/views/catalog/_form_basic_info.html.haml:237 ../../app/views/catalog/_sandt_tree_show.html.haml:119
 msgid "State Machine (NS/Cls/Inst)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:35
+#: ../../app/helpers/ems_infra_helper/textual_summary.rb:166
+msgid "States of Root Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:35 ../yaml_strings.rb:1434
 msgid "Statistics"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_selected_by_servers.html.haml:48 ../../app/views/ops/_selected_by_servers.html.haml:181 ../../app/views/ops/_selected_by_roles.html.haml:17 ../../app/views/ops/_selected_by_roles.html.haml:64 ../../app/views/ops/_server_desc.html.haml:29 ../../app/views/ops/_diagnostics_replication_tab.html.haml:32 ../../app/views/ems_middleware/_main.html.haml:10 ../../app/views/miq_request/_request.html.haml:31 ../../app/views/miq_request/_request_details.html.haml:44 ../../app/views/miq_request/_ae_prov_show.html.haml:22 ../../app/views/ems_container/_main.html.haml:10 ../../app/views/report/_widget_show.html.haml:65 ../../app/views/report/_export_widgets.html.haml:29 ../../app/views/shared/views/ems_common/_main.html.haml:9 ../../app/assets/javascripts/dialog_import_export.js:25
+#. TRANSLATORS: file: product/views/AutomationRequest.yaml
+#. TRANSLATORS: file: product/views/CloudNetwork.yaml
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+#. TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/MiqProvision.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#. TRANSLATORS: file: product/views/MiqRequest.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#. TRANSLATORS: file: product/views/ScanHistory.yaml
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#: ../../app/helpers/host_helper/textual_summary.rb:371 ../../app/helpers/vm_helper/textual_summary.rb:729 ../../app/helpers/container_group_helper/textual_summary.rb:16 ../../app/helpers/container_node_helper/textual_summary.rb:17 ../../app/views/ops/_selected_by_servers.html.haml:48 ../../app/views/ops/_selected_by_servers.html.haml:181 ../../app/views/ops/_selected_by_roles.html.haml:17 ../../app/views/ops/_selected_by_roles.html.haml:64 ../../app/views/ops/_server_desc.html.haml:29 ../../app/views/ops/_diagnostics_replication_tab.html.haml:32 ../../app/views/ems_middleware/_main.html.haml:10 ../../app/views/miq_request/_request.html.haml:31 ../../app/views/miq_request/_request_details.html.haml:44 ../../app/views/miq_request/_ae_prov_show.html.haml:22 ../../app/views/ems_container/_main.html.haml:10 ../../app/views/report/_widget_show.html.haml:65 ../../app/views/report/_export_widgets.html.haml:29 ../../app/views/shared/views/ems_common/_main.html.haml:9 ../../app/assets/javascripts/dialog_import_export.js:25 ../yaml_strings.rb:2856
 msgid "Status"
 msgstr ""
 
-#: ../../app/helpers/application_helper.rb:1330
-msgid "Status = %s"
+#: ../../app/helpers/application_helper.rb:1337
+msgid "Status = %{row}"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/PersistentVolume.yaml
+#: ../yaml_strings.rb:3891
+msgid "Status Phase"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#: ../yaml_strings.rb:3393
+msgid "Status Reason"
 msgstr ""
 
 #: ../../app/views/ops/_zone_tree.html.haml:6
@@ -24785,7 +33708,7 @@ msgstr ""
 msgid "Status of Roles for Servers in %{kind} %{description}"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_topology/container_topology_controller.js:224
+#: ../../app/assets/javascripts/services/topology_service.js:7
 msgid "Status: "
 msgstr ""
 
@@ -24813,7 +33736,7 @@ msgstr ""
 msgid "Stopped On"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:123 ../../app/helpers/application_helper/chargeback.rb:10 ../../app/views/chargeback/_assignments_list.html.haml:35 ../../app/views/configuration/_ui_2.html.haml:392 ../model_attributes.rb:2081
+#: ../../app/presenters/menu/default_menu.rb:123 ../../app/controllers/storage_controller.rb:260 ../../app/helpers/application_helper/chargeback.rb:10 ../../app/views/chargeback/_assignments_list.html.haml:35 ../../app/views/configuration/_ui_2.html.haml:403 ../model_attributes.rb:2081
 msgid "Storage"
 msgstr ""
 
@@ -24915,7 +33838,7 @@ msgstr ""
 msgid "Storage - Volumes"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:55
+#: ../../app/helpers/host_helper/textual_summary.rb:194 ../../app/views/layouts/listnav/_host.html.haml:55
 msgid "Storage Adapters"
 msgstr ""
 
@@ -24929,17 +33852,19 @@ msgstr ""
 msgid "Storage Allocated Cost"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/StorageManager.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.StorageManager
-#: ../dictionary_strings.rb:1707
+#: ../yaml_strings.rb:3351 ../dictionary_strings.rb:1707
 msgid "Storage Manager"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.StorageManager (plural form)
-#: ../../app/presenters/menu/default_menu.rb:128 ../../app/views/ops/_settings_evm_servers_tab.html.haml:132 ../../app/views/configuration/_ui_2.html.haml:419 ../dictionary_strings.rb:1709
+#: ../../app/presenters/menu/default_menu.rb:128 ../../app/controllers/storage_manager_controller.rb:519 ../../app/views/ops/_settings_evm_servers_tab.html.haml:132 ../../app/views/configuration/_ui_2.html.haml:430 ../yaml_strings.rb:1494 ../dictionary_strings.rb:1709
 msgid "Storage Managers"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:33
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:53 ../../app/helpers/container_group_helper/textual_summary.rb:33
 msgid "Storage Medium Type"
 msgstr ""
 
@@ -24951,6 +33876,11 @@ msgstr ""
 
 #: ../../app/views/host/_main.html.haml:15 ../../app/views/ems_cluster/_main.html.haml:10 ../../app/views/layouts/listnav/_host.html.haml:154 ../../app/views/layouts/listnav/_ems_cluster.html.haml:94 ../../app/views/vm_common/_main.html.haml:14 ../../app/views/storage/_main.html.haml:17
 msgid "Storage Relationships"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1386
+msgid "Storage Systems"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.storage_metric
@@ -24971,6 +33901,11 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.column.storage_used_cost
 #: ../dictionary_strings.rb:1203
 msgid "Storage Used Cost"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1406
+msgid "Storage Volumes"
 msgstr ""
 
 #: ../model_attributes.rb:2100
@@ -25121,6 +34056,11 @@ msgstr ""
 msgid "Storage|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../yaml_strings.rb:3243
+msgid "Store Type"
+msgstr ""
+
 #: ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:461 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:559
 msgid "String"
 msgstr ""
@@ -25129,20 +34069,29 @@ msgstr ""
 msgid "String List"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2409
+msgid "String Truncated to 50 Characters with Elipses (...)"
+msgstr ""
+
 #: ../../app/views/report/_form_styling.html.haml:26
 msgid "Style"
 msgstr ""
 
-#: ../../app/controllers/report_controller/reports.rb:277
-msgid "Styling for '%s', first value is in error: "
-msgstr ""
-
-#: ../../app/controllers/report_controller/reports.rb:279
-msgid "Styling for '%s', second value is in error: "
+#: ../../app/controllers/report_controller/reports.rb:278
+msgid "Styling for '%{item}', first value is in error: %{message}"
 msgstr ""
 
 #: ../../app/controllers/report_controller/reports.rb:281
-msgid "Styling for '%s', third value is in error: "
+msgid "Styling for '%{item}', second value is in error: %{message}"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:284
+msgid "Styling for '%{item}', third value is in error: %{message}"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:384
+msgid "Styling tab is not available until at least 1 field has been selected"
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_class_fields.html.haml:97
@@ -25177,12 +34126,17 @@ msgstr ""
 msgid "Submit this reconfigure request"
 msgstr ""
 
-#: ../../app/views/vm_common/_config.html.haml:211
+#: ../../app/views/vm_common/_config.html.haml:208
 msgid "Subnet Mask"
 msgstr ""
 
 #: ../../app/views/layouts/_discover.html.haml:52
 msgid "Subnet Range"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Flavor.yaml
+#: ../yaml_strings.rb:3464
+msgid "Subnet Required"
 msgstr ""
 
 #: ../../app/views/alert/_rss_list.html.haml:50
@@ -25207,16 +34161,40 @@ msgid_plural "Successfully deleted Saved Reports from the CFME Database"
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2315
+msgid "Suffixed Bytes (B, KB, MB, GB)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2321
+msgid "Suffixed Gigabytes (GB)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2317
+msgid "Suffixed Kilobytes (KB, MB, GB)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2319
+msgid "Suffixed Megabytes (MB, GB)"
+msgstr ""
+
 #: ../../app/views/report/_form_chart.html.haml:104
 msgid "Sum 'Other' values"
 msgstr ""
 
-#: ../../app/views/ops/_all_tabs.html.haml:162 ../../app/views/ops/_all_tabs.html.haml:281 ../../app/views/provider_foreman/_configuration_profile.html.haml:4 ../../app/views/layouts/_tl_options.html.haml:186 ../../app/views/layouts/listnav/_cloud_volume.html.haml:16 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:16 ../../app/views/layouts/listnav/_container_group.html.haml:16 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_middleware_server.html.haml:16 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:16 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:16 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:16 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_persistent_volume.html.haml:16 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:16 ../../app/views/layouts/listnav/_container_node.html.haml:16 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_ems_middleware.html.haml:16 ../../app/views/layouts/listnav/_ems_cloud.html.haml:16 ../../app/views/layouts/listnav/_availability_zone.html.haml:16 ../../app/views/layouts/listnav/_security_group.html.haml:16 ../../app/views/layouts/listnav/_container_route.html.haml:16 ../../app/views/layouts/listnav/_container_service.html.haml:16 ../../app/views/layouts/listnav/_container_project.html.haml:16 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12 ../../app/views/miq_capacity/_planning_tabs.html.haml:4 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:4 ../../app/views/miq_capacity/_utilization_tabs.html.haml:4
+#: ../../app/views/ops/_all_tabs.html.haml:162 ../../app/views/ops/_all_tabs.html.haml:281 ../../app/views/provider_foreman/_configuration_profile.html.haml:4 ../../app/views/layouts/_tl_options.html.haml:186 ../../app/views/layouts/listnav/_cloud_volume.html.haml:12 ../../app/views/layouts/listnav/_miq_ae_class.html.haml:12 ../../app/views/layouts/listnav/_resource_pool.html.haml:13 ../../app/views/layouts/listnav/_host.html.haml:38 ../../app/views/layouts/listnav/_auth_key_pair_cloud.html.haml:12 ../../app/views/layouts/listnav/_container_group.html.haml:12 ../../app/views/layouts/listnav/_repository.html.haml:12 ../../app/views/layouts/listnav/_storage.html.haml:13 ../../app/views/layouts/listnav/_flavor.html.haml:12 ../../app/views/layouts/listnav/_container_image_registry.html.haml:12 ../../app/views/layouts/listnav/_ontap_storage_volume.html.haml:12 ../../app/views/layouts/listnav/_middleware_server.html.haml:12 ../../app/views/layouts/listnav/_middleware_deployment.html.haml:12 ../../app/views/layouts/listnav/_cloud_volume_snapshot.html.haml:16 ../../app/views/layouts/listnav/_service.html.haml:12 ../../app/views/layouts/listnav/_ontap_logical_disk.html.haml:13 ../../app/views/layouts/listnav/_ems_container.html.haml:12 ../../app/views/layouts/listnav/_cloud_tenant.html.haml:12 ../../app/views/layouts/listnav/_container_image.html.haml:12 ../../app/views/layouts/listnav/_ems_cluster.html.haml:13 ../../app/views/layouts/listnav/_persistent_volume.html.haml:12 ../../app/views/layouts/listnav/_storage_manager.html.haml:12 ../../app/views/layouts/listnav/_ontap_file_share.html.haml:12 ../../app/views/layouts/listnav/_ems_infra.html.haml:14 ../../app/views/layouts/listnav/_container_replicator.html.haml:12 ../../app/views/layouts/listnav/_container_node.html.haml:12 ../../app/views/layouts/listnav/_ontap_storage_system.html.haml:12 ../../app/views/layouts/listnav/_ems_middleware.html.haml:12 ../../app/views/layouts/listnav/_ems_cloud.html.haml:12 ../../app/views/layouts/listnav/_availability_zone.html.haml:12 ../../app/views/layouts/listnav/_security_group.html.haml:12 ../../app/views/layouts/listnav/_container_route.html.haml:12 ../../app/views/layouts/listnav/_container_service.html.haml:12 ../../app/views/layouts/listnav/_container_project.html.haml:12 ../../app/views/layouts/listnav/_orchestration_stack.html.haml:12 ../../app/views/layouts/listnav/_pxe_server.html.haml:12 ../../app/views/miq_capacity/_planning_tabs.html.haml:4 ../../app/views/miq_capacity/_bottlenecks_tabs.html.haml:4 ../../app/views/miq_capacity/_utilization_tabs.html.haml:4
 msgid "Summary"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/dashboard_summary_toggle_view.rb:13
 msgid "Summary View"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:335
+msgid "Summary tab is not available until at least 1 field has been selected"
 msgstr ""
 
 #: ../../app/views/configuration/_timeprofile_days_hours.html.haml:20
@@ -25227,19 +34205,31 @@ msgstr ""
 msgid "Support Case must be provided to collect logs"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/vm_center.rb:197 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:193 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:154 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:248 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:188 ../../app/views/catalog/_form_resources_info.html.haml:118
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/vm_center.rb:197 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:193 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:154 ../../app/helpers/application_helper/toolbar/vm_infras_center.rb:248 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:188 ../../app/views/catalog/_form_resources_info.html.haml:118 ../yaml_strings.rb:2063
 msgid "Suspend"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:32 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:32
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2065
+msgid "Suspend Instance"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/diagnostics_region_center.rb:32 ../../app/helpers/application_helper/toolbar/diagnostics_zone_center.rb:32 ../yaml_strings.rb:1366
 msgid "Suspend Role"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:677
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2179
+msgid "Suspend VM"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:697
 msgid "Suspend is not allowed for the selected item"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/diagnostics.rb:685
+#: ../../app/controllers/ops_controller/diagnostics.rb:705
 msgid "Suspend successfully initiated"
 msgstr ""
 
@@ -25279,6 +34269,10 @@ msgstr ""
 msgid "Switch"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:658
+msgid "Switch: %{name}"
+msgstr ""
+
 #: ../model_attributes.rb:2120
 msgid "Switch|Allow promiscuous"
 msgstr ""
@@ -25311,6 +34305,15 @@ msgstr ""
 msgid "Switch|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+#: ../yaml_strings.rb:3747
+msgid "Sync/Async"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:410
+msgid "Synchronizing"
+msgstr ""
+
 #: ../../app/views/miq_policy/_event_details.html.haml:228 ../../app/views/miq_policy/_event_details.html.haml:420
 msgid "Synchronous"
 msgstr ""
@@ -25327,6 +34330,14 @@ msgstr ""
 msgid "Sysprep \"%s\" upload was successful"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:433
+msgid "System"
+msgstr ""
+
+#: ../../app/helpers/container_node_helper/textual_summary.rb:60
+msgid "System BIOS UUID"
+msgstr ""
+
 #: ../../app/views/report/_form_columns.html.haml:65
 msgid "System Default"
 msgstr ""
@@ -25336,9 +34347,15 @@ msgstr ""
 msgid "System Image Type"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/PxeImageType.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.PxeImageType (plural form)
-#: ../dictionary_strings.rb:1665
+#: ../../app/controllers/pxe_controller.rb:90 ../yaml_strings.rb:1571 ../dictionary_strings.rb:1665
 msgid "System Image Types"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:73 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:66 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:45
+msgid "System Name"
 msgstr ""
 
 #: ../model_attributes.rb:2128
@@ -25421,6 +34438,21 @@ msgstr ""
 msgid "SystemService|Typename"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#: ../yaml_strings.rb:3771
+msgid "Systemd Active"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#: ../yaml_strings.rb:3769
+msgid "Systemd Load"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/SystemService.yaml
+#: ../yaml_strings.rb:3773
+msgid "Systemd Sub"
+msgstr ""
+
 #: ../../app/views/layouts/exp_atom/_edit_field.html.haml:110 ../../app/views/layouts/exp_atom/_edit_find.html.haml:220
 msgid "THROUGH"
 msgstr ""
@@ -25437,6 +34469,10 @@ msgstr ""
 msgid "Tab Title"
 msgstr ""
 
+#: ../../app/controllers/report_controller/dashboards.rb:343
+msgid "Tab Title must be unique for this group"
+msgstr ""
+
 #: ../../app/views/ops/_db_info.html.haml:109
 msgid "Table"
 msgstr ""
@@ -25445,15 +34481,21 @@ msgstr ""
 msgid "Tables with Most Rows"
 msgstr ""
 
-#: ../../app/views/ops/_db_summary.html.haml:16
+#: ../../app/helpers/ops_helper/textual_summary.rb:116 ../../app/views/ops/_db_summary.html.haml:16
 msgid "Tables with Most Wasted Space"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:100
+msgid "Tables with the Most Rows"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/report_view.rb:20
 msgid "Tabular View"
 msgstr ""
 
-#: ../../app/views/layouts/exp_atom/_editor.html.haml:83 ../../app/views/report/_form_filter_chargeback.html.haml:82 ../../app/views/miq_policy/_action_details.html.haml:318 ../model_attributes.rb:2146
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ContainerImage.yaml
+#: ../../app/helpers/ui_constants.rb:484 ../../app/views/layouts/exp_atom/_editor.html.haml:83 ../../app/views/report/_form_filter_chargeback.html.haml:82 ../../app/views/miq_policy/_action_details.html.haml:318 ../yaml_strings.rb:498 ../model_attributes.rb:2146
 msgid "Tag"
 msgstr ""
 
@@ -25477,7 +34519,11 @@ msgstr ""
 msgid "Tag to Apply"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:21 ../model_attributes.rb:2148
+#: ../../app/helpers/ui_constants.rb:445 ../../app/helpers/ui_constants.rb:449 ../../app/helpers/ui_constants.rb:453 ../../app/helpers/ui_constants.rb:458 ../../app/helpers/ui_constants.rb:459 ../../app/helpers/ui_constants.rb:464 ../../app/helpers/ui_constants.rb:476
+msgid "Tagged %{tables}"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:661 ../../app/views/configuration/_ui_2.html.haml:21 ../model_attributes.rb:2148
 msgid "Tagging"
 msgstr ""
 
@@ -25495,6 +34541,11 @@ msgstr ""
 
 #: ../model_attributes.rb:2147
 msgid "Tag|Name"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:560
+msgid "Take a Host / Node out of Maintenance Mode"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/host_center.rb:126
@@ -25517,12 +34568,23 @@ msgstr ""
 msgid "Target Port"
 msgstr ""
 
+#: ../../app/controllers/host_controller.rb:757
+msgid "Target: %{text}"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.table.miq_task
 #: ../dictionary_strings.rb:2023
 msgid "Task"
 msgstr ""
 
-#: ../../app/views/miq_task/_tasks_options.html.haml:128
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#: ../yaml_strings.rb:3562
+msgid "Task Name"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../../app/views/miq_task/_tasks_options.html.haml:128 ../yaml_strings.rb:3606
 msgid "Task State"
 msgstr ""
 
@@ -25530,8 +34592,9 @@ msgstr ""
 msgid "Task Status"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.miq_task (plural form)
-#: ../../app/presenters/menu/default_menu.rb:163 ../dictionary_strings.rb:2025
+#: ../../app/presenters/menu/default_menu.rb:163 ../yaml_strings.rb:1163 ../dictionary_strings.rb:2025
 msgid "Tasks"
 msgstr ""
 
@@ -25541,29 +34604,61 @@ msgstr ""
 msgid "Template"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2255
+msgid "Template Access Rules"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:545
+msgid "Template Analysis"
+msgstr ""
+
 #: ../../app/assets/javascripts/controllers/schedule/schedule_form_controller.js:154
 msgid "Template Selection"
 msgstr ""
 
-#: ../../app/views/catalog/_ot_add.html.haml:54
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#: ../../app/views/catalog/_ot_add.html.haml:54 ../yaml_strings.rb:2739
 msgid "Template Type"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Template (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.template_infra (plural form)
-#: ../../app/views/layouts/listnav/_host.html.haml:138 ../../app/views/layouts/listnav/_repository.html.haml:29 ../../app/views/layouts/listnav/_ems_infra.html.haml:72 ../../app/views/configuration/_ui_2.html.haml:307 ../dictionary_strings.rb:1447 ../dictionary_strings.rb:2111
+#: ../../app/controllers/host_controller.rb:92 ../../app/controllers/ems_common.rb:58 ../../app/controllers/vm_infra_controller.rb:33 ../../app/views/layouts/listnav/_host.html.haml:138 ../../app/views/layouts/listnav/_repository.html.haml:29 ../../app/views/layouts/listnav/_ems_infra.html.haml:72 ../../app/views/configuration/_ui_2.html.haml:318 ../yaml_strings.rb:57 ../dictionary_strings.rb:1447 ../dictionary_strings.rb:2111
 msgid "Templates"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:49
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/vm_or_template_controller.rb:23 ../../app/views/configuration/_ui_2.html.haml:49 ../yaml_strings.rb:18
 msgid "Templates & Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:20
+msgid "Templates & Images Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:59
+msgid "Templates Accordion"
 msgstr ""
 
 #: ../../app/views/provider_foreman/_main.html.haml:16 ../../app/views/provider_foreman/_main_configuration_profile.html.haml:16
 msgid "Tenancy"
 msgstr ""
 
-#: ../model_attributes.rb:2150
+#. TRANSLATORS: file: product/views/ServiceCatalog.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+#: ../../app/controllers/ops_controller/ops_rbac.rb:855 ../yaml_strings.rb:3189 ../model_attributes.rb:2150
 msgid "Tenant"
 msgstr ""
 
@@ -25575,7 +34670,7 @@ msgstr ""
 msgid "Tenant ID, Client ID and matching Client Key fields are needed to perform verification of credentials"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_tenant_details.html.haml:151
+#: ../../app/helpers/ops_helper/textual_summary.rb:138 ../../app/views/ops/_rbac_tenant_details.html.haml:151
 msgid "Tenant Quota"
 msgstr ""
 
@@ -25599,7 +34694,9 @@ msgstr ""
 msgid "TenantQuota|Value"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:28 ../../app/views/configuration/_ui_2.html.haml:145
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Tenant.yaml
+#: ../../app/presenters/tree_builder_ops_rbac.rb:33 ../../app/presenters/menu/default_menu.rb:28 ../../app/controllers/ops_controller.rb:704 ../../app/controllers/ops_controller.rb:719 ../../app/views/configuration/_ui_2.html.haml:145 ../yaml_strings.rb:1308
 msgid "Tenants"
 msgstr ""
 
@@ -25671,8 +34768,14 @@ msgstr ""
 msgid "Tenant|Use config for attributes"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:197 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:249
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:197 ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:249 ../yaml_strings.rb:2085
 msgid "Terminate"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2087
+msgid "Terminate the Guest OS on Instances"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/vm_clouds_center.rb:248
@@ -25711,23 +34814,23 @@ msgstr ""
 msgid "The CFME Server is still starting. If this message persists, please contact your CFME administrator."
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:238
+#: ../../app/controllers/repository_controller.rb:239
 msgid "The Default Repository SmartProxy is not valid, contact your CFME Administrator"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:232
+#: ../../app/controllers/repository_controller.rb:233
 msgid "The Default Repository SmartProxy no longer exists, contact your CFME Administrator"
 msgstr ""
 
-#: ../../app/controllers/repository_controller.rb:243
-msgid "The Default Repository SmartProxy, \"%s\", is not running, contact your CFME Administrator"
+#: ../../app/controllers/repository_controller.rb:244
+msgid "The Default Repository SmartProxy, \"%{name}\", is not running, contact your CFME Administrator"
 msgstr ""
 
-#: ../../app/views/miq_policy/_alert_profile_details.html.haml:194
+#: ../../app/helpers/ui_constants.rb:443 ../../app/helpers/ui_constants.rb:462 ../../app/helpers/ui_constants.rb:473 ../../app/views/miq_policy/_alert_profile_details.html.haml:194
 msgid "The Enterprise"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:546
+#: ../../app/controllers/ems_common.rb:552
 msgid "The Host Default VNC Port Range ending port must be equal to or higher than the starting point"
 msgstr ""
 
@@ -25739,76 +34842,88 @@ msgstr ""
 msgid "The VM has been suspended, powered off or the connection to the server has been lost. \\nThis console window will now close."
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:1448
+#: ../../app/controllers/application_controller/filter.rb:1339
 msgid "The check count value must be an integer to commit this expression element"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:713
+#: ../../app/controllers/application_controller/filter.rb:715
 msgid "The current search details have been reset"
-msgstr ""
-
-#: ../../app/controllers/repository_controller.rb:301 ../../app/controllers/report_controller/dashboards.rb:119 ../../app/controllers/report_controller/widgets.rb:112 ../../app/controllers/report_controller/saved_reports.rb:101 ../../app/controllers/report_controller/schedules.rb:88
-msgid "The selected %s was deleted"
-msgstr ""
-
-#: ../../app/controllers/report_controller/widgets.rb:109 ../../app/controllers/report_controller/schedules.rb:88
-msgid "The selected %s were deleted"
-msgstr ""
-
-#: ../../app/controllers/report_controller/schedules.rb:141
-msgid "The selected %s were disabled"
-msgstr ""
-
-#: ../../app/controllers/report_controller/schedules.rb:138
-msgid "The selected %s were enabled"
 msgstr ""
 
 #: ../../app/controllers/application_controller.rb:1614
 msgid "The selected %{label} is not in the current region"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller/policies.rb:129 ../../app/controllers/miq_policy_controller/miq_actions.rb:80 ../../app/controllers/miq_policy_controller/alerts.rb:60 ../../app/controllers/miq_policy_controller/conditions.rb:133 ../../app/controllers/miq_policy_controller/policy_profiles.rb:85
+#: ../../app/controllers/report_controller/widgets.rb:112 ../../app/controllers/miq_policy_controller/policies.rb:129 ../../app/controllers/miq_policy_controller/miq_actions.rb:80 ../../app/controllers/miq_policy_controller/alerts.rb:60 ../../app/controllers/miq_policy_controller/conditions.rb:133 ../../app/controllers/miq_policy_controller/policy_profiles.rb:85
 msgid "The selected %{models} was deleted"
+msgstr ""
+
+#: ../../app/controllers/report_controller/widgets.rb:109
+msgid "The selected %{models} were deleted"
 msgstr ""
 
 #: ../../app/controllers/miq_policy_controller/alert_profiles.rb:118 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:419
 msgid "The selected %{model} was deleted"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:2478
+#: ../../app/controllers/miq_ae_class_controller.rb:2480
 msgid "The selected %{model} were marked as %{action}"
 msgstr ""
 
-#: ../../app/controllers/chargeback_controller.rb:308
-msgid "The selected %{records} were deleted"
-msgstr ""
-
-#: ../../app/controllers/chargeback_controller.rb:324 ../../app/controllers/catalog_controller.rb:335 ../../app/controllers/ems_common.rb:865 ../../app/controllers/application_controller/ci_processing.rb:1925 ../../app/controllers/application_controller/ci_processing.rb:1953
+#: ../../app/controllers/catalog_controller.rb:295 ../../app/controllers/ems_common.rb:880 ../../app/controllers/application_controller/ci_processing.rb:1939 ../../app/controllers/application_controller/ci_processing.rb:1967
 msgid "The selected %{record} was deleted"
 msgstr ""
 
-#: ../../app/controllers/miq_ae_class_controller.rb:1863 ../../app/controllers/miq_ae_class_controller.rb:1891 ../../app/controllers/catalog_controller.rb:345
+#: ../../app/controllers/miq_ae_class_controller.rb:1865 ../../app/controllers/miq_ae_class_controller.rb:1893 ../../app/controllers/catalog_controller.rb:305
 msgid "The selected %{record} were deleted"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:145
+msgid "The selected %{schedules} were disabled"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:142
+msgid "The selected %{schedules} were enabled"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:91
+msgid "The selected %{schedule} was deleted"
+msgstr ""
+
+#: ../../app/controllers/report_controller/schedules.rb:89
+msgid "The selected %{schedule} were deleted"
 msgstr ""
 
 #: ../../app/controllers/miq_request_controller.rb:532
 msgid "The selected %{tables} were deleted"
 msgstr ""
 
-#: ../../app/controllers/miq_request_controller.rb:542 ../../app/controllers/ops_controller/diagnostics.rb:700
+#: ../../app/controllers/miq_request_controller.rb:542 ../../app/controllers/ops_controller/diagnostics.rb:720
 msgid "The selected %{table} was deleted"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:890
+#: ../../app/controllers/report_controller/dashboards.rb:119
+msgid "The selected Dashboard was deleted"
+msgstr ""
+
+#: ../../app/controllers/application_controller/filter.rb:892
 msgid "The selected Filter can not be set as Default because it requires user input"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:888
+#: ../../app/controllers/application_controller/filter.rb:890
 msgid "The selected Filter record was not found"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_report_center.rb:46
 msgid "The selected Reports will be permanently removed from the database. Are you sure you want to delete this Report?"
+msgstr ""
+
+#: ../../app/controllers/repository_controller.rb:306
+msgid "The selected Repository was deleted"
+msgstr ""
+
+#: ../../app/controllers/report_controller/saved_reports.rb:103
+msgid "The selected Saved Report was deleted"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/saved_reports_center.rb:33
@@ -25819,19 +34934,19 @@ msgstr ""
 msgid "The selected Saved Reports will be permanently removed from the database. Are you sure you want to delete this saved Report?"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:124
+#: ../../app/controllers/report_controller/schedules.rb:128
 msgid "The selected Schedule has been queued to run"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:126
+#: ../../app/controllers/report_controller/schedules.rb:130
 msgid "The selected Schedules have been queued to run"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:201
+#: ../../app/controllers/ops_controller/settings/schedules.rb:202
 msgid "The selected Schedules were disabled"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/schedules.rb:199
+#: ../../app/controllers/ops_controller/settings/schedules.rb:200
 msgid "The selected Schedules were enabled"
 msgstr ""
 
@@ -25855,17 +34970,26 @@ msgstr ""
 msgid "The test email is being delivered, check \"%{email}\" to verify it was successful"
 msgstr ""
 
-#: ../../app/controllers/application_controller.rb:1302 ../../app/controllers/application_controller.rb:2570 ../../app/controllers/ontap_file_share_controller.rb:57 ../../app/controllers/dashboard_controller.rb:621 ../../app/controllers/ontap_storage_system_controller.rb:62
+#: ../../app/controllers/application_controller.rb:1302 ../../app/controllers/application_controller.rb:2569 ../../app/controllers/ontap_file_share_controller.rb:57 ../../app/controllers/dashboard_controller.rb:605 ../../app/controllers/ontap_storage_system_controller.rb:62
 msgid "The user is not authorized for this task or item."
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:106
+#: ../../app/controllers/application_controller/filter.rb:108
 msgid "There is an error in the selected expression element, perhaps it was imported or edited manually."
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.thin_provisioned
 #: ../dictionary_strings.rb:955
 msgid "Thin Provisioned"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../yaml_strings.rb:3263
+msgid "Thin Provisioning"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:450 ../../app/helpers/vm_helper/textual_summary.rb:549
+msgid "Thin Provisioning Used"
 msgstr ""
 
 #: ../../app/views/report/_form_tl_settings.html.haml:89
@@ -25900,12 +35024,24 @@ msgstr ""
 msgid "This Event is not assigned to any Policies."
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:504
+msgid "This Hour"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:526
+msgid "This Month"
+msgstr ""
+
 #: ../../app/views/report/_form_filter_chargeback.html.haml:180
 msgid "This Month (partial)"
 msgstr ""
 
 #: ../../app/views/miq_policy/_policy_details.html.haml:451
 msgid "This Policy is not assigned to any Profiles."
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:534
+msgid "This Quarter"
 msgstr ""
 
 #: ../../app/views/ops/_diagnostics_timelines_tab.html.haml:16 ../../app/views/ops/_diagnostics_utilization_tab.html.haml:13
@@ -25920,15 +35056,23 @@ msgstr ""
 msgid "This VM will revert to selected snapshot. Are you sure you want to revert to the selected snapshot?"
 msgstr ""
 
+#: ../../app/helpers/ui_constants.rb:519
+msgid "This Week"
+msgstr ""
+
 #: ../../app/views/report/_form_filter_chargeback.html.haml:178
 msgid "This Week (partial)"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:541
+msgid "This Year"
 msgstr ""
 
 #: ../../app/assets/javascripts/dialog_field_refresh.js:115
 msgid "This element is disabled because it is read only"
 msgstr ""
 
-#: ../../app/controllers/application_controller/filter.rb:107
+#: ../../app/controllers/application_controller/filter.rb:109
 msgid "This element should be removed and recreated or you can report the error to your CFME administrator."
 msgstr ""
 
@@ -25972,8 +35116,13 @@ msgstr ""
 msgid "Tile View"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2365
+msgid "Time (H:M:S Z)"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.model.TimeProfile
-#: ../../app/views/layouts/_perf_options.html.haml:130 ../../app/views/report/_form_filter_performance.html.haml:52 ../../app/views/miq_capacity/_utilization_options.html.haml:65 ../../app/views/miq_capacity/_planning_options.html.haml:435 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:116 ../dictionary_strings.rb:1715
+#: ../../app/controllers/configuration_controller.rb:356 ../../app/views/layouts/_perf_options.html.haml:130 ../../app/views/report/_form_filter_performance.html.haml:52 ../../app/views/miq_capacity/_utilization_options.html.haml:65 ../../app/views/miq_capacity/_planning_options.html.haml:435 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:116 ../dictionary_strings.rb:1715
 msgid "Time Profile"
 msgstr ""
 
@@ -25981,9 +35130,15 @@ msgstr ""
 msgid "Time Profile Information"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.TimeProfile (plural form)
-#: ../../app/controllers/configuration_controller.rb:632 ../dictionary_strings.rb:1717
+#: ../../app/controllers/configuration_controller.rb:296 ../../app/controllers/configuration_controller.rb:640 ../yaml_strings.rb:1151 ../dictionary_strings.rb:1717
 msgid "Time Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#: ../yaml_strings.rb:2429
+msgid "Time Stamp"
 msgstr ""
 
 #: ../../app/views/ops/_schedule_form_timer.html.haml:41 ../../app/views/configuration/_ui_1.html.haml:145 ../../app/views/report/_schedule_form_timer.html.haml:86 ../../app/views/report/_form_filter_chargeback.html.haml:214 ../../app/views/miq_capacity/_bottlenecks_options.html.haml:54 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:128
@@ -25992,6 +35147,10 @@ msgstr ""
 
 #: ../model_attributes.rb:2171
 msgid "Time profile"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:575
+msgid "TimeProfile \"%{name}\": Error during 'save': %{error_message}"
 msgstr ""
 
 #: ../model_attributes.rb:2172
@@ -26022,8 +35181,38 @@ msgstr ""
 msgid "TimeProfile|Updated on"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:280
+msgid "Timeline"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#: ../yaml_strings.rb:2427
+msgid "Timeline All Bottleneck Events"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+#: ../yaml_strings.rb:2597
+msgid "Timeline All Events"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+#: ../yaml_strings.rb:2583
+msgid "Timeline All Policy Events"
+msgstr ""
+
 #: ../../app/views/miq_policy/_alert_evm_event.html.haml:5 ../../app/views/miq_policy/_alert_details.html.haml:412
 msgid "Timeline Event"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+#: ../yaml_strings.rb:2687
+msgid "Timeline Events Hourly"
+msgstr ""
+
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+#: ../yaml_strings.rb:2685
+msgid "Timeline Policy Events Hourly"
 msgstr ""
 
 #: ../../app/views/report/_form_preview.html.haml:8
@@ -26034,12 +35223,25 @@ msgstr ""
 msgid "Timeline Settings"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:10 ../../app/helpers/application_helper/toolbar/vm_center.rb:151 ../../app/helpers/application_helper/toolbar/host_center.rb:103 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:148 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:105 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:117 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:55 ../../app/helpers/application_helper/toolbar/container_center.rb:52 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:63 ../../app/helpers/application_helper/toolbar/container_project_center.rb:36 ../../app/helpers/application_helper/toolbar/container_node_center.rb:43 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:68 ../../app/helpers/application_helper/toolbar/container_group_center.rb:36 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:43 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:107 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:36 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:35 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:74 ../../app/views/ops/_all_tabs.html.haml:186 ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:46 ../../app/views/layouts/listnav/_ems_container.html.haml:38 ../../app/views/layouts/listnav/_ems_container.html.haml:46 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:46 ../../app/views/layouts/listnav/_container_node.html.haml:46 ../../app/views/layouts/listnav/_ems_cloud.html.haml:18 ../../app/views/layouts/listnav/_container_project.html.haml:46
+#: ../../app/controllers/report_controller/reports.rb:356
+msgid "Timeline tab is not available unless at least 1 time field has been selected"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:346
+msgid "Timeline tab is not available until at least 1 field has been selected"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:10 ../../app/controllers/vm_common.rb:73 ../../app/controllers/dashboard_controller.rb:518 ../../app/controllers/dashboard_controller.rb:536 ../../app/controllers/host_controller.rb:69 ../../app/controllers/availability_zone_controller.rb:88 ../../app/controllers/ems_common.rb:40 ../../app/controllers/ems_common.rb:398 ../../app/controllers/ems_cluster_controller.rb:104 ../../app/helpers/application_helper/toolbar/vm_center.rb:151 ../../app/helpers/application_helper/toolbar/host_center.rb:103 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:148 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:105 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:117 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:55 ../../app/helpers/application_helper/toolbar/container_center.rb:52 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:63 ../../app/helpers/application_helper/toolbar/container_project_center.rb:36 ../../app/helpers/application_helper/toolbar/container_node_center.rb:43 ../../app/helpers/application_helper/toolbar/ems_cloud_center.rb:68 ../../app/helpers/application_helper/toolbar/container_group_center.rb:36 ../../app/helpers/application_helper/toolbar/ems_middleware_center.rb:43 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:107 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:36 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:35 ../../app/helpers/application_helper/toolbar/ems_infra_center.rb:74 ../../app/views/ops/_all_tabs.html.haml:186 ../../app/views/layouts/listnav/_host.html.haml:79 ../../app/views/layouts/listnav/_container_group.html.haml:42 ../../app/views/layouts/listnav/_ems_container.html.haml:34 ../../app/views/layouts/listnav/_ems_container.html.haml:42 ../../app/views/layouts/listnav/_ems_cluster.html.haml:32 ../../app/views/layouts/listnav/_ems_infra.html.haml:19 ../../app/views/layouts/listnav/_container_replicator.html.haml:42 ../../app/views/layouts/listnav/_container_node.html.haml:42 ../../app/views/layouts/listnav/_ems_cloud.html.haml:14 ../../app/views/layouts/listnav/_container_project.html.haml:42 ../yaml_strings.rb:485
 msgid "Timelines"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1808
+#: ../../app/controllers/vm_common.rb:1889
 msgid "Timelines for %{model} \"%{name}\""
+msgstr ""
+
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:478 ../../app/helpers/vm_infra_helper/textual_summary.rb:616 ../../app/helpers/vm_helper/textual_summary.rb:713
+msgid "Timeout (ms)"
 msgstr ""
 
 #: ../../app/views/report/_widget_show.html.haml:288 ../../app/views/report/_schedule_form_timer.html.haml:6
@@ -26054,7 +35256,9 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: ../../app/views/alert/_rss_list.html.haml:39 ../../app/views/configuration/_timeprofile_form.html.haml:162 ../../app/views/report/_widget_show.html.haml:14 ../../app/views/report/_widget_form.html.haml:19 ../../app/views/report/_form.html.haml:42 ../../app/views/report/_report_info.html.haml:9 ../../app/views/report/_report_info.html.haml:243
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/MiqWidget.yaml
+#: ../../app/views/alert/_rss_list.html.haml:39 ../../app/views/configuration/_timeprofile_form.html.haml:162 ../../app/views/report/_widget_show.html.haml:14 ../../app/views/report/_widget_form.html.haml:19 ../../app/views/report/_form.html.haml:42 ../../app/views/report/_report_info.html.haml:9 ../../app/views/report/_report_info.html.haml:243 ../yaml_strings.rb:3383
 msgid "Title"
 msgstr ""
 
@@ -26086,8 +35290,12 @@ msgstr ""
 msgid "To E-mail Address"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:541
+#: ../../app/controllers/ems_common.rb:547
 msgid "To configure the Host Default VNC Port Range, both start and end ports are required"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:399 ../../app/helpers/ui_constants.rb:508
+msgid "Today"
 msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:176
@@ -26106,8 +35314,24 @@ msgstr ""
 msgid "Top values to show"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:107 ../../app/presenters/menu/default_menu.rb:117 ../../app/helpers/ems_middleware_helper/textual_summary.rb:64 ../../app/helpers/ems_container_helper/textual_summary.rb:95
+#: ../../app/presenters/menu/default_menu.rb:107 ../../app/presenters/menu/default_menu.rb:117 ../../app/controllers/middleware_topology_controller.rb:14 ../../app/controllers/container_topology_controller.rb:14 ../../app/helpers/ems_middleware_helper/textual_summary.rb:64 ../../app/helpers/ems_container_helper/textual_summary.rb:95
 msgid "Topology"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:104 ../../app/helpers/resource_pool_helper/textual_summary.rb:47
+msgid "Total %{title} CPU Cores"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:32
+msgid "Total %{title} CPU Resources"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:42
+msgid "Total %{title} CPUs"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:37
+msgid "Total %{title} Memory"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.total_ios_per_sec
@@ -26115,9 +35339,51 @@ msgstr ""
 msgid "Total (IOPS)"
 msgstr ""
 
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:471 ../../app/helpers/vm_helper/textual_summary.rb:570
+msgid "Total Allocation"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:92
+msgid "Total CPU Resources"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.aggregate_cpu_speed
 #: ../dictionary_strings.rb:161
 msgid "Total CPU Speed"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:100 ../yaml_strings.rb:3685
+msgid "Total CPUs"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:3822
+msgid "Total Configuration Profiles"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:116
+msgid "Total Configured CPUs"
+msgstr ""
+
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:109
+msgid "Total Configured Memory"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2971
+msgid "Total Configured Systems"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:56
+msgid "Total Configured VM CPUs"
+msgstr ""
+
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:52
+msgid "Total Configured VM Memory"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.total_cost
@@ -26125,19 +35391,32 @@ msgstr ""
 msgid "Total Cost"
 msgstr ""
 
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:492 ../../app/helpers/vm_helper/textual_summary.rb:591
+msgid "Total Datastore Used Space"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.v_total_storages
 #: ../dictionary_strings.rb:1083
 msgid "Total Datastores"
 msgstr ""
 
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:163
+msgid "Total Files"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_total_hosts
-#: ../dictionary_strings.rb:1073
+#: ../yaml_strings.rb:3253 ../dictionary_strings.rb:1073
 msgid "Total Hosts"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.ems_cloud.total_miq_templates
 #: ../dictionary_strings.rb:9
 msgid "Total Images"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:86
+msgid "Total Index Nodes"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.availability_zone.total_vms
@@ -26147,8 +35426,9 @@ msgstr ""
 msgid "Total Instances"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Service.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.aggregate_memory
-#: ../dictionary_strings.rb:165
+#: ../../app/helpers/ems_cluster_helper/textual_summary.rb:96 ../yaml_strings.rb:3687 ../dictionary_strings.rb:165
 msgid "Total Memory"
 msgstr ""
 
@@ -26166,15 +35446,46 @@ msgstr ""
 msgid "Total Processors"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Storage.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.provisioned_storage
 #. TRANSLATORS: en.yml key: dictionary.column.v_total_provisioned
-#: ../dictionary_strings.rb:717 ../dictionary_strings.rb:1077
+#: ../yaml_strings.rb:3251 ../dictionary_strings.rb:717 ../dictionary_strings.rb:1077
 msgid "Total Provisioned Space"
 msgstr ""
 
+#: ../../app/helpers/ops_helper/textual_summary.rb:139
+msgid "Total Quota"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/InstanceOrImage.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+#. TRANSLATORS: file: product/views/MiqTemplate.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_total_snapshots
-#: ../dictionary_strings.rb:1081
+#: ../yaml_strings.rb:3501 ../dictionary_strings.rb:1081
 msgid "Total Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../../app/helpers/storage_helper/textual_summary.rb:55 ../yaml_strings.rb:3245
+msgid "Total Space"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:71
+msgid "Total Space on Volume"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#: ../yaml_strings.rb:3594
+msgid "Total Templates"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.used_disk_storage
@@ -26182,8 +35493,31 @@ msgstr ""
 msgid "Total Used Disk Space"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../yaml_strings.rb:3689
+msgid "Total VM Disk Count"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../yaml_strings.rb:3691
+msgid "Total VM Disk Space Allocated"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../yaml_strings.rb:3693
+msgid "Total VM Disk Space Used"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Service.yaml
+#: ../yaml_strings.rb:3695
+msgid "Total VM Memory on Disk"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#. TRANSLATORS: file: product/views/Service.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.v_total_vms
-#: ../dictionary_strings.rb:1089
+#: ../yaml_strings.rb:3591 ../dictionary_strings.rb:1089
 msgid "Total VMs"
 msgstr ""
 
@@ -26241,7 +35575,7 @@ msgstr ""
 msgid "Trap Number"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1027
+#: ../../app/controllers/miq_policy_controller.rb:1029
 msgid "Trap Number is required"
 msgstr ""
 
@@ -26249,7 +35583,7 @@ msgstr ""
 msgid "Trap Object ID"
 msgstr ""
 
-#: ../../app/controllers/miq_policy_controller.rb:1029
+#: ../../app/controllers/miq_policy_controller.rb:1031
 msgid "Trap Object ID is required"
 msgstr ""
 
@@ -26274,6 +35608,18 @@ msgstr ""
 msgid "Trend Target Limit"
 msgstr ""
 
+#: ../../app/controllers/report_controller/reports.rb:230
+msgid "Trend Target Limit must be configured"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:233
+msgid "Trend Target Limit must be numeric"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:368
+msgid "Trend Target Limit: Value must be numeric"
+msgstr ""
+
 #: ../../app/views/report/_form_columns_trend.html.haml:80
 msgid "Trend Target Percents"
 msgstr ""
@@ -26284,6 +35630,10 @@ msgstr ""
 
 #: ../../app/views/report/_form_columns_trend.html.haml:6
 msgid "Trending for"
+msgstr ""
+
+#: ../../app/controllers/report_controller/reports.rb:227
+msgid "Trending for is required"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_utilization_options.html.haml:16 ../../app/views/miq_capacity/_planning_options.html.haml:413
@@ -26306,10 +35656,33 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
+#. TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+#. TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+#. TRANSLATORS: file: product/views/CloudVolume.yaml
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ContainerService.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+#. TRANSLATORS: file: product/views/MiqAction.yaml
+#. TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+#. TRANSLATORS: file: product/views/MiqWidget-all.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStack.yaml
+#. TRANSLATORS: file: product/views/ScanItemSet.yaml
+#. TRANSLATORS: file: product/views/ServerBuild.yaml
+#. TRANSLATORS: file: product/views/ServiceTemplate.yaml
+#. TRANSLATORS: file: product/views/StorageManager.yaml
+#. TRANSLATORS: file: product/views/Tenant.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.action_type_description
 #. TRANSLATORS: en.yml key: dictionary.column.emstype_description
 #. TRANSLATORS: en.yml key: dictionary.column.mode
-#: ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/ops/_settings_database_tab.html.haml:37 ../../app/views/ops/_schedule_form_filter.html.haml:19 ../../app/views/ops/_ap_show.html.haml:48 ../../app/views/ops/_log_collection.html.haml:27 ../../app/views/ops/_settings_import_tab.html.haml:20 ../../app/views/ops/_diagnostics_database_tab.html.haml:19 ../../app/views/ops/_diagnostics_database_tab.html.haml:140 ../../app/views/ops/_ap_form.html.haml:57 ../../app/views/provider_foreman/_form.html.haml:44 ../../app/views/storage_manager/_form.html.haml:41 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:53 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:69 ../../app/views/layouts/_ae_resolve_options.html.haml:92 ../../app/views/layouts/_ae_resolve_options.html.haml:116 ../../app/views/layouts/_edit_log_depot_settings.html.haml:21 ../../app/views/vm_common/_disks.html.haml:9 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_widget_show.html.haml:178 ../../app/views/report/_db_list.html.haml:15 ../../app/views/report/_widget_form_rss.html.haml:15 ../../app/views/shared/views/ems_common/angular/_form.html.haml:40 ../../app/views/shared/views/ems_common/_form.html.haml:35 ../../app/views/shared/buttons/_ab_list.html.haml:51 ../../app/views/shared/buttons/_ab_show.html.haml:135 ../../app/views/pxe/_pxe_image_type_form.html.haml:34 ../../app/views/pxe/_template_form.html.haml:70 ../../app/views/pxe/_pxe_img_form.html.haml:17 ../../app/views/pxe/_iso_img_form.html.haml:17 ../../app/views/pxe/_pxe_wimg_form.html.haml:17 ../../app/views/miq_policy/_event_details.html.haml:230 ../../app/views/miq_policy/_event_details.html.haml:422 ../../app/views/miq_policy/_alert_snmp.html.haml:108 ../../app/views/miq_policy/_action_options.html.haml:454 ../../app/views/miq_policy/_alert_details.html.haml:380 ../../app/views/miq_policy/_action_details.html.haml:398 ../dictionary_strings.rb:155 ../dictionary_strings.rb:385 ../dictionary_strings.rb:593
+#: ../../app/helpers/container_service_helper/textual_summary.rb:50 ../../app/helpers/container_helper/textual_summary.rb:121 ../../app/helpers/pxe_helper/textual_summary.rb:56 ../../app/helpers/pxe_helper/textual_summary.rb:80 ../../app/helpers/pxe_helper/textual_summary.rb:108 ../../app/helpers/pxe_helper/textual_summary.rb:144 ../../app/helpers/container_project_helper/textual_summary.rb:42 ../../app/views/ops/_settings_database_tab.html.haml:37 ../../app/views/ops/_schedule_form_filter.html.haml:19 ../../app/views/ops/_ap_show.html.haml:48 ../../app/views/ops/_log_collection.html.haml:27 ../../app/views/ops/_settings_import_tab.html.haml:20 ../../app/views/ops/_diagnostics_database_tab.html.haml:19 ../../app/views/ops/_diagnostics_database_tab.html.haml:140 ../../app/views/ops/_ap_form.html.haml:57 ../../app/views/provider_foreman/_form.html.haml:44 ../../app/views/storage_manager/_form.html.haml:41 ../../app/views/miq_ae_customization/_old_dialogs_form.html.haml:53 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:69 ../../app/views/layouts/_ae_resolve_options.html.haml:92 ../../app/views/layouts/_ae_resolve_options.html.haml:116 ../../app/views/layouts/_edit_log_depot_settings.html.haml:21 ../../app/views/vm_common/_disks.html.haml:9 ../../app/views/miq_ae_class/_class_fields.html.haml:97 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_widget_show.html.haml:178 ../../app/views/report/_db_list.html.haml:15 ../../app/views/report/_widget_form_rss.html.haml:15 ../../app/views/shared/views/ems_common/angular/_form.html.haml:40 ../../app/views/shared/views/ems_common/_form.html.haml:35 ../../app/views/shared/buttons/_ab_list.html.haml:51 ../../app/views/shared/buttons/_ab_show.html.haml:135 ../../app/views/pxe/_pxe_image_type_form.html.haml:34 ../../app/views/pxe/_template_form.html.haml:70 ../../app/views/pxe/_pxe_img_form.html.haml:17 ../../app/views/pxe/_iso_img_form.html.haml:17 ../../app/views/pxe/_pxe_wimg_form.html.haml:17 ../../app/views/miq_policy/_event_details.html.haml:230 ../../app/views/miq_policy/_event_details.html.haml:422 ../../app/views/miq_policy/_alert_snmp.html.haml:108 ../../app/views/miq_policy/_action_options.html.haml:454 ../../app/views/miq_policy/_alert_details.html.haml:380 ../../app/views/miq_policy/_action_details.html.haml:398 ../yaml_strings.rb:2453 ../dictionary_strings.rb:155 ../dictionary_strings.rb:385 ../dictionary_strings.rb:593
 msgid "Type"
 msgstr ""
 
@@ -26318,7 +35691,7 @@ msgstr ""
 msgid "Type Name"
 msgstr ""
 
-#: ../../app/controllers/ems_common.rb:138
+#: ../../app/controllers/storage_manager_controller.rb:84 ../../app/controllers/storage_manager_controller.rb:91 ../../app/controllers/storage_manager_controller.rb:120 ../../app/controllers/pxe_controller/pxe_customization_templates.rb:116 ../../app/controllers/ems_common.rb:142
 msgid "Type is required"
 msgstr ""
 
@@ -26326,12 +35699,17 @@ msgstr ""
 msgid "Type:"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_topology/container_topology_controller.js:223
+#: ../../app/assets/javascripts/services/topology_service.js:6
 msgid "Type: "
 msgstr ""
 
 #: ../../app/views/miq_ae_class/_instance_fields.html.haml:46
 msgid "Type: %s"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#: ../yaml_strings.rb:3552
+msgid "UI Tasks"
 msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:183
@@ -26343,31 +35721,87 @@ msgstr ""
 msgid "UID"
 msgstr ""
 
-#: ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:36 ../../app/views/layouts/_edit_log_depot_settings.html.haml:60 ../../app/views/miq_ae_tools/_results_uri.html.haml:16 ../../app/views/pxe/_pxe_form.html.haml:55
+#: ../../app/helpers/pxe_helper/textual_summary.rb:12 ../../app/views/layouts/angular-bootstrap/_edit_log_depot_settings_angular_bootstrap.html.haml:36 ../../app/views/layouts/_edit_log_depot_settings.html.haml:60 ../../app/views/miq_ae_tools/_results_uri.html.haml:16 ../../app/views/pxe/_pxe_form.html.haml:55
 msgid "URI"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/MiqWorker.yaml
+#: ../yaml_strings.rb:3538
+msgid "URI / Queue Name"
+msgstr ""
+
+#: ../../app/helpers/pxe_helper/textual_summary.rb:8
+msgid "URI Prefix"
+msgstr ""
+
+#: ../../app/controllers/pxe_controller/pxe_servers.rb:302 ../../app/controllers/pxe_controller/pxe_servers.rb:306
+msgid "URI is required"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#: ../yaml_strings.rb:2948
+msgid "URL"
 msgstr ""
 
 #: ../../app/views/ops/_settings_server_tab.html.haml:658
 msgid "URL (i.e. www.mypage.com)"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1046
+#: ../../app/helpers/ui_constants.rb:52
+msgid "US Executive - 7.25in x 10.5in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:57
+msgid "US Folio - 8.5in x 13.0in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:55
+msgid "US Government - 8.0in x 11.0in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:53
+msgid "US Ledger - 17.0in x 11.0in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:51
+msgid "US Legal - 8.5in x 14.0in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:50
+msgid "US Letter - 8.5in x 11.0in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:56
+msgid "US Statement - 5.5in x 8.5in"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:54
+msgid "US Tabloid - 11.0in x 17.0in"
+msgstr ""
+
+#: ../../app/controllers/catalog_controller.rb:1041
 msgid "Unable to create a new template copy \"%{name}\": new template content cannot be empty."
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:1042
+#: ../../app/controllers/catalog_controller.rb:1037
 msgid "Unable to create a new template copy \"%{name}\": old and new template content have to differ."
 msgstr ""
 
-#: ../../app/controllers/ems_infra_controller.rb:75
-msgid "Unable to initiate scaling: %s"
+#: ../../app/controllers/ems_infra_controller.rb:63
+msgid "Unable to initiate scaling, obtaining of status failed: %{message}"
+msgstr ""
+
+#: ../../app/controllers/ems_infra_controller.rb:76
+msgid "Unable to initiate scaling: %{message}"
 msgstr ""
 
 #: ../../app/views/catalog/_form_basic_info.html.haml:61 ../../app/views/catalog/_sandt_tree_show.html.haml:61
 msgid "Unassigned"
 msgstr ""
 
-#: ../../app/presenters/tree_node_builder.rb:226 ../../app/controllers/provider_foreman_controller.rb:958 ../../app/controllers/provider_foreman_controller.rb:983 ../../app/controllers/provider_foreman_controller.rb:996
+#: ../../app/presenters/tree_node_builder.rb:226 ../../app/controllers/provider_foreman_controller.rb:910 ../../app/controllers/provider_foreman_controller.rb:935 ../../app/controllers/provider_foreman_controller.rb:948
 msgid "Unassigned Profiles Group"
 msgstr ""
 
@@ -26380,8 +35814,12 @@ msgid "Unattended GUI"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.uncommitted_storage
-#: ../dictionary_strings.rb:985
+#: ../../app/helpers/storage_helper/textual_summary.rb:65 ../dictionary_strings.rb:985
 msgid "Uncommitted Space"
+msgstr ""
+
+#: ../../app/helpers/container_group_helper/textual_summary.rb:103 ../../app/helpers/container_node_helper/textual_summary.rb:80
+msgid "Underlying %{name}"
 msgstr ""
 
 #: ../../app/views/layouts/_exp_editor.html.haml:19
@@ -26392,11 +35830,16 @@ msgstr ""
 msgid "Unexpected error encountered"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../yaml_strings.rb:3802
+msgid "Unit"
+msgstr ""
+
 #: ../../app/views/ops/_tenant_quota_form.html.haml:37
 msgid "Units"
 msgstr ""
 
-#: ../../app/views/dashboard/_widget_footer.html.haml:24 ../../app/views/pxe/_pxe_img_form.html.haml:22 ../../app/views/pxe/_iso_img_form.html.haml:22 ../../app/views/pxe/_pxe_wimg_form.html.haml:22
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:110 ../../app/helpers/host_helper/textual_summary.rb:163 ../../app/helpers/vm_infra_helper/textual_summary.rb:130 ../../app/helpers/vm_helper/textual_summary.rb:164 ../../app/views/dashboard/_widget_footer.html.haml:24 ../../app/views/pxe/_pxe_img_form.html.haml:22 ../../app/views/pxe/_iso_img_form.html.haml:22 ../../app/views/pxe/_pxe_wimg_form.html.haml:22
 msgid "Unknown"
 msgstr ""
 
@@ -26408,15 +35851,34 @@ msgstr ""
 msgid "Unknown image source"
 msgstr ""
 
-#: ../../app/views/ops/_settings_evm_servers_tab.html.haml:85 ../../app/views/ops/_zone_form.html.haml:199
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:133 ../../app/helpers/resource_pool_helper/textual_summary.rb:163 ../../app/views/ops/_settings_evm_servers_tab.html.haml:85 ../../app/views/ops/_zone_form.html.haml:199
 msgid "Unlimited"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:976
+msgid "Unlock"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:978
+msgid "Unlock Domain"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_ae_domain_center.rb:23
 msgid "Unlock this Domain"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/rhn.rb:295
+#. TRANSLATORS: file: product/views/Storage.yaml
+#: ../../app/helpers/storage_helper/textual_summary.rb:116 ../yaml_strings.rb:3259
+msgid "Unmanaged VMs"
+msgstr ""
+
+#: ../../app/helpers/vm_infra_helper/textual_summary.rb:500 ../../app/helpers/vm_helper/textual_summary.rb:599
+msgid "Unused/Overcommited Allocation"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/rhn.rb:299
 msgid "Update"
 msgstr ""
 
@@ -26426,6 +35888,11 @@ msgstr ""
 
 #: ../../app/views/ops/rhn/_server_table.html.haml:92
 msgid "Update Status"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#: ../yaml_strings.rb:3753
+msgid "Update Type"
 msgstr ""
 
 #: ../../app/views/dashboard/login.html.haml:89
@@ -26440,11 +35907,21 @@ msgstr ""
 msgid "Update this entry"
 msgstr ""
 
-#: ../../app/views/dashboard/_widget_footer.html.haml:6
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#: ../../app/views/dashboard/_widget_footer.html.haml:6 ../yaml_strings.rb:3555
 msgid "Updated"
 msgstr ""
 
-#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:60 ../../app/views/report/_report_info.html.haml:96 ../../app/views/catalog/_ot_tree_show.html.haml:76
+#. TRANSLATORS: file: product/views/ChargebackRate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+#. TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+#. TRANSLATORS: file: product/views/Repository.yaml
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#. TRANSLATORS: file: product/views/Vsc.yaml
+#: ../../app/views/miq_ae_customization/_dialog_info.html.haml:60 ../../app/views/report/_report_info.html.haml:96 ../../app/views/catalog/_ot_tree_show.html.haml:76 ../yaml_strings.rb:2816
 msgid "Updated On"
 msgstr ""
 
@@ -26480,6 +35957,10 @@ msgstr ""
 
 #: ../../app/views/provider_foreman/_form.html.haml:75
 msgid "Url"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:393
+msgid "Usage"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.write_data
@@ -27036,8 +36517,8 @@ msgstr ""
 msgid "Use the Browse button to locate CSV file"
 msgstr ""
 
-#: ../../app/controllers/catalog_controller.rb:468
-msgid "Use the Browse button to locate a %s image file"
+#: ../../app/controllers/catalog_controller.rb:433
+msgid "Use the Browse button to locate a .png or .jpg image file"
 msgstr ""
 
 #: ../../app/controllers/miq_ae_tools_controller.rb:203 ../../app/controllers/report_controller.rb:91 ../../app/controllers/miq_policy_controller.rb:163
@@ -27048,8 +36529,20 @@ msgstr ""
 msgid "Use the Browse button to locate an Upload file"
 msgstr ""
 
-#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:19 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:29
+#: ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:15 ../../app/assets/javascripts/controllers/container_dashboard/util/charts-mixin.js:25
 msgid "Used"
+msgstr ""
+
+#: ../../app/helpers/storage_helper/textual_summary.rb:70
+msgid "Used + Uncommitted Space"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:167
+msgid "Used Files"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:91
+msgid "Used Index Nodes"
 msgstr ""
 
 #: ../../app/views/vm_common/_disks.html.haml:17
@@ -27057,13 +36550,22 @@ msgid "Used Size"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_used_space
-#: ../dictionary_strings.rb:1091
+#: ../../app/helpers/storage_helper/textual_summary.rb:48 ../dictionary_strings.rb:1091
 msgid "Used Space"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.v_used_space_percent_of_total
 #: ../dictionary_strings.rb:1093
 msgid "Used Space Percent of Total"
+msgstr ""
+
+#: ../../app/helpers/ops_helper/textual_summary.rb:81
+msgid "Used Space on Volume"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
+#: ../yaml_strings.rb:3786
+msgid "Used Storage"
 msgstr ""
 
 #: ../../app/views/layouts/_multi_auth_credentials.html.haml:118 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:184
@@ -27090,11 +36592,17 @@ msgstr ""
 msgid "Used to gather Capacity & Utilization metrics."
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1707 ../../app/views/miq_task/_tasks_options.html.haml:39 ../../app/views/report/_report_list.html.haml:148 ../../app/views/report/_report_info.html.haml:76 ../model_attributes.rb:2179
+#. TRANSLATORS: file: product/views/Job.yaml
+#. TRANSLATORS: file: product/views/MiqTask.yaml
+#: ../../app/controllers/vm_common.rb:1788 ../../app/views/miq_task/_tasks_options.html.haml:39 ../../app/views/report/_report_list.html.haml:148 ../../app/views/report/_report_info.html.haml:76 ../yaml_strings.rb:3565 ../model_attributes.rb:2179
 msgid "User"
 msgid_plural "Users"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../../app/helpers/ui_constants.rb:434
+msgid "User Accounts"
+msgstr ""
 
 #: ../../app/views/shared/views/_prov_dialog.html.haml:259
 msgid "User Data"
@@ -27110,6 +36618,10 @@ msgstr ""
 
 #: ../../app/views/ops/_rbac_user_details.html.haml:17
 msgid "User Information"
+msgstr ""
+
+#: ../../app/controllers/configuration_controller.rb:625
+msgid "User Interface Configuration"
 msgstr ""
 
 #: ../../app/controllers/configuration_controller.rb:207 ../../app/controllers/configuration_controller.rb:220
@@ -27136,7 +36648,8 @@ msgstr ""
 msgid "User Role"
 msgstr ""
 
-#: ../../app/views/layouts/_role_visibility.html.haml:38 ../../app/views/shared/buttons/_ab_show.html.haml:220
+#. TRANSLATORS: file: product/views/MiqUserRole.yaml
+#: ../../app/views/layouts/_role_visibility.html.haml:38 ../../app/views/shared/buttons/_ab_show.html.haml:220 ../yaml_strings.rb:3920
 msgid "User Roles"
 msgstr ""
 
@@ -27150,6 +36663,10 @@ msgstr ""
 
 #: ../../app/views/ops/_settings_authentication_tab.html.haml:130 ../../app/views/ops/_ldap_region_show.html.haml:75 ../../app/views/ops/_ldap_domain_form.html.haml:39 ../../app/views/ops/_ldap_domain_show.html.haml:42 ../../app/views/_ldap_domain_form.html.haml:39
 msgid "User Type"
+msgstr ""
+
+#: ../../app/controllers/vm_common.rb:1281
+msgid "User is not authorized to view %{model} \"%{name}\""
 msgstr ""
 
 #: ../../app/controllers/ops_controller/ops_rbac.rb:531
@@ -27168,8 +36685,12 @@ msgstr ""
 msgid "User will input the value"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+#. TRANSLATORS: file: product/views/MiqReportResult.yaml
+#. TRANSLATORS: file: product/views/MiqSchedule.yaml
+#. TRANSLATORS: file: product/views/User.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.userid
-#: ../../app/views/ops/_diagnostics_savedreports.html.haml:18 ../../app/views/ops/_zone_form.html.haml:133 ../../app/views/ops/_rbac_user_details.html.haml:55 ../../app/views/ops/_settings_workers_tab.html.haml:554 ../../app/views/ops/_rbac_group_details.html.haml:212 ../../app/views/ops/_diagnostics_database_tab.html.haml:67 ../../app/views/storage_manager/_form.html.haml:156 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:4 ../../app/views/layouts/_auth_credentials_keypair.html.haml:7 ../../app/views/layouts/_auth_credentials.html.haml:9 ../../app/views/layouts/_discover_credentials.html.haml:13 ../../app/views/layouts/angular/_auth_credentials_angular.html.haml:3 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:160 ../../app/views/dashboard/login.html.haml:35 ../../app/views/dashboard/login.html.haml:39 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_report_info.html.haml:155 ../dictionary_strings.rb:5
+#: ../../app/views/ops/_diagnostics_savedreports.html.haml:18 ../../app/views/ops/_zone_form.html.haml:133 ../../app/views/ops/_rbac_user_details.html.haml:55 ../../app/views/ops/_settings_workers_tab.html.haml:554 ../../app/views/ops/_rbac_group_details.html.haml:212 ../../app/views/ops/_diagnostics_database_tab.html.haml:67 ../../app/views/storage_manager/_form.html.haml:156 ../../app/views/layouts/angular-bootstrap/_auth_credentials_angular_bootstrap.html.haml:4 ../../app/views/layouts/_auth_credentials_keypair.html.haml:7 ../../app/views/layouts/_auth_credentials.html.haml:9 ../../app/views/layouts/_discover_credentials.html.haml:13 ../../app/views/layouts/angular/_auth_credentials_angular.html.haml:3 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:160 ../../app/views/dashboard/login.html.haml:35 ../../app/views/dashboard/login.html.haml:39 ../../app/views/configuration/_ui_4.html.haml:15 ../../app/views/report/_report_info.html.haml:155 ../yaml_strings.rb:2718 ../dictionary_strings.rb:5
 msgid "Username"
 msgstr ""
 
@@ -27177,11 +36698,11 @@ msgstr ""
 msgid "Username and matching password fields are needed to run a database backup"
 msgstr ""
 
-#: ../../app/controllers/application_controller/ci_processing.rb:831
+#: ../../app/controllers/pxe_controller/pxe_servers.rb:309 ../../app/controllers/application_controller/ci_processing.rb:831
 msgid "Username is required"
 msgstr ""
 
-#: ../../app/controllers/ops_controller/settings/ldap.rb:179 ../../app/controllers/ems_common.rb:522 ../../app/controllers/application_controller/ci_processing.rb:836
+#: ../../app/controllers/storage_manager_controller.rb:277 ../../app/controllers/ops_controller/settings/ldap.rb:179 ../../app/controllers/ops_controller/settings/zones.rb:124 ../../app/controllers/ems_common.rb:528 ../../app/controllers/application_controller/ci_processing.rb:836
 msgid "Username must be entered if Password is entered"
 msgstr ""
 
@@ -27189,7 +36710,11 @@ msgstr ""
 msgid "Username must be entered to perform LDAP Group Look Up"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:187 ../../app/views/layouts/_item.html.haml:112
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Account-groups.yaml
+#. TRANSLATORS: file: product/views/Account-users.yaml
+#. TRANSLATORS: file: product/views/User.yaml
+#: ../../app/presenters/tree_builder_ops_rbac.rb:24 ../../app/controllers/ops_controller.rb:698 ../../app/controllers/ops_controller.rb:707 ../../app/helpers/vm_cloud_helper/textual_summary.rb:284 ../../app/helpers/host_helper/textual_summary.rb:407 ../../app/helpers/vm_infra_helper/textual_summary.rb:306 ../../app/helpers/vm_helper/textual_summary.rb:404 ../../app/views/layouts/listnav/_host.html.haml:187 ../../app/views/layouts/_item.html.haml:112 ../yaml_strings.rb:1247
 msgid "Users"
 msgstr ""
 
@@ -27197,7 +36722,7 @@ msgstr ""
 msgid "Users (%s)"
 msgstr ""
 
-#: ../../app/helpers/application_helper/toolbar_builder.rb:1080
+#: ../../app/helpers/application_helper/toolbar_builder.rb:1079
 msgid "Users are only allowed to delete their own requests"
 msgstr ""
 
@@ -27261,7 +36786,8 @@ msgstr ""
 msgid "User|Userid"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:154 ../../app/helpers/application_helper/toolbar/vm_center.rb:144 ../../app/helpers/application_helper/toolbar/host_center.rb:96 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:142 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:99 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:111 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:48 ../../app/helpers/application_helper/toolbar/container_service_center.rb:36 ../../app/helpers/application_helper/toolbar/container_center.rb:58 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:56 ../../app/helpers/application_helper/toolbar/container_project_center.rb:43 ../../app/helpers/application_helper/toolbar/container_node_center.rb:36 ../../app/helpers/application_helper/toolbar/storage_center.rb:52 ../../app/helpers/application_helper/toolbar/container_group_center.rb:43 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:28 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:43 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:43 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:100 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:43 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:28 ../../app/views/ops/_all_tabs.html.haml:183 ../../app/views/ops/_all_tabs.html.haml:299
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:154 ../../app/helpers/application_helper/toolbar/vm_center.rb:144 ../../app/helpers/application_helper/toolbar/host_center.rb:96 ../../app/helpers/application_helper/toolbar/x_vm_center.rb:142 ../../app/helpers/application_helper/toolbar/x_miq_template_center.rb:99 ../../app/helpers/application_helper/toolbar/x_vm_cloud_center.rb:111 ../../app/helpers/application_helper/toolbar/ems_container_center.rb:48 ../../app/helpers/application_helper/toolbar/container_service_center.rb:36 ../../app/helpers/application_helper/toolbar/container_center.rb:58 ../../app/helpers/application_helper/toolbar/ontap_storage_volume_center.rb:28 ../../app/helpers/application_helper/toolbar/ems_cluster_center.rb:56 ../../app/helpers/application_helper/toolbar/container_project_center.rb:43 ../../app/helpers/application_helper/toolbar/container_node_center.rb:36 ../../app/helpers/application_helper/toolbar/storage_center.rb:52 ../../app/helpers/application_helper/toolbar/container_group_center.rb:43 ../../app/helpers/application_helper/toolbar/ontap_logical_disk_center.rb:28 ../../app/helpers/application_helper/toolbar/ontap_file_share_center.rb:43 ../../app/helpers/application_helper/toolbar/ontap_storage_system_center.rb:43 ../../app/helpers/application_helper/toolbar/miq_template_center.rb:100 ../../app/helpers/application_helper/toolbar/container_replicator_center.rb:43 ../../app/helpers/application_helper/toolbar/availability_zone_center.rb:28 ../../app/views/ops/_all_tabs.html.haml:183 ../../app/views/ops/_all_tabs.html.haml:299 ../yaml_strings.rb:322
 msgid "Utilization"
 msgstr ""
 
@@ -27281,6 +36807,16 @@ msgstr ""
 msgid "VC Custom Attributes"
 msgstr ""
 
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#: ../yaml_strings.rb:2707
+msgid "VIM Usage for a Day"
+msgstr ""
+
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+#: ../yaml_strings.rb:2689
+msgid "VIM Usage for an Hour"
+msgstr ""
+
 #: ../../app/views/configuration/_ui_1.html.haml:25
 msgid "VM"
 msgstr ""
@@ -27293,12 +36829,35 @@ msgstr ""
 msgid "VM %s Remote Console"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_role_details.html.haml:51
+#. TRANSLATORS: file: product/views/MiqUserRole.yaml
+#: ../../app/views/ops/_rbac_role_details.html.haml:51 ../yaml_strings.rb:3922
 msgid "VM & Template Access Restriction"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2141
+msgid "VM Access Rules"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:544
+msgid "VM Analysis"
 msgstr ""
 
 #: ../../app/views/ops/_settings_workers_tab.html.haml:461
 msgid "VM Analysis Collectors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1177
+msgid "VM Analysis Tasks"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/schedules.rb:551
+msgid "VM Compliance Check"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:435
+msgid "VM Configuration"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_report.html.haml:8
@@ -27313,7 +36872,7 @@ msgstr ""
 msgid "VM Limits"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:110
+#: ../../app/controllers/storage_controller.rb:209 ../../app/helpers/storage_helper/textual_summary.rb:210 ../../app/views/layouts/listnav/_storage.html.haml:110
 msgid "VM Memory Files"
 msgstr ""
 
@@ -27322,8 +36881,10 @@ msgstr ""
 msgid "VM Memory Files Percent of Used"
 msgstr ""
 
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+#. TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.vm_name
-#: ../dictionary_strings.rb:1209
+#: ../yaml_strings.rb:2692 ../dictionary_strings.rb:1209
 msgid "VM Name"
 msgstr ""
 
@@ -27343,7 +36904,7 @@ msgstr ""
 msgid "VM Properties"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:94
+#: ../../app/controllers/storage_controller.rb:191 ../../app/helpers/storage_helper/textual_summary.rb:175 ../../app/views/layouts/listnav/_storage.html.haml:94
 msgid "VM Provisioned Disk Files"
 msgstr ""
 
@@ -27363,7 +36924,7 @@ msgstr ""
 msgid "VM Selection"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_storage.html.haml:102
+#: ../../app/controllers/storage_controller.rb:200 ../../app/helpers/storage_helper/textual_summary.rb:193 ../../app/views/layouts/listnav/_storage.html.haml:102
 msgid "VM Snapshot Files"
 msgstr ""
 
@@ -27413,15 +36974,19 @@ msgstr ""
 msgid "VM or Templates"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:990
-msgid "VM successfully removed from service \"%s\""
+#: ../../app/controllers/vm_common.rb:1051
+msgid "VM successfully removed from service \"%{name}\""
 msgstr ""
 
 #: ../../app/views/report/_form_filter_chargeback.html.haml:122
 msgid "VM/Instance"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:107
+#: ../../app/controllers/vm_common.rb:433 ../../app/controllers/host_controller.rb:706
+msgid "VM: %{name} (Click to view)"
+msgstr ""
+
+#: ../../app/presenters/tree_builder.rb:156
 msgid "VMDB"
 msgstr ""
 
@@ -27460,7 +37025,7 @@ msgstr ""
 msgid "VMM Build Number"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_host.html.haml:67
+#: ../../app/helpers/host_helper/textual_summary.rb:129 ../../app/views/layouts/listnav/_host.html.haml:67
 msgid "VMM Information"
 msgstr ""
 
@@ -27479,17 +37044,57 @@ msgstr ""
 msgid "VMM Version"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+#. TRANSLATORS: file: product/views/OntapFileShare.yaml
+#. TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+#. TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+#. TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+#. TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.table.vms
-#: ../../app/views/service/_svcs_show.html.haml:30 ../../app/views/layouts/listnav/_host.html.haml:130 ../../app/views/layouts/listnav/_storage.html.haml:37 ../../app/views/layouts/listnav/_ems_infra.html.haml:65 ../../app/views/configuration/_ui_2.html.haml:293 ../../app/views/miq_capacity/_planning_summary.html.haml:20 ../dictionary_strings.rb:2131
+#: ../../app/controllers/host_controller.rb:92 ../../app/controllers/ems_common.rb:61 ../../app/controllers/vm_infra_controller.rb:28 ../../app/helpers/host_helper/textual_summary.rb:311 ../../app/views/service/_svcs_show.html.haml:30 ../../app/views/layouts/listnav/_host.html.haml:130 ../../app/views/layouts/listnav/_storage.html.haml:37 ../../app/views/layouts/listnav/_ems_infra.html.haml:65 ../../app/views/configuration/_ui_2.html.haml:304 ../../app/views/miq_capacity/_planning_summary.html.haml:20 ../yaml_strings.rb:49 ../dictionary_strings.rb:2131
 msgid "VMs"
 msgstr ""
 
-#: ../../app/views/configuration/_ui_2.html.haml:49
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/vm_or_template_controller.rb:18 ../../app/views/configuration/_ui_2.html.haml:49 ../yaml_strings.rb:14
 msgid "VMs & Instances"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_group_details.html.haml:284 ../../app/views/layouts/listnav/_ems_infra.html.haml:36
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:16
+msgid "VMs & Instances Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/vm_infra_controller.rb:23 ../../app/helpers/ems_infra_helper/textual_summary.rb:78 ../../app/views/ops/_rbac_group_details.html.haml:284 ../../app/views/layouts/listnav/_ems_infra.html.haml:36 ../yaml_strings.rb:32
 msgid "VMs & Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:34
+msgid "VMs & Templates Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:51
+msgid "VMs Accordion"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+#. TRANSLATORS: file: product/views/VmOrTemplate.yaml
+#: ../yaml_strings.rb:3489
+msgid "VMs and Templates"
 msgstr ""
 
 #: ../../app/views/vm_cloud/_main.html.haml:17 ../../app/views/vm_common/_main.html.haml:16
@@ -27570,6 +37175,11 @@ msgstr ""
 msgid "VNC Proxy Port must be numeric"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../yaml_strings.rb:3849
+msgid "Valid"
+msgstr ""
+
 #: ../../app/views/ops/_settings_database_tab.html.haml:123 ../../app/views/ops/_settings_database_tab.html.haml:134 ../../app/views/ops/_ldap_server_entry.html.haml:135 ../../app/views/ops/_amazon_verify_button.html.haml:2 ../../app/views/ops/_amazon_verify_button.html.haml:16 ../../app/views/ops/_ldap_verify_button.html.haml:4 ../../app/views/ops/_ldap_verify_button.html.haml:18 ../../app/views/layouts/_form_buttons.html.haml:23 ../../app/views/layouts/_form_buttons.html.haml:37 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:36 ../../app/views/layouts/_edit_form_buttons.html.haml:155 ../../app/views/layouts/_form_buttons_verify.html.haml:19 ../../app/views/layouts/_form_buttons_verify.html.haml:28 ../../app/views/layouts/_form_buttons_verify.html.haml:46
 msgid "Validate"
 msgstr ""
@@ -27610,7 +37220,11 @@ msgstr ""
 msgid "Validator Type"
 msgstr ""
 
-#: ../../app/helpers/container_helper/textual_summary.rb:112 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/views/ops/_tenant_quota_form.html.haml:32 ../../app/views/miq_ae_customization/_field_values.html.haml:18 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:11 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/miq_ae_class/_instance_form.html.haml:89 ../../app/views/miq_ae_class/_instance_fields.html.haml:17 ../../app/views/report/_form_columns_trend.html.haml:61 ../../app/views/miq_policy/_alert_snmp.html.haml:110 ../../app/views/miq_policy/_action_options.html.haml:459 ../../app/views/miq_policy/_alert_details.html.haml:382 ../../app/views/miq_policy/_action_details.html.haml:400
+#. TRANSLATORS: file: product/views/AdvancedSetting.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+#. TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../../app/helpers/container_helper/textual_summary.rb:121 ../../app/helpers/container_group_helper/textual_summary.rb:57 ../../app/views/ops/_tenant_quota_form.html.haml:32 ../../app/views/miq_ae_customization/_field_values.html.haml:18 ../../app/views/miq_ae_customization/_tag_field_values.html.haml:11 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:482 ../../app/views/miq_ae_customization/_dialog_field_form.html.haml:580 ../../app/views/miq_ae_class/_instance_form.html.haml:89 ../../app/views/miq_ae_class/_instance_fields.html.haml:17 ../../app/views/report/_form_columns_trend.html.haml:61 ../../app/views/miq_policy/_alert_snmp.html.haml:110 ../../app/views/miq_policy/_action_options.html.haml:459 ../../app/views/miq_policy/_alert_details.html.haml:382 ../../app/views/miq_policy/_action_details.html.haml:400 ../yaml_strings.rb:2894
 msgid "Value"
 msgstr ""
 
@@ -27646,6 +37260,13 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/CimStorageExtent.yaml
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#. TRANSLATORS: file: product/views/Patch.yaml
+#: ../../app/helpers/ops_helper/textual_summary.rb:45 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:35 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:21 ../yaml_strings.rb:3433
+msgid "Vendor"
+msgstr ""
+
 #: ../../app/views/report/sample_chart.html.haml:123
 msgid "Vendor A"
 msgstr ""
@@ -27678,12 +37299,21 @@ msgstr ""
 msgid "Verify Peer Certificate"
 msgstr ""
 
-#: ../../app/views/support/show.html.haml:17 ../../app/views/miq_policy/_alert_snmp.html.haml:64 ../../app/views/miq_policy/_action_options.html.haml:399 ../../app/views/miq_policy/_alert_details.html.haml:343 ../../app/views/miq_policy/_action_details.html.haml:355
+#. TRANSLATORS: file: product/views/GuestApplication.yaml
+#. TRANSLATORS: file: product/views/Host.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/ProductUpdate.yaml
+#: ../../app/helpers/ops_helper/textual_summary.rb:49 ../../app/views/support/show.html.haml:17 ../../app/views/miq_policy/_alert_snmp.html.haml:64 ../../app/views/miq_policy/_action_options.html.haml:399 ../../app/views/miq_policy/_alert_details.html.haml:343 ../../app/views/miq_policy/_action_details.html.haml:355 ../yaml_strings.rb:3438
 msgid "Version"
 msgstr ""
 
 #: ../../app/views/ops/_selected_by_servers.html.haml:141 ../../app/views/ops/_selected_by_roles.html.haml:189 ../../app/views/ops/_server_desc.html.haml:93
 msgid "Version / Build"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:97
+msgid "View"
 msgstr ""
 
 #: ../../app/views/miq_ae_customization/_old_dialogs_folders.html.haml:9
@@ -27694,8 +37324,68 @@ msgstr ""
 msgid "View '%s' Folder"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1558
+msgid "View All Customization Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1590
+msgid "View All ISO Datastores"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1531
+msgid "View All PXE Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:830
+msgid "View All Records"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:239
+msgid "View All Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1575
+msgid "View All System Image Types"
+msgstr ""
+
 #: ../../app/views/ops/_settings_details_tab.html.haml:64 ../../app/views/ops/_settings_details_tab.html.haml:67
 msgid "View Analysis Profiles"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:316
+msgid "View Availability Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1446
+msgid "View Base Storage Extents"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:147
+msgid "View Catalog Items"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:192
+msgid "View Catalogs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:274
+msgid "View Cloud Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:469
+msgid "View Clusters / Deployment Roles"
 msgstr ""
 
 #: ../../app/views/chargeback/_rates_list.html.haml:9 ../../app/views/chargeback/_rates_list.html.haml:20
@@ -27706,24 +37396,181 @@ msgstr ""
 msgid "View Condition"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2013
+msgid "View Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1836
+msgid "View Container Image Registries"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1820
+msgid "View Container Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1771
+msgid "View Container Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1921
+msgid "View Container Projects"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1798
+msgid "View Container Replicators"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1907
+msgid "View Container Routes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1883
+msgid "View Container Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1941
+msgid "View Containers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2313
+msgid "View Containers Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1642
+msgid "View Containers Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1971
+msgid "View Containers Topology"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:665
+msgid "View Dashboard"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:459
+msgid "View Datacenters"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:616
+msgid "View Datastores"
+msgstr ""
+
 #: ../../app/views/pxe/_template_folders.html.haml:9
 msgid "View Examples (read only)' Folder"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_details_tab.html.haml:56 ../../app/views/ops/_rbac_details_tab.html.haml:67
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1462
+msgid "View File Shares"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:412
+msgid "View Flavors"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_rbac_details_tab.html.haml:56 ../../app/views/ops/_rbac_details_tab.html.haml:67 ../yaml_strings.rb:1271
 msgid "View Groups"
 msgstr ""
 
-#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:510
+msgid "View Hosts / Nodes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2107
+msgid "View Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:427
+msgid "View Infrastructure Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/layouts/listnav/_miq_ae_class.html.haml:19 ../yaml_strings.rb:2023
 msgid "View Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:368
+msgid "View Key Pairs"
 msgstr ""
 
 #: ../../app/views/ops/_settings_details_tab.html.haml:104 ../../app/views/ops/_settings_details_tab.html.haml:107
 msgid "View LDAP Regions"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1482
+msgid "View Local File Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1426
+msgid "View Logical Disks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1720
+msgid "View Middleware Deployments"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1668
+msgid "View Middleware Providers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1694
+msgid "View Middleware Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1975
+msgid "View Middleware Topology"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1618
+msgid "View Orchestration Stacks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:213
+msgid "View Orchestration Templates"
+msgstr ""
+
 #: ../../app/views/ops/_rbac_tenant_details.html.haml:49
 msgid "View Parent Tenant"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1858
+msgid "View Persistent Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1745
+msgid "View Pods"
 msgstr ""
 
 #: ../../app/helpers/application_helper/toolbar/miq_templates_center.rb:77 ../../app/helpers/application_helper/toolbar/template_infras_center.rb:86
@@ -27750,19 +37597,122 @@ msgstr ""
 msgid "View Policy Simulation for this VM"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_details_tab.html.haml:76 ../../app/views/ops/_rbac_details_tab.html.haml:87
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2127
+msgid "View Policy Simulation of Images"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2045
+msgid "View Policy Simulation of Instances"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2279
+msgid "View Policy Simulation of Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2167
+msgid "View Policy Simulation of VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1983
+msgid "View Providers, Configuration Profiles, Configured Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:693
+msgid "View Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:639
+msgid "View Repositories"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:99
+msgid "View Requests"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_rbac_details_tab.html.haml:76 ../../app/views/ops/_rbac_details_tab.html.haml:87 ../yaml_strings.rb:1291
 msgid "View Roles"
 msgstr ""
 
-#: ../../app/views/ops/_settings_details_tab.html.haml:90 ../../app/views/ops/_settings_details_tab.html.haml:93
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:685
+msgid "View Saved Reports"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_settings_details_tab.html.haml:90 ../../app/views/ops/_settings_details_tab.html.haml:93 ../yaml_strings.rb:726
 msgid "View Schedules"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:397
+msgid "View Security Groups"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1356
+msgid "View Servers"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:241
+msgid "View Services"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1380
+msgid "View Settings"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:382
+msgid "View Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1498
+msgid "View Storage Managers"
 msgstr ""
 
 #: ../../app/views/chargeback/_rates_list.html.haml:28 ../../app/views/chargeback/_rates_list.html.haml:33
 msgid "View Storage Rates"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_details_tab.html.haml:96 ../../app/views/ops/_rbac_details_tab.html.haml:107
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1390
+msgid "View Storage Systems"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1410
+msgid "View Storage Volumes"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:1167
+msgid "View Tasks"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2297
+msgid "View Template Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2259
+msgid "View Templates"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_rbac_details_tab.html.haml:96 ../../app/views/ops/_rbac_details_tab.html.haml:107 ../yaml_strings.rb:336
 msgid "View Tenants"
 msgstr ""
 
@@ -27770,12 +37720,33 @@ msgstr ""
 msgid "View This Alert"
 msgstr ""
 
-#: ../../app/views/ops/_rbac_details_tab.html.haml:36 ../../app/views/ops/_rbac_details_tab.html.haml:47
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/views/ops/_rbac_details_tab.html.haml:36 ../../app/views/ops/_rbac_details_tab.html.haml:47 ../yaml_strings.rb:1249
 msgid "View Users"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2233
+msgid "View VM Snapshots"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:2145
+msgid "View VMs"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:354
+msgid "View Volumes"
 msgstr ""
 
 #: ../../app/views/ops/_settings_details_tab.html.haml:77 ../../app/views/ops/_settings_details_tab.html.haml:80
 msgid "View Zones"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:832
+msgid "View all Records in Control Explorer"
 msgstr ""
 
 #: ../../app/views/support/show.html.haml:56
@@ -27946,22 +37917,42 @@ msgstr ""
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm
 #. TRANSLATORS: en.yml key: dictionary.table.vm_infra
 #. TRANSLATORS: en.yml key: dictionary.table.vm_or_template
-#: ../dictionary_strings.rb:1441 ../dictionary_strings.rb:2123 ../dictionary_strings.rb:2127
+#: ../../app/helpers/container_group_helper/textual_summary.rb:101 ../../app/helpers/container_node_helper/textual_summary.rb:78 ../dictionary_strings.rb:1441 ../dictionary_strings.rb:2123 ../dictionary_strings.rb:2127
 msgid "Virtual Machine"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:28
+msgid "Virtual Machine Views"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#. TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+#. TRANSLATORS: file: product/views/Vm-all_vms.yaml
+#. TRANSLATORS: file: product/views/Vm.yaml
+#. TRANSLATORS: file: product/views/Vm__restricted.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.ManageIQ::Providers::InfraManager::Vm (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.vm_infra (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.vm_or_template (plural form)
-#: ../../app/presenters/menu/default_menu.rb:46 ../dictionary_strings.rb:1443 ../dictionary_strings.rb:2125 ../dictionary_strings.rb:2129
+#: ../../app/presenters/menu/default_menu.rb:46 ../../app/controllers/vm_controller.rb:20 ../../app/controllers/vm_common.rb:237 ../../app/controllers/vm_common.rb:357 ../yaml_strings.rb:26 ../dictionary_strings.rb:1443 ../dictionary_strings.rb:2125 ../dictionary_strings.rb:2129
 msgid "Virtual Machines"
+msgstr ""
+
+#: ../../app/helpers/vm_helper.rb:23
+msgid "Virtual Private Cloud"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:542 ../yaml_strings.rb:3622
+msgid "Virtualization Type"
 msgstr ""
 
 #: ../../app/views/layouts/_role_visibility.html.haml:8 ../../app/views/report/_widget_show.html.haml:331 ../../app/views/shared/buttons/_ab_show.html.haml:196
 msgid "Visibility"
 msgstr ""
 
-#: ../../app/controllers/configuration_controller.rb:629
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/controllers/configuration_controller.rb:637 ../yaml_strings.rb:1139
 msgid "Visual"
 msgstr ""
 
@@ -28217,6 +38208,11 @@ msgstr ""
 msgid "Vmdb table"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3598
+msgid "VmdbDatabaseConnection"
+msgstr ""
+
 #: ../model_attributes.rb:2274
 msgid "VmdbDatabaseMetric|Active connections"
 msgstr ""
@@ -28257,6 +38253,11 @@ msgstr ""
 msgid "VmdbDatabaseMetric|Timestamp"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+#: ../yaml_strings.rb:3796
+msgid "VmdbDatabaseSetting"
+msgstr ""
+
 #: ../model_attributes.rb:2266
 msgid "VmdbDatabase|Data directory"
 msgstr ""
@@ -28283,6 +38284,11 @@ msgstr ""
 
 #: ../model_attributes.rb:2272
 msgid "VmdbDatabase|Version"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#: ../yaml_strings.rb:3279
+msgid "VmdbIndex"
 msgstr ""
 
 #: ../model_attributes.rb:2285
@@ -28385,6 +38391,11 @@ msgstr ""
 msgid "VmdbMetric|Wasted bytes"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+#: ../yaml_strings.rb:2869
+msgid "VmdbTableEvm"
+msgstr ""
+
 #: ../model_attributes.rb:2312
 msgid "VmdbTable|Name"
 msgstr ""
@@ -28398,7 +38409,7 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
-#: ../../app/helpers/container_group_helper/textual_summary.rb:51
+#: ../../app/helpers/persistent_volume_helper/textual_summary.rb:159 ../../app/helpers/container_group_helper/textual_summary.rb:51
 msgid "Volume ID"
 msgstr ""
 
@@ -28406,10 +38417,11 @@ msgstr ""
 msgid "Volume Path"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.table.persistent_volume (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.persistent_volumes
 #. TRANSLATORS: en.yml key: dictionary.table.ontap_logical_disk
-#: ../../app/presenters/menu/default_menu.rb:29 ../../app/presenters/menu/default_menu.rb:95 ../../app/views/container_group/_main.html.haml:15 ../../app/views/configuration/_ui_2.html.haml:215 ../dictionary_strings.rb:1829 ../dictionary_strings.rb:1831 ../dictionary_strings.rb:2045
+#: ../../app/presenters/menu/default_menu.rb:29 ../../app/presenters/menu/default_menu.rb:95 ../../app/views/container_group/_main.html.haml:15 ../../app/views/configuration/_ui_2.html.haml:215 ../yaml_strings.rb:1854 ../dictionary_strings.rb:1829 ../dictionary_strings.rb:1831 ../dictionary_strings.rb:2045
 msgid "Volumes"
 msgstr ""
 
@@ -28457,9 +38469,23 @@ msgstr ""
 msgid "WINS Server"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3610
+msgid "Wait Time"
+msgstr ""
+
 #. TRANSLATORS: en.yml key: dictionary.column.wait_time_sec
 #: ../dictionary_strings.rb:1249
 msgid "Wait Time (Seconds)"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3608
+msgid "Waiting Resource"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:407
+msgid "Waiting to Start"
 msgstr ""
 
 #: ../../app/views/miq_task/_tasks_options.html.haml:96 ../../app/views/miq_task/_tasks_options.html.haml:120 ../../app/views/miq_task/_tasks_options.html.haml:120
@@ -28690,7 +38716,7 @@ msgstr ""
 msgid "Warning: This #{ui_lookup(:table=>\"storages\")} and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this #{ui_lookup(:table=>\"storages\")}?"
 msgstr ""
 
-#: ../../app/controllers/report_controller/schedules.rb:302 ../../app/controllers/ops_controller/settings/schedules.rb:414
+#: ../../app/controllers/report_controller/schedules.rb:306 ../../app/controllers/ops_controller/settings/schedules.rb:419
 msgid "Warning: This 'Run Once' timer is in the past and will never run as currently configured"
 msgstr ""
 
@@ -28786,7 +38812,9 @@ msgstr ""
 msgid "Warning: This item and ALL of its components will be permanently removed from the Virtual Management Database.  Are you sure you want to remove this item?"
 msgstr ""
 
-#: ../../app/views/ops/_db_info.html.haml:75 ../../app/views/ops/_db_info.html.haml:168 ../../app/views/ops/_db_info.html.haml:219
+#. TRANSLATORS: file: product/views/VmdbIndex.yaml
+#. TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+#: ../../app/helpers/ops_helper/textual_summary.rb:117 ../../app/views/ops/_db_info.html.haml:75 ../../app/views/ops/_db_info.html.haml:168 ../../app/views/ops/_db_info.html.haml:219 ../yaml_strings.rb:2884
 msgid "Wasted"
 msgstr ""
 
@@ -28794,8 +38822,16 @@ msgstr ""
 msgid "Web Service Workers"
 msgstr ""
 
-#: ../../app/views/ops/_settings_server_tab.html.haml:572 ../../app/views/layouts/_multi_auth_credentials.html.haml:36 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:34
+#: ../../app/helpers/host_helper/textual_summary.rb:532 ../../app/views/ops/_settings_server_tab.html.haml:572 ../../app/views/layouts/_multi_auth_credentials.html.haml:36 ../../app/views/layouts/angular/_multi_auth_credentials.html.haml:34
 msgid "Web Services"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:807
+msgid "Web Services Listen Port must be numeric"
+msgstr ""
+
+#: ../../app/controllers/host_controller.rb:797
+msgid "Web Services Password and Verify Password fields do not match"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.column.ws_port
@@ -28807,16 +38843,27 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:154
+#: ../../app/helpers/ui_constants.rb:300 ../../app/views/report/_form_filter_chargeback.html.haml:154
 msgid "Week"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2399
+msgid "Week of Year (52)"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2401
+msgid "Week of Year (52nd)"
 msgstr ""
 
 #: ../../app/views/report/_schedule_form_timer.html.haml:20
 msgid "Weekly"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/MiqAlert.yaml
 #. TRANSLATORS: en.yml key: dictionary.column.evaluation_description
-#: ../dictionary_strings.rb:391
+#: ../yaml_strings.rb:3701 ../dictionary_strings.rb:391
 msgid "What is evaluated"
 msgstr ""
 
@@ -28834,10 +38881,10 @@ msgid "Widget"
 msgstr ""
 
 #: ../../app/controllers/report_controller/widgets.rb:127
-msgid "Widget content generation error: "
+msgid "Widget content generation error: %{message}"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:261
+#: ../../app/controllers/report_controller.rb:257
 msgid "Widget import cancelled"
 msgstr ""
 
@@ -28846,33 +38893,38 @@ msgid "Widget name"
 msgstr ""
 
 #. TRANSLATORS: en.yml key: dictionary.model.MiqWidget (plural form)
-#: ../../app/views/report/_export_widgets.html.haml:75 ../../app/views/report/_report_info.html.haml:228 ../dictionary_strings.rb:1595
+#: ../../app/presenters/tree_builder_report_export.rb:27 ../../app/views/report/_export_widgets.html.haml:75 ../../app/views/report/_report_info.html.haml:228 ../dictionary_strings.rb:1595
 msgid "Widgets"
 msgstr ""
 
-#: ../../app/controllers/report_controller.rb:255
+#: ../../app/controllers/report_controller.rb:251
 msgid "Widgets imported successfully"
 msgstr ""
 
-#: ../../app/controllers/vm_common.rb:1711
+#: ../../app/controllers/vm_common.rb:1792
 msgid "Win32 Service"
 msgid_plural "Win32 Services"
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+#: ../../app/helpers/vm_cloud_helper/textual_summary.rb:358 ../../app/helpers/vm_infra_helper/textual_summary.rb:371 ../../app/helpers/vm_helper/textual_summary.rb:470 ../yaml_strings.rb:3614
+msgid "Win32 Services"
+msgstr ""
+
 #: ../../app/views/pxe/_pxe_server_details.html.haml:65
 msgid "Windows Boot Env"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_img_form.html.haml:37
+#: ../../app/helpers/pxe_helper/textual_summary.rb:64 ../../app/views/pxe/_pxe_img_form.html.haml:37
 msgid "Windows Boot Environment"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_server_details.html.haml:98
+#: ../../app/presenters/tree_builder_pxe_servers.rb:41 ../../app/presenters/tree_builder_pxe_servers.rb:43 ../../app/views/pxe/_pxe_server_details.html.haml:98
 msgid "Windows Images"
 msgstr ""
 
-#: ../../app/views/pxe/_pxe_form.html.haml:114
+#: ../../app/helpers/pxe_helper/textual_summary.rb:24 ../../app/views/pxe/_pxe_form.html.haml:114
 msgid "Windows Images Directory"
 msgstr ""
 
@@ -28904,6 +38956,15 @@ msgstr ""
 msgid "Within Above Field, Sort By"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+#: ../yaml_strings.rb:3600
+msgid "Worker"
+msgstr ""
+
+#: ../../app/controllers/ops_controller/diagnostics.rb:72
+msgid "Worker on Server '%{name}' restarted"
+msgstr ""
+
 #: ../../app/views/ops/_all_tabs.html.haml:30 ../../app/views/ops/_all_tabs.html.haml:165
 msgid "Workers"
 msgstr ""
@@ -28916,8 +38977,14 @@ msgstr ""
 msgid "Workload"
 msgstr ""
 
-#: ../../app/presenters/menu/default_menu.rb:19
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../../app/presenters/menu/default_menu.rb:19 ../yaml_strings.rb:6
 msgid "Workloads"
+msgstr ""
+
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
+#: ../yaml_strings.rb:8
+msgid "Workloads Views"
 msgstr ""
 
 #: ../../app/views/layouts/_exp_editor.html.haml:93
@@ -28948,11 +39015,28 @@ msgstr ""
 msgid "XML View"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+#: ../yaml_strings.rb:2403
+msgid "Year (YYYY)"
+msgstr ""
+
+#: ../../app/helpers/ui_constants.rb:105
+msgid "Yellow"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:6
+msgid "Yellow Background"
+msgstr ""
+
+#: ../../app/helpers/report_helper.rb:5
+msgid "Yellow Text"
+msgstr ""
+
 #: ../../app/views/report/_form_sort.html.haml:78 ../../app/views/report/_report_list.html.haml:178 ../../app/views/miq_policy/_alert_details.html.haml:55 ../../app/views/miq_policy/_policy_details.html.haml:70
 msgid "Yes"
 msgstr ""
 
-#: ../../app/views/report/_form_filter_chargeback.html.haml:176
+#: ../../app/helpers/ui_constants.rb:509 ../../app/views/report/_form_filter_chargeback.html.haml:176
 msgid "Yesterday"
 msgstr ""
 
@@ -28960,7 +39044,7 @@ msgstr ""
 msgid "You are about to enter fullscreen mode. Press Ctl+Alt to return to windowed mode."
 msgstr ""
 
-#: ../../app/controllers/application_controller.rb:2549
+#: ../../app/controllers/application_controller.rb:2548
 msgid "You are not authorized to view %{model_name} '%{resource_name}'"
 msgstr ""
 
@@ -28976,14 +39060,27 @@ msgstr ""
 msgid "Your Red Hat Account login or Red Hat Network Satellite login"
 msgstr ""
 
+#. TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+#. TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+#. TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+#. TRANSLATORS: file: product/views/MiqServer.yaml
+#. TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
 #. TRANSLATORS: en.yml key: dictionary.model.Zone
 #. TRANSLATORS: en.yml key: dictionary.table.zone
-#: ../../app/helpers/provider_configuration_manager_helper.rb:39 ../../app/helpers/provider_foreman_helper.rb:50 ../../app/views/ops/_ldap_region_show.html.haml:44 ../../app/views/ops/rhn/_server_table.html.haml:90 ../../app/views/ops/_schedule_show.html.haml:122 ../../app/views/ops/_all_tabs.html.haml:8 ../../app/views/ops/_ldap_region_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:116 ../../app/views/miq_task/_tasks_options.html.haml:16 ../../app/views/report/_show_schedule.html.haml:120 ../../app/views/report/_report_info.html.haml:160 ../../app/views/shared/views/ems_common/angular/_form.html.haml:279 ../../app/views/shared/views/ems_common/_form.html.haml:120 ../dictionary_strings.rb:1743 ../dictionary_strings.rb:2133 ../model_attributes.rb:2330
+#: ../../app/helpers/provider_configuration_manager_helper.rb:39 ../../app/helpers/storage_manager_helper/textual_summary.rb:31 ../../app/helpers/provider_foreman_helper.rb:50 ../../app/helpers/provider_foreman_helper.rb:135 ../../app/views/ops/_ldap_region_show.html.haml:44 ../../app/views/ops/rhn/_server_table.html.haml:90 ../../app/views/ops/_schedule_show.html.haml:122 ../../app/views/ops/_all_tabs.html.haml:8 ../../app/views/ops/_ldap_region_form.html.haml:55 ../../app/views/storage_manager/_form.html.haml:116 ../../app/views/miq_task/_tasks_options.html.haml:16 ../../app/views/report/_show_schedule.html.haml:120 ../../app/views/report/_report_info.html.haml:160 ../../app/views/shared/views/ems_common/angular/_form.html.haml:279 ../../app/views/shared/views/ems_common/_form.html.haml:120 ../yaml_strings.rb:2958 ../dictionary_strings.rb:1743 ../dictionary_strings.rb:2133 ../model_attributes.rb:2330
 msgid "Zone"
 msgstr ""
 
 #: ../../app/views/ops/_zone_form.html.haml:7
 msgid "Zone Information"
+msgstr ""
+
+#: ../../app/helpers/ontap_logical_disk_helper/textual_summary.rb:49 ../../app/helpers/ontap_storage_system_helper/textual_summary.rb:39 ../../app/helpers/ontap_storage_volume_helper/textual_summary.rb:42 ../../app/helpers/ontap_file_share_helper/textual_summary.rb:39 ../../app/helpers/cim_base_storage_extent_helper/textual_summary.rb:25
+msgid "Zone Name"
 msgstr ""
 
 #: ../../app/controllers/ops_controller/settings/zones.rb:19
@@ -28998,10 +39095,11 @@ msgstr ""
 msgid "Zone:"
 msgstr ""
 
+#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #. TRANSLATORS: en.yml key: dictionary.model.Zone (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.zone (plural form)
 #. TRANSLATORS: en.yml key: dictionary.table.zones
-#: ../../app/views/ops/_settings_details_tab.html.haml:82 ../dictionary_strings.rb:1745 ../dictionary_strings.rb:2135 ../dictionary_strings.rb:2137
+#: ../../app/presenters/tree_builder_ops_settings.rb:23 ../../app/views/ops/_settings_details_tab.html.haml:82 ../yaml_strings.rb:1230 ../dictionary_strings.rb:1745 ../dictionary_strings.rb:2135 ../dictionary_strings.rb:2137
 msgid "Zones"
 msgstr ""
 
@@ -29027,6 +39125,30 @@ msgstr ""
 
 #: ../../app/presenters/widget_presenter.rb:94
 msgid "Zoom in on this chart"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:784 ../../app/controllers/ops_controller/settings/schedules.rb:254 ../../app/controllers/host_controller.rb:461
+msgid "[%{name}] Record added ("
+msgstr ""
+
+#: ../../app/controllers/ops_controller/settings/analysis_profiles.rb:161
+msgid "[%{name}] Record created ("
+msgstr ""
+
+#: ../../app/controllers/ems_common.rb:814
+msgid "[%{name}] Record delete initiated"
+msgstr ""
+
+#: ../../app/controllers/storage_manager_controller.rb:470 ../../app/controllers/catalog_controller.rb:642 ../../app/controllers/ops_controller/settings/tags.rb:20 ../../app/controllers/ops_controller/diagnostics.rb:733 ../../app/controllers/ems_common.rb:829
+msgid "[%{name}] Record deleted"
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:786 ../../app/controllers/ops_controller/settings/analysis_profiles.rb:179 ../../app/controllers/ops_controller/settings/schedules.rb:256 ../../app/controllers/host_controller.rb:463
+msgid "[%{name}] Record updated ("
+msgstr ""
+
+#: ../../app/controllers/ops_controller.rb:462
+msgid "[Region: %{description} [%{region}]]"
 msgstr ""
 
 #: ../../app/views/ops/_selected_by_servers.html.haml:186
@@ -29065,6 +39187,10 @@ msgstr ""
 msgid "days back"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/tags.rb:287
+msgid "description:[%{session}] to [%{name}]"
+msgstr ""
+
 #: ../../app/views/ops/_zone_tree.html.haml:31
 msgid "dimmed"
 msgstr ""
@@ -29073,7 +39199,7 @@ msgstr ""
 msgid "do not change the outcome of the scope or expression"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:94
+#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:91
 msgid "down"
 msgstr ""
 
@@ -29097,6 +39223,10 @@ msgstr ""
 msgid "instances"
 msgstr ""
 
+#: ../../app/controllers/ops_controller.rb:97 ../../app/controllers/catalog_controller.rb:59
+msgid "invalid button action"
+msgstr ""
+
 #: ../../app/views/ops/_ldap_forest_entries.html.haml:76 ../../app/views/ops/_ldap_forest_entries.html.haml:121
 msgid "ldap"
 msgstr ""
@@ -29118,6 +39248,10 @@ msgstr ""
 msgid "memory_mb"
 msgstr ""
 
+#: ../../app/controllers/ops_controller/settings/tags.rb:282
+msgid "name:[%{session}] to [%{name}]"
+msgstr ""
+
 #: ../../lib/report_formatter/chart_common.rb:394 ../../lib/report_formatter/chart_common.rb:426 ../../lib/report_formatter/chart_common.rb:474 ../../lib/report_formatter/chart_common.rb:504 ../../lib/report_formatter/chart_common.rb:507
 msgid "no value"
 msgstr ""
@@ -29130,16 +39264,32 @@ msgstr ""
 msgid "normal"
 msgstr ""
 
+#: ../../app/controllers/ems_common.rb:114
+msgid "other %{message}"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:64
+msgid "other %{title}"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:77
+msgid "other Host"
+msgstr ""
+
+#: ../../app/controllers/ems_cluster_controller.rb:51
+msgid "other VM"
+msgstr ""
+
 #: ../../app/views/ops/_selected_by_servers.html.haml:199 ../../app/views/ops/_selected_by_roles.html.haml:84
 msgid "primary"
 msgstr ""
 
-#: ../../app/views/miq_policy/_rsop_results.html.haml:77
-msgid "red italics"
+#: ../../app/controllers/application_controller/ci_processing.rb:1322
+msgid "provider"
 msgstr ""
 
-#: ../../app/presenters/tree_builder.rb:74
-msgid "report"
+#: ../../app/views/miq_policy/_rsop_results.html.haml:77
+msgid "red italics"
 msgstr ""
 
 #: ../../app/views/ops/_selected_by_servers.html.haml:202 ../../app/views/ops/_selected_by_roles.html.haml:87
@@ -29150,7 +39300,7 @@ msgstr ""
 msgid "selected to copy"
 msgstr ""
 
-#: ../../app/controllers/provider_foreman_controller.rb:101
+#: ../../app/controllers/provider_foreman_controller.rb:105
 msgid "system"
 msgid_plural "systems"
 msgstr[0] ""
@@ -29160,11 +39310,11 @@ msgstr[1] ""
 msgid "that match the entered search string"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:94
+#: ../../app/views/report/_column_lists.html.haml:91
 msgid "to bottom"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:94
+#: ../../app/views/report/_column_lists.html.haml:91
 msgid "to top"
 msgstr ""
 
@@ -29184,12 +39334,17 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
-#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:94
+#: ../../app/views/report/_column_lists.html.haml:38 ../../app/views/report/_column_lists.html.haml:91
 msgid "up"
 msgstr ""
 
 #: ../../app/views/layouts/exp_atom/_edit_field.html.haml:164 ../../app/views/layouts/exp_atom/_edit_count.html.haml:47 ../../app/views/layouts/exp_atom/_edit_tag.html.haml:56
 msgid "user input"
+msgstr ""
+
+#. TRANSLATORS: file: product/views/ResourcePool.yaml
+#: ../../app/helpers/resource_pool_helper/textual_summary.rb:27 ../yaml_strings.rb:3596
+msgid "vApp"
 msgstr ""
 
 #: ../../app/views/miq_capacity/_planning_options.html.haml:169 ../../app/views/miq_capacity/_planning_vm_profile.html.haml:25

--- a/config/yaml_strings.rb
+++ b/config/yaml_strings.rb
@@ -1,0 +1,3924 @@
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access to Everything")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Workloads")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Workloads Views")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Accordions")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Accordions under Workloads")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VMs & Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VMs & Instances Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Templates & Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Templates & Images Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Virtual Machines")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Virtual Machine Views")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Accordions under Virtual Machines")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VMs & Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VMs & Templates Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VMs Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+_("Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Templates Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/AvailabilityZone.yaml
+# TRANSLATORS: file: product/views/CloudTenant.yaml
+# TRANSLATORS: file: product/views/Flavor.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqAeInstance.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+_("Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Instance Views")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Accordions under Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Instances by Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Instances by Provider Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Images by Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Images by Provider Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Instances Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+_("Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Images Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("List")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Operate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Approve and Deny")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Approve and Deny Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Request")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Requests")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Request")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Catalogs Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Catalogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ServiceCatalog.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+_("Catalog Items")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under All Catalog Items Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Catalog Items")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Catalog Items")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Catalog Items from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Composite Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Composite Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Composite Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Composite Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Atomic Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an Atomic Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Atomic Catalog Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Button")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Catalog Items")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Catalog Items Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Service Catalogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under All Service Catalogs Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Available Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Order Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Request to Order Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+_("Catalogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Catalogs Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Catalogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Catalog from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Composite Catalog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+_("Orchestration Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Orchestration Templates Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Orchestration Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Orchestration Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Orchestration Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Orchestration Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Orchestration Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Orchestration Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Orchestration Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Orchestration Templates Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create Service Dialog from Orchestration Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("My Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under All Services Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Services from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Ownership")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Ownership of VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reconfigure Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reconfigure Services Options")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Retirement Date")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Retirement Date for Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Retire Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+_("Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Timeline")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discover")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discover Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies of Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Cloud Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Cloud Providers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Cloud Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Cloud Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Availability Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Availability Zone")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Cloud Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Cloud Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Cloud Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Cloud Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Auth Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Auth Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Key Pairs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Cloud Volume Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Cloud Volume Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+_("Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Security Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Security Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Flavors")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Flavor")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+_("Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discover Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies of Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Infrastructure Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Infrastructure Providers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an Infrastructure Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add an Infrastructure Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Scale")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Scale an Infrastructure Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Datacenters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Datacenters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Datacenters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Datacenters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare List of Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Clusters / Deployment Roles Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Timelines")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Analysis")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis on Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies on Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+_("Tag")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags for Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Clusters / Deployment Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Clusters / Deployment Roles from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare List of Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Hosts / Nodes Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis for Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Analyze then Check Compliance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Analyze then Check Compliance for Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Check Compliance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Check Compliance of Last Known Configuration for Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies for Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related to Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Host / Node Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power On")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power On a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power Off")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power Off a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Enter Maintenance Mode")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Put a Host / Node into Maintenance Mode")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Exit Maintenance Mode")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Take a Host / Node out of Maintenance Mode")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown Host to Standby")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown a Host / Node to Standby Mode")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown Host")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart Host")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Hosts / Nodes from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Host / Node")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provision Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Request to Provision Hosts / Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+_("Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Everything under Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies of Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Resource Pools")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Resource Pools from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+_("Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis for Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Datastore Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Datastores from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Repository.yaml
+_("Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Repository")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies of Repository")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Relationships and Power States of Repository")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Repositories")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Repository")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Repositories from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Repository")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add and Remove a Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add and Remove Dashboard Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset Dashboard Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset Dashboard Widgets to the defaults")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Saved Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Saved Reports Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Saved Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Saved Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Saved Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Reports Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download CSV Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Report in CSV Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download PDF Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Report in PDF Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Text Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Report in Text Format")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Run a selected Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Reports")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Report")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+_("Schedules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Schedules Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Schedules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Schedules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Run Now")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Queue up Schedules to run now")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Schedules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Schedule")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Schedule")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Schedule")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Enable")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Enable a Schedule")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Disable")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Disable a Schedule")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Dashboards")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Dashboard Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Dashboards")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Sequence")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit sequence of Dashboards")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Dashboard Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Dashboard Widgets Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Generate Content")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Generate Content for a selected Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Widget")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Widgets")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Report Menus")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Report Menus Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Import / Export")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Import / Export Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Chargeback")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Chargeback")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reports Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Rates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Rates Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Chargeback Rate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Chargeback Rate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Chargeback Rate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Chargeback Rate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Assignments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Assignments Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Timelines")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("RSS")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under RSS")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Control Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All Records")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View all Records in Control Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqPolicySet.yaml
+# TRANSLATORS: file: product/views/PolicySet.yaml
+_("Policy Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policy Profiles Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Policy Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Policy Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Policy Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Policy Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqPolicy.yaml
+# TRANSLATORS: file: product/views/Policy.yaml
+_("Policies")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policies Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Policies")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Condition Assignment")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Policy's Condition assignments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Event Assignment")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Policy's Event assignments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Condition.yaml
+_("Conditions")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Conditions Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Conditions")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Condition")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Condition")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Condition to specified Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Condition to a new Condition assigned to specified Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Condition")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Condition")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove from Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Condition from specified Policy")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqEvent.yaml
+_("Events")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policy Events Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Event")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqAction.yaml
+_("Actions")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policy Actions Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Policy Actions")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Policy Action")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Policy Action")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Policy Action")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Alert Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policy Alert Profiles Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Policy Alert Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Policy Alert Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Policy Alert Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit assignments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Policy Alert Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("Alerts")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Policy Alerts Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Policy Alerts")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Policy Alert")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Policy Alert")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Policy Alert")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Policy Alert")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Simulation")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Policy Simulation")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Import/Export")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Policy Import/Export")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Policy Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Domains")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Automate Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Automate Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Priority Order")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Priority Order of Domains")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Lock/Unlock")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Lock/Unlock Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Unlock")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Unlock Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Lock")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Lock Domain")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Namespace")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Namespace")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Automate Namespace")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Namespace")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Automate Namespace")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Selected Automate Namespace/Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Automate Class")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Automate Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Automate Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Automate Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Automate Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Automate Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Automate Method")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Schema")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Schema")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Automate Schema")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Sequence of Automate Schema")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Simulation")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Customization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Customization Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Dialog.yaml
+_("Dialogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Dialogs Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Dialogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Tab")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Tab to Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Box")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Box to Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Element")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Element to Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discard Item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discard Dialog item")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discard resource")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Discard Dialog resource")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provisioning Dialogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provisioning Dialogs Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Provisioning Dialogs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Provisioning Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Provisioning Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Provisioning Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Provisioning Dialog")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Buttons")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Buttons Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Button Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Button Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Button Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Buttons")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reorder")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Buttons Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Buttons")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Button")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Simulate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Simulate using Button details")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Import/Export")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Automate Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display of Utilization Data")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Planning")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display of Planning Data")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Bottlenecks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display of Bottlenecks data")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("My Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under My Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify My Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Visual")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Visuals")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Default Views")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Default Views")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Default Filters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Default Filters")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Time Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All VM Analysis Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of All VM Analysis Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Other Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of All UI Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VM Analysis Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of VM Analysis Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Other UI Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of UI Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload the current display")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Older")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Older Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete All")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete All Tasks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Cancel")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Cancel Task")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Configuration")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Configuration")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Settings Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ScanItemSet.yaml
+_("Analysis Profiles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Host Analysis Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add VM Analysis Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Analysis Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Analysis Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Analysis Profile")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Product Updates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Product Updates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Product Updates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Zones")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Zone")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Zone")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Zone")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Control")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Control Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/User.yaml
+_("Users")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Users")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Users")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Users")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Operate User")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Group.yaml
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+_("Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Groups")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Sequence of User Groups for LDAP Look Up")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Operate Group")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Roles")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy a Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Tenant.yaml
+_("Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Tenant/Project")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Tenant/Project")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Tenant/Project")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete a Tenant/Project")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Quotas")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Tenant Quotas")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Operate Tenants")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Diagnostics")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Diagnostics Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Diagnostics Server Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Operate Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Collect All Logs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Collect Current Logs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Audit Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download EVM Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Download Production Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Log Depot Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Audit Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh EVM Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Production Log")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload Workers Display")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart Worker")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload Current Display")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Diagnostics Region Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Start Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Suspend Role")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Demote Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Promote Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Diagnostics Zone Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload current display")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Database")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Database Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Settings")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload Display")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("About")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("CIM Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Storage Systems Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create Logical Disks on Storage Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Storage Systems Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("CIM Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Storage Volumes Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Storage Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Storage Volumes Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("CIM Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Statistics")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Logical Disks Utilization Statistics")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Logical Disks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Logical Disks Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Base Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("CIM Base Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Base Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Storage Extents Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Base Storage Extents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Storage Extents Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("SNIA File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display File Shares Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create Datastores from File Shares")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit File Shares Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Local File System")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("SNIA Local File Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Local File Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Local File Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Local File Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Local File Systems Utilization")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Local File Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Local File Systems Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on SMI-S Agents")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Inventory")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Inventory and power states for all items related of Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Status")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Status for all items related of Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Storage Managers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add an Storage Manager")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Storage Managers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an Storage Manager")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("PXE")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under PXE Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/PxeServer.yaml
+_("PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify PXE Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add an PXE Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove PXE Servers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an PXE Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit PXE Image")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an PXE Image")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Windows Image")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit an Windows Image")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/CustomizationTemplate.yaml
+_("Customization Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Customization Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All Customization Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Customization Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add an Customization Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Customization Templates from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Customization Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Copy Customization Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/PxeImageType.yaml
+_("System Image Types")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under System Image Types")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All System Image Types")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify System Image Types")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add System Image Types")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove System Image Types from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit System Image Type")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/IsoDatastore.yaml
+_("ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View All ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add an ISO Datastore")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove ISO Datastores from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit ISO Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit ISO Images on ISO Datastores")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Common")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Common Buttons")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Initiate refresh of recent C&U data")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reload charts")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Orchestration Stacks from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Orchestration Stack")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Orchestration Stacks")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Orchestration Stack")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Retire Orchestration Stack")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Containers Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Containers Providers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Containers Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Containers Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Middleware Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Middleware Providers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Middleware Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Middleware Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("MiddlewareServer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Middleware Servers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Middleware Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Middleware Server")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Middleware Servers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("MiddlewareDeployment")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Middleware Deployments from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Middleware Deployment")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Middleware Deployment")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Middleware Deployments")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Pods from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Pod")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Pod")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Pods")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Container Nodes from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Nodes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+_("Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Container Replicators from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Container Replicator")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Container Replicator")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Replicators")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Container Image Registries from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Container Image Registry")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Container Image Registry")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Image Registries")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Persistent Volume")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Persistent Volumes from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Persistent Volume")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Persistent Volume")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Persistent Volumes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+# TRANSLATORS: file: product/views/Service.yaml
+# TRANSLATORS: file: product/views/SystemService.yaml
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Service")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Container Services from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Services")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Routes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Project")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Container Projects")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Containers Explorer")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Relationships")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under All Containers Accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Container")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Containers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Container")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Container")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Container")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Container")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Tags of Containers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Containers Topology")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Containers Topology")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Middleware Topology")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Middleware Topology")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Configuration Management")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Configuration Management")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Providers accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Providers, Configuration Profiles, Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Providers and Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Configured Systems Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provision Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships for all items related of Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Providers")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Proviers from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Add a Provider")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything under Configured Systems accordion")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Configured Systems")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("All VM and Instance Access Rules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Instance Access Rules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Rules for Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Instances related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Instances related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare multiple Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Instances Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Check Compliance of Last Known Configuration")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Policy Simulation of Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Retirement Date for Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Retire Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Ownership of Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power On Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power Off Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Pause")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Pause Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Suspend")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Suspend Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shelve")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shelve Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shelve Offload")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shelve Offload Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown Guest")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown the Guest OS on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart Guest")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart the Guest OS on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Terminate")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Terminate the Guest OS on Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Instance Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provision Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Request to Provision Instances")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Instances from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Instance")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit EVM Server Relationship")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Image Access Rules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Rules for Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Images related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Images related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare multiple Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Images Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis on Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies on Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Policy Simulation of Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Ownership of Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Image Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Images")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Images from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Image")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("VM Access Rules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Rules for Virtual Machines")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of VMs related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual VMs related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare multiple VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display VMs Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Extract Running Processes")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Extract Running Processes of VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Policy Simulation of VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Retirement Date for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Retire VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power On VM")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Power Off VM")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Suspend VM")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reset VM")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Shutdown the Guest OS on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Restart the Guest OS on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Console using MKS")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Open a web-based console for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Console using VNC")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Open a web-based VNC console for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Console using VMRC")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Open a web-based VMRC console for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit VM Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Provision VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Request to Provision VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Clone VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Publish VMs to a Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Request to Publish VMs to a Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Migrate VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Migrate VMs to another Host/Datastore")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove VMs from the VMDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a VM")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Right-Size VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("CPU/Memory Recommendations")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reconfigure VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Reconfigure VM Memory/CPUs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything for VM Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View VM Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of VM Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on VM Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create new Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create a new snapshot for VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Snapshots on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete All Existing Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete All Existing Snapshots on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Revert to selected snapshot")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Revert to selected snapshot on VMs")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Template Access Rules")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Access Rules for Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Templates related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Individual Templates related to a CI")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Compare multiple Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Templates Drift")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Show Capacity & Utilization data of Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Timelines for Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform SmartState Analysis on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Manage Policies on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Policy Simulation of Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Set Ownership of Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Refresh relationships and power states for all items related of Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit Template Tags")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Modify Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Clone Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Remove Templates from the TemplateDB")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Edit a Template")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Everything for Template Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Template Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Display Lists of Template Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Perform Operations on Template Snapshots")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Create a new snapshot for Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete Snapshots on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Delete All Existing Snapshots on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Revert to selected snapshot on Templates")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("Containers Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_product_features.yml
+_("View Containers Dashboard")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Suffixed Bytes (B, KB, MB, GB)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Suffixed Kilobytes (KB, MB, GB)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Suffixed Megabytes (MB, GB)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Suffixed Gigabytes (GB)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Number (1,234)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Number (1,234.0)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Number, 2 Decimals (1,234.00)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Currency, 2 Decimals ($1,234.00)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Kilobytes per Second (10 KBps)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Megahertz (12 Mhz)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Megahertz Avg (12.1 Mhz)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Percentage (99%)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Percent, 1 Decimal (99.0%)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Percent, 2 Decimals (99.00%)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Boolean (True/False)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Boolean (T/F)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Boolean (Yes/No)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Boolean (Y/N)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Boolean (Pass/Fail)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date (M/D/YYYY)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date (M/D/YY)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date Range (M/D/Y - M/D/Y)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day Range (M/D - M/D)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day Range Start (M/D)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date (M/D)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Time (H:M:S Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date/Time (M/D/Y H:M:S Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date/Hour (M/D/Y H:00 Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Date/Hour (M/D/Y H AM|PM Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Hour (H:00 Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Hour (H AM|PM Z)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Hour of Day (24)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day Full (Monday)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day Short (Mon)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day of Week (1)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day of Month (27)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Day of Month (27th)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Month and Year (January 2011)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Month and Year Short (Jan 11)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Month Full (January)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Month Short (Jan)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Month of Year (12)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Week of Year (52)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Week of Year (52nd)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Year (YYYY)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Comma seperated list")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Elapsed Time (10 Days, 0 Hours, 1 Minute, 44 Seconds)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("String Truncated to 50 Characters with Elipses (...)")
+# TRANSLATORS: file: db/fixtures/miq_report_formats.yml
+_("Convert Numbers Larger than 1.0e+15 to Exponential Form")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+_("Analytics Report")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+# TRANSLATORS: file: product/views/User.yaml
+_("Role")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+_("Messages Ready to Process")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+_("Messages Being Processed")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+_("Age of Next Message to Process")
+# TRANSLATORS: file: product/ops/miq_reports/analytics.yaml
+_("Age of Last Message to Process")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+_("Timeline All Bottleneck Events")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+_("Time Stamp")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+# TRANSLATORS: file: product/views/MiqAction.yaml
+# TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+# TRANSLATORS: file: product/views/ScanItemSet.yaml
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+# TRANSLATORS: file: product/views/Tenant.yaml
+_("Type")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/AdvancedSetting.yaml
+# TRANSLATORS: file: product/views/AvailabilityZone.yaml
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/CloudNetwork.yaml
+# TRANSLATORS: file: product/views/CloudTenant.yaml
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+# TRANSLATORS: file: product/views/ConditionSet.yaml
+# TRANSLATORS: file: product/views/Container.yaml
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+# TRANSLATORS: file: product/views/ContainerRoute.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+# TRANSLATORS: file: product/views/CustomizationTemplate.yaml
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+# TRANSLATORS: file: product/views/Filesystem.yaml
+# TRANSLATORS: file: product/views/Flavor.yaml
+# TRANSLATORS: file: product/views/Group.yaml
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/IsoDatastore.yaml
+# TRANSLATORS: file: product/views/LdapRegion.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+# TRANSLATORS: file: product/views/MiqActionSet.yaml
+# TRANSLATORS: file: product/views/MiqAeInstance.yaml
+# TRANSLATORS: file: product/views/MiqDialog.yaml
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/MiqUserRole.yaml
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+# TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+# TRANSLATORS: file: product/views/Patch.yaml
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+# TRANSLATORS: file: product/views/Policy.yaml
+# TRANSLATORS: file: product/views/PolicySet.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+# TRANSLATORS: file: product/views/PxeImageType.yaml
+# TRANSLATORS: file: product/views/PxeServer.yaml
+# TRANSLATORS: file: product/views/RegistryItem.yaml
+# TRANSLATORS: file: product/views/Repository.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+# TRANSLATORS: file: product/views/ScanItemSet.yaml
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+# TRANSLATORS: file: product/views/Service.yaml
+# TRANSLATORS: file: product/views/ServiceCatalog.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+# TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+# TRANSLATORS: file: product/views/Storage.yaml
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+# TRANSLATORS: file: product/views/SystemService.yaml
+# TRANSLATORS: file: product/views/Tenant.yaml
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Name")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Event Type")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+_("Severity")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_bottleneck_events.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+# TRANSLATORS: file: product/views/ScanHistory.yaml
+_("Message")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+_("Timeline All Policy Events")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Date Created")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Miq Event Description")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Miq Policy Description")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Result")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+_("Timeline All Events")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Date Time")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Event Source")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+# TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+# TRANSLATORS: file: product/views/ContainerRoute.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiddlewareServer.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Provider")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Cluster")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Source Host")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Source VM")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Source VM Location")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Destination Host")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Destination VM")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Destination VM Location")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/AvailabilityZone.yaml
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+_("Availability Zone")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Provider User Name")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Container Node")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+_("Pod")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Container Project")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+# TRANSLATORS: file: product/views/Container.yaml
+_("Container")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_daily.yaml
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Container Replicator")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_policy_events_hourly.yaml
+_("Timeline Policy Events Hourly")
+# TRANSLATORS: file: product/timelines/miq_reports/tl_events_hourly.yaml
+_("Timeline Events Hourly")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("VIM Usage for an Hour")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("VM Name")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("Avg CPU MHz")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("Avg RAM")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("Avg Disk Space")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("Avg Disk I/O KBs (Total Bytes)")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_hour.yaml
+_("Avg Net I/O KBs (Total Bytes)")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+_("VIM Usage for a Day")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+_("Max RAM")
+# TRANSLATORS: file: product/usage/miq_reports/vim_usage_day.yaml
+_("Max Disk Space")
+# TRANSLATORS: file: product/views/User.yaml
+_("Full Name")
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+# TRANSLATORS: file: product/views/User.yaml
+_("Username")
+# TRANSLATORS: file: product/views/User.yaml
+_("E-mail")
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+# TRANSLATORS: file: product/views/User.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Group")
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/User.yaml
+_("Last Logon")
+# TRANSLATORS: file: product/views/User.yaml
+_("Last Logoff")
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+_("Azure Orchestration Templates")
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+_("Azure Orchestration Template")
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+_("Template Type")
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+_("Draft")
+# TRANSLATORS: file: product/views/AdvancedSetting.yaml
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/ChargebackRate.yaml
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/Condition.yaml
+# TRANSLATORS: file: product/views/ConditionSet.yaml
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+# TRANSLATORS: file: product/views/CustomizationTemplate.yaml
+# TRANSLATORS: file: product/views/Dialog.yaml
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+# TRANSLATORS: file: product/views/LdapRegion.yaml
+# TRANSLATORS: file: product/views/MiqAction.yaml
+# TRANSLATORS: file: product/views/MiqActionSet.yaml
+# TRANSLATORS: file: product/views/MiqAeClass.yaml
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+# TRANSLATORS: file: product/views/MiqDialog.yaml
+# TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+# TRANSLATORS: file: product/views/MiqEvent.yaml
+# TRANSLATORS: file: product/views/MiqPolicy.yaml
+# TRANSLATORS: file: product/views/MiqPolicySet.yaml
+# TRANSLATORS: file: product/views/MiqProvision.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+# TRANSLATORS: file: product/views/Patch.yaml
+# TRANSLATORS: file: product/views/Policy.yaml
+# TRANSLATORS: file: product/views/PolicySet.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+# TRANSLATORS: file: product/views/ScanItemSet.yaml
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+# TRANSLATORS: file: product/views/Service.yaml
+# TRANSLATORS: file: product/views/ServiceCatalog.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+# TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+# TRANSLATORS: file: product/views/SystemService.yaml
+# TRANSLATORS: file: product/views/Tenant.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("Description")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+# TRANSLATORS: file: product/views/Repository.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+# TRANSLATORS: file: product/views/Service.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Created On")
+# TRANSLATORS: file: product/views/ChargebackRate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateAzure.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+# TRANSLATORS: file: product/views/Repository.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Updated On")
+# TRANSLATORS: file: product/views/PolicySet.yaml
+_("PolicySet")
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+_("Miq Reports")
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Queued At")
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Run At")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+_("Source")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/CloudNetwork.yaml
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/MiqProvision.yaml
+# TRANSLATORS: file: product/views/MiqReportResult-all.yaml
+# TRANSLATORS: file: product/views/MiqReportResult.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+# TRANSLATORS: file: product/views/ScanHistory.yaml
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+_("Status")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+# TRANSLATORS: file: product/views/MiqPolicy.yaml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Active")
+# TRANSLATORS: file: product/views/Service.yaml
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Service")
+# TRANSLATORS: file: product/views/Vsc.yaml
+_("Created By")
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+_("VmdbTableEvm")
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+_("Rows")
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+# TRANSLATORS: file: product/views/Filesystem.yaml
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+_("Size")
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+_("Wasted")
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+# TRANSLATORS: file: product/views/VmdbTableEvm.yaml
+_("Percent Bloat")
+# TRANSLATORS: file: product/views/AdvancedSetting.yaml
+_("AdvancedSetting")
+# TRANSLATORS: file: product/views/AdvancedSetting.yaml
+# TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+# TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("Value")
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/AdvancedSetting.yaml
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+# TRANSLATORS: file: product/views/MiqAeClass.yaml
+# TRANSLATORS: file: product/views/MiqAeInstance.yaml
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Display Name")
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+_("Datastore Other VM Files")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+_("File Name")
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+_("Extension")
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+_("Size (Bytes)")
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_misc_files.yaml
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+_("Last Modified Time")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("ConfigurationManagerForeman")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Provider Name")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("URL")
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Zone")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Last Refresh Date")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Region Description")
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ConfigurationManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Total Configured Systems")
+# TRANSLATORS: file: product/views/Flavor.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+_("Flavor")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("IP Addresses")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Compliant")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Allocated Size")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("Architecture")
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-vms.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/Storage.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Last Analysis Time")
+# TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+_("ImageRegistries")
+# TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+_("ContainerImageRegistry")
+# TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiddlewareServer.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Host")
+# TRANSLATORS: file: product/views/ContainerImageRegistry.yaml
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("Port")
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+_("ConfigurationProfile")
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("Environment")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/ConfigurationProfile.yaml
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/Repository.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+# TRANSLATORS: file: product/views/Storage.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Region")
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/Group.yaml
+_("Account ID")
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/Group.yaml
+_("Home Directory")
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/Group.yaml
+_("Local")
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/Group.yaml
+_("Domain")
+# TRANSLATORS: file: product/views/Account-groups.yaml
+# TRANSLATORS: file: product/views/Account-users.yaml
+_("Comment")
+# TRANSLATORS: file: product/views/Account-users.yaml
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+_("Enabled")
+# TRANSLATORS: file: product/views/Account-users.yaml
+_("Expires")
+# TRANSLATORS: file: product/views/LdapRegion.yaml
+_("LdapRegion")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+_("File System Drivers")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Service Type")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Start")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Image Path")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Depend on Service")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Depend on Group")
+# TRANSLATORS: file: product/views/SystemService-filesystem_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Object Name")
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+_("Snia Local File System")
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+_("SniaLocalFileSystems")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+_("Hosts")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+_("Operational Status")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+# TRANSLATORS: file: product/views/SniaLocalFileSystem.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("Last Update Status")
+# TRANSLATORS: file: product/views/ServiceCatalog.yaml
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+# TRANSLATORS: file: product/views/ServiceTemplateCatalog.yaml
+_("Tenant")
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+_("Cloud Volume Snapshot")
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+_("CloudVolumeSnapshot")
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+_("Cloud Volume")
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+_("Based Volumes")
+# TRANSLATORS: file: product/views/AvailabilityZone.yaml
+# TRANSLATORS: file: product/views/CloudTenant.yaml
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot-cloud_volume_snapshots.yaml
+# TRANSLATORS: file: product/views/CloudVolumeSnapshot.yaml
+# TRANSLATORS: file: product/views/Flavor.yaml
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+_("Cloud Provider")
+# TRANSLATORS: file: product/views/PxeImageType.yaml
+_("Provision Type")
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+_("Schedule")
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+_("Interval")
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+_("Last Run Time")
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+_("Next Run Time")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/MiqSchedule.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("EVM Zone")
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+_("CloudFormations Orchestration Templates")
+# TRANSLATORS: file: product/views/OrchestrationTemplateCfn.yaml
+_("CloudFormations Orchestration Template")
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/Storage.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Datastore")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Store Type")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Total Space")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Free Space")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("% Free Space")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Total Provisioned Space")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Total Hosts")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Managed/Registered VMs")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Managed/Unregistered VMs")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Unmanaged VMs")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Directory Hierarchy")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Thin Provisioning")
+# TRANSLATORS: file: product/views/Storage.yaml
+_("Raw Disk Mappings")
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+_("Security Group")
+# TRANSLATORS: file: product/views/SecurityGroup.yaml
+_("SecurityGroup")
+# TRANSLATORS: file: product/views/MiqAeClass.yaml
+_("Classes")
+# TRANSLATORS: file: product/views/MiqAeClass.yaml
+_("Fully Qualified Name")
+# TRANSLATORS: file: product/views/MiqAeClass.yaml
+_("Inherits From")
+# TRANSLATORS: file: product/views/MiqAction.yaml
+_("Action")
+# TRANSLATORS: file: product/views/VmdbIndex.yaml
+_("VmdbIndex")
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+_("Snia File Share")
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+_("OntapFileShares")
+# TRANSLATORS: file: product/views/OntapFileShare.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+_("Element Name")
+# TRANSLATORS: file: product/views/RegistryItem.yaml
+_("Registry")
+# TRANSLATORS: file: product/views/RegistryItem.yaml
+_("Data")
+# TRANSLATORS: file: product/views/RegistryItem.yaml
+_("Format")
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("ConfiguredSystem")
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("ConfiguredSystems")
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("Hostname")
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("Last Checkin")
+# TRANSLATORS: file: product/views/ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("Build State")
+# TRANSLATORS: file: product/views/ScanHistory.yaml
+_("Analysis History")
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/ScanHistory.yaml
+_("Started")
+# TRANSLATORS: file: product/views/ScanHistory.yaml
+_("Finished")
+# TRANSLATORS: file: product/views/MiqProvision.yaml
+_("Provisions")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqProvision.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+_("Last Message")
+# TRANSLATORS: file: product/views/StorageFile-files.yaml
+_("Datastore Files")
+# TRANSLATORS: file: product/views/Tenant.yaml
+_("Parent")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+_("Middleware Providers")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+_("EmsMiddleware")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_MiddlewareManager.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+_("IP Address")
+# TRANSLATORS: file: product/views/OrchestrationStackParameter.yaml
+_("Parameters")
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("Storage Manager")
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("IPAddress")
+# TRANSLATORS: file: product/views/StorageManager.yaml
+_("Created At")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+_("EmsInfra")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager.yaml
+_("Discovered IP Address")
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+# TRANSLATORS: file: product/views/ContainerRoute.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("Project Name")
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("Ready")
+# TRANSLATORS: file: product/views/Container.yaml
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+_("Containers")
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+_("Phase")
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+_("Restart Policy")
+# TRANSLATORS: file: product/views/ContainerGroup.yaml
+_("DNS Policy")
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Miq Widgets")
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Title")
+# TRANSLATORS: file: product/views/MiqDialog.yaml
+# TRANSLATORS: file: product/views/MiqWidget-all.yaml
+# TRANSLATORS: file: product/views/MiqWidget.yaml
+_("Default")
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+_("Orchestration Stack")
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+_("OrchestrationStack")
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+_("Status Reason")
+# TRANSLATORS: file: product/views/CloudNetwork.yaml
+# TRANSLATORS: file: product/views/OrchestrationStack.yaml
+_("Cloud Networks")
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+_("Processor Sockets")
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+_("Processor Cores Per Socket")
+# TRANSLATORS: file: product/views/Flavor.yaml
+# TRANSLATORS: file: product/views/Vm-VmReconfigureRequest.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Memory")
+# TRANSLATORS: file: product/views/ContainerRoute.yaml
+_("Container Route")
+# TRANSLATORS: file: product/views/ContainerRoute.yaml
+_("ContainerRoute")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+_("Cim Base Storage Extent")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+_("CimBaseStorageExtents")
+# TRANSLATORS: file: product/views/CimBaseStorageExtent.yaml
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+_("Health Status")
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+_("HOT Orchestration Templates")
+# TRANSLATORS: file: product/views/OrchestrationTemplateHot.yaml
+_("HOT Orchestration Template")
+# TRANSLATORS: file: product/views/Repository.yaml
+_("Repository")
+# TRANSLATORS: file: product/views/Repository.yaml
+_("Relative Path")
+# TRANSLATORS: file: product/views/OrchestrationTemplate.yaml
+_("Orchestration Template")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+_("Applications")
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Vendor")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("Version")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+_("Release")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+_("Package Name")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+_("Product Key")
+# TRANSLATORS: file: product/views/GuestApplication.yaml
+_("Path")
+# TRANSLATORS: file: product/views/StorageFile-vm_ram_files.yaml
+_("Datastore VM Memory Files")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("CPUs")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("CPU Cores")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("32 Bit Architecture")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("64 Bit Architecture")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("HVM (Hardware Virtual Machine)")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("Paravirtualization")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("Block Storage Based")
+# TRANSLATORS: file: product/views/Flavor.yaml
+_("Subnet Required")
+# TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+_("Outputs")
+# TRANSLATORS: file: product/views/OrchestrationStackOutput.yaml
+_("Key")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager.yaml
+_("Ansible Tower Providers")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager_ConfiguredSystem.yaml
+_("Configuration Profile")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_AnsibleTower_ConfigurationManager_ConfiguredSystem.yaml
+_("Ansible Tower Configured System")
+# TRANSLATORS: file: product/views/MiqServer.yaml
+_("EVM Server")
+# TRANSLATORS: file: product/views/MiqServer.yaml
+_("EVM Servers")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/MiqServer.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+_("Build")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("VMs and Templates")
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Template.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_InfraManager_Vm.yaml
+# TRANSLATORS: file: product/views/MiqTemplate-all_miq_templates.yaml
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/Vm-all_vms.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_archived.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_orphaned.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate-all_vms_and_templates.yaml
+# TRANSLATORS: file: product/views/VmOrTemplate.yaml
+_("Total Snapshots")
+# TRANSLATORS: file: product/views/MiqTemplate.yaml
+# TRANSLATORS: file: product/views/Vm.yaml
+_("Cloud")
+# TRANSLATORS: file: product/views/InstanceOrImage.yaml
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Vm-all_vms_and_templates.yaml
+_("Instances and Images")
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+_("Linux Init Processes")
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+_("Enabled Run Levels")
+# TRANSLATORS: file: product/views/SystemService-linux_initprocesses.yaml
+_("Disabled Run Levels")
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+_("Clusters")
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+_("Datacenter")
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+_("All VMs")
+# TRANSLATORS: file: product/views/EmsCluster.yaml
+_("All Templates")
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+_("Cim Storage Volume")
+# TRANSLATORS: file: product/views/OntapStorageVolume.yaml
+_("OntapStorageVolumes")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("EVM Worker")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("EVM Workers")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("PID")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("SPID")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("URI / Queue Name")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("Last Heartbeat")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+_("Memory Usage")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("Memory Size")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+_("CPU Percent")
+# TRANSLATORS: file: product/views/MiqWorker.yaml
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+_("CPU Time")
+# TRANSLATORS: file: product/views/MiqTask.yaml
+_("UI Tasks")
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+_("Updated")
+# TRANSLATORS: file: product/views/Container.yaml
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+_("State")
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+_("Task Name")
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/MiqTask.yaml
+_("User")
+# TRANSLATORS: file: product/views/MiqDialog.yaml
+_("Miq Dialogs")
+# TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
+_("Middleware Deployments")
+# TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
+_("Deployment Name")
+# TRANSLATORS: file: product/views/MiddlewareDeployment.yaml
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Server")
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("Container Services")
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("ContainerService")
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("Portal IP")
+# TRANSLATORS: file: product/views/ContainerService.yaml
+_("Session Affinity")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager.yaml
+_("EmsCloud")
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+_("Direct VMs")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total VMs")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+_("Total Templates")
+# TRANSLATORS: file: product/views/ResourcePool.yaml
+_("vApp")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("VmdbDatabaseConnection")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Worker")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Address")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Blocked By")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Task State")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Waiting Resource")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Wait Time")
+# TRANSLATORS: file: product/views/VmdbDatabaseConnection.yaml
+_("Command")
+# TRANSLATORS: file: product/views/SystemService-win32_services.yaml
+_("Win32 Services")
+# TRANSLATORS: file: product/views/MiqActionSet.yaml
+_("Action Sets")
+# TRANSLATORS: file: product/views/MiqActionSet.yaml
+_("ActionSet")
+# TRANSLATORS: file: product/views/ScanItemSet.yaml
+_("ScanItemSet")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+_("Virtualization Type")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_Template.yaml
+_("Root Device Type")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+_("Containers Providers")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_ContainerManager.yaml
+_("EmsContainer")
+# TRANSLATORS: file: product/views/MiddlewareServer.yaml
+_("Middleware Servers")
+# TRANSLATORS: file: product/views/MiddlewareServer.yaml
+_("Server Name")
+# TRANSLATORS: file: product/views/MiddlewareServer.yaml
+_("Feed")
+# TRANSLATORS: file: product/views/Host.yaml
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("Platform")
+# TRANSLATORS: file: product/views/Host.yaml
+_("IPMI Enabled")
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+_("ContainerReplicator")
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+_("Replicas")
+# TRANSLATORS: file: product/views/ContainerReplicator.yaml
+_("Current Replicas")
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+_("Container Projects")
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+_("ContainerProject")
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+_("Container Routes")
+# TRANSLATORS: file: product/views/ContainerProject.yaml
+_("Container Replicators")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Approval State")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Request ID")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Requester")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Request Type")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Completed")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Approved/Denied On")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Last Update")
+# TRANSLATORS: file: product/views/AutomationRequest.yaml
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Reason")
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+_("EVM Server Builds")
+# TRANSLATORS: file: product/views/ServerBuild.yaml
+_("Date/Time")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Retired")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total CPUs")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total Memory")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total VM Disk Count")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total VM Disk Space Allocated")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total VM Disk Space Used")
+# TRANSLATORS: file: product/views/Service.yaml
+_("Total VM Memory on Disk")
+# TRANSLATORS: file: product/views/MiqEvent.yaml
+_("Event")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("Based On")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("What is evaluated")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("Email")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("SNMP")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("Event on Timeline")
+# TRANSLATORS: file: product/views/MiqAlert.yaml
+_("Management Event Raised")
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Request State")
+# TRANSLATORS: file: product/views/MiqRequest.yaml
+_("Approved/Denied By")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Resources")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Logical Resource")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Physical Resource")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Resource Category")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Resource Status")
+# TRANSLATORS: file: product/views/OrchestrationStackResource.yaml
+_("Resource Status Reason")
+# TRANSLATORS: file: product/views/CloudTenant.yaml
+_("Cloud Tenant")
+# TRANSLATORS: file: product/views/CloudTenant.yaml
+_("CloudTenant")
+# TRANSLATORS: file: product/views/SystemService-kernel_drivers.yaml
+_("Kernel Drivers")
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+_("Display in Catalog")
+# TRANSLATORS: file: product/views/ServiceTemplate.yaml
+_("Catalog")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+_("Auth Key Pair")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+_("AuthKeyPair")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_CloudManager_AuthKeyPair.yaml
+_("Fingerprint")
+# TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+_("Event Actions")
+# TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+_("Event Action")
+# TRANSLATORS: file: product/views/MiqEvent-actions.yaml
+_("Sync/Async")
+# TRANSLATORS: file: product/views/StorageFile-disk_files.yaml
+_("Datastore VM Provisioned Disk Files")
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("EVM Server Maintenance")
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("Update Type")
+# TRANSLATORS: file: product/views/ProductUpdate.yaml
+_("Component")
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("Container Nodes")
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("ContainerNode")
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("Operating System")
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("Kernel Version")
+# TRANSLATORS: file: product/views/ContainerNode.yaml
+_("Runtime Version")
+# TRANSLATORS: file: product/views/SystemService.yaml
+_("Running")
+# TRANSLATORS: file: product/views/SystemService.yaml
+_("Systemd Load")
+# TRANSLATORS: file: product/views/SystemService.yaml
+_("Systemd Active")
+# TRANSLATORS: file: product/views/SystemService.yaml
+_("Systemd Sub")
+# TRANSLATORS: file: product/views/SystemService.yaml
+_("Enabled run levels")
+# TRANSLATORS: file: product/views/Condition.yaml
+_("Condition")
+# TRANSLATORS: file: product/views/Job.yaml
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Owner")
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Processors")
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Allocated Storage")
+# TRANSLATORS: file: product/views/Vm__restricted.yaml
+_("Used Storage")
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+_("Container Images")
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+_("ContainerImage")
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+_("Id")
+# TRANSLATORS: file: product/views/ContainerImage.yaml
+_("Image Registry")
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("VmdbDatabaseSetting")
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("Minimum")
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("Maximum")
+# TRANSLATORS: file: product/views/VmdbDatabaseSetting.yaml
+_("Unit")
+# TRANSLATORS: file: product/views/Policy.yaml
+_("Policy")
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+_("NetApp Filers")
+# TRANSLATORS: file: product/views/OntapStorageSystem.yaml
+_("OntapStorageSystems")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("Files")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("File Version")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("Contents Available")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("Permissions")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("Collected On")
+# TRANSLATORS: file: product/views/Filesystem.yaml
+_("Last Modified")
+# TRANSLATORS: file: product/views/ManageIQ_Providers_Foreman_ConfigurationManager.yaml
+_("Total Configuration Profiles")
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+_("FirewallRule")
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+_("Protocol")
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+_("End Port")
+# TRANSLATORS: file: product/views/FirewallRule.yaml
+_("Direction")
+# TRANSLATORS: file: product/views/IsoDatastore.yaml
+# TRANSLATORS: file: product/views/PxeServer.yaml
+_("Last Refreshed On")
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+_("Cloud Volumes based on Snapshot")
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+_("CloudVolume")
+# TRANSLATORS: file: product/views/CloudVolume-based_volumes.yaml
+# TRANSLATORS: file: product/views/CloudVolume.yaml
+_("Bootable?")
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Patches")
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Service Pack")
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Date Installed")
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Valid")
+# TRANSLATORS: file: product/views/Patch.yaml
+_("Installed")
+# TRANSLATORS: file: product/views/ChargebackRate.yaml
+_("Chargeback Rates")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Event Logs")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Event Id")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Computer Name")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Level")
+# TRANSLATORS: file: product/views/EventLog-event_logs.yaml
+_("Category")
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+_("Cim Logical Disk")
+# TRANSLATORS: file: product/views/OntapLogicalDisk.yaml
+_("OntapLogicalDisks")
+# TRANSLATORS: file: product/views/Container.yaml
+_("Pod Name")
+# TRANSLATORS: file: product/views/Container.yaml
+_("Image")
+# TRANSLATORS: file: product/views/AvailabilityZone.yaml
+_("AvailabilityZone")
+# TRANSLATORS: file: product/views/Dialog.yaml
+_("Label")
+# TRANSLATORS: file: product/views/Job.yaml
+_("Jobs")
+# TRANSLATORS: file: product/views/Job.yaml
+_("Queued")
+# TRANSLATORS: file: product/views/Job.yaml
+_("Owner Message")
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+_("Persistent Volumes")
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+_("PersistentVolume")
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+_("Access Modes")
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+_("Reclaim Policy")
+# TRANSLATORS: file: product/views/PersistentVolume.yaml
+_("Status Phase")
+# TRANSLATORS: file: product/views/StorageFile-debris_files.yaml
+_("Datastore Non-VM Files")
+# TRANSLATORS: file: product/views/StorageFile-snapshot_files.yaml
+_("Datastore VM Snapshot Files")
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+_("Cim Storage Extent")
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+_("CimStorageExtents")
+# TRANSLATORS: file: product/views/CimStorageExtent.yaml
+_("Health State")
+# TRANSLATORS: file: product/views/ConditionSet.yaml
+_("Condition Sets")
+# TRANSLATORS: file: product/views/ConditionSet.yaml
+_("ConditionSet")
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+_("Processes")
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+_("Memory %")
+# TRANSLATORS: file: product/views/OsProcess-processes.yaml
+_("CPU %")
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+# TRANSLATORS: file: product/views/MiqUserRole.yaml
+_("Read Only")
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+_("Number of Users")
+# TRANSLATORS: file: product/views/MiqGroup.yaml
+_("Sequence")
+# TRANSLATORS: file: product/views/MiqUserRole.yaml
+_("User Roles")
+# TRANSLATORS: file: product/views/MiqUserRole.yaml
+_("VM & Template Access Restriction")
+# TRANSLATORS: file: product/views/MiqUserRole.yaml
+_("Number of Groups")

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -35,4 +35,61 @@ namespace :gettext do
       f.puts(output_strings)
     end
   end
+
+  task :extract_yaml_strings do
+    def update_output(string, file, output)
+      return if string.nil? || string.empty?
+      if output.key?(string)
+        output[string].append(file)
+      else
+        output[string] = [file]
+      end
+    end
+
+    def parse_object(object, keys, file, output)
+      if object.kind_of?(Hash)
+        object.keys.each do |key|
+          if keys.include?(key) || keys.include?(key.to_s)
+            if object[key].kind_of?(Array)
+              object[key].each { |i| update_output(i, file, output) }
+            else
+              update_output(object[key], file, output)
+            end
+          end
+          parse_object(object[key], keys, file, output)
+        end
+      elsif object.kind_of?(Array)
+        object.each do |item|
+          parse_object(item, keys, file, output)
+        end
+      end
+    end
+
+    yamls = {
+      "db/fixtures/miq_product_features.*" => %w(name description),
+      "db/fixtures/miq_report_formats.*"   => %w(description),
+      "product/ops/miq_reports/*.*"        => %w(title name headers),
+      "product/timelines/miq_reports/*.*"  => %w(title name headers),
+      "product/usage/miq_reports/*.*"      => %w(title name headers),
+      "product/views/*.*"                  => %w(title name headers)
+    }
+
+    output = {}
+
+    yamls.keys.each do |yaml_glob|
+      Dir.glob(yaml_glob).each do |file|
+        yml = YAML.load_file(Rails.root.join(file))
+        parse_object(yml, yamls[yaml_glob], file, output)
+      end
+    end
+
+    File.open(Rails.root.join("config/yaml_strings.rb"), "w+") do |f|
+      output.keys.each do |key|
+        output[key].sort.uniq.each do |file|
+          f.puts "# TRANSLATORS: file: #{file}"
+        end
+        f.puts '_("%s")' % key
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implemented:

* A new rake task `gettext:extract_yaml_strings`, which collects strings from yaml files of interest
under `db/fixtures/` and `product/` directories and puts them into `config/yaml_strings.rb` for
`gettext:find` rake task to find.
* Localized headers in report views
* Localized product features view
* updated `manageiq.pot` to contain new strings from yaml files