### PR TITLE
Upgrade RubyZip Gem to 1.2

### DIFF
--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -39,7 +39,8 @@ gem "ovirt",                   "~>0.7.2",           :require => false
 gem "pg",                      "~>0.18.2",          :require => false
 gem "psych",                   "~>2.0.12"
 gem "rest-client",             "=2.0.0.rc1",        :require => false
-gem "rubyzip",                 "=0.9.5",            :require => false  # TODO: Review 0.9.7 breaking log collection in FB14646
+gem "rubyzip",                 "~>1.2.0",           :require => false
+gem "zip-zip",                 "~>0.3.0",           :require => false
 gem "rufus-lru",               "~>1.0.3",           :require => false
 gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false

--- a/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
+++ b/spec/lib/miq_automation_engine/models/miq_ae_datastore_spec.rb
@@ -98,7 +98,7 @@ describe MiqAeDatastore do
     fd = double(:original_filename => "dummy.zip", :read => "junk", :eof => true, :close => true)
     import_file = File.expand_path(File.join(Rails.root, "tmp/miq_automate_engine", "dummy.zip"))
     expect { MiqAeDatastore.upload(fd, "dummy.zip") }
-      .to raise_error(/end of central directory signature not found/)
+      .to raise_error(/has zero size. Did you mean to pass the create flag?/)
     expect(File.exist?(import_file)).to be_falsey
   end
 

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -102,20 +102,20 @@ describe VMDB::Util do
   end
 
   it ".add_zip_entry" do
+    require 'zip/zipfilesystem'
     file  = "/var/log/messages.log"
     entry = "ROOT/var/log/messages.log"
     mtime = Time.parse("2013-09-24 09:00:45 -0400")
     expect(File).to receive(:mtime).with(file).and_return(mtime)
-    expect(File).to receive(:directory?).with(file).and_return(false)
     expect(described_class).to receive(:zip_entry_from_path).with(file).and_return(entry)
 
-    zip = double
-    expect(zip).to receive(:add).with(entry, file)
+    zip       = double
+    ztime     = Zip::DOSTime.at(mtime.to_i)
+    zip_entry = Zip::Entry.new(zip, entry, nil, nil, nil, nil, nil, nil, ztime)
+    expect(zip).to receive(:add).with(zip_entry, file)
     zip_file = double
-    expect(zip_file).to receive(:utime).with(mtime, entry)
-    expect(zip).to receive(:file).and_return(zip_file)
 
-    expect(described_class.add_zip_entry(zip, file)).to eq([entry, mtime])
+    expect(described_class.add_zip_entry(zip, file, zip_file)).to eq([entry, mtime])
   end
 
   it ".get_evm_log_for_date" do


### PR DESCRIPTION
The rubyzip gem has been locked at 0.9.5 for 4 years due to a namespace conflict
caused by a change in 0.9.7.  The api changed in 1.0 (3 years ago) and there are other gems that
rely on the new API, including winrm-fs, which is needed for winrm-elevated, being added
via another PR.

In addition gem ZipZip allows older RubyZip api code to continue to function alongside code using
the newer api so no code changes are necessary in our log handling code for this upgrade.

Spec tests against the new gem which cause the issue back with 0.9.7 pass.
A different spec test for an empty zip file was changed because the gem error message
changed between 0.9.5 and 1.2.0.

@Fryguy @jrafanie @chessbyte @roliveri please review and merge when appropriate.  Thank you.