### PR TITLE
Bump schedule worker threshold since generation GC uses more memory.

### DIFF
--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -543,7 +543,7 @@ workers:
       :job_timeout_interval: 60.seconds
       :log_active_configuration_interval: 1.days
       :log_database_statistics_interval: 1.days
-      :memory_threshold: 250.megabytes
+      :memory_threshold: 300.megabytes
       :nice_delta: 3
       :orchestration_stack_retired_interval: 10.minutes
       :performance_collection_interval: 3.minutes


### PR DESCRIPTION
cc @dmetzger57 