### PR TITLE
Automate - Add missing vm_retire_warn event instance.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_retire_warn.yaml
+++ b/db/fixtures/ae_datastore/ManageIQ/System/Event/MiqEvent/POLICY.class/vm_retire_warn.yaml
@@ -1,0 +1,16 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: vm_retire_warn
+    inherits: 
+    description: 
+  fields:
+  - logical_event:
+      value: vm_retire_warn
+  - rel4:
+      value: "/System/Process/parse_provider_category"
+  - rel5:
+      value: "/${/#ae_provider_category}/VM/Retirement/Email/vm_retirement_emails"


### PR DESCRIPTION
Event instance needed to generate retirement warning emails.

https://bugzilla.redhat.com/show_bug.cgi?id=1310394