### PR TITLE
If domain_prefix not provided, ldap.bind to username

### DIFF
--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -280,7 +280,8 @@ class MiqLdap
     user_prefix = "cn" if user_prefix == "dn"
     case user_type
     when "samaccountname"
-      return "#{@domain_prefix}\\#{username}"
+      return "#{@domain_prefix}\\#{username}" unless @domain_prefix.blank?
+      return username
     when "upn", "userprincipalname"
       return username if @user_suffix.blank?
       return username if username =~ /^.+@.+$/ # already qualified with user@domain


### PR DESCRIPTION
When a user sets up authentication by LDAP and chooses usertype "samaccountname", it is possible that he will not provide a domain_prefix and not provide a prefixed login username manually.

In this situation, ldap.bind() will call fqusername() and get back a slashed username, '\username'. This is probably not the intention of the user and will fail ldap.bind().