### PR TITLE
Undefined method hardware for nil

### DIFF
--- a/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/openstack/cloud_manager/provision_workflow.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow < ::MiqPro
   def allowed_instance_types(_options = {})
     source                  = load_ar_obj(get_source_vm)
     flavors                 = get_targets_for_ems(source, :cloud_filter, Flavor, 'flavors')
+    return {} if flavors.blank?
     minimum_disk_required   = [source.hardware.size_on_disk, source.hardware.disk_size_minimum.to_i].max
     minimum_memory_required = source.hardware.memory_mb_minimum.to_i * 1.megabyte
     flavors.each_with_object({}) do |flavor, h|

--- a/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb
@@ -155,6 +155,20 @@ describe ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow do
       described_class.new({}, admin.userid)
     end
 
+    context "Without a Template" do
+      let(:workflow) do
+        stub_dialog
+        allow_any_instance_of(described_class).to receive(:update_field_visibility)
+        described_class.new({}, admin.userid)
+      end
+
+      it "#allowed_instance_types" do
+        provider.flavors << FactoryGirl.create(:flavor_openstack)
+
+        expect(workflow.allowed_instance_types).to eq({})
+      end
+    end
+
     context "With a Valid Template" do
       let(:workflow) do
         stub_dialog


### PR DESCRIPTION
Occurred when instantiating a ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow without a source template due to trying to filter available flavors