### PR TITLE
Cache VMDB::Config.new at the tenant class level.

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -273,7 +273,7 @@ class Tenant < ApplicationRecord
   # @return the attribute value
   def tenant_attribute(attr_name, setting_name)
     if use_config_for_attributes?
-      ret = get_vmdb_config.fetch_path(:server, setting_name)
+      ret = self.class.get_vmdb_config.fetch_path(:server, setting_name)
       block_given? ? yield(ret) : ret
     else
       self[attr_name]
@@ -287,7 +287,7 @@ class Tenant < ApplicationRecord
     self.name = nil unless name.present?
   end
 
-  def get_vmdb_config
+  def self.get_vmdb_config
     @vmdb_config ||= VMDB::Config.new("vmdb").config
   end
 


### PR DESCRIPTION
It's not clear why caching this at the instance level is doing anything
beneficial.  If we want to cache this, it should be at the class level.

From profiling some dashboard and api controller specs:

15 examples in dashboard controller call Tenant#seed:

Calls the validators on each new tenant
Paperclip::Attachment#blank? 60 times
Paperclip::Attachment#file? 60 times
...
Tenant#logo_file_name 30 times
Tenant#tenant_attribute 30 times
Tenant#get_vmdb_config 30 times
...
VMDB::Config#retrieve_config 30 times

Note, getting rid of this still causes other places to get VMDB::Config but at
least it's not from Tenant#seed.

with ruby prof, 5% of the ~13% in Tenant#seed is spent doing VMDB::Config.new which gets the serialized yaml from the configurations table and YAML loads it.

![image](https://cloud.githubusercontent.com/assets/19339/13367053/5def4f06-dcad-11e5-9f2e-4c7fc02c587c.png)
