### PR TITLE
Only filter targets if not already filtered in db

### DIFF
--- a/app/models/rbac.rb
+++ b/app/models/rbac.rb
@@ -477,7 +477,7 @@ module Rbac
 
     user_filters['ids_via_descendants'] = ids_via_descendants(rbac_class(klass), options.delete(:match_via_descendants), :user => user, :miq_group => miq_group)
 
-    exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) unless search_filter.nil? || klass.respond_to?(:instances_are_derived?)
+    exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.respond_to?(:instances_are_derived?)
     conditions, include_for_find = MiqExpression.merge_where_clauses_and_includes([conditions, sub_filter, where_clause, exp_sql, ids_clause], [include_for_find, exp_includes])
 
     attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
@@ -496,7 +496,7 @@ module Rbac
       auth_count  = targets.length
     end
 
-    unless search_filter.nil?
+    if search_filter && targets && (!exp_attrs || !exp_attrs[:supported_by_sql])
       rejects     = targets.reject { |obj| self.matches_search_filters?(obj, search_filter, tz) }
       auth_count -= rejects.length
       targets -= rejects


### PR DESCRIPTION
According to a few lines up in 480, we are running the search filter
in the database

If this is the case, there is no need to run this again in ruby.

Now if `klass.respond_to?(:instances_are_derived?)` is true, or the
filter does not work in the database, then the filter still needs to be
performed locally.

/cc @gtanzillo let me know if this makes sense
/cc @jrafanie 