### PR TITLE
Tag: fix sporadic miq_action categories

### DIFF
--- a/app/controllers/miq_policy_controller/miq_actions.rb
+++ b/app/controllers/miq_policy_controller/miq_actions.rb
@@ -435,10 +435,7 @@ module MiqPolicyController::MiqActions
     end
 
     if %w(inherit_parent_tags remove_tags).include?(@action.action_type)
-      @cats = @action.options[:cats].map do |cat|
-        tag = Tag.find_by_classification_name(cat)
-        Classification.where(:tag_id => tag.id).pluck(:description)
-      end.flatten.sort_by(&:downcase).join(" | ")
+      @cats = Classification.find_by_names(@action.options[:cats]).pluck(:description).sort_by(&:downcase).join(" | ")
     end
   end
 end

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -304,6 +304,13 @@ class Classification < ApplicationRecord
     find_by_tag_id(tag.id) if tag
   end
 
+  def self.find_by_names(names, region_id = my_region_number, ns = DEFAULT_NAMESPACE)
+    tag_names = names.map { |name| Classification.name2tag(name, 0, ns) }
+    # NOTE: tags is a subselect - not an array of ids
+    tags = Tag.in_region(region_id).where(:name => tag_names).select(:id)
+    where(:tag_id => tags)
+  end
+
   def tag2ns(tag)
     unless tag.nil?
       ta = tag.split("/")

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -457,9 +457,8 @@ class Classification < ApplicationRecord
     if parent_id == 0
       File.join(ns, name)
     else
-      c = Classification.find(parent_id)
-      return nil if c.nil?
-      File.join(ns, c.name, name)
+      c = parent_id.kind_of?(Classification) ? parent_id : Classification.find(parent_id)
+      File.join(ns, c.name, name) if c
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -109,12 +109,15 @@ class Tag < ApplicationRecord
     list
   end
 
-  def self.find_by_classification_name(name, region_id = Classification.my_region_number, ns = Classification::DEFAULT_NAMESPACE)
-    if region_id.nil?
-      Tag.find_by_name(Classification.name2tag(name, 0, ns))
-    else
-      Tag.in_region(region_id).find_by_name(Classification.name2tag(name, 0, ns))
-    end
+  def self.find_by_classification_name(name, region_id = Classification.my_region_number,
+                                       ns = Classification::DEFAULT_NAMESPACE, parent_id = 0)
+    in_region(region_id).find_by_name(Classification.name2tag(name, parent_id, ns))
+  end
+
+  def self.find_or_create_by_classification_name(name, region_id = Classification.my_region_number,
+                                                 ns = Classification::DEFAULT_NAMESPACE, parent_id = 0)
+    tag_name = Classification.name2tag(name, parent_id, ns)
+    in_region(region_id).find_by_name(tag_name) || create(:name => tag_name)
   end
 
   def ==(comparison_object)

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -150,8 +150,7 @@ module ArRegion
   end
 
   def region_number
-    return my_region_number if self.new_record?
-    id ? (id / self.class.rails_sequence_factor) : nil
+    id ? (id / self.class.rails_sequence_factor) : my_region_number
   end
   alias_method :region_id, :region_number
 

--- a/spec/controllers/miq_policy_controller/miq_actions_spec.rb
+++ b/spec/controllers/miq_policy_controller/miq_actions_spec.rb
@@ -62,9 +62,11 @@ describe MiqPolicyController do
       end
     end
     describe "#action_get_info" do
+      let(:cat1) { FactoryGirl.create(:classification, :description => res.first) }
+      let(:cat2) { FactoryGirl.create(:classification, :description => res.second) }
+
       before do
-        FactoryGirl.create(:classification, :description => res.first)
-        FactoryGirl.create(:classification, :description => res.second)
+        cat1 ; cat2
         controller.instance_variable_set(:@sb, :active_tree => :action_tree)
       end
 
@@ -72,11 +74,10 @@ describe MiqPolicyController do
       let(:action) do
         FactoryGirl.create(:miq_action,
                            :action_type => 'inherit_parent_tags',
-                           :options     => {:cats => %w(category_0000000000001 category_0000000000002)})
+                           :options     => {:cats => [cat1.name, cat2.name]})
       end
 
       it "joins classification tags" do
-        skip "This doesn't do what we think it does. Should be reviewed again. Skipping to make suite pass for other features."
         controller.send(:action_get_info, action)
         expect(controller.instance_variable_get(:@cats)).to eq(res.join(' | '))
       end

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -101,6 +101,7 @@ describe "AR Regions extension" do
       expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 29).region_id).to eq(@base_region + 2)
 
       expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new.region_id).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm.my_region_number)
