### PR TITLE
reload the tenant object

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -300,6 +300,7 @@ class Tenant < ApplicationRecord
   end
 
   def create_tenant_group
+    reload # https://github.com/rails/rails/issues/23844
     update_attributes!(:default_miq_group => MiqGroup.create_tenant_group(self)) unless default_miq_group_id
     self
   end


### PR DESCRIPTION
Because of changes in Rails 5, the validation code in
ActiveModel fails on uniqueness for the same record.
Reloading the object saves the changes before we trigger
an update_attributes!