### PR TITLE
Implement SSA of network-mounted HyperV virtual disks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/matthewd/rubyrep.git", :branch => "rails5"
 gem "simple-rss",                     "~>1.3.1",   :require => false
 gem "winrm",                          "~>1.7.2",   :require => false
-gem "winrm-elevated",                 "~>0.1.0",   :require => false
+gem "winrm-elevated",                 "~>0.2.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/matthewd/rubyrep.git", :branch => "rails5"
 gem "simple-rss",                     "~>1.3.1",   :require => false
 gem "winrm",                          "~>1.7.2",   :require => false
+gem "winrm-elevated",                 "~>0.1.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,6 @@ gem "ruport",                         "=1.7.0",                       :git => "g
 gem "net-ldap",                       "~>0.7.0",   :require => false
 gem "rubyrep",                        "=1.2.0",    :require => false, :git => "git://github.com/matthewd/rubyrep.git", :branch => "rails5"
 gem "simple-rss",                     "~>1.3.1",   :require => false
-gem "winrm",                          "~>1.7.2",   :require => false
-gem "winrm-elevated",                 "~>0.2.0",   :require => false
 gem "ziya",                           "=2.3.0",    :require => false, :git => "git://github.com/ManageIQ/ziya.git", :tag => "v2.3.0-2"
 
 # Not vendored, but required

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -281,7 +281,7 @@ class JobProxyDispatcher
     end
 
     if @vm.storage.nil?
-      unless %w(amazon openstack).include?(@vm.vendor)
+      unless %w(amazon openStack microsoft).include?(@vm.vendor)
         msg = "Vm [#{@vm.path}] is not located on a storage, aborting job [#{job.guid}]."
         queue_signal(job, {:args => [:abort, msg, "error"]})
         return []

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresh_parser.rb
@@ -261,8 +261,10 @@ module ManageIQ::Providers::Microsoft
     end
 
     def map_mount_point_to_datastore(properties)
+      log_header = "MIQ(#{self.class.name}.#{__method__})"
       properties[:DiskVolumes].each.with_object({}) do |dv, h|
         mount_point    = dv[:Props][:Name].match(DRIVE_LETTER).to_s
+        $scvmm_log.debug("#{log_header} Drive #{dv[:Props][:Name]} missing drive letter") if mount_point.blank?
         next if mount_point.blank?
         storage        = @data_index.fetch_path(:storages, dv[:Props][:ID])
         h[mount_point] = storage

--- a/app/models/manageiq/providers/microsoft/infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/refresher.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::Microsoft
     def post_process_refresh_classes
       # TODO: previously this only looped over VM classes, but, since SCVMM is
       # infra, it should probably include Host, too
-      [::Vm]
+      [::VmOrTemplate, ::Host]
     end
   end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/template.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/template.rb
@@ -1,2 +1,16 @@
 class ManageIQ::Providers::Microsoft::InfraManager::Template < ManageIQ::Providers::InfraManager::Template
+  def proxies4job(_job = nil)
+    {
+      :proxies => [MiqServer.my_server],
+      :message => 'Perform SmartState Analysis on this VM'
+    }
+  end
+
+  def has_active_proxy?
+    true
+  end
+
+  def has_proxy?
+    true
+  end
 end

--- a/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/vm.rb
@@ -14,6 +14,21 @@ class ManageIQ::Providers::Microsoft::InfraManager::Vm < ManageIQ::Providers::In
     validate_unsupported("Migrate")
   end
 
+  def proxies4job(_job = nil)
+    {
+      :proxies => [MiqServer.my_server],
+      :message => 'Perform SmartState Analysis on this VM'
+    }
+  end
+
+  def has_active_proxy?
+    true
+  end
+
+  def has_proxy?
+    true
+  end
+
   def validate_publish
     validate_unsupported("Publish VM")
   end