+      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new(:id => @base_id + 29).regoin_id).to eq(@base_region + 2)
     end
 
     it "#compressed_id" do

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -1,52 +1,54 @@
 describe "AR Regions extension" do
+  let(:base_class) { ManageIQ::Providers::Vmware::InfraManager::Vm }
+
   before(:each) do
-    allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:rails_sequence_factor).and_return(10)
+    allow(base_class).to receive(:rails_sequence_factor).and_return(10)
   end
 
   after(:each) do
-    ManageIQ::Providers::Vmware::InfraManager::Vm.clear_region_cache
+    base_class.clear_region_cache
   end
 
   it ".id_to_region" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.id_to_region(5)).to eq(0)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.id_to_region(15)).to eq(1)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.id_to_region(25)).to eq(2)
+    expect(base_class.id_to_region(5)).to eq(0)
+    expect(base_class.id_to_region(15)).to eq(1)
+    expect(base_class.id_to_region(25)).to eq(2)
   end
 
   it ".region_to_range" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.region_to_range(0)).to eq(0..9)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.region_to_range(1)).to eq(10..19)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.region_to_range(2)).to eq(20..29)
+    expect(base_class.region_to_range(0)).to eq(0..9)
+    expect(base_class.region_to_range(1)).to eq(10..19)
+    expect(base_class.region_to_range(2)).to eq(20..29)
   end
 
   it ".compressed_id?" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?(5)).to     be_falsey
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?(15)).to    be_falsey
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?(25)).to    be_falsey
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?("5")).to   be_falsey
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?("1r5")).to be_truthy
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compressed_id?("2r5")).to be_truthy
+    expect(base_class.compressed_id?(5)).to     be_falsey
+    expect(base_class.compressed_id?(15)).to    be_falsey
+    expect(base_class.compressed_id?(25)).to    be_falsey
+    expect(base_class.compressed_id?("5")).to   be_falsey
+    expect(base_class.compressed_id?("1r5")).to be_truthy
+    expect(base_class.compressed_id?("2r5")).to be_truthy
   end
 
   it ".split_id" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id(5)).to eq([0, 5])
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id(15)).to eq([1, 5])
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id(25)).to eq([2, 5])
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id("5")).to eq([0, 5])
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id("1r5")).to eq([1, 5])
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.split_id("2r5")).to eq([2, 5])
+    expect(base_class.split_id(5)).to eq([0, 5])
+    expect(base_class.split_id(15)).to eq([1, 5])
+    expect(base_class.split_id(25)).to eq([2, 5])
+    expect(base_class.split_id("5")).to eq([0, 5])
+    expect(base_class.split_id("1r5")).to eq([1, 5])
+    expect(base_class.split_id("2r5")).to eq([2, 5])
   end
 
   it ".compress_id" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compress_id(5)).to eq("5")
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compress_id(15)).to eq("1r5")
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.compress_id(25)).to eq("2r5")
+    expect(base_class.compress_id(5)).to eq("5")
+    expect(base_class.compress_id(15)).to eq("1r5")
+    expect(base_class.compress_id(25)).to eq("2r5")
   end
 
   it ".uncompress_id" do
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.uncompress_id("5")).to eq(5)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.uncompress_id("1r5")).to eq(15)
-    expect(ManageIQ::Providers::Vmware::InfraManager::Vm.uncompress_id("2r5")).to eq(25)
+    expect(base_class.uncompress_id("5")).to eq(5)
+    expect(base_class.uncompress_id("1r5")).to eq(15)
+    expect(base_class.uncompress_id("2r5")).to eq(25)
   end
 
   context "with some records" do
@@ -55,75 +57,73 @@ describe "AR Regions extension" do
       loop do
         dummy = FactoryGirl.create(:vm_vmware)
         @base_id = dummy.id
-        break if (@base_id % ManageIQ::Providers::Vmware::InfraManager::Vm.rails_sequence_factor) == 0
+        @base_region, small_id = dummy.split_id
+        break if small_id == 0
         dummy.destroy
       end
 
