### PR TITLE
Add tenant quota report and widget

### DIFF
--- a/app/helpers/ops_helper/textual_summary.rb
+++ b/app/helpers/ops_helper/textual_summary.rb
@@ -142,7 +142,7 @@ module OpsHelper::TextualSummary
     h
   end
 
-  def convert_to_format(format, text_modifier, value)
+  def self.convert_to_format(format, text_modifier, value)
     fmt_value = case format.to_s
                   when "general_number_precision_0"
                     value.to_i
@@ -162,7 +162,7 @@ module OpsHelper::TextualSummary
       return TenantQuota.default_text_for(metric)
     end
 
-    convert_to_format(format, text_modifier, value)
+    OpsHelper::TextualSummary.convert_to_format(format, text_modifier, value)
   end
 
   def get_tenant_quota_allocations

--- a/app/models/miq_expression.rb
+++ b/app/models/miq_expression.rb
@@ -52,6 +52,7 @@ class MiqExpression
     StoragePerformance
     ManageIQ::Providers::CloudManager::Template
     ManageIQ::Providers::InfraManager::Template
+    Tenant
     User
     VimPerformanceTrend
     Vm
@@ -144,6 +145,7 @@ class MiqExpression
     storage_adapters
     storage_files
     switches
+    tenant_quotas
     users
     vms
     volumes

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -70,6 +70,10 @@ module MiqReport::Generator::Html
             output << "<td#{style_class}>"
             output << ui_lookup(:model => d.data[c])
             output << "</td>"
+          elsif db == "Tenant" && TenantQuota.can_format_field?(c, d.data["tenant_quotas.name"])
+            output << "<td#{style_class} " + 'style="text-align:right">'
+            output << CGI.escapeHTML(TenantQuota.format_quota_value(c, d.data[c], d.data["tenant_quotas.name"]))
+            output << "</td>"
           elsif db == "VimUsage"                 # Format usage columns
             case c
             when "cpu_usagemhz_rate_average"

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -69,11 +69,9 @@ module MiqReport::Generator::Html
           if c == "resource_type"                     # Lookup models in resource_type col
             output << "<td#{style_class}>"
             output << ui_lookup(:model => d.data[c])
-            output << "</td>"
           elsif db == "Tenant" && TenantQuota.can_format_field?(c, d.data["tenant_quotas.name"])
             output << "<td#{style_class} " + 'style="text-align:right">'
             output << CGI.escapeHTML(TenantQuota.format_quota_value(c, d.data[c], d.data["tenant_quotas.name"]))
-            output << "</td>"
           elsif db == "VimUsage"                 # Format usage columns
             case c
             when "cpu_usagemhz_rate_average"
@@ -106,11 +104,9 @@ module MiqReport::Generator::Html
               output << "<td#{style_class}>"
               output << d.data[c].to_s
             end
-            output << "</td>"
           elsif ["<compare>", "<drift>"].include?(db.to_s)
             output << "<td#{style_class}>"
             output << CGI.escapeHTML(d.data[c].to_s)
-            output << "</td>"
           else
             if d.data[c].kind_of?(Time)
               output << "<td#{style_class} " + 'style="text-align:center">'
@@ -123,8 +119,8 @@ module MiqReport::Generator::Html
                                             d.data[c],
                                             :format => self.col_formats[c_idx] ? self.col_formats[c_idx] : :_default_,
                                             :tz     => tz))
-            output << "</td>"
           end
+          output << "</td>"
         end
 
         output << "</tr>"

--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -49,8 +49,30 @@ class TenantQuota < ApplicationRecord
   scope :vms_allocated,       -> { where(:name => :vms_allocated) }
   scope :templates_allocated, -> { where(:name => :templates_allocated) }
 
+  virtual_column :name, :type => :string
+  virtual_column :total, :type => :integer
+  virtual_column :used, :type => :float
+  virtual_column :allocated, :type => :float
+  virtual_column :available, :type => :float
+
+  alias_attribute :total, :value
+
   before_validation(:on => :create) do
     self.unit = default_unit unless unit.present?
+  end
+
+  def self.format_quota_value(field, field_value, tenant_quota_name)
+    if field == "tenant_quotas.name"
+      TenantQuota.tenant_quota_description(tenant_quota_name.to_sym)
+    else
+      row = QUOTA_BASE[tenant_quota_name.to_sym]
+      OpsHelper::TextualSummary.convert_to_format(row[:format], row[:text_modifier], field_value)
+    end
+  end
+
+  def self.can_format_field?(field, tenant_quota_name)
+    table_field, = field.split(".")
+    to_s.tableize == table_field ? NAMES.include?(tenant_quota_name) : false
   end
 
   def self.default_text_for(metric)