--- a/gems/pending/Gemfile
+++ b/gems/pending/Gemfile
@@ -45,6 +45,8 @@ gem "rufus-lru",               "~>1.0.3",           :require => false
 gem "sys-uname",               "~>1.0.1",           :require => false
 gem "trollop",                 "~>2.0",             :require => false
 gem "uuidtools",               "~>2.1.3",           :require => false
+gem "winrm",                   "~>1.7.2",           :require => false
+gem "winrm-elevated",          "~>0.2.0",           :require => false
 gem 'sys-proctable',           "~> 1.0",            :require => false
 
 # Linux-only section

--- a/gems/pending/MiqVm/miq_scvmm_vm.rb
+++ b/gems/pending/MiqVm/miq_scvmm_vm.rb
@@ -25,6 +25,7 @@ class MiqScvmmVm < MiqVm
   def init_disk_info(disk_info, disk_file)
     disk_info.hyperv_connection        = {}
     disk_info.fileName                 = disk_file
+    disk_info.driveType                = @scvmm.get_drivetype(disk_file)
     disk_info.hyperv_connection[:host] = @ost.miq_hyperv[:host]
     disk_info.hyperv_connection[:port] = @ost.miq_hyperv[:port]
     if @ost.miq_hyperv[:domain].nil?

--- a/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
+++ b/gems/pending/Scvmm/miq_scvmm_parse_powershell.rb
@@ -4,6 +4,7 @@ class MiqScvmmParsePowershell
     if stderr =~ /Exception/ || stderr =~ /At line:/
       raise "Error running PowerShell command.\n #{stderr}"
     end
+    $log.debug "MiqScvmmParsePowershell: STDERR is \"#{stderr}\"" unless stderr.nil? || $log.nil?
     attribute.split("\r\n").last
   end
 

--- a/gems/pending/disk/modules/MSCommon.rb
+++ b/gems/pending/disk/modules/MSCommon.rb
@@ -69,7 +69,12 @@ module MSCommon
 
   def self.connect_to_hyperv(ostruct)
     connection  = ostruct.hyperv_connection
-    hyperv_disk = MiqHyperVDisk.new(connection[:host], connection[:user], connection[:password], connection[:port])
+    @network    = ostruct.driveType == "Network"
+    hyperv_disk = MiqHyperVDisk.new(connection[:host],
+                                    connection[:user],
+                                    connection[:password],
+                                    connection[:port],
+                                    @network)
     hyperv_disk.open(ostruct.fileName)
     hyperv_disk
   end

--- a/gems/pending/disk/modules/MSVSDiffDisk.rb
+++ b/gems/pending/disk/modules/MSVSDiffDisk.rb
@@ -99,6 +99,7 @@ module MSVSDiffDisk
     if locator.key?('fileName')
       @parent_ostruct                   = OpenStruct.new
       @parent_ostruct.fileName          = locator['fileName']
+      @parent_ostruct.driveType         = dInfo.driveType
       @parent_ostruct.hyperv_connection = @hyperv_connection unless @hyperv_connection.nil?
       @parent                           = MiqDisk.getDisk(@parent_ostruct)
     end

--- a/gems/pending/disk/modules/MSVSDiskProbe.rb
+++ b/gems/pending/disk/modules/MSVSDiskProbe.rb
@@ -49,7 +49,12 @@ module MSVSDiskProbe
 
   def self.connect_to_hyperv(ostruct)
     connection  = ostruct.hyperv_connection
-    hyperv_disk = MiqHyperVDisk.new(connection[:host], connection[:user], connection[:password], connection[:port])
+    network     = ostruct.driveType == "Network"
+    hyperv_disk = MiqHyperVDisk.new(connection[:host],
+                                    connection[:user],
+                                    connection[:password],
+                                    connection[:port],
+                                    network)
     hyperv_disk.open(ostruct.fileName)
     hyperv_disk
   end

