### PR TITLE
Optimize User roles spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -278,8 +278,6 @@ describe User do
 
     context "#miq_groups=" do
       before(:each) do
-        @filter1        = "this is filter 1"
-        @group3.filters = @filter1
         @user = FactoryGirl.create(:user, :miq_groups => [@group3])
       end
 
@@ -310,8 +308,6 @@ describe User do
 
     context "#current_group=" do
       before(:each) do
-        @filter1            = "this is filter 1"
-        @group1.filters     = @filter1
         @user = FactoryGirl.create(:user, :miq_groups => [@group1, @group2])
       end
 


### PR DESCRIPTION
A quick conversion of the `before` block in the context of User's spec which tests roles. All of these roles/groups are being created for every example, including simple built validations. Breaks up contexts for easier reading, a saved second or two in the test run, and adding for things in the future (_cough_ user groups _cough_)