--- a/product/dashboard/widgets/tenant_quotas.yaml
+++ b/product/dashboard/widgets/tenant_quotas.yaml
@@ -1,0 +1,17 @@
+description: tenant_quotas
+title: Tenant Quotas
+content_type: report
+options:
+visibility:
+  :roles:
+  - _ALL_
+user_id:
+resource_name: Tenant Quotas
+resource_type: MiqReport
+miq_schedule_options:
+  :run_at:
+    :interval: 
+      :value: "1"
+      :unit: daily
+enabled: true
+read_only: true

--- a/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
+++ b/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
@@ -1,0 +1,42 @@
+--- 
+title: "Tenant Quotas"
+order: Ascending
+menu_name: "Tenant Quotas"
+rpt_group: Custom
+priority: 231
+rpt_type: Custom
+db: Tenant
+include:
+  tenant_quotas:
+    columns:
+    - name
+    - total
+    - used
+    - allocated
+    - available
+cols:
+- name
+- tenant_quotas.name
+- tenant_quotas.total
+- tenant_quotas.used
+- tenant_quotas.allocated
+- tenant_quotas.available
+col_order:
+- name
+- tenant_quotas.name
+- tenant_quotas.total
+- tenant_quotas.used
+- tenant_quotas.allocated
+- tenant_quotas.available
+template_type: report
+group: y
+sortby: 
+- name
+headers:
+- Tenant Name
+- Quota Name
+- Total Quota
+- In Use
+- Allocated
+- Available
+

--- a/spec/factories/tenant_quota.rb
+++ b/spec/factories/tenant_quota.rb
@@ -2,9 +2,33 @@ FactoryGirl.define do
   factory :tenant_quota do
     factory :tenant_quota_cpu do
       name :cpu_allocated
-      unit "FIXNUM"
+      unit "fixnum"
       value 16
       warn_value 12
+    end
+
+    factory :tenant_quota_mem do
+      name :mem_allocated
+      unit "bytes"
+      value 2_147_483_648 # 2 GB
+    end
+
+    factory :tenant_quota_storage do
+      name :storage_allocated
+      unit "bytes"
+      value 2_147_483_648 # 2 GB
+    end
+
+    factory :tenant_quota_vms do
+      name :vms_allocated
+      unit "FIXNUM"
+      value 2
+    end
+
+    factory :tenant_quota_templates do
+      name :templates_allocated
+      unit "FIXNUM"
+      value 2
     end
   end
 end

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 131)
+    include_examples(".seed called multiple times", 132)
   end
 end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -484,5 +484,83 @@ describe MiqReport do
         report.generate_table(:userid => "admin")
       end
     end