--- a/gems/pending/disk/modules/MSVSDynamicDisk.rb
+++ b/gems/pending/disk/modules/MSVSDynamicDisk.rb
@@ -12,12 +12,12 @@ module MSVSDynamicDisk
     else
       raise "Unrecognized mountMode: #{dInfo.mountMode}"
     end
-    if @dInfo.hyperv_connection
-      @ms_disk_file = MSCommon.connect_to_hyperv(@dInfo)
-    else
-      @ms_disk_file = MiqLargeFile.open(@dInfo.fileName, fileMode)
-    end
-    MSCommon.d_init_common(@dInfo, @ms_disk_file)
+    @ms_disk_file = if dInfo.hyperv_connection
+                      MSCommon.connect_to_hyperv(dInfo)
+                    else
+                      MiqLargeFile.open(dInfo.fileName, fileMode)
+                    end
+    MSCommon.d_init_common(dInfo, @ms_disk_file)
   end
 
   def getBase

--- a/gems/pending/disk/modules/VhdxDiskProbe.rb
+++ b/gems/pending/disk/modules/VhdxDiskProbe.rb
@@ -34,7 +34,12 @@ module VhdxDiskProbe
 
   def self.connect_to_hyperv(ostruct)
     connection  = ostruct.hyperv_connection
-    hyperv_disk = MiqHyperVDisk.new(connection[:host], connection[:user], connection[:password], connection[:port])
+    network     = ostruct.driveType == "Network"
+    hyperv_disk = MiqHyperVDisk.new(connection[:host],
+                                    connection[:user],
+                                    connection[:password],
+                                    connection[:port],
+                                    network)
     hyperv_disk.open(ostruct.fileName)
     hyperv_disk
   end

--- a/gems/pending/spec/Scvmm/miq_hyperv_disk_spec.rb
+++ b/gems/pending/spec/Scvmm/miq_hyperv_disk_spec.rb
@@ -1,0 +1,22 @@
+require 'util/miq_winrm'
+require 'Scvmm/miq_hyperv_disk'
+require 'Scvmm/miq_scvmm_vm_ssa_info'
+
+describe MiqHyperVDisk do
+  before(:each) do
+    @host     = "localhost"
+    @user     = "user"
+    @password = "password"
+  end
+
+  context "Initialize MiqHyperVDisk with a network argument" do
+    it "accepts a network boolean" do
+      expect { MiqHyperVDisk.new(@host, @user, @password, nil, true) }.to_not raise_error
+      expect { MiqHyperVDisk.new(@host, @user, @password, nil, false) }.to_not raise_error
+    end
+
+    it "does not require a network boolean" do
+      expect { MiqHyperVDisk.new(@host, @user, @password) }.to_not raise_error
+    end
+  end
+end

