### PR TITLE
Add migration to add pks to all tables

### DIFF
--- a/db/migrate/20160106214719_add_composite_primary_keys_to_join_tables.rb
+++ b/db/migrate/20160106214719_add_composite_primary_keys_to_join_tables.rb
@@ -1,0 +1,33 @@
+class AddCompositePrimaryKeysToJoinTables < ActiveRecord::Migration
+  TABLE_MAP = {
+    "cloud_tenants_vms"                                  => "cloud_tenant_id, vm_id",
+    "conditions_miq_policies"                            => "miq_policy_id, condition_id",
+    "configuration_locations_configuration_profiles"     => "configuration_location_id, configuration_profile_id",
+    "configuration_organizations_configuration_profiles" => "configuration_organization_id, configuration_profile_id",
+    "configuration_profiles_configuration_tags"          => "configuration_profile_id, configuration_tag_id",
+    "configuration_tags_configured_systems"              => "configured_system_id, configuration_tag_id",
+    "container_groups_container_services"                => "container_service_id, container_group_id",
+    "customization_scripts_operating_system_flavors"     => "customization_script_id, operating_system_flavor_id",
+    "direct_configuration_profiles_configuration_tags"   => "configuration_profile_id, configuration_tag_id",
+    "direct_configuration_tags_configured_systems"       => "configured_system_id, configuration_tag_id",
+    "key_pairs_vms"                                      => "authentication_id, vm_id",
+    "miq_groups_users"                                   => "miq_group_id, user_id",
+    "miq_roles_features"                                 => "miq_user_role_id, miq_product_feature_id",
+    "miq_servers_product_updates"                        => "product_update_id, miq_server_id",
+    "network_ports_security_groups"                      => "network_port_id, security_group_id",
+    "security_groups_vms"                                => "security_group_id, vm_id",
+    "storages_vms_and_templates"                         => "storage_id, vm_or_template_id"
+  }.freeze
+
+  def up
+    TABLE_MAP.each do |table, key|
+      execute("ALTER TABLE #{table} ADD PRIMARY KEY (#{key})")
+    end
+  end
+
+  def down
+    TABLE_MAP.keys.each do |table|
+      execute("ALTER TABLE #{table} DROP CONSTRAINT #{table}_pkey")
+    end
+  end
+end

--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -553,6 +553,16 @@ module ActiveRecord
         end.compact
       end
 
+      def primary_key?(table_name)
+        select_value(<<-SQL)
+          SELECT EXISTS(
+            SELECT 1
+            FROM pg_index
+            WHERE indrelid = '#{table_name}'::regclass AND indisprimary = true
+          )
+        SQL
+      end
+
       def table_metrics_bloat(table_name)
         data = select(<<-SQL, "Table Metrics Bloat Analysis")
                 SELECT tablename                                                    AS table_name

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -1,0 +1,19 @@
+describe "ar_dba extension" do
+  let(:connection) { ApplicationRecord.connection }
+
+  describe "#primary_key?" do
+    it "returns false for a table without a primary key" do
+      table_name = "no_pk_test"
+      connection.select_value("CREATE TABLE #{table_name} (id INTEGER)")
+      expect(connection.primary_key?(table_name)).to be false
+    end
+
+    it "returns true for a table with a primary key" do
+      expect(connection.primary_key?("miq_databases")).to be true
+    end
+
+    it "returns true for composite primary keys" do
+      expect(connection.primary_key?("storages_vms_and_templates")).to be true
+    end
+  end
+end

--- a/spec/replication/primary_key_spec.rb
+++ b/spec/replication/primary_key_spec.rb
@@ -1,0 +1,12 @@
+describe "all tables" do
+  let(:connection) { ApplicationRecord.connection }
+
+  it "have a primary key" do
+    no_pk = []
+    connection.tables.each do |t|
+      next if t == "schema_migrations"
+      no_pk << t unless connection.primary_key?(t)
+    end
+    expect(no_pk.size).to eq(0), "No primary key found for: #{no_pk.join(", ")}"
+  end
+end


### PR DESCRIPTION
Prep for adding pglogical replication.
Any table replicated by pglogical needs a primary key.

@gtanzillo @Fryguy 