-      @base_region = (@base_id / ManageIQ::Providers::Vmware::InfraManager::Vm.rails_sequence_factor)
-      allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:my_region_number).and_return(@base_region + 1)
-      allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:rails_sequence_start).and_return(ManageIQ::Providers::Vmware::InfraManager::Vm.my_region_number * ManageIQ::Providers::Vmware::InfraManager::Vm.rails_sequence_factor + @base_id)
-      allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:rails_sequence_end).and_return(ManageIQ::Providers::Vmware::InfraManager::Vm.rails_sequence_start + ManageIQ::Providers::Vmware::InfraManager::Vm.rails_sequence_factor - 1)
+      allow(base_class).to receive(:my_region_number).and_return(@base_region + 1)
 
       29.times { FactoryGirl.create(:vm_vmware) } # 1 less because we created the base one above
     end
 
     it ".in_my_region" do
-      recs = ManageIQ::Providers::Vmware::InfraManager::Vm.in_my_region
+      recs = base_class.in_my_region
       expect(recs.count).to eq(10)
-      expect(recs.all? { |v| v.region_number == ManageIQ::Providers::Vmware::InfraManager::Vm.my_region_number }).to be_truthy
+      expect(recs.all? { |v| v.region_number == base_class.my_region_number }).to be_truthy
     end
 
     context ".in_region" do
       it "with region param" do
-        recs = ManageIQ::Providers::Vmware::InfraManager::Vm.in_region(@base_region)
+        recs = base_class.in_region(@base_region)
         expect(recs.count).to eq(10)
         expect(recs.all? { |v| v.region_number == @base_region }).to be_truthy
       end
 
       it "with nil param" do
-        recs = ManageIQ::Providers::Vmware::InfraManager::Vm.in_region(nil)
+        recs = base_class.in_region(nil)
         expect(recs.count).to eq(30)
       end
     end
 
     it ".with_region" do
-      recs = ManageIQ::Providers::Vmware::InfraManager::Vm.with_region(@base_region) { ManageIQ::Providers::Vmware::InfraManager::Vm.all }
+      recs = base_class.with_region(@base_region) { base_class.all }
       expect(recs.count).to eq(10)
       expect(recs.all? { |v| v.region_number == @base_region }).to be_truthy
     end
 
     it "#region_id" do
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 5).region_id).to eq(@base_region)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 9).region_id).to eq(@base_region)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 15).region_id).to eq(@base_region + 1)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 19).region_id).to eq(@base_region + 1)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 25).region_id).to eq(@base_region + 2)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 29).region_id).to eq(@base_region + 2)
+      expect(base_class.find(@base_id + 5).region_id).to eq(@base_region)
+      expect(base_class.find(@base_id + 9).region_id).to eq(@base_region)
+      expect(base_class.find(@base_id + 15).region_id).to eq(@base_region + 1)
+      expect(base_class.find(@base_id + 19).region_id).to eq(@base_region + 1)
+      expect(base_class.find(@base_id + 25).region_id).to eq(@base_region + 2)
+      expect(base_class.find(@base_id + 29).region_id).to eq(@base_region + 2)
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new.region_id).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm.my_region_number)
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new(:id => @base_id + 29).regoin_id).to eq(@base_region + 2)
+      expect(base_class.new.region_id).to eq(base_class.my_region_number)
+      expect(base_class.new(:id => @base_id + 29).region_id).to eq(@base_region + 2)
     end
 
     it "#compressed_id" do
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 5).compressed_id).to eq("#{@base_region}r5")
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 9).compressed_id).to eq("#{@base_region}r9")
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 15).compressed_id).to eq("#{@base_region + 1}r5")
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 19).compressed_id).to eq("#{@base_region + 1}r9")
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 25).compressed_id).to eq("#{@base_region + 2}r5")
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 29).compressed_id).to eq("#{@base_region + 2}r9")
+      expect(base_class.find(@base_id + 5).compressed_id).to eq("#{@base_region}r5")
+      expect(base_class.find(@base_id + 9).compressed_id).to eq("#{@base_region}r9")
+      expect(base_class.find(@base_id + 15).compressed_id).to eq("#{@base_region + 1}r5")
+      expect(base_class.find(@base_id + 19).compressed_id).to eq("#{@base_region + 1}r9")
+      expect(base_class.find(@base_id + 25).compressed_id).to eq("#{@base_region + 2}r5")
+      expect(base_class.find(@base_id + 29).compressed_id).to eq("#{@base_region + 2}r9")
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new.compressed_id).to be_nil
+      expect(base_class.new.compressed_id).to be_nil
     end
 
     it "#split_id" do
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 5).split_id).to eq([@base_region, 5])
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 9).split_id).to eq([@base_region, 9])
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 15).split_id).to eq([@base_region + 1, 5])
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 19).split_id).to eq([@base_region + 1, 9])
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 25).split_id).to eq([@base_region + 2, 5])
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.find(@base_id + 29).split_id).to eq([@base_region + 2, 9])
+      expect(base_class.find(@base_id + 5).split_id).to eq([@base_region, 5])
+      expect(base_class.find(@base_id + 9).split_id).to eq([@base_region, 9])
+      expect(base_class.find(@base_id + 15).split_id).to eq([@base_region + 1, 5])
+      expect(base_class.find(@base_id + 19).split_id).to eq([@base_region + 1, 9])
+      expect(base_class.find(@base_id + 25).split_id).to eq([@base_region + 2, 5])
+      expect(base_class.find(@base_id + 29).split_id).to eq([@base_region + 2, 9])
 
