### PR TITLE
Fix sporadic infra_helper test

### DIFF
--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -26,11 +26,11 @@ describe EmsRefresh::SaveInventoryInfra do
       expect(refresher.find_host({:ems_ref => "some_ems_ref_2", :name => "name"}, 1)).to   eq(host_with_ems_id)
     end
 
-    it "with ems_ref, hostname and ipaddress" do
+    it "with hostname and ipaddress" do
       FactoryGirl.create(:host, :ems_ref => "some_ems_ref", :hostname => "my.hostname", :ipaddress => "192.168.1.1")
       expected_host = FactoryGirl.create(:host, :ems_ref => "some_ems_ref", :hostname => "my.hostname", :ipaddress => "192.168.1.2")
 
-      expect(refresher.find_host(expected_host.slice(:ems_ref, :hostname, :ipaddress), nil)).to eq(expected_host)
+      expect(refresher.find_host(expected_host.slice(:hostname, :ipaddress), nil)).to eq(expected_host)
     end
   end
 end


### PR DESCRIPTION
If an ems_ref is giving for host_find, it short circuits the ip and
hostname check - so this test was not determinant

This passes in the variables that are actually used

```
EmsRefresh::SaveInventoryInfra.find_host with ems_ref, hostname and ipaddress
     Failure/Error:
  expect(refresher.find_host(
    expected_host.slice(:ems_ref, :hostname, :ipaddress), nil)
  ).to eq(expected_host)
```
/cc @jrafanie 