### PR TITLE
Add daily pod utilization and image creation cards to container provider dashboard

### DIFF
--- a/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
+++ b/app/assets/javascripts/controllers/container_dashboard/container_dashboard_controller.js
@@ -16,6 +16,8 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
         routes:     dashboardUtilsFactory.createRoutesStatus()
       };
 
+      $scope.loadingDone = false;
+
       // Heatmaps init
       $scope.nodeCpuUsage = {
         title: __('CPU'),
@@ -52,12 +54,6 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
         chartId: 'memoryDonutChart',
         thresholds: {'warning':'60','error':'90'}
       };
-
-      $scope.nodeCpuUsage.loadingDone = false;
-      $scope.nodeMemoryUsage.loadingDone = false;
-
-      // Network
-      $scope.networkUtilizationLoadingDone = false;
 
       $scope.refresh = function() {
         var id;
@@ -112,7 +108,6 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
           $scope.memoryUsageData = chartsMixin.processUtilizationData(data.ems_utilization.mem,
                                                                       "dates",
                                                                       $scope.memoryUsageConfig.units);
-          $scope.utilizationLoadingDone = true;
 
           // Heatmaps
           $scope.nodeCpuUsage = chartsMixin.processHeatmapData($scope.nodeCpuUsage, data.heatmaps.nodeCpuUsage);
@@ -123,25 +118,32 @@ miqHttpInject(angular.module('containerDashboard', ['ui.bootstrap', 'patternfly'
           $scope.nodeMemoryUsage.loadingDone = true;
 
           // Network metrics
-          $scope.networkUtilizationHourlyConfig = chartsMixin.chartConfig.hourlyNetworkUsageConfig;
           $scope.networkUtilizationDailyConfig = chartsMixin.chartConfig.dailyNetworkUsageConfig;
-
-          if (data.hourly_network_metrics != undefined) {
-           data.hourly_network_metrics.xData = data.hourly_network_metrics.xData.map(function (date) {
-              return dashboardUtilsFactory.parseDate(date)
-            });
-          }
-
-          $scope.hourlyNetworkUtilization =
-            chartsMixin.processUtilizationData(data.hourly_network_metrics,
-                                               "dates",
-                                               $scope.networkUtilizationHourlyConfig.units)
 
           $scope.dailyNetworkUtilization =
             chartsMixin.processUtilizationData(data.daily_network_metrics,
                                                "dates",
                                                $scope.networkUtilizationDailyConfig.units);
-          $scope.networkUtilizationLoadingDone = true;
+
+          // Pod metrics
+          $scope.podEntityTrendDailyConfig = chartsMixin.chartConfig.dailyPodUsageConfig;
+
+          $scope.dailyPodEntityTrend =
+              chartsMixin.processPodUtilizationData(data.daily_pod_metrics,
+                  "dates",
+                  $scope.podEntityTrendDailyConfig.createdLabel,
+                  $scope.podEntityTrendDailyConfig.deletedLabel);
+
+          // Image metrics
+          $scope.imageEntityTrendDailyConfig = chartsMixin.chartConfig.dailyImageUsageConfig;
+
+          $scope.dailyImageEntityTrend =
+              chartsMixin.processUtilizationData(data.daily_image_metrics,
+                  "dates",
+                  $scope.imageEntityTrendDailyConfig.createdLabel);
+
+          // Trend lines data
+          $scope.loadingDone = true;
         });
       };
       $scope.refresh();

--- a/app/views/shared/views/_show_containers_dashboard.html.haml
+++ b/app/views/shared/views/_show_containers_dashboard.html.haml
@@ -1,7 +1,7 @@
 .container-fluid.container-tiles-pf.containers-dashboard.miq-dashboard-view{"ng-app"        => "containerDashboard",
                                                                             "ng-controller" => "containerDashboardController as dashboard"}
   .row.row-tile-pf
-    .col-xs-6.col-sm-4.col-md-2
+    .col-xs-12.col-sm-12.col-md-2
       .col-xs-12.provider-card{"pf-card"         => "",
                                "show-top-border" => "true",
                                "ng-if"           => "providerTypeIconClass"}
@@ -64,13 +64,13 @@
                :url                       => "navigation"}
 
   .row.row-tile-pf
-    .col-xs-6.col-sm-6.col-md-6
+    .col-xs-12.col-sm-6.col-md-7
       %div{"head-title"   => _("Aggregated Node Utilization"),
            :hidetopborder => "true",
            "pf-card"      => ""}
 
-        .spinner.spinner-lg.loading{"ng-if" => "!utilizationLoadingDone"}
-        .row{"ng-if" => "utilizationLoadingDone"}
+        .spinner.spinner-lg.loading{"ng-if" => "!loadingDone"}
+        .row{"ng-if" => "loadingDone"}
 
           .col-xs-6.col-sm-6.col-md-6
             %div{"ng-if" => "cpuUsageData"}
@@ -92,7 +92,36 @@
             %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': !memoryUsageData }"}
               = _("Last 30 Days")
 
