### PR TITLE
Remove guid from MiqGroups

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -20,7 +20,7 @@ class MiqGroup < ApplicationRecord
 
   delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
 
-  validates :description, :guid, :presence => true, :uniqueness => true
+  validates :description, :presence => true, :uniqueness => true
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
 
@@ -32,7 +32,6 @@ class MiqGroup < ApplicationRecord
 
   acts_as_miq_taggable
   include ReportableMixin
-  include UuidMixin
   include CustomAttributeMixin
   include ActiveVmAggregationMixin
   include TimezoneMixin

--- a/db/migrate/20160226164206_remove_guid_from_miq_groups.rb
+++ b/db/migrate/20160226164206_remove_guid_from_miq_groups.rb
@@ -1,0 +1,5 @@
+class RemoveGuidFromMiqGroups < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :miq_groups, :guid, :string, :limit => 36
+  end
+end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -7,7 +7,6 @@ FactoryGirl.define do
       role nil
     end
 
-    guid { MiqUUID.new_guid }
     sequence(:sequence)  # don't want to spend time looking these up
     description { |g| g.role ? "EvmGroup-#{g.role}" : generate(:miq_group_description) }
 

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -11,7 +11,7 @@
 # - Delete multiple groups                /api/groups                           action "delete"
 #
 describe ApiController do
-  let(:expected_attributes) { %w(id guid description group_type tenant_id) }
+  let(:expected_attributes) { %w(id description group_type tenant_id) }
 
   let(:sample_group1) { {:description => "sample_group_1"} }
   let(:sample_group2) { {:description => "sample_group_2"} }


### PR DESCRIPTION
From all the Git spelunking @jrafanie and I have done, guid on MiqGroups appears to have been added when the model was originally created but _never_ used. Gutting this as part of our user_group table split.