### PR TITLE
Add `evm:dbsync:destroy_local_region` task

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -11,21 +11,7 @@ class MiqRegionRemote < ApplicationRecord
 
     with_remote_connection(host, port, username, password, database, adapter) do |conn|
       _log.info "Clearing region [#{region}] from remote host [#{host}]..."
-
-      tables ||= conn.tables.reject { |t| t =~ /^schema_migrations|^ar_internal_metadata|^rr/ }.sort
-      tables.each do |t|
-        pk = conn.primary_key(t)
-        if pk
-          conditions = sanitize_conditions(region_to_conditions(region, pk))
-        else
-          id_cols = connection.columns(t).select { |c| c.name.ends_with?("_id") }
-          conditions = id_cols.collect { |c| "(#{sanitize_conditions(region_to_conditions(region, c.name))})" }.join(" OR ")
-        end
-
-        rows = conn.delete("DELETE FROM #{t} WHERE #{conditions}")
-        _log.info "Cleared [#{rows}] rows from table [#{t}]"
-      end
-
+      MiqRegion.destroy_region(conn, region, tables)
       _log.info "Clearing region [#{region}] from remote host [#{host}]...Complete"
     end
   end

--- a/lib/tasks/evm_dbsync.rake
+++ b/lib/tasks/evm_dbsync.rake
@@ -20,6 +20,21 @@ namespace :evm do
       exit if !tables.empty? && $final_rake_task.nil? || $final_rake_task == :destroy_remote_region
     end
 
+    desc "Remove remote region data from local database"
+    task :destroy_local_region => :environment do
+      region_number = ARGV[1].to_i
+
+      if region_number == MiqRegion.my_region_number
+        puts "Refusing to destroy local region #{MiqRegion.my_region_number}"
+      else
+        puts "Destroying region #{region_number} ..."
+        MiqRegion.destroy_region(ApplicationRecord.connection, region_number)
+        puts "Destroying region #{region_number} ... Complete"
+      end
+
+      exit if $final_rake_task.nil? || $final_rake_task == :destroy_local_region
+    end
+
     desc "Uninstall Rubyrep triggers and tables locally"
     task :local_uninstall => :environment do
       tables = ARGV[1..-1]


### PR DESCRIPTION
If a user has replication configured and removes a regional database, that region's data will be "stuck" in the master database.

The new task, `evm:dbsync:destroy_local_region`, takes a region number and uses the same logic as destroy_remote_region to remove the data, but locally.

https://bugzilla.redhat.com/show_bug.cgi?id=1295574
@gtanzillo @Fryguy 