-      expect(ManageIQ::Providers::Vmware::InfraManager::Vm.new.split_id).to eq([ManageIQ::Providers::Vmware::InfraManager::Vm.my_region_number, nil])
+      expect(base_class.new.split_id).to eq([base_class.my_region_number, nil])
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -96,6 +96,11 @@ describe Tag do
       expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent.id).name).to eq(entry_ns)
     end
 
+    it "finds tag by name, ns and parent" do
+      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent)).not_to be_nil
+      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent).name).to eq(entry_ns)
+    end
+
     it "finds tag in region" do
       expect(Tag.find_by_classification_name("test_category", my_region_number)).not_to be_nil
     end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -41,9 +41,8 @@ describe Tag do
     before(:each) do
       FactoryGirl.create(:classification_department_with_tags)
 
-      @tag_details    = {:category => "department", :name => "finance", :path => "/managed/department/finance"}
-      @tag            = Tag.find_by_name(@tag_details[:path])
-      @category       = Classification.find_by_name(@tag_details[:category], nil)
+      @tag            = Tag.find_by_name("/managed/department/finance")
+      @category       = Classification.find_by_name("department")
       @classification = @tag.classification
     end
 
@@ -66,16 +65,21 @@ describe Tag do
     end
   end
 
-  context "classification" do
+  describe ".find_by_classification_name" do
+    let(:root_ns)   { "/managed" }
+    let(:parent_ns) { "/managed/test_category" }
+    let(:entry_ns)  { "/managed/test_category/test_entry" }
+    let(:my_region_number) { Tag.my_region_number }
+    let(:parent) { FactoryGirl.create(:classification, :name => "test_category") }
+
     before do
-      parent = FactoryGirl.create(:classification, :name => "test_category")
       FactoryGirl.create(:classification_tag,      :name => "test_entry",         :parent => parent)
       FactoryGirl.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
     end
 
     it "finds tag by name" do
       expect(Tag.find_by_classification_name("test_category")).not_to be_nil
-      expect(Tag.find_by_classification_name("test_category").name).to eq('/managed/test_category')
+      expect(Tag.find_by_classification_name("test_category").name).to eq(parent_ns)
     end
 
     it "doesn't find non tag" do
@@ -83,9 +87,25 @@ describe Tag do
     end
 
     it "finds tag by name and ns" do
-      ns = '/managed/test_category'
-      expect(Tag.find_by_classification_name("test_entry", nil, ns)).not_to be_nil
-      expect(Tag.find_by_classification_name("test_entry", nil, ns).name).to eq("#{ns}/test_entry")
+      expect(Tag.find_by_classification_name("test_entry", nil, parent_ns)).not_to be_nil
+      expect(Tag.find_by_classification_name("test_entry", nil, parent_ns).name).to eq(entry_ns)
+    end
+
+    it "finds tag by name, ns, and parent_id" do
+      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent.id)).not_to be_nil
+      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent.id).name).to eq(entry_ns)
+    end
+
+    it "finds tag in region" do
+      expect(Tag.find_by_classification_name("test_category", my_region_number)).not_to be_nil
+    end
+
+    it "filters tag in wrong region" do
+      expect(Tag.find_by_classification_name("test_category", my_region_number + 1)).to be_nil
+    end
+
+    it "find tag in any region" do
+      expect(Tag.find_by_classification_name("test_category", nil)).not_to be_nil
     end
   end
 


### PR DESCRIPTION
The first commit fixes a sporadic test failure that worked for units but failed for the unit suite.

While fixing/debugging this, I stumbled upon logic that would set invalid categories to resources (vm, CIMs).

The original code did not properly take the region into account when looking up values.
It chose incorrect categories and could assign categories from the wrong region.

- added tests
- removed unneeded code
- converted `Classification.find_by_name` from (N * 2) queries to 1 query.

/cc @gmcculloug Too much? I could just delete all commits but the first one.
/cc @carbonin you may understand regions the best - thoughts on these changes?