### PR TITLE
[auth] Ldap Authenticator fix with unbound handles 

### DIFF
--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -16,8 +16,8 @@ module Authenticator
     end
 
     # Unbound LDAP handle
-    def miqldap
-      @miqldap ||= MiqLdap.new(:auth => config)
+    def miq_ldap
+      @miq_ldap ||= MiqLdap.new(:auth => config)
     end
 
     def ldap_bind(username, password)
@@ -26,7 +26,7 @@ module Authenticator
     end
 
     def find_or_create_by_ldap(username)
-      username = miqldap.fqusername(username)
+      username = miq_ldap.fqusername(username)
       user = User.find_by_userid(username)
       return user unless user.nil?
 
@@ -63,7 +63,7 @@ module Authenticator
     end
 
     def normalize_username(username)
-      miqldap.normalize(miqldap.fqusername(username))
+      miq_ldap.normalize(miq_ldap.fqusername(username))
     end
 
     def _authenticate(username, password, _request)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -15,13 +15,18 @@ module Authenticator
       @ldap ||= ldap_bind(config[:bind_dn], config[:bind_pwd])
     end
 
+    # Unbound LDAP handle
+    def miqldap
+      @miqldap ||= MiqLdap.new(:auth => config)
+    end
+
     def ldap_bind(username, password)
       ldap = MiqLdap.new(:auth => config)
       ldap if ldap.bind(username, password)
     end
 
     def find_or_create_by_ldap(username)
-      username = ldap.fqusername(username)
+      username = miqldap.fqusername(username)
       user = User.find_by_userid(username)
       return user unless user.nil?
 
@@ -58,7 +63,7 @@ module Authenticator
     end
 
     def normalize_username(username)
-      ldap.normalize(ldap.fqusername(username))
+      miqldap.normalize(miqldap.fqusername(username))
     end
 
     def _authenticate(username, password, _request)

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -21,7 +21,7 @@ describe Authenticator::Ldap do
       @fqusername  = "#{@username}@#{@user_suffix}"
 
       init_ldap_setup
-      allow(@ldap).to receive_messages(:fqusername => @fqusername)
+      allow(@miq_ldap).to receive_messages(:fqusername => @fqusername)
     end
 
     it "initial status" do
@@ -58,7 +58,7 @@ describe Authenticator::Ldap do
     end
 
     it "ldap bind fails" do
-      allow(@login_ldap).to receive_messages(:bind => false)
+      allow(@miq_ldap).to receive_messages(:bind => false)
 
       expect(AuditEvent).to receive(:failure)
       expect(-> { subject }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
@@ -106,9 +106,9 @@ describe Authenticator::Ldap do
   end
 
   def init_ldap_setup
-    @login_ldap = double('login_ldap')
-    allow(@login_ldap).to receive_messages(:bind => true)
-    allow(MiqLdap).to receive(:new).and_return(@login_ldap)
+    @miq_ldap = double('miq_ldap')
+    allow(@miq_ldap).to receive_messages(:bind => true)
+    allow(MiqLdap).to receive(:new).and_return(@miq_ldap)
 
     @ldap = double('ldap')
     allow(@auth).to receive_messages(:ldap => @ldap)
@@ -127,7 +127,7 @@ describe Authenticator::Ldap do
   end
 
   def setup_to_get_fqdn
-    allow(@ldap).to receive_messages(:fqusername => "some FQDN")
-    allow(@ldap).to receive_messages(:normalize => "some normalized name")
+    allow(@miq_ldap).to receive_messages(:fqusername => "some FQDN")
+    allow(@miq_ldap).to receive_messages(:normalize => "some normalized name")
   end
 end


### PR DESCRIPTION
Fix issue when the ldap bind is not properly configured, ldap handle
nil and fqusername causes a stack trace while using that handle.

Authenticator needs to use a valid unbound handle for calls like
fqusername, and normalize which are not connection bound.