### PR TITLE
Remove filters from users

### DIFF
--- a/app/controllers/ops_controller/settings.rb
+++ b/app/controllers/ops_controller/settings.rb
@@ -216,17 +216,6 @@ module OpsController::Settings
     @edit[:new][:description] = params[:region_description] if params[:region_description]
   end
 
-  # Set filters in the user record from the @edit[:new] hash values
-  def user_set_filters(user)
-    @set_filter_values = []
-    @edit[:new][:filters].each do |_key, value|
-      @set_filter_values.push(value)
-    end
-    user_make_subarrays # Need to have category arrays of item arrays for and/or logic
-    user.set_managed_filters(@set_filter_values)
-    user.set_belongsto_filters(@edit[:new][:belongsto].values)  # Set belongs to to hash values
-  end
-
   # Need to make arrays by category containing arrays of items so the filtering logic can apply
   # AND between the categories, but OR between the items within a category
   def user_make_subarrays

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,6 @@ class User < ApplicationRecord
   # use authenticate_bcrypt rather than .authenticate to avoid confusion
   # with the class method of the same name (User.authenticate)
   alias_method :authenticate_bcrypt, :authenticate
-  serialize :filters
 
   include ReportableMixin
 
@@ -192,19 +191,6 @@ class User < ApplicationRecord
 
   def get_timezone
     settings.fetch_path(:display, :timezone) || self.class.server_timezone
-  end
-
-  def current_group=(group)
-    log_prefix = "User: [#{userid}]"
-    super
-
-    if group
-      self.filters = group.filters
-      _log.info("#{log_prefix} Assigning Role: [#{group.miq_user_role_name}] from Group: [#{group.description}]")
-    else
-      self.filters = nil
-      _log.info("#{log_prefix} Removing Role: [#{miq_user_role_name}] and Group: [#{miq_group_description}]")
-    end
   end
 
   def miq_groups=(groups)

--- a/db/migrate/20160224224115_remove_filters_from_users.rb
+++ b/db/migrate/20160224224115_remove_filters_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveFiltersFromUsers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :filters, :text
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,7 +25,6 @@ describe User do
         :email      => "admin@email.com",
         :password   => "smartvm",
         :settings   => {"Setting1"  => 1, "Setting2"  => 2, "Setting3"  => 3},
-        :filters    => {"Filter1"   => 1, "Filter2"   => 2, "Filter3"   => 3},
         :miq_groups => [@miq_group],
         :first_name => "Bob",
         :last_name  => "Smith"
@@ -259,11 +258,6 @@ describe User do
         expect(@user.current_group).to eq(@group3)
       end
 
-      it "sets filters" do
-        expect(@user.filters).to eq(@group3.filters)
-        expect(@user.filters).to eq(@filter1)
-      end
-
       it "when including current group" do
         @user.miq_groups = [@group1, @group2, @group3]
         expect(@user.valid?).to be_truthy
@@ -290,11 +284,6 @@ describe User do
 
       it "sets current_group" do
         expect(@user.current_group).to eq(@group1)
-      end
-
-      it "sets filters" do
-        expect(@user.filters).to eq(@group1.filters)
-        expect(@user.filters).to eq(@filter1)
       end
 
       it "when belongs to miq_groups" do


### PR DESCRIPTION
Filters aren't actually used by anything (anymore). Users just delegate to miq_group filters. :tada:

@miq-bot add_label core, technical debt, tenancy 