### PR TITLE
Avoid tenant validation hitting VMDB::Config

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -57,7 +57,7 @@ module EvmSpecHelper
   end
 
   def self.remote_miq_server(attrs = {})
-    Tenant.seed
+    Tenant.root_tenant || Tenant.create!(:use_config_for_attributes => false)
 
     server = FactoryGirl.create(:miq_server, attrs)
     server


### PR DESCRIPTION
These validations of the logo attachment, are not needed in test, and end up
calling VMDB::Config.new for each test using this helper method.

We can bypass this by using `use_config_for_attributes` => false.

This is a more surgical solution over #6975.