+
+    context "Tenant Quota Report" do
+      include QuotaHelper
+
+      let(:child_tenant) { FactoryGirl.create(:tenant, :parent => @tenant) }
+
+      let(:tenant_quota_cpu) { FactoryGirl.create(:tenant_quota_cpu, :tenant => @tenant, :value => 2) }
+      let(:tenant_quota_mem) { FactoryGirl.create(:tenant_quota_mem, :tenant => @tenant, :value => 4_294_967_296) }
+
+      let(:tenant_quota_storage) do
+        FactoryGirl.create(:tenant_quota_storage, :tenant => @tenant, :value => 4_294_967_296)
+      end
+
+      let(:tenant_quota_vms)       { FactoryGirl.create(:tenant_quota_vms, :tenant => @tenant, :value => 4) }
+      let(:tenant_quota_templates) { FactoryGirl.create(:tenant_quota_templates, :tenant => @tenant, :value => 4) }
+
+      let(:report) do
+        include = {"tenant_quotas" => {"columns" => %w(name total used allocated available)}}
+        cols = ["name", "tenant_quotas.name", "tenant_quotas.total", "tenant_quotas.used", "tenant_quotas.allocated",
+                "tenant_quotas.available"]
+        headers = ["Tenant Name", "Quota Name", "Total Quota", "Total Quota", "In Use", "Allocated", "Available"]
+        FactoryGirl.create(:miq_report, :title => "Tenant Quotas", :order => 'Ascending', :rpt_group => "Custom",
+                           :priority => 231, :rpt_type => 'Custom', :db => 'Tenant', :include => include, :cols => cols,
+                           :col_order => cols, :template_type => "report", :headers => headers)
+      end
+
+      def generate_table_cell(formatted_value)
+        "<td style=\"text-align:right\">#{formatted_value}</td>"
+      end
+
+      def generate_html_row(is_even, tenant_name, formatted_values)
+        row = []
+        row << "<tr class='row#{is_even ? '0' : '1'}-nocursor'><td>#{tenant_name}</td>"
+
+        [:name, :total, :used, :allocated, :available].each do |metric|
+          row << generate_table_cell(formatted_values[metric])
+        end
+
+        row << "</tr>"
+        row.join
+      end
+
+      before do
+        setup_model
+        @tenant.tenant_quotas = [tenant_quota_cpu, tenant_quota_mem, tenant_quota_storage, tenant_quota_vms,
+                                 tenant_quota_templates]
+        @expected_html_rows = []
+
+        formatted_values = {:name => "Allocated Virtual CPUs", :total => "2 Count", :used => "0 Count",
+                            :allocated => "0 Count", :available => "2 Count"}
+        @expected_html_rows.push(generate_html_row(true, @tenant.name, formatted_values))
+
+        formatted_values = {:name => "Allocated Memory in GB", :total => "4.0 GB", :used => "1.0 GB",
+                            :allocated => "0.0 GB", :available => "3.0 GB"}
+        @expected_html_rows.push(generate_html_row(false, @tenant.name, formatted_values))
+
+        formatted_values = {:name => "Allocated Storage in GB", :total => "4.0 GB",
+                            :used => "#{1_000_000.0 / 1.gigabyte} GB", :allocated => "0.0 GB",
+                            :available => "#{(4.gigabytes - 1_000_000.0) / 1.gigabyte} GB"}
+        @expected_html_rows.push(generate_html_row(true, @tenant.name, formatted_values))
+
+        formatted_values = {:name => "Allocated Number of Virtual Machines", :total => "4 Count", :used => "1 Count",
+                            :allocated => "0 Count", :available => "3 Count"}
+        @expected_html_rows.push(generate_html_row(false, @tenant.name, formatted_values))
+
+        formatted_values = {:name => "Allocated Number of Templates", :total => "4 Count", :used => "1 Count",
+                            :allocated => "0 Count", :available => "3 Count"}
+        @expected_html_rows.push(generate_html_row(true, @tenant.name, formatted_values))
+      end
+
+      it "returns expected html outputs with formatted values" do
+        report.generate_table
+        rows_array = report.build_html_rows
+        rows_array.each_with_index do |row, index|
+          expect(@expected_html_rows[index]).to eq(row)
+        end
+      end
+    end
   end
 end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,5 +1,5 @@
 describe MiqWidget do
-  include_examples(".seed called multiple times", 9)
+  include_examples(".seed called multiple times", 10)
 
   before(:each) do
     EvmSpecHelper.local_miq_server

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -30,6 +30,7 @@ module QuotaHelper
     @ram_size = 1024
     @disk_size = 1_000_000
     @num_cpu = 0
+
     @hw1 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_mb => @ram_size)
     @hw2 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_mb => @ram_size)
     @hw3 = FactoryGirl.create(:hardware, :cpu_sockets => @num_cpu, :memory_mb => @ram_size)
@@ -49,6 +50,7 @@ module QuotaHelper
     @tenant.tenant_quotas.create(:name => :vms_allocated, :value => 4)
     @tenant.tenant_quotas.create(:name => :storage_allocated, :value => 4096)
     @tenant.tenant_quotas.create(:name => :cpu_allocated, :value => 2)
+    @tenant.tenant_quotas.create(:name => :templates_allocated, :value => 4)
   end
 
   def create_vms


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1299963
https://trello.com/c/fq0qvvtp/98-rfe-reporting-unable-to-report-on-cf-tenant-quotas

I added tenant quota report to VM Sprawl -> Candidates -> Tenant Quotas Report is this location ok @gtanzillo  ?

I added TenantQuota's model methods for formatting values in human format  (2 GB, 2 Count..), because col_formatters in yaml are not usable here, because for determining TenantQuota value we need also column `TenantQuota#name` to determine type of quota and unit (for example `mem_allocated` have unit GB `cpu_allocated` have unit Count, ..). (it seems that col_formatters are basically only input-output functions). Please correct me If I am wrong.

Screenshot(only enforced tenant quotas are )
report:
![report](https://cloud.githubusercontent.com/assets/14937244/13392044/3d4a9b66-ded8-11e5-812d-59c149f5bd5d.png)

widget:
![widget](https://cloud.githubusercontent.com/assets/14937244/13392050/42a9fe1c-ded8-11e5-8f13-2885d589cabe.png)

@gtanzillo Can you review it, please ? Thanks!


