### PR TITLE
Changes to show "Details" tab for all types of Catalog Items

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -167,7 +167,9 @@ class CatalogController < ApplicationController
       @tabactive = @edit[:new][:current_tab_key]
     end
     render :update do |page|                    # Use JS to update the display
-      page.replace_html("form_div", :partial => "st_form") if params[:st_prov_type]
+      # for generic/orchestration type tabs do not show up on screen as there is only a single tab when form is initialized
+      # when display in catalog is checked, replace div so tabs can be redrawn
+      page.replace("form_div", :partial => "st_form") if params[:st_prov_type] || params[:display]
       page.replace_html("basic_info_div", :partial => "form_basic_info") if params[:display] || params[:template_id]
       if params[:display]
         page << "miq_tabs_show_hide('#details_tab', '#{(params[:display] == "1")}')"

--- a/app/views/catalog/_form.html.haml
+++ b/app/views/catalog/_form.html.haml
@@ -2,9 +2,9 @@
   %ul.nav.nav-tabs
     = miq_tab_header('basic', @sb[:st_form_active_tab]) do
       = _('Basic Info')
+    = miq_tab_header('details', @sb[:st_form_active_tab]) do
+      = _('Details')
     - unless @edit[:new][:st_prov_type] == "generic_orchestration"
-      = miq_tab_header('details', @sb[:st_form_active_tab]) do
-        = _('Details')
       - if @edit[:new][:service_type] == "composite"
         = miq_tab_header('resources', @sb[:st_form_active_tab]) do
           = _('Resources')
@@ -16,9 +16,9 @@
   .tab-content
     = miq_tab_content('basic', @sb[:st_form_active_tab]) do
       = render :partial => "form_basic_info"
+    = miq_tab_content('details', @sb[:st_form_active_tab], :class => 'cm-tab') do
+      = render :partial => "form_details_info"
     - unless @edit[:new][:st_prov_type] == "generic_orchestration"
-      = miq_tab_content('details', @sb[:st_form_active_tab], :class => 'cm-tab') do
-        = render :partial => "form_details_info"
       - if @edit[:new][:service_type] == "composite"
         = miq_tab_content('resources', @sb[:st_form_active_tab]) do
           = render :partial => "form_resources_info"

--- a/app/views/catalog/_sandt_tree_show.html.haml
+++ b/app/views/catalog/_sandt_tree_show.html.haml
@@ -3,7 +3,7 @@
   %ul.nav.nav-tabs
     = miq_tab_header('basic') do
       = _('Basic Info')
-    - if @record.display && @record.prov_type != "generic_orchestration"
+    - if @record.display
       = miq_tab_header('details') do
         = _('Details')
     - if @record.composite?
@@ -99,7 +99,7 @@
             .col-md-6
               = submit_tag(_("Upload"), :id => "upload", :class => "upload btn btn-default")
               = _('* Requirements: File-type - PNG; Dimensions - 350x70.')
-    - if @record.display && @record.prov_type != "generic_orchestration"
+    - if @record.display
       = miq_tab_content('details') do
         %h3
           = _('Basic Information')


### PR DESCRIPTION
Show "Details" tab that has Long Description field for all types of Catalog Items if "Display in Catalog" is checked.

https://bugzilla.redhat.com/show_bug.cgi?id=1310117
https://bugzilla.redhat.com/show_bug.cgi?id=1311996

@dclarizio please review

before:
![orchestartion_catalog_item_add_before](https://cloud.githubusercontent.com/assets/3450808/13405966/060d139c-deef-11e5-9e5e-dfd1c73ced59.png)

after:
![catalog_item_add](https://cloud.githubusercontent.com/assets/3450808/13405988/292fc6c6-deef-11e5-9883-ef11e1e97b61.png)
![orchestration_catalog_item_add_after](https://cloud.githubusercontent.com/assets/3450808/13405992/2c61c678-deef-11e5-839d-60015bb1961e.png)
