### PR TITLE
[WIP]Fix double render error when displaying an error flash message on edit or add provider

### DIFF
--- a/app/controllers/provider_foreman_controller.rb
+++ b/app/controllers/provider_foreman_controller.rb
@@ -179,8 +179,8 @@ class ProviderForemanController < ApplicationController
         @in_a_form = false
         @sb[:action] = nil
         add_flash("#{field.to_s.capitalize} #{msg}", :error)
-        replace_right_cell
       end
+      replace_right_cell
     end
   end
 


### PR DESCRIPTION
When an error occurs during editing or adding a configuration manager provider, a double render error occurs instead of a flash message being displayed

Will add specs