### PR TITLE
Handle omitted LimitRange spec and/or spec.limits from k8s.

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -375,7 +375,8 @@ module ManageIQ::Providers::Kubernetes
     def parse_range_items(limit_range)
       new_result_h = create_limits_matrix
 
-      limit_range.spec.limits.each do |item|
+      limits = limit_range.try(:spec).try(:limits) || []
+      limits.each do |item|
         item[:max].to_h.each do |resource_name, limit|
           new_result_h[item[:type].to_sym][resource_name.to_sym][:max] = limit
         end

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -469,25 +469,33 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
       end
     end
 
-    it "handles limits without specification" do
-      expect(parser.send(:parse_range,
-                         RecursiveOpenStruct.new(
-                           :metadata => {
-                             :name              => 'test-range',
-                             :namespace         => 'test-namespace',
-                             :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-                             :resourceVersion   => '2',
-                             :creationTimestamp => '2015-08-17T09:16:46Z',
-                           },
-                           :spec     => {
-                             :limits => []
-                           })))
-        .to eq(:name                  => 'test-range',
-               :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
-               :ems_created_on        => '2015-08-17T09:16:46Z',
-               :resource_version      => '2',
-               :project               => nil,
-               :container_limit_items => [])
+    it "handles missing limits specification" do
+      metadata = {
+        :name              => 'test-range',
+        :namespace         => 'test-namespace',
+        :uid               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+        :resourceVersion   => '2',
+        :creationTimestamp => '2015-08-17T09:16:46Z',
+      }
+      ranges = [
+        {:metadata => metadata},
+        {:metadata => metadata, :spec => nil},
+        {:metadata => metadata, :spec => {}},
+        {:metadata => metadata, :spec => {:limits => nil}},
+        {:metadata => metadata, :spec => {:limits => []}}
+      ]
+      parsed = {
+        :name                  => 'test-range',
+        :ems_ref               => 'af3d1a10-44c0-11e5-b186-0aaeec44370e',
+        :ems_created_on        => '2015-08-17T09:16:46Z',
+        :resource_version      => '2',
+        :project               => nil,
+        :container_limit_items => []
+      }
+      ranges.each do |range|
+        expect(parser.send(:parse_range, RecursiveOpenStruct.new(range)))
+          .to eq(parsed)
+      end
     end
   end
 


### PR DESCRIPTION
[Review carefully, I'm new to MIQ, k8s, Ruby and Go.  All and any criticism welcome.]

This hopefully solves crash seen in the wild: https://bugzilla.redhat.com/1305324 where `spec.limits` was `nil`.
It might be overzelous.

What I see from [types.go][] is that `LimitRange.Spec` is `json:"spec,omitempty"` but `LimitRangeSpec.Limits` isn't, it should always be an array.
[omitempty doc](https://golang.org/pkg/encoding/json/) says:
> The empty values are false, 0, any nil pointer or interface value, and any array, slice, map, or string of length zero.

This suggests that only `spec` missing entirely or `:spec => {:limits => []}` are the plausible scenarious;
`:spec => nil`, `:spec => {}` and `:spec => {:limits => nil}` shouldn't happen.
Nevertheless, `limits` being nil is what the traceback suggests?
But I see RecursiveOpenStruct [returns nil for missing attributes][2], so I suspect what happenned in the traceback is that `limits` wasn't there.  However shouldn't then `spec` have been omitempty'd and `spec.limits` crashed instead of `spec.limits.each`?  I'm still confused...

- Since ROS returns nil for missing attributes, `limit_range.spec.try(:limits) || []` would also work (it passes the 5 test scenarios).  IMHO `try` on spec helps readability clarifyng we expect spec to be missing, but perhaps all code here relies on nil-for-missing anyway?
- Also I wasn't sure if `|| []`, `.to_a` or an explicit condition skipping the loop is best.

[types.go]: https://github.com/kubernetes/kubernetes/blob/release-1.1/pkg/api/types.go#L1780-L1828
[2]: https://github.com/aetherknight/recursive-open-struct/blob/v0.6.5/spec/recursive_open_struct/open_struct_behavior_spec.rb#L16-L18