### PR TITLE
Remove old User#miq_group deprecation

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -452,7 +452,7 @@ class MiqWidget < ApplicationRecord
   def self.available_for_user(user)
     user = get_user(user)
     role = user.miq_user_role_name
-    group = user.miq_group_description
+    group = user.current_group.description
 
     # Return all widgets that either has this user's role or is allowed for all roles, or has this user's group
     all.select do |w|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,9 +40,6 @@ class User < ApplicationRecord
 
   include ReportableMixin
 
-  include DeprecationMixin
-  deprecate_belongs_to :miq_group, :current_group
-
   @@role_ns  = "/managed/user"
   @@role_cat = "role"
 

--- a/app/views/ops/_rbac_user_details.html.haml
+++ b/app/views/ops/_rbac_user_details.html.haml
@@ -100,13 +100,13 @@
             - else
               - params = {}
             %span.product.product-group{params}
-              = h(@user.miq_group_description)
+              = h(@user.current_group.description)
           - else
-            = h(@user.miq_group_description)
+            = h(@user.current_group.description)
         - else
           - if disabled
             %p.form-control-static
-              = h(@user.miq_group_description)
+              = h(@user.current_group.description)
           - else
             - options = (@edit[:new][:group] ? [] : [[_("<Choose a Group>"), nil]]) + @edit[:groups]
             = select_tag('chosen_group',

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -381,7 +381,7 @@ describe MiqReport do
     it "with has_many through" do
       ems      = FactoryGirl.create(:ems_vmware_with_authentication)
       user     = FactoryGirl.create(:user_with_group)
-      group    = user.miq_group
+      group    = user.current_group
       template = FactoryGirl.create(:template_vmware, :ext_management_system => ems)
       vm       = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
       hardware = FactoryGirl.create(:hardware, :vm => vm)


### PR DESCRIPTION
This isn't possible to continue using with tenancy changes, and was
initially introduced in May 2014 (pre OSS, 3-4 releases ago...)

Closes #6708

@miq-bot add_label core, tenancy