### PR TITLE
Tell us which attribute is missing from the resources.

### DIFF
--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -301,7 +301,7 @@ module ApiSpecHelper
   def expect_result_resources_to_include_keys(collection, keys)
     expect(@result).to have_key(collection)
     results = @result[collection]
-    fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy }
+    fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
   end
 
   def expect_result_resources_to_have_only_keys(collection, keys)


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq/pull/6962, we removed the guid column
from MiqGroup and it wasn't obvious why spec/requests/api/groups_spec.rb was
failing.

Adding the missing key/attribute should make this more obvious.

Before:

```
  Failure/Error: fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy }
    expected: truthy value
        got: false
```

After:

```
  Failure/Error: fetch_value(keys).each { |key| expect(results.all? { |r| r.key?(key) }).to be_truthy, "resource missing: #{key}" }
    resource missing: guid
```