--- a/gems/pending/spec/util/miq_winrm_spec.rb
+++ b/gems/pending/spec/util/miq_winrm_spec.rb
@@ -1,0 +1,54 @@
+require 'util/miq_winrm'
+
+describe MiqWinRM do
+  before(:each) do
+    @host     = "localhost"
+    @user     = "user"
+    @password = "password"
+    @winrm    = MiqWinRM.new
+  end
+
+  context "New Object" do
+    it "has a nil executor" do
+      expect(@winrm.executor).to be_nil
+    end
+  end
+
+  context "New Connection" do
+    it "creates a network connection" do
+      expect { @winrm.connect(:user => @user, :pass => @password, :hostname => @host) }.to_not raise_error
+    end
+  end
+
+  context "Existing Connection Attributes" do
+    before(:each) do
+      @connection = @winrm.connect(:user => @user, :pass => @password, :hostname => @host)
+    end
+
+    it "is the correct WinRM class" do
+      expect(@connection).to be_a(WinRM::WinRMWebService)
+    end
+
+    it "still has a nil executor" do
+      expect(@winrm.executor).to be_nil
+    end
+
+    it "has the correct attributes" do
+      expect(@winrm.username).to eq(@user)
+      expect(@winrm.password).to eq(@password)
+      expect(@winrm.hostname).to eq(@host)
+      expect(@winrm.port).to eq(5985)
+    end
+  end
+
+  context "New Elevated Runner" do
+    before(:each) do
+      @connection = @winrm.connect(:user => @user, :pass => @password, :hostname => @host)
+    end
+
+    it "Creates an Elevated Runner successfully" do
+      expect { @winrm.elevate }.to_not raise_error
+      expect(@winrm.elevate).to be_a(WinRM::Elevated::Runner)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/template_spec.rb
@@ -1,0 +1,33 @@
+describe ManageIQ::Providers::Microsoft::InfraManager::Template do
+  context "#active_proxy?" do
+    let(:template_microsoft) { ManageIQ::Providers::Microsoft::InfraManager::Template.new }
+
+    it "returns true" do
+      expect(template_microsoft.has_active_proxy?).to eq(true)
+    end
+  end
+
+  context "#has_proxy?" do
+    let(:template_microsoft) { ManageIQ::Providers::Microsoft::InfraManager::Template.new }
+
+    it "returns true" do
+      expect(template_microsoft.has_proxy?).to eq(true)
+    end
+  end
+
+  context "#proxies4job" do
+    before do
+      @template_microsoft = ManageIQ::Providers::Microsoft::InfraManager::Template.new
+      allow(MiqServer).to receive(:my_server).and_return("default")
+      @proxies = @template_microsoft.proxies4job
+    end
+
+    it "has the correct message" do
+      expect(@proxies[:message]).to eq('Perform SmartState Analysis on this VM')
+    end
+
+    it "returns the default proxy" do
+      expect(@proxies[:proxies].first).to eq('default')
+    end
+  end
+end

--- a/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/microsoft/infra_manager/vm_spec.rb
@@ -1,0 +1,33 @@
+describe ManageIQ::Providers::Microsoft::InfraManager::Vm do
+  context "#active_proxy?" do
+    let(:vm_microsoft) { ManageIQ::Providers::Microsoft::InfraManager::Vm.new }
+
+    it "returns true" do
+      expect(vm_microsoft.has_active_proxy?).to eq(true)
+    end
+  end
+
+  context "#has_proxy?" do
+    let(:vm_microsoft) { ManageIQ::Providers::Microsoft::InfraManager::Vm.new }
+
+    it "returns true" do
+      expect(vm_microsoft.has_proxy?).to eq(true)
+    end
+  end
+
+  context "#proxies4job" do
+    before do
+      @vm_microsoft = ManageIQ::Providers::Microsoft::InfraManager::Vm.new
+      allow(MiqServer).to receive(:my_server).and_return("default")
+      @proxies = @vm_microsoft.proxies4job
+    end
+
+    it "has the correct message" do
+      expect(@proxies[:message]).to eq('Perform SmartState Analysis on this VM')
+    end
+
+    it "returns the default proxy" do
+      expect(@proxies[:proxies].first).to eq('default')
+    end
+  end
+end


### PR DESCRIPTION
Add changes to implement running SSA on HyperV virtual disks which are
network mounted on the server.

1) in the MiqScvmmVm.init_disk_info determine whether a disk is network mounted.
2) in the Vhdx and Vhd disk modules pass the network attribute when instantiating
   a MiqHyperVDisk, and pass the attribute along when getting a parent disk (in the
   case of checkpoints/snapshots).
3) Add the winrm-elevated accessor to MiqWinRM, and make sure MiqHyperVDisk uses the correct
accessor to run remote commands depending upon whether the virtual disk is remote-mounted
or not.
4) Allow scanning of Microsoft VMs without storage in the DB (See Issue #5383)

Prerequisites: 
1) https://github.com/WinRb/winrm-elevated/pull/2
2) https://github.com/ManageIQ/manageiq/pull/6938

@Fryguy @jrafanie @chessbyte @roliveri Please review, comment, and merge when appropriate.
I will reach out to the winrm-elevated gem owner to see what we can expect from him.

Thanks.