### PR TITLE
Remove polymorphic resource from MiqGroups

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -247,11 +247,12 @@ module Authenticator
       end
     end
 
+    # TODO: Fix this icky select matching with tenancy
     def match_groups(external_group_names)
       return [] if external_group_names.empty?
       external_group_names = external_group_names.collect(&:downcase)
 
-      internal_groups = MiqServer.my_server.permitted_groups
+      internal_groups = MiqGroup.order(:sequence).to_a
 
       external_group_names.each { |g| _log.debug("External Group: #{g}") }
       internal_groups.each      { |g| _log.debug("Internal Group: #{g.description.downcase}") }

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -5,7 +5,6 @@ class MiqGroup < ApplicationRecord
 
   belongs_to :tenant
   belongs_to :miq_user_role
-  belongs_to :resource, :polymorphic => true
   has_and_belongs_to_many :users
   has_many   :vms,         :dependent => :nullify
   has_many   :miq_templates, :dependent => :nullify

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -656,13 +656,6 @@ class MiqServer < ApplicationRecord
     "#{name} [#{id}]"
   end
 
-  def permitted_groups
-    groups = miq_groups.order(:sequence).to_a
-    groups = zone.miq_groups.order(:sequence).to_a if groups.empty?
-    groups = MiqGroup.where(:resource => nil).order(:sequence).to_a if groups.empty?
-    groups
-  end
-
   def server_timezone
     get_config("vmdb").config.fetch_path(:server, :timezone) || "UTC"
   end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -21,7 +21,6 @@ class MiqServer < ApplicationRecord
   belongs_to              :vm, :inverse_of => :miq_server
   belongs_to              :zone
   has_many                :messages,  :as => :handler, :class_name => 'MiqQueue'
-  has_many                :miq_groups, :as => :resource
   has_many                :miq_events, :as => :target, :dependent => :destroy
 
   cattr_accessor          :my_guid_cache

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -10,7 +10,6 @@ class Zone < ApplicationRecord
 
   has_many :miq_servers
   has_many :ext_management_systems
-  has_many :miq_groups, :as => :resource
   has_many :miq_schedules, :dependent => :destroy
   has_many :storage_managers
   has_many :ldap_regions

--- a/db/migrate/20160225033835_remove_resource_id_and_resource_type_from_miq_groups.rb
+++ b/db/migrate/20160225033835_remove_resource_id_and_resource_type_from_miq_groups.rb
@@ -1,0 +1,6 @@
+class RemoveResourceIdAndResourceTypeFromMiqGroups < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_groups, :resource_id, :bigint
+    remove_column :miq_groups, :resource_type, :string
+  end
+end

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -73,9 +73,6 @@ describe Authenticator::Amazon do
     allow(User).to receive(:authenticator).and_return(subject)
 
     miq_group = FactoryGirl.create(:miq_group, :description => miq_group_name)
-    allow(MiqServer).to receive(:my_server).and_return(
-      double(:my_server, :permitted_groups => [miq_group])
-    )
     allow(MiqLdap).to receive(:using_ldap?) { false }
 
     allow_any_instance_of(described_class).to receive(:aws_connect) do |_instance, access_key_id, _secret_access_key, service|

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -20,9 +20,6 @@ describe Authenticator::Httpd do
     wibble = FactoryGirl.create(:miq_group, :description => 'wibble')
     wobble = FactoryGirl.create(:miq_group, :description => 'wobble')
 
-    allow(MiqServer).to receive(:my_server).and_return(
-      double(:my_server, :permitted_groups => [wibble, wobble])
-    )
     allow(MiqLdap).to receive(:using_ldap?) { false }
   end
 

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -55,10 +55,6 @@ describe Authenticator::Ldap do
   before(:each) do
     wibble = FactoryGirl.create(:miq_group, :description => 'wibble')
     wobble = FactoryGirl.build_stubbed(:miq_group, :description => 'wobble')
-
-    allow(MiqServer).to receive(:my_server).and_return(
-      double(:my_server, :permitted_groups => [wibble, wobble])
-    )
   end
 
   let(:user_data) do


### PR DESCRIPTION
This doesn't appear to be used anywhere _really_ - `permitted_groups` is a method that appears to always just use all MiqGroups because there are never any resources. No entries found in any example DBs via @gtanzillo