### PR TITLE
Make AMQP heartbeat configurable

### DIFF
--- a/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
+++ b/app/models/manageiq/providers/openstack/event_catcher_mixin.rb
@@ -10,9 +10,10 @@ module ManageIQ::Providers::Openstack::EventCatcherMixin
         options[:username] = @ems.authentication_userid(:amqp)
         options[:password] = @ems.authentication_password(:amqp)
       end
-      options[:topics]   = worker_settings[:topics]
-      options[:duration] = worker_settings[:duration]
-      options[:capacity] = worker_settings[:capacity]
+      options[:topics]    = worker_settings[:topics]
+      options[:duration]  = worker_settings[:duration]
+      options[:capacity]  = worker_settings[:capacity]
+      options[:heartbeat] = worker_settings[:amqp_heartbeat]
 
       options[:client_ip] = server.ipaddress
       @event_monitor_handle = OpenstackEventMonitor.new(options)

--- a/config/vmdb.tmpl.yml
+++ b/config/vmdb.tmpl.yml
@@ -310,6 +310,7 @@ workers:
         :duration: 10.seconds
         :capacity: 50
         :amqp_port: 5672
+        :amqp_heartbeat: 30
       :event_catcher_openstack_infra:
         :poll: 15.seconds
         :topics:
@@ -322,6 +323,7 @@ workers:
         :duration: 10.seconds
         :capacity: 50
         :amqp_port: 5672
+        :amqp_heartbeat: 30
       :event_catcher_amazon:
         :poll: 15.seconds
       :event_catcher_kubernetes:

--- a/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
+++ b/gems/pending/openstack/amqp/openstack_rabbit_event_monitor.rb
@@ -19,7 +19,8 @@ class OpenstackRabbitEventMonitor < OpenstackEventMonitor
   # It creates a test mock point for specs
   def self.connect(options = {})
     connection_options = {:host => options[:hostname]}
-    connection_options[:port] = options[:port] || DEFAULT_AMQP_PORT
+    connection_options[:port]      = options[:port] || DEFAULT_AMQP_PORT
+    connection_options[:heartbeat] = options[:heartbeat] || DEFAULT_AMQP_HEARTBEAT
     if options.key? :username
       connection_options[:username] = options[:username]
       connection_options[:password] = options[:password]

--- a/gems/pending/openstack/openstack_event_monitor.rb
+++ b/gems/pending/openstack/openstack_event_monitor.rb
@@ -7,6 +7,7 @@ require 'active_support/core_ext/class/subclasses'
 
 class OpenstackEventMonitor
   DEFAULT_AMQP_PORT = 5672
+  DEFAULT_AMQP_HEARTBEAT = 30
 
   def self.new(options = {})
     # plugin initializer


### PR DESCRIPTION
By default bunny takes the setting from the AMQP settings. If
this setting is too low (like 1s) it might fail to give response
in time, causing reconnect.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1302362