-    .col-xs-6.col-sm-6.col-md-6
+    .col-xs-12.col-sm-6.col-md-5
+      .row.row-tile-pf
+        .col-xs-12.col-sm-12.col-md-12
+          %div{"head-title" => "{{networkUtilizationDailyConfig.headTitle}}",
+               "pf-card" => ""}
+
+            .spinner.spinner-lg.loading{"ng-if" => "!loadingDone"}
+            %div{"chart-data" => "dailyNetworkUtilization",
+                 "chart-height" => "chartHeight",
+                 :config => "networkUtilizationDailyConfig",
+                 "ng-if" => "loadingDone",
+                 "pf-trends-chart" => ""}
+
+      .row.row-tile-pf
+        .col-xs-12.col-sm-12.col-md-12
+          %div{"head-title" => "{{imageEntityTrendDailyConfig.headTitle}}",
+               "pf-card" => ""}
+
+            .spinner.spinner-lg.loading{"ng-if" => "!imageEntityTrendDailyConfig"}
+            %div{"chart-data" => "dailyImageEntityTrend",
+                 "chart-height" => "chartHeight",
+                 :config => "imageEntityTrendDailyConfig",
+                 "ng-if" => "loadingDone",
+                 "pf-line-chart" => ""}
+
+            %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': !imageEntityTrendDailyConfig }"}
+              = _("Last 30 Days")
+
+  .row.row-tile-pf.row-tile-pf-last
+    .col-xs-12.col-sm-6.col-md-7
       %div{"column-sizing-class"          => "col-xs-8 col-sm-6 col-md-6",
            "heat-map-usage-legend-labels" => "nodeHeatMapUsageLegendLabels",
            "heatmap-chart-height"         => "dashboardHeatmapChartHeight",
@@ -101,25 +130,18 @@
            :hidetopborder                 => "true",
            :title                         => _("Node Utilization")}
 
-  .row.row-tile-pf.row-tile-pf-last
-    .col-md-6
-      %div{"head-title" => "{{networkUtilizationHourlyConfig.headTitle}}",
-           "pf-card"    => ""}
+    .col-xs-12.col-sm-6.col-md-5
+      .row.row-tile-pf
+        .col-xs-12.col-sm-12.col-md-12
+          %div{"head-title" => "{{podEntityTrendDailyConfig.headTitle}}",
+               "pf-card" => ""}
 
-        .spinner.spinner-lg.loading{"ng-if" => "!networkUtilizationLoadingDone"}
-        %div{"chart-data"      => "hourlyNetworkUtilization",
-             "chart-height"    => "chartHeight",
-             :config           => "networkUtilizationHourlyConfig",
-             "ng-if"           => "networkUtilizationLoadingDone",
-             "pf-trends-chart" => ""}
+            .spinner.spinner-lg.loading{"ng-if" => "!podEntityTrendDailyConfig"}
+            %div{"chart-data" => "dailyPodEntityTrend",
+                 "chart-height" => "chartHeight",
+                 :config => "podEntityTrendDailyConfig",
+                 "ng-if" => "loadingDone",
+                 "pf-line-chart" => ""}
 
-    .col-md-6
-      %div{"head-title" => "{{networkUtilizationDailyConfig.headTitle}}",
-           "pf-card"    => ""}
-
-        .spinner.spinner-lg.loading{"ng-if" => "!networkUtilizationLoadingDone"}
-        %div{"chart-data"      => "dailyNetworkUtilization",
-             "chart-height"    => "chartHeight",
-             :config           => "networkUtilizationDailyConfig",
-             "ng-if"           => "networkUtilizationLoadingDone",
-             "pf-trends-chart" => ""}
+            %span.trend-footer-pf{"ng-class" => "{ 'chart-transparent-text': !podEntityTrendDailyConfig }"}
+              = _("Last 30 Days")

--- a/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
+++ b/spec/javascripts/controllers/containers/container_dashboard_controller_spec.js
@@ -38,7 +38,10 @@ describe('containerDashboardController gets data and', function() {
 
     it('in network metrics', function() {
       expect($scope.dailyNetworkUtilization).toBeDefined();
-      expect($scope.hourlyNetworkUtilization).toBeDefined();
+    });
+
+    it('in pod metrics', function() {
+      expect($scope.dailyPodEntityTrend).toBeDefined();
     });
   });
 });
@@ -83,7 +86,10 @@ describe('containerDashboardController gets no data and', function() {
 
     it('in network metrics', function() {
       expect($scope.dailyNetworkUtilization.dataAvailable).toBeDefined();
-      expect($scope.hourlyNetworkUtilization.dataAvailable).toBeDefined();
+    });
+
+    it('in pod metrics', function() {
+      expect($scope.dailyPodEntityTrend.dataAvailable).toBeDefined();
     });
   });
 });

--- a/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_no_data_response.json
@@ -61,6 +61,7 @@
       "mem": null
     },
     "daily_network_metrics" : null,
-    "hourly_network_metrics" : null
+    "daily_pod_metrics" : null,
+    "daily_image_metrics" : null
   }
 }

--- a/spec/javascripts/fixtures/json/container_dashboard_response.json
+++ b/spec/javascripts/fixtures/json/container_dashboard_response.json
@@ -104,12 +104,28 @@
         2431
       ]
     },
-    "hourly_network_metrics" : {
+    "daily_pod_metrics" : {
       "xData": [
-        "2015-12-21T11:00:00.000Z"
+        "2015-12-07",
+        "2015-12-08"
+      ],
+      "yCreated": [
+        8,
+        87
+      ],
+      "yDeleted": [
+        38,
+        42
+      ]
+    },
+    "daily_image_metrics" : {
+      "xData": [
+        "2015-12-07",
+        "2015-12-08"
       ],
       "yData": [
-        1599
+        23,
+        45
       ]
     }
   }


### PR DESCRIPTION
#### Description
Reorder container provider dashboard, and add two new cards:
1. pod utilization trends
2. image creation trends 

**View**
![screenshot-2016-04-13-20-33-10](https://cloud.githubusercontent.com/assets/2181522/14503095/2cf4c334-01b7-11e6-849c-7b94aa211a31.png)


**View on small screen**
![manageiq container dashboards](https://cloud.githubusercontent.com/assets/2181522/14308961/197899a0-fbe2-11e5-8f9f-cc9038c257b8.png)

