### PR TITLE
Skip writing the vmdb.yml.db in test.

### DIFF
--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -259,7 +259,7 @@ module VMDB
       config.store_path(keys, value)
     end
 
-    def save(save_db_file = true)
+    def save
       raise "configuration invalid, see errors for details" unless validate
 
       begin
@@ -272,10 +272,10 @@ module VMDB
       case configuration_source
       when :database
         @db_record = Configuration.create_or_update(svr, @config, @name)
-        save_file(@cfile_db) if save_db_file
+        save_file(@cfile_db) unless Rails.env.test?
         _log.info("Saved Config [#{@name}] from database in file: [#{@cfile_db}]")
       when :filesystem
-        save_file(@cfile_db) if save_db_file
+        save_file(@cfile_db) unless Rails.env.test?
         _log.info("Saved Config [#{@name}] in file: [#{@cfile_db}]")
       end
       update_cache_metadata

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -35,7 +35,7 @@ describe VMDB::Config do
     server        = EvmSpecHelper.create_guid_miq_server_zone[1]
     config        = VMDB::Config.new("vmdb")
     config.config = {:log_depot => {:uri => "smb://server/share", :username => "user", :password => password}}
-    config.save(false)
+    config.save
 
     expect(VMDB::Config.get_file("vmdb")).to eq(
       "---\nlog_depot:\n  uri: smb://server/share\n  username: user\n  password: #{enc_pass}\n"
@@ -47,7 +47,7 @@ describe VMDB::Config do
       EvmSpecHelper.create_guid_miq_server_zone
       config = VMDB::Config.new("vmdb")
       config.config = {:one => {:two => :three}}
-      config.save(false)
+      config.save
       expect(Configuration.count).to eq(1)
       expect(Configuration.first).to have_attributes(:typ => 'vmdb', :settings => {:one => {:two => :three}})
     end


### PR DESCRIPTION
Follow up to #6675.

Apparently, there were other places in the miq_server_spec.rb that we also were
saving the configuration.  Instead of also changing these locations to not save,
we should blindly skip saving the vmdb.yml.db